### PR TITLE
package.json#proxy should proxy all /api requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,16 @@
   "version": "0.0.1",
   "main": "src/index.js",
   "license": "MIT",
-  "proxy": "http://localhost:16686",
+  "proxy": {
+    "/api": {
+        "target": "http://localhost:16686",
+        "logLevel": "silent",
+        "secure": false,
+        "changeOrigin": true,
+        "ws": true,
+        "xfwd": true
+    }
+  },
   "homepage": null,
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
Fixes #139.

Create-react-app [does not proxy requests that accept `text/html`](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-dev-utils/WebpackDevServerUtils.js#L319). 

But, `package.json#proxy` can be defined to avert this behavior, which this PR does.