### PR TITLE
Verify stored search settings

### DIFF
--- a/src/components/SearchTracePage/TraceSearchForm.js
+++ b/src/components/SearchTracePage/TraceSearchForm.js
@@ -223,8 +223,19 @@ const mapStateToProps = state => {
   let lastSearchOperation;
 
   if (lastSearch) {
-    lastSearchService = lastSearch.service;
-    lastSearchOperation = lastSearch.operation;
+    // last search is only valid if the service is in the list of services
+    const { operation: lastOp, service: lastSvc } = lastSearch;
+    if (lastSvc && lastSvc !== '-') {
+      if (state.services.services.includes(lastSvc)) {
+        lastSearchService = lastSvc;
+        if (lastOp && lastOp !== '-') {
+          const ops = state.services.operationsForService[lastSvc];
+          if (lastOp === 'all' || (ops && ops.includes(lastOp))) {
+            lastSearchOperation = lastOp;
+          }
+        }
+      }
+    }
   }
 
   const {
@@ -242,6 +253,7 @@ const mapStateToProps = state => {
   if (traceIDParams) {
     traceIDs = traceIDParams instanceof Array ? traceIDParams.join(',') : traceIDParams;
   }
+
   return {
     destroyOnUnmount: false,
     initialValues: {

--- a/src/reducers/services.js
+++ b/src/reducers/services.js
@@ -18,7 +18,8 @@ import { fetchServices, fetchServiceOperations as fetchOps } from '../actions/ja
 import { baseStringComparator } from '../utils/sort';
 
 const initialState = {
-  services: [],
+  // `services` initial value of `null` indicates they haven't yet been loaded
+  services: null,
   operationsForService: {},
   loading: false,
   error: null,
@@ -48,7 +49,7 @@ function fetchOpsDone(state, { meta, payload }) {
   if (Array.isArray(operations)) {
     operations.sort(baseStringComparator);
   }
-  const operationsForService = { ...state.operationsForService, [meta.serviceName]: operations };
+  const operationsForService = { ...state.operationsForService, [meta.serviceName]: operations || [] };
   return { ...state, operationsForService };
 }
 

--- a/src/reducers/services.test.js
+++ b/src/reducers/services.test.js
@@ -19,7 +19,7 @@ const initialState = serviceReducer(undefined, {});
 
 function verifyInitialState() {
   expect(initialState).toEqual({
-    services: [],
+    services: null,
     loading: false,
     error: null,
     operationsForService: {},
@@ -47,12 +47,8 @@ it('should handle a fetch services with loading state', () => {
   const state = serviceReducer(initialState, {
     type: `${fetchServices}_PENDING`,
   });
-  expect(state).toEqual({
-    services: [],
-    operationsForService: {},
-    loading: true,
-    error: null,
-  });
+  const expected = { ...initialState, loading: true };
+  expect(state).toEqual(expected);
 });
 
 it('should handle successful services fetch', () => {
@@ -90,12 +86,11 @@ it('should handle a successful fetching operations for a service ', () => {
     meta: { serviceName: 'serviceA' },
     payload: { data: ops.slice() },
   });
-  expect(state).toEqual({
-    services: [],
+  const expected = {
+    ...initialState,
     operationsForService: {
       serviceA: ops,
     },
-    loading: false,
-    error: null,
-  });
+  };
+  expect(state).toEqual(expected);
 });


### PR DESCRIPTION
Fix #88.

Preload operations for stored service search value.

On the search page, show a loading indicator if the services are not yet loaded.
Then, only use the values stored in localStorage if they are consistent with
what has been loaded.

Signed-off-by: Joe Farro <joef@uber.com>