### PR TITLE
Resolve #96 - problem with Jest and watchman

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm start
 | Command | Description |
 | ------- | ----------- |
 | `npm start` | Starts development server with hot reloading and api proxy. |
-| `npm test` | Runs all the test |
+| `npm test -- --coverage` | Runs all the tests |
 | `npm run lint` | Lint the project (eslint, prettier, flow) |
 | `npm run build` | Runs production build. Outputs files to `/dist`. |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The app was built with [create-react-app](https://github.com/facebookincubator/c
 Fork, then clone the `jaeger-ui` repo and change directory into it.
 
 ```
-git clone https://github.com/uber/jaeger-ui.git
+git clone https://github.com/jaegertracing/jaeger-ui.git
 cd jaeger-ui
 ```
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "history": "^4.6.3",
     "is-promise": "^2.1.0",
     "isomorphic-fetch": "^2.2.1",
+    "jest": "^21.2.1",
     "json-markup": "^1.1.0",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",

--- a/src/components/TracePage/TraceTimelineViewer/ListView/__snapshots__/index.test.js.snap
+++ b/src/components/TracePage/TraceTimelineViewer/ListView/__snapshots__/index.test.js.snap
@@ -11,184 +11,188 @@ ShallowWrapper {
   "node": <div
     onScroll={[Function]}
     style={
-        Object {
-            "height": "100%",
-            "overflowY": "auto",
-            "position": "relative",
-          }
+      Object {
+        "height": "100%",
+        "overflowY": "auto",
+        "position": "relative",
+      }
     }
->
+  >
     <div
-        style={
-            Object {
-                "height": 1640,
-                "position": "relative",
-              }
+      style={
+        Object {
+          "height": 1640,
+          "position": "relative",
         }
+      }
     >
-        <div
-            className="SomeClassName"
-            style={
-                Object {
-                    "margin": 0,
-                    "padding": 0,
-                    "position": "absolute",
-                    "top": 0,
-                  }
+      <div
+        className="SomeClassName"
+        style={
+          Object {
+            "margin": 0,
+            "padding": 0,
+            "position": "absolute",
+            "top": 0,
+          }
+        }
+      >
+        <Item
+          data-item-key="0"
+          style={
+            Object {
+              "height": 2,
+              "position": "absolute",
+              "top": 0,
             }
+          }
         >
-            <Item
-                data-item-key="0"
-                style={
-                    Object {
-                        "height": 2,
-                        "position": "absolute",
-                        "top": 0,
-                      }
-                }
-            />
-            <Item
-                data-item-key="1"
-                style={
-                    Object {
-                        "height": 4,
-                        "position": "absolute",
-                        "top": 2,
-                      }
-                }
-            >
-                1
-            </Item>
-            <Item
-                data-item-key="2"
-                style={
-                    Object {
-                        "height": 6,
-                        "position": "absolute",
-                        "top": 6,
-                      }
-                }
-            >
-                2
-            </Item>
-            <Item
-                data-item-key="3"
-                style={
-                    Object {
-                        "height": 8,
-                        "position": "absolute",
-                        "top": 12,
-                      }
-                }
-            >
-                3
-            </Item>
-            <Item
-                data-item-key="4"
-                style={
-                    Object {
-                        "height": 10,
-                        "position": "absolute",
-                        "top": 20,
-                      }
-                }
-            >
-                4
-            </Item>
-        </div>
+          0
+        </Item>
+        <Item
+          data-item-key="1"
+          style={
+            Object {
+              "height": 4,
+              "position": "absolute",
+              "top": 2,
+            }
+          }
+        >
+          1
+        </Item>
+        <Item
+          data-item-key="2"
+          style={
+            Object {
+              "height": 6,
+              "position": "absolute",
+              "top": 6,
+            }
+          }
+        >
+          2
+        </Item>
+        <Item
+          data-item-key="3"
+          style={
+            Object {
+              "height": 8,
+              "position": "absolute",
+              "top": 12,
+            }
+          }
+        >
+          3
+        </Item>
+        <Item
+          data-item-key="4"
+          style={
+            Object {
+              "height": 10,
+              "position": "absolute",
+              "top": 20,
+            }
+          }
+        >
+          4
+        </Item>
+      </div>
     </div>
-</div>,
+  </div>,
   "nodes": Array [
     <div
       onScroll={[Function]}
       style={
-            Object {
-                  "height": "100%",
-                  "overflowY": "auto",
-                  "position": "relative",
-                }
+        Object {
+          "height": "100%",
+          "overflowY": "auto",
+          "position": "relative",
+        }
       }
->
+    >
       <div
-            style={
-                  Object {
-                        "height": 1640,
-                        "position": "relative",
-                      }
-            }
+        style={
+          Object {
+            "height": 1640,
+            "position": "relative",
+          }
+        }
       >
-            <div
-                  className="SomeClassName"
-                  style={
-                        Object {
-                              "margin": 0,
-                              "padding": 0,
-                              "position": "absolute",
-                              "top": 0,
-                            }
-                  }
-            >
-                  <Item
-                        data-item-key="0"
-                        style={
-                              Object {
-                                    "height": 2,
-                                    "position": "absolute",
-                                    "top": 0,
-                                  }
-                        }
-                  />
-                  <Item
-                        data-item-key="1"
-                        style={
-                              Object {
-                                    "height": 4,
-                                    "position": "absolute",
-                                    "top": 2,
-                                  }
-                        }
-                  >
-                        1
-                  </Item>
-                  <Item
-                        data-item-key="2"
-                        style={
-                              Object {
-                                    "height": 6,
-                                    "position": "absolute",
-                                    "top": 6,
-                                  }
-                        }
-                  >
-                        2
-                  </Item>
-                  <Item
-                        data-item-key="3"
-                        style={
-                              Object {
-                                    "height": 8,
-                                    "position": "absolute",
-                                    "top": 12,
-                                  }
-                        }
-                  >
-                        3
-                  </Item>
-                  <Item
-                        data-item-key="4"
-                        style={
-                              Object {
-                                    "height": 10,
-                                    "position": "absolute",
-                                    "top": 20,
-                                  }
-                        }
-                  >
-                        4
-                  </Item>
-            </div>
+        <div
+          className="SomeClassName"
+          style={
+            Object {
+              "margin": 0,
+              "padding": 0,
+              "position": "absolute",
+              "top": 0,
+            }
+          }
+        >
+          <Item
+            data-item-key="0"
+            style={
+              Object {
+                "height": 2,
+                "position": "absolute",
+                "top": 0,
+              }
+            }
+          >
+            0
+          </Item>
+          <Item
+            data-item-key="1"
+            style={
+              Object {
+                "height": 4,
+                "position": "absolute",
+                "top": 2,
+              }
+            }
+          >
+            1
+          </Item>
+          <Item
+            data-item-key="2"
+            style={
+              Object {
+                "height": 6,
+                "position": "absolute",
+                "top": 6,
+              }
+            }
+          >
+            2
+          </Item>
+          <Item
+            data-item-key="3"
+            style={
+              Object {
+                "height": 8,
+                "position": "absolute",
+                "top": 12,
+              }
+            }
+          >
+            3
+          </Item>
+          <Item
+            data-item-key="4"
+            style={
+              Object {
+                "height": 10,
+                "position": "absolute",
+                "top": 20,
+              }
+            }
+          >
+            4
+          </Item>
+        </div>
       </div>
-</div>,
+    </div>,
   ],
   "options": Object {},
   "renderer": ReactShallowRenderer {
@@ -207,7 +211,7 @@ ShallowWrapper {
         viewBuffer={10}
         viewBufferMin={5}
         windowScroller={false}
-/>,
+      />,
       "_debugID": 3,
       "_hostContainerInfo": null,
       "_hostParent": null,
@@ -218,7 +222,7 @@ ShallowWrapper {
         "_htmlElm": <html>
           <head />
           <body />
-</html>,
+        </html>,
         "_htmlTopOffset": -1,
         "_initItemHolder": [Function],
         "_initWrapper": [Function],
@@ -365,184 +369,188 @@ ShallowWrapper {
         "_currentElement": <div
           onScroll={[Function]}
           style={
-                    Object {
-                              "height": "100%",
-                              "overflowY": "auto",
-                              "position": "relative",
-                            }
+            Object {
+              "height": "100%",
+              "overflowY": "auto",
+              "position": "relative",
+            }
           }
->
+        >
           <div
-                    style={
-                              Object {
-                                        "height": 1640,
-                                        "position": "relative",
-                                      }
-                    }
+            style={
+              Object {
+                "height": 1640,
+                "position": "relative",
+              }
+            }
           >
-                    <div
-                              className="SomeClassName"
-                              style={
-                                        Object {
-                                                  "margin": 0,
-                                                  "padding": 0,
-                                                  "position": "absolute",
-                                                  "top": 0,
-                                                }
-                              }
-                    >
-                              <Item
-                                        data-item-key="0"
-                                        style={
-                                                  Object {
-                                                            "height": 2,
-                                                            "position": "absolute",
-                                                            "top": 0,
-                                                          }
-                                        }
-                              />
-                              <Item
-                                        data-item-key="1"
-                                        style={
-                                                  Object {
-                                                            "height": 4,
-                                                            "position": "absolute",
-                                                            "top": 2,
-                                                          }
-                                        }
-                              >
-                                        1
-                              </Item>
-                              <Item
-                                        data-item-key="2"
-                                        style={
-                                                  Object {
-                                                            "height": 6,
-                                                            "position": "absolute",
-                                                            "top": 6,
-                                                          }
-                                        }
-                              >
-                                        2
-                              </Item>
-                              <Item
-                                        data-item-key="3"
-                                        style={
-                                                  Object {
-                                                            "height": 8,
-                                                            "position": "absolute",
-                                                            "top": 12,
-                                                          }
-                                        }
-                              >
-                                        3
-                              </Item>
-                              <Item
-                                        data-item-key="4"
-                                        style={
-                                                  Object {
-                                                            "height": 10,
-                                                            "position": "absolute",
-                                                            "top": 20,
-                                                          }
-                                        }
-                              >
-                                        4
-                              </Item>
-                    </div>
+            <div
+              className="SomeClassName"
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": 0,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <Item
+                data-item-key="0"
+                style={
+                  Object {
+                    "height": 2,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+              >
+                0
+              </Item>
+              <Item
+                data-item-key="1"
+                style={
+                  Object {
+                    "height": 4,
+                    "position": "absolute",
+                    "top": 2,
+                  }
+                }
+              >
+                1
+              </Item>
+              <Item
+                data-item-key="2"
+                style={
+                  Object {
+                    "height": 6,
+                    "position": "absolute",
+                    "top": 6,
+                  }
+                }
+              >
+                2
+              </Item>
+              <Item
+                data-item-key="3"
+                style={
+                  Object {
+                    "height": 8,
+                    "position": "absolute",
+                    "top": 12,
+                  }
+                }
+              >
+                3
+              </Item>
+              <Item
+                data-item-key="4"
+                style={
+                  Object {
+                    "height": 10,
+                    "position": "absolute",
+                    "top": 20,
+                  }
+                }
+              >
+                4
+              </Item>
+            </div>
           </div>
-</div>,
+        </div>,
         "_debugID": 4,
         "_renderedOutput": <div
           onScroll={[Function]}
           style={
-                    Object {
-                              "height": "100%",
-                              "overflowY": "auto",
-                              "position": "relative",
-                            }
+            Object {
+              "height": "100%",
+              "overflowY": "auto",
+              "position": "relative",
+            }
           }
->
+        >
           <div
-                    style={
-                              Object {
-                                        "height": 1640,
-                                        "position": "relative",
-                                      }
-                    }
+            style={
+              Object {
+                "height": 1640,
+                "position": "relative",
+              }
+            }
           >
-                    <div
-                              className="SomeClassName"
-                              style={
-                                        Object {
-                                                  "margin": 0,
-                                                  "padding": 0,
-                                                  "position": "absolute",
-                                                  "top": 0,
-                                                }
-                              }
-                    >
-                              <Item
-                                        data-item-key="0"
-                                        style={
-                                                  Object {
-                                                            "height": 2,
-                                                            "position": "absolute",
-                                                            "top": 0,
-                                                          }
-                                        }
-                              />
-                              <Item
-                                        data-item-key="1"
-                                        style={
-                                                  Object {
-                                                            "height": 4,
-                                                            "position": "absolute",
-                                                            "top": 2,
-                                                          }
-                                        }
-                              >
-                                        1
-                              </Item>
-                              <Item
-                                        data-item-key="2"
-                                        style={
-                                                  Object {
-                                                            "height": 6,
-                                                            "position": "absolute",
-                                                            "top": 6,
-                                                          }
-                                        }
-                              >
-                                        2
-                              </Item>
-                              <Item
-                                        data-item-key="3"
-                                        style={
-                                                  Object {
-                                                            "height": 8,
-                                                            "position": "absolute",
-                                                            "top": 12,
-                                                          }
-                                        }
-                              >
-                                        3
-                              </Item>
-                              <Item
-                                        data-item-key="4"
-                                        style={
-                                                  Object {
-                                                            "height": 10,
-                                                            "position": "absolute",
-                                                            "top": 20,
-                                                          }
-                                        }
-                              >
-                                        4
-                              </Item>
-                    </div>
+            <div
+              className="SomeClassName"
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": 0,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <Item
+                data-item-key="0"
+                style={
+                  Object {
+                    "height": 2,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+              >
+                0
+              </Item>
+              <Item
+                data-item-key="1"
+                style={
+                  Object {
+                    "height": 4,
+                    "position": "absolute",
+                    "top": 2,
+                  }
+                }
+              >
+                1
+              </Item>
+              <Item
+                data-item-key="2"
+                style={
+                  Object {
+                    "height": 6,
+                    "position": "absolute",
+                    "top": 6,
+                  }
+                }
+              >
+                2
+              </Item>
+              <Item
+                data-item-key="3"
+                style={
+                  Object {
+                    "height": 8,
+                    "position": "absolute",
+                    "top": 12,
+                  }
+                }
+              >
+                3
+              </Item>
+              <Item
+                data-item-key="4"
+                style={
+                  Object {
+                    "height": 10,
+                    "position": "absolute",
+                    "top": 20,
+                  }
+                }
+              >
+                4
+              </Item>
+            </div>
           </div>
-</div>,
+        </div>,
       },
       "_renderedNodeType": 0,
       "_rootNodeID": 0,
@@ -565,6 +573,6 @@ ShallowWrapper {
     viewBuffer={10}
     viewBufferMin={5}
     windowScroller={false}
-/>,
+  />,
 }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,10 @@ ansi-escapes@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://unpm.uberinternal.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -125,7 +129,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.1.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -267,6 +271,10 @@ assert@^1.1.1:
 ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://unpm.uberinternal.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -525,6 +533,13 @@ babel-jest@20.0.3, babel-jest@^20.0.3:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^20.0.3"
 
+babel-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/babel-jest/-/babel-jest-21.2.0.tgz#2ce059519a9374a2c46f2455b6fbef5ad75d863e"
+  dependencies:
+    babel-plugin-istanbul "^4.0.0"
+    babel-preset-jest "^21.2.0"
+
 babel-loader@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.1.tgz#b87134c8b12e3e4c2a94e0546085bc680a2b8488"
@@ -565,6 +580,10 @@ babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
+babel-plugin-jest-hoist@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -589,7 +608,7 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -916,6 +935,13 @@ babel-preset-jest@^20.0.3:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz#cbacaadecb5d689ca1e1de1360ebfc66862c178a"
   dependencies:
     babel-plugin-jest-hoist "^20.0.3"
+
+babel-preset-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
+  dependencies:
+    babel-plugin-jest-hoist "^21.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-react-app@^3.0.2:
   version "3.0.2"
@@ -1370,6 +1396,14 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
 chalk@^2.0.0, chalk@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chalk@^2.0.1:
+  version "2.2.0"
+  resolved "https://unpm.uberinternal.com/chalk/-/chalk-2.2.0.tgz#477b3bf2f9b8fd5ca9e429747e37f724ee7af240"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -2801,6 +2835,17 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+expect@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/expect/-/expect-21.2.1.tgz#003ac2ac7005c3c29e73b38a272d4afadd6d1d7b"
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^21.2.1"
+    jest-get-type "^21.2.0"
+    jest-matcher-utils "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-regex-util "^21.2.0"
+
 express@^4.13.3:
   version "4.15.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.15.4.tgz#032e2253489cf8fce02666beca3d11ed7a2daed1"
@@ -3088,7 +3133,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@1.1.2, fsevents@^1.0.0:
+fsevents@1.1.2, fsevents@^1.0.0, fsevents@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
   dependencies:
@@ -3954,6 +3999,12 @@ jest-changed-files@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-20.0.3.tgz#9394d5cc65c438406149bef1bf4d52b68e03e3f8"
 
+jest-changed-files@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
+  dependencies:
+    throat "^4.0.0"
+
 jest-cli@^20.0.4:
   version "20.0.4"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-20.0.4.tgz#e532b19d88ae5bc6c417e8b0593a6fe954b1dc93"
@@ -3989,6 +4040,40 @@ jest-cli@^20.0.4:
     worker-farm "^1.3.1"
     yargs "^7.0.2"
 
+jest-cli@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-cli/-/jest-cli-21.2.1.tgz#9c528b6629d651911138d228bdb033c157ec8c00"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    istanbul-api "^1.1.1"
+    istanbul-lib-coverage "^1.0.1"
+    istanbul-lib-instrument "^1.4.2"
+    istanbul-lib-source-maps "^1.1.0"
+    jest-changed-files "^21.2.0"
+    jest-config "^21.2.1"
+    jest-environment-jsdom "^21.2.1"
+    jest-haste-map "^21.2.0"
+    jest-message-util "^21.2.1"
+    jest-regex-util "^21.2.0"
+    jest-resolve-dependencies "^21.2.0"
+    jest-runner "^21.2.1"
+    jest-runtime "^21.2.1"
+    jest-snapshot "^21.2.1"
+    jest-util "^21.2.1"
+    micromatch "^2.3.11"
+    node-notifier "^5.0.2"
+    pify "^3.0.0"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    worker-farm "^1.3.1"
+    yargs "^9.0.0"
+
 jest-config@^20.0.4:
   version "20.0.4"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-20.0.4.tgz#e37930ab2217c913605eff13e7bd763ec48faeea"
@@ -4004,6 +4089,22 @@ jest-config@^20.0.4:
     jest-validate "^20.0.3"
     pretty-format "^20.0.3"
 
+jest-config@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
+  dependencies:
+    chalk "^2.0.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^21.2.1"
+    jest-environment-node "^21.2.1"
+    jest-get-type "^21.2.0"
+    jest-jasmine2 "^21.2.1"
+    jest-regex-util "^21.2.0"
+    jest-resolve "^21.2.0"
+    jest-util "^21.2.1"
+    jest-validate "^21.2.1"
+    pretty-format "^21.2.1"
+
 jest-diff@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-20.0.3.tgz#81f288fd9e675f0fb23c75f1c2b19445fe586617"
@@ -4013,9 +4114,22 @@ jest-diff@^20.0.3:
     jest-matcher-utils "^20.0.3"
     pretty-format "^20.0.3"
 
+jest-diff@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
+
 jest-docblock@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
+
+jest-docblock@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
 jest-environment-jsdom@^20.0.3:
   version "20.0.3"
@@ -4025,12 +4139,31 @@ jest-environment-jsdom@^20.0.3:
     jest-util "^20.0.3"
     jsdom "^9.12.0"
 
+jest-environment-jsdom@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz#38d9980c8259b2a608ec232deee6289a60d9d5b4"
+  dependencies:
+    jest-mock "^21.2.0"
+    jest-util "^21.2.1"
+    jsdom "^9.12.0"
+
 jest-environment-node@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-20.0.3.tgz#d488bc4612af2c246e986e8ae7671a099163d403"
   dependencies:
     jest-mock "^20.0.3"
     jest-util "^20.0.3"
+
+jest-environment-node@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
+  dependencies:
+    jest-mock "^21.2.0"
+    jest-util "^21.2.1"
+
+jest-get-type@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
 
 jest-haste-map@^20.0.4:
   version "20.0.5"
@@ -4041,6 +4174,17 @@ jest-haste-map@^20.0.4:
     jest-docblock "^20.0.3"
     micromatch "^2.3.11"
     sane "~1.6.0"
+    worker-farm "^1.3.1"
+
+jest-haste-map@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-haste-map/-/jest-haste-map-21.2.0.tgz#1363f0a8bb4338f24f001806571eff7a4b2ff3d8"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^21.2.0"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
     worker-farm "^1.3.1"
 
 jest-jasmine2@^20.0.4:
@@ -4057,12 +4201,33 @@ jest-jasmine2@^20.0.4:
     once "^1.4.0"
     p-map "^1.1.1"
 
+jest-jasmine2@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz#9cc6fc108accfa97efebce10c4308548a4ea7592"
+  dependencies:
+    chalk "^2.0.1"
+    expect "^21.2.1"
+    graceful-fs "^4.1.11"
+    jest-diff "^21.2.1"
+    jest-matcher-utils "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-snapshot "^21.2.1"
+    p-cancelable "^0.3.0"
+
 jest-matcher-utils@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
   dependencies:
     chalk "^1.1.3"
     pretty-format "^20.0.3"
+
+jest-matcher-utils@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
 
 jest-matchers@^20.0.3:
   version "20.0.3"
@@ -4081,19 +4246,41 @@ jest-message-util@^20.0.3:
     micromatch "^2.3.11"
     slash "^1.0.0"
 
+jest-message-util@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-message-util/-/jest-message-util-21.2.1.tgz#bfe5d4692c84c827d1dcf41823795558f0a1acbe"
+  dependencies:
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+
 jest-mock@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-20.0.3.tgz#8bc070e90414aa155c11a8d64c869a0d5c71da59"
 
+jest-mock@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
+
 jest-regex-util@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-20.0.3.tgz#85bbab5d133e44625b19faf8c6aa5122d085d762"
+
+jest-regex-util@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
 
 jest-resolve-dependencies@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz#6e14a7b717af0f2cb3667c549de40af017b1723a"
   dependencies:
     jest-regex-util "^20.0.3"
+
+jest-resolve-dependencies@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz#9e231e371e1a736a1ad4e4b9a843bc72bfe03d09"
+  dependencies:
+    jest-regex-util "^21.2.0"
 
 jest-resolve@^20.0.4:
   version "20.0.4"
@@ -4102,6 +4289,29 @@ jest-resolve@^20.0.4:
     browser-resolve "^1.11.2"
     is-builtin-module "^1.0.0"
     resolve "^1.3.2"
+
+jest-resolve@^21.2.0:
+  version "21.2.0"
+  resolved "https://unpm.uberinternal.com/jest-resolve/-/jest-resolve-21.2.0.tgz#068913ad2ba6a20218e5fd32471f3874005de3a6"
+  dependencies:
+    browser-resolve "^1.11.2"
+    chalk "^2.0.1"
+    is-builtin-module "^1.0.0"
+
+jest-runner@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-runner/-/jest-runner-21.2.1.tgz#194732e3e518bfb3d7cbfc0fd5871246c7e1a467"
+  dependencies:
+    jest-config "^21.2.1"
+    jest-docblock "^21.2.0"
+    jest-haste-map "^21.2.0"
+    jest-jasmine2 "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-runtime "^21.2.1"
+    jest-util "^21.2.1"
+    pify "^3.0.0"
+    throat "^4.0.0"
+    worker-farm "^1.3.1"
 
 jest-runtime@^20.0.4:
   version "20.0.4"
@@ -4123,6 +4333,28 @@ jest-runtime@^20.0.4:
     strip-bom "3.0.0"
     yargs "^7.0.2"
 
+jest-runtime@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-runtime/-/jest-runtime-21.2.1.tgz#99dce15309c670442eee2ebe1ff53a3cbdbbb73e"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^21.2.0"
+    babel-plugin-istanbul "^4.0.0"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    graceful-fs "^4.1.11"
+    jest-config "^21.2.1"
+    jest-haste-map "^21.2.0"
+    jest-regex-util "^21.2.0"
+    jest-resolve "^21.2.0"
+    jest-util "^21.2.1"
+    json-stable-stringify "^1.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    strip-bom "3.0.0"
+    write-file-atomic "^2.1.0"
+    yargs "^9.0.0"
+
 jest-snapshot@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-20.0.3.tgz#5b847e1adb1a4d90852a7f9f125086e187c76566"
@@ -4133,6 +4365,17 @@ jest-snapshot@^20.0.3:
     jest-util "^20.0.3"
     natural-compare "^1.4.0"
     pretty-format "^20.0.3"
+
+jest-snapshot@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^21.2.1"
+    jest-matcher-utils "^21.2.1"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^21.2.1"
 
 jest-util@^20.0.3:
   version "20.0.3"
@@ -4146,6 +4389,18 @@ jest-util@^20.0.3:
     leven "^2.1.0"
     mkdirp "^0.5.1"
 
+jest-util@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-util/-/jest-util-21.2.1.tgz#a274b2f726b0897494d694a6c3d6a61ab819bb78"
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    jest-message-util "^21.2.1"
+    jest-mock "^21.2.0"
+    jest-validate "^21.2.1"
+    mkdirp "^0.5.1"
+
 jest-validate@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-20.0.3.tgz#d0cfd1de4f579f298484925c280f8f1d94ec3cab"
@@ -4155,11 +4410,26 @@ jest-validate@^20.0.3:
     leven "^2.1.0"
     pretty-format "^20.0.3"
 
+jest-validate@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^21.2.0"
+    leven "^2.1.0"
+    pretty-format "^21.2.1"
+
 jest@20.0.4:
   version "20.0.4"
   resolved "https://registry.yarnpkg.com/jest/-/jest-20.0.4.tgz#3dd260c2989d6dad678b1e9cc4d91944f6d602ac"
   dependencies:
     jest-cli "^20.0.4"
+
+jest@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
+  dependencies:
+    jest-cli "^21.2.1"
 
 jquery@x.*:
   version "3.2.1"
@@ -5186,6 +5456,10 @@ osenv@^0.1.0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-cancelable@^0.3.0:
+  version "0.3.0"
+  resolved "https://unpm.uberinternal.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -5691,6 +5965,13 @@ pretty-format@^20.0.3:
   dependencies:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
+
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://unpm.uberinternal.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 private@^0.1.6, private@^0.1.7:
   version "0.1.7"
@@ -6484,6 +6765,20 @@ samsam@1.x, samsam@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
+sane@^2.0.0:
+  version "2.2.0"
+  resolved "https://unpm.uberinternal.com/sane/-/sane-2.2.0.tgz#d6d2e2fcab00e3d283c93b912b7c3a20846f1d56"
+  dependencies:
+    anymatch "^1.3.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^2.0.0"
+    minimatch "^3.0.2"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.18.0"
+  optionalDependencies:
+    fsevents "^1.1.1"
+
 sane@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
@@ -6826,6 +7121,13 @@ string-length@^1.0.1:
   dependencies:
     strip-ansi "^3.0.0"
 
+string-length@^2.0.0:
+  version "2.0.0"
+  resolved "https://unpm.uberinternal.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^4.0.0"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -7025,6 +7327,10 @@ text-table@0.2.0, text-table@~0.2.0:
 throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
+
+throat@^4.0.0:
+  version "4.1.0"
+  resolved "https://unpm.uberinternal.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
 through@^2.3.6:
   version "2.3.8"
@@ -7336,6 +7642,13 @@ watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
 
+watch@~0.18.0:
+  version "0.18.0"
+  resolved "https://unpm.uberinternal.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
+
 watchpack@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.4.0.tgz#4a1472bcbb952bd0a9bb4036801f954dfb39faac"
@@ -7536,6 +7849,14 @@ write-file-atomic@^1.1.2:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+write-file-atomic@^2.1.0:
+  version "2.3.0"
+  resolved "https://unpm.uberinternal.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
@@ -7625,6 +7946,24 @@ yargs@^7.0.2:
 yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
+
+yargs@^9.0.0:
+  version "9.0.1"
+  resolved "https://unpm.uberinternal.com/yargs/-/yargs-9.0.1.tgz#52acc23feecac34042078ee78c0c007f5085db4c"
   dependencies:
     camelcase "^4.1.0"
     cliui "^3.2.0"


### PR DESCRIPTION
Fix #96. Non-functional change.

Was able to reproduce #96 locally with:

```
yarn test -- --no-watchman
```

Issue stems from something specific to `jest` pre `jest@20.1.0-alpha.3`, [apparently](https://github.com/facebook/jest/issues/1767#issuecomment-313434888).

[A way to resolve the issue is](https://github.com/facebook/jest/issues/3436#issuecomment-302543205):

```
brew install watchman
```

Or, upgrading jest resolved the issue (when running with `--no-watchman`).

Only precarious thing about upgrading `jest` is it is now pinned in the repo instead of implied by `react-scripts` (the latest version of which uses `jest@20.0.4`). So, the install should be reverted when `react-scripts` comes around to having the newer version of `jest`.

