### PR TITLE
Fix #105 test error, fetch requires absolute urls

### DIFF
--- a/src/actions/jaeger-api.test.js
+++ b/src/actions/jaeger-api.test.js
@@ -12,12 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable import/first */
+jest.mock('node-fetch', () => () =>
+  Promise.resolve({
+    status: 200,
+    data: () => Promise.resolve({ data: null }),
+    json: () => Promise.resolve({ data: null }),
+  })
+);
+
 import sinon from 'sinon';
 import isPromise from 'is-promise';
 
-import JaegerAPI from '../api/jaeger';
-
 import * as jaegerApiActions from './jaeger-api';
+import JaegerAPI from '../api/jaeger';
 
 it('@JAEGER_API/FETCH_TRACE should fetch the trace by id', () => {
   const api = JaegerAPI;

--- a/src/middlewares/index.test.js
+++ b/src/middlewares/index.test.js
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import sinon from 'sinon';
+/* eslint-disable import/first */
+jest.mock('node-fetch', () => () =>
+  Promise.resolve({
+    status: 200,
+    data: () => Promise.resolve({ data: null }),
+    json: () => Promise.resolve({ data: null }),
+  })
+);
+
 import { change } from 'redux-form';
+import sinon from 'sinon';
+
 import * as jaegerMiddlewares from './index';
 import { fetchServiceOperations } from '../actions/jaeger-api';
 


### PR DESCRIPTION
Fix #105.

The `node-fetch` package was being invoked during the tests. Incidentally, with relative URLs, which was causing warnings to be issued, and in some scenarios, errors.

Was able to reproduce the errors with: `$ yarn test -- -i`

This PR mocks `node-fetch` during tests to avert these issues.

Signed-off-by: Joe Farro <joef@uber.com>