### PR TITLE
Fix #92 browser prompt error

### DIFF
--- a/src/reducers/services.js
+++ b/src/reducers/services.js
@@ -29,10 +29,8 @@ function fetchStarted(state) {
 }
 
 function fetchServicesDone(state, { payload }) {
-  const services = payload.data;
-  if (Array.isArray(services)) {
-    services.sort(baseStringComparator);
-  }
+  const services = payload.data || [];
+  services.sort(baseStringComparator);
   return { ...state, services, error: null, loading: false };
 }
 

--- a/src/reducers/services.test.js
+++ b/src/reducers/services.test.js
@@ -29,6 +29,20 @@ function verifyInitialState() {
 beforeEach(verifyInitialState);
 afterEach(verifyInitialState);
 
+it('#92 - ensures services is at least an empty array', () => {
+  const services = null;
+  const state = serviceReducer(initialState, {
+    type: `${fetchServices}_FULFILLED`,
+    payload: { data: services },
+  });
+  expect(state).toEqual({
+    services: [],
+    operationsForService: {},
+    loading: false,
+    error: null,
+  });
+});
+
 it('should handle a fetch services with loading state', () => {
   const state = serviceReducer(initialState, {
     type: `${fetchServices}_PENDING`,


### PR DESCRIPTION
Fix #92.

Services default to `null` when no traces have been encountered (e.g. system is just started, etc). Instead, use an empty array.

Signed-off-by: Joe Farro <joef@uber.com>