### PR TITLE
Encode service names in API calls

### DIFF
--- a/src/api/jaeger.js
+++ b/src/api/jaeger.js
@@ -55,7 +55,7 @@ const JaegerAPI = {
     return getJSON(`${this.apiRoot}services`);
   },
   fetchServiceOperations(serviceName) {
-    return getJSON(`${this.apiRoot}services/${serviceName}/operations`);
+    return getJSON(`${this.apiRoot}services/${encodeURIComponent(serviceName)}/operations`);
   },
   fetchDependencies(endTs = new Date().getTime(), lookback = DEFAULT_DEPENDENCY_LOOKBACK) {
     return getJSON(`${this.apiRoot}dependencies`, { endTs, lookback });


### PR DESCRIPTION
Fix #138.

