### PR TITLE
Use logfmt for search tag input format

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "proxy": {
     "/api": {
-        "target": "http://localhost:16686",
-        "logLevel": "silent",
-        "secure": false,
-        "changeOrigin": true,
-        "ws": true,
-        "xfwd": true
+      "target": "http://localhost:16686",
+      "logLevel": "silent",
+      "secure": false,
+      "changeOrigin": true,
+      "ws": true,
+      "xfwd": true
     }
   },
   "homepage": null,
@@ -54,6 +54,7 @@
     "jest": "^21.2.1",
     "json-markup": "^1.1.0",
     "lodash": "^4.17.4",
+    "logfmt": "^1.2.0",
     "moment": "^2.18.1",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",

--- a/src/components/SearchTracePage/TraceSearchForm.css
+++ b/src/components/SearchTracePage/TraceSearchForm.css
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.SearchForm--tagsHintInfo {
+  padding-left: 1.7em;
+}
+
+.SearchForm--tagsHintEg {
+  color: teal;
+}

--- a/src/components/SearchTracePage/TraceSearchForm.js
+++ b/src/components/SearchTracePage/TraceSearchForm.js
@@ -28,6 +28,8 @@ import SearchDropdownInput from './SearchDropdownInput';
 import * as jaegerApiActions from '../../actions/jaeger-api';
 import { formatDate, formatTime } from '../../utils/date';
 
+import './TraceSearchForm.css';
+
 export function getUnixTimeStampInMSFromForm({ startDate, startDateTime, endDate, endDateTime }) {
   const start = `${startDate} ${startDateTime}`;
   const end = `${endDate} ${endDateTime}`;
@@ -140,7 +142,6 @@ export function TraceSearchFormImpl(props) {
   const selectedServicePayload = services.find(s => s.name === selectedService);
   const operationsForService = (selectedServicePayload && selectedServicePayload.operations) || [];
   const noSelectedService = selectedService === '-' || !selectedService;
-  // const tagInfoIcon = <i className="info circle icon" />;
   return (
     <div className="search-form">
       <form className="ui form" onSubmit={handleSubmit}>
@@ -171,15 +172,25 @@ export function TraceSearchFormImpl(props) {
             Tags{' '}
             <Popup
               on="click"
+              wide="very"
               trigger={<i className="info circle icon grey" />}
               content={
-                <span>
-                  Values should be in the{' '}
-                  <a href="https://brandur.org/logfmt" rel="noopener noreferrer" target="_blank">
-                    logfmt
-                  </a>{' '}
-                  format
-                </span>
+                <div>
+                  <h5>
+                    Values should be in the{' '}
+                    <a href="https://brandur.org/logfmt" rel="noopener noreferrer" target="_blank">
+                      logfmt
+                    </a>{' '}
+                    format.
+                  </h5>
+                  <ul className="SearchForm--tagsHintInfo">
+                    <li>Use space for conjunctions</li>
+                    <li>Values containing whitespace should be enclosed in quotes</li>
+                  </ul>
+                  <code className="SearchForm--tagsHintEg">
+                    error=true db.statement=&quot;select * from User&quot;
+                  </code>
+                </div>
               }
             />
           </label>
@@ -340,7 +351,7 @@ export function mapStateToProps(state) {
       const key = parts[0];
       if (key) {
         // eslint-disable-next-line no-param-reassign
-        accum[key] = parts[1] == null ? 'null' : parts[1];
+        accum[key] = parts[1] == null ? '' : parts[1];
         return true;
       }
       return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4870,6 +4870,10 @@ lodash@^3.10.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@~2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -4882,6 +4886,14 @@ log-update@^1.0.2:
   dependencies:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
+
+logfmt@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/logfmt/-/logfmt-1.2.0.tgz#1ccc067c1cfe65f3ecf5856c09d2654f69203572"
+  dependencies:
+    lodash "~2.4.1"
+    split "0.2.x"
+    through "2.3.x"
 
 loglevel@^1.4.1:
   version "1.4.1"
@@ -7128,6 +7140,12 @@ spdy@^3.4.1:
     select-hose "^2.0.0"
     spdy-transport "^2.0.18"
 
+split@0.2.x:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.2.10.tgz#67097c601d697ce1368f418f06cd201cf0521a57"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -7400,7 +7418,7 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-through@^2.3.6:
+through@2, through@2.3.x, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
Fixes #145.

Fixes #11.

Changes the input format for tag matching in the search for to logfmt. Now populates a `tags` query string parameter when submitting the search HTTP request. The `tags` GET param is JSON with all values converted to strings (per [this comment](https://github.com/jaegertracing/jaeger/issues/550#issuecomment-352850811)).

This change is backward compatible with URLs that have the former format. When the old format (`key:value|key2:value2`) is in the URL, it is still parsed but added to the form in the logfmt format.

Added a tooltip that links to information on [logfmt](https://brandur.org/logfmt).

<img width="306" alt="screen shot 2017-12-21 at 3 41 28 am" src="https://user-images.githubusercontent.com/2304337/34247740-91f82f3e-e601-11e7-80a7-dfd224095ce5.png">

