### PR TITLE
Add timezone tooltip to custom lookback form-field

### DIFF
--- a/src/components/SearchTracePage/TraceSearchForm.css
+++ b/src/components/SearchTracePage/TraceSearchForm.css
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.SearchForm--hintTrigger {
+  cursor: pointer;
+}
+
 .SearchForm--tagsHintInfo {
   padding-left: 1.7em;
 }

--- a/src/components/SearchTracePage/TraceSearchForm.js
+++ b/src/components/SearchTracePage/TraceSearchForm.js
@@ -222,7 +222,7 @@ export function TraceSearchFormImpl(props) {
                 on="click"
                 wide="very"
                 trigger={<i className="SearchForm--hintTrigger info circle icon grey" />}
-                content={<h5>Times are expressed in {tz} timezone and converted to UTC</h5>}
+                content={<h5>Times are expressed in {tz} timezone</h5>}
               />
             </label>
             <div>
@@ -244,7 +244,7 @@ export function TraceSearchFormImpl(props) {
                 on="click"
                 wide="very"
                 trigger={<i className="SearchForm--hintTrigger info circle icon grey" />}
-                content={<h5>Times are expressed in {tz} timezone and converted to UTC</h5>}
+                content={<h5>Times are expressed in {tz} timezone</h5>}
               />
             </label>
             <div>

--- a/src/components/SearchTracePage/TraceSearchForm.js
+++ b/src/components/SearchTracePage/TraceSearchForm.js
@@ -142,6 +142,7 @@ export function TraceSearchFormImpl(props) {
   const selectedServicePayload = services.find(s => s.name === selectedService);
   const operationsForService = (selectedServicePayload && selectedServicePayload.operations) || [];
   const noSelectedService = selectedService === '-' || !selectedService;
+  const tz = selectedLookback === 'custom' ? new Date().toTimeString().replace(/^.*?GMT/, 'UTC') : null;
   return (
     <div className="search-form">
       <form className="ui form" onSubmit={handleSubmit}>
@@ -173,7 +174,7 @@ export function TraceSearchFormImpl(props) {
             <Popup
               on="click"
               wide="very"
-              trigger={<i className="info circle icon grey" />}
+              trigger={<i className="SearchForm--hintTrigger info circle icon grey" />}
               content={
                 <div>
                   <h5>
@@ -215,7 +216,15 @@ export function TraceSearchFormImpl(props) {
 
         {selectedLookback === 'custom' && (
           <div className="search-form--start-time field js-test-start-input">
-            <label htmlFor="service">Start Time</label>
+            <label htmlFor="service">
+              Start Time{' '}
+              <Popup
+                on="click"
+                wide="very"
+                trigger={<i className="SearchForm--hintTrigger info circle icon grey" />}
+                content={<h5>Times are expressed in {tz} timezone and converted to UTC</h5>}
+              />
+            </label>
             <div>
               <div className="ui input">
                 <Field name="startDate" component="input" type="date" placeholder="Start Date" />
@@ -229,7 +238,15 @@ export function TraceSearchFormImpl(props) {
 
         {selectedLookback === 'custom' && (
           <div className="search-form--end-time field js-test-end-input">
-            <label htmlFor="service">End time</label>
+            <label htmlFor="service">
+              End time{' '}
+              <Popup
+                on="click"
+                wide="very"
+                trigger={<i className="SearchForm--hintTrigger info circle icon grey" />}
+                content={<h5>Times are expressed in {tz} timezone and converted to UTC</h5>}
+              />
+            </label>
             <div>
               <div className="ui input">
                 <Field name="endDate" component="input" type="date" placeholder="End Date" />


### PR DESCRIPTION
Fix #154.

EST Timezone:

<img width="572" alt="screen shot 2017-12-24 at 3 51 46 pm" src="https://user-images.githubusercontent.com/2304337/34329165-0c697818-e8c3-11e7-9a41-92bf8479470a.png">

PST Timezone

<img width="564" alt="screen shot 2017-12-24 at 12 52 32 pm" src="https://user-images.githubusercontent.com/2304337/34329166-14b91e06-e8c3-11e7-9c43-6906c03dae6e.png">

