### PR TITLE
Update default span row heights for new aesthetics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Changes merged into master
 
 
+### [#169](https://github.com/jaegertracing/jaeger-ui/pull/169) Use Ant Design instead of Semantic UI
+
+- Fix [#164](https://github.com/jaegertracing/jaeger-ui/issues/164) - Use Ant Design instead of Semantic UI
+- Fix [#165](https://github.com/jaegertracing/jaeger-ui/issues/165) - Search results are shown without a date
+- Fix [#69](https://github.com/jaegertracing/jaeger-ui/issues/69) - Missing endpoints in jaeger ui dropdown
+
+
+### [#168](https://github.com/jaegertracing/jaeger-ui/pull/168) Fix 2 digit lookback (12h, 24h) parsing
+
+- Fix [#167](https://github.com/jaegertracing/jaeger-ui/issues/167) - 12 and 24 hour search lookbacks not converted to start timestamp correctly
+
+
+### [#162](https://github.com/jaegertracing/jaeger-ui/pull/162) Only JSON.parse JSON strings in tags/logs values
+
+- Fix [#146](https://github.com/jaegertracing/jaeger-ui/issues/146) - Tags with string type displayed as integers in UI, bigint js problem
+
+
+### [#161](https://github.com/jaegertracing/jaeger-ui/pull/161) Add timezone tooltip to custom lookback form-field
+
+- Fix [#154](https://github.com/jaegertracing/jaeger-ui/issues/154) - Explain time zone of the lookback parameter
+
+
+### [#153](https://github.com/jaegertracing/jaeger-ui/pull/153) Add View Option for raw/unadjusted trace
+
+- Fix [#152](https://github.com/jaegertracing/jaeger-ui/issues/152) - Add View Option for raw/unadjusted trace
+
+
 ### [#147](https://github.com/jaegertracing/jaeger-ui/pull/147) Use logfmt for search tag input format
 
 - Fix [#145](https://github.com/jaegertracing/jaeger-ui/issues/145) - Support logfmt for tags text input in the search form

--- a/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
+++ b/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
@@ -67,9 +67,9 @@ type VirtualizedTraceViewProps = {
 
 // export for tests
 export const DEFAULT_HEIGHTS = {
-  bar: 21,
-  detail: 169,
-  detailWithLogs: 223,
+  bar: 28,
+  detail: 161,
+  detailWithLogs: 197,
 };
 
 const NUM_TICKS = 5;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import { document } from 'global';
 import JaegerUIApp from './components/App';
 import { init as initTracking } from './utils/metrics';
 
+import 'u-basscss/css/flexbox.css';
 import 'u-basscss/css/layout.css';
 import 'u-basscss/css/margin.css';
 import 'u-basscss/css/position.css';


### PR DESCRIPTION
Fix #173.

The aesthetic changes from the ant-design PR included making the span bar rows taller.

This needs to be captured in the default row heights. If the user scrolls past rows without rendering them (e.g. CMD+Down on Mac), the only concept the list view has of the row heights for the skipped rows is the default height. If the default height is not accurate, things become glitchy.

This PR also adds a util css file that I inadvertently left out.