### PR TITLE
Support archiving traces, enabled via UI config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changes merged into master
 
-### [#194](https://github.com/jaegertracing/jaeger-ui/pull/194) Support archiving traces, enabled via UI config
-
-* Fix [#7](https://github.com/jaegertracing/jaeger-ui/issues/7) - Add support to "archive traces"
-
 ### [#192](https://github.com/jaegertracing/jaeger-ui/pull/192) Change fallback trace name to be more informative
 
 * Fix [#190](https://github.com/jaegertracing/jaeger-ui/issues/190) - Change `cannot-find-trace-name` to `trace-without-root-span`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changes merged into master
 
+### [#194](https://github.com/jaegertracing/jaeger-ui/pull/194) Support archiving traces, enabled via UI config
+
+* Fix [#7](https://github.com/jaegertracing/jaeger-ui/issues/7) - Add support to "archive traces"
+
+### [#192](https://github.com/jaegertracing/jaeger-ui/pull/192) Change fallback trace name to be more informative
+
+* Fix [#190](https://github.com/jaegertracing/jaeger-ui/issues/190) - Change `cannot-find-trace-name` to `trace-without-root-span`
+
+### [#189](https://github.com/jaegertracing/jaeger-ui/pull/189) Track JS errors in GA
+
+* Fix [#39](https://github.com/jaegertracing/jaeger-ui/issues/39) - Log js client side errors in our server side logs
+
+### [#179](https://github.com/jaegertracing/jaeger-ui/pull/179) Resolve perf issues on the search page
+
+* Fix [#178](https://github.com/jaegertracing/jaeger-ui/issues/178) - Performance regression - Search page
+
 ### [#169](https://github.com/jaegertracing/jaeger-ui/pull/169) Use Ant Design instead of Semantic UI
 
 * Fix [#164](https://github.com/jaegertracing/jaeger-ui/issues/164) - Use Ant Design instead of Semantic UI

--- a/src/actions/jaeger-api.js
+++ b/src/actions/jaeger-api.js
@@ -21,6 +21,12 @@ export const fetchTrace = createAction(
   id => ({ id })
 );
 
+export const archiveTrace = createAction(
+  '@JAEGER_API/ARCHIVE_TRACE',
+  id => JaegerAPI.archiveTrace(id),
+  id => ({ id })
+);
+
 export const searchTraces = createAction(
   '@JAEGER_API/SEARCH_TRACES',
   query => JaegerAPI.searchTraces(query),

--- a/src/api/jaeger.js
+++ b/src/api/jaeger.js
@@ -33,10 +33,11 @@ export function getMessageFromError(errData, status) {
   }
 }
 
-function getJSON(url, query) {
-  return fetch(`${url}${query ? `?${queryString.stringify(query)}` : ''}`, {
-    credentials: 'include',
-  }).then(response => {
+function getJSON(url, options = {}) {
+  const { query = null, ...init } = options;
+  init.credentials = 'same-origin';
+  const queryStr = query ? `?${queryString.stringify(query)}` : '';
+  return fetch(`${url}${queryStr}`, init).then(response => {
     if (response.status < 400) {
       return response.json();
     }
@@ -78,8 +79,11 @@ const JaegerAPI = {
   fetchTrace(id) {
     return getJSON(`${this.apiRoot}traces/${id}`);
   },
+  archiveTrace(id) {
+    return getJSON(`${this.apiRoot}archive/${id}`, { method: 'POST' });
+  },
   searchTraces(query) {
-    return getJSON(`${this.apiRoot}traces`, query);
+    return getJSON(`${this.apiRoot}traces`, { query });
   },
   fetchServices() {
     return getJSON(`${this.apiRoot}services`);
@@ -88,7 +92,7 @@ const JaegerAPI = {
     return getJSON(`${this.apiRoot}services/${encodeURIComponent(serviceName)}/operations`);
   },
   fetchDependencies(endTs = new Date().getTime(), lookback = DEFAULT_DEPENDENCY_LOOKBACK) {
-    return getJSON(`${this.apiRoot}dependencies`, { endTs, lookback });
+    return getJSON(`${this.apiRoot}dependencies`, { query: { endTs, lookback } });
   },
 };
 

--- a/src/components/TracePage/ArchiveNotifier/duck.js
+++ b/src/components/TracePage/ArchiveNotifier/duck.js
@@ -1,0 +1,83 @@
+// @flow
+
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createActions, handleActions } from 'redux-actions';
+
+import { archiveTrace } from '../../../actions/jaeger-api';
+import type { ApiError } from '../../../types/api-error';
+import type { TracesArchive } from '../../../types/archive';
+import generateActionTypes from '../../../utils/generate-action-types';
+
+type ArchiveAction = {
+  meta: {
+    id: string,
+  },
+  payload?: ApiError | string,
+};
+
+const initialState: TracesArchive = {};
+
+const actionTypes = generateActionTypes('@jaeger-ui/archive-trace', ['ACKNOWLEDGE']);
+
+const fullActions = createActions({
+  [actionTypes.ACKNOWLEDGE]: traceID => traceID,
+});
+
+export const actions = { ...fullActions.jaegerUi.archiveTrace, archiveTrace };
+
+// reducers
+
+function acknowledge(state: TracesArchive, { payload }: ArchiveAction) {
+  const traceID = typeof payload === 'string' ? payload : null;
+  if (!traceID) {
+    // make flow happy
+    throw new Error('Invalid state, missing traceID for archive acknowledge');
+  }
+  const traceArchive = state[traceID];
+  if (traceArchive && traceArchive.isLoading) {
+    // acknowledgement during loading is invalid (should not happen)
+    return state;
+  }
+  const next = { ...traceArchive, isAcknowledged: true };
+  return { ...state, [traceID]: next };
+}
+
+function archiveStarted(state: TracesArchive, { meta }: ArchiveAction) {
+  return { ...state, [meta.id]: { isLoading: true } };
+}
+
+function archiveDone(state: TracesArchive, { meta }: ArchiveAction) {
+  return { ...state, [meta.id]: { isArchived: true, isAcknowledged: false } };
+}
+
+function archiveErred(state: TracesArchive, { meta, payload }: ArchiveAction) {
+  if (!payload) {
+    // make flow happy
+    throw new Error('Invalid state, missing API error details');
+  }
+  const traceArchive = { error: payload, isArchived: false, isError: true, isAcknowledged: false };
+  return { ...state, [meta.id]: traceArchive };
+}
+
+export default handleActions(
+  {
+    [actionTypes.ACKNOWLEDGE]: acknowledge,
+    [`${archiveTrace}_PENDING`]: archiveStarted,
+    [`${archiveTrace}_FULFILLED`]: archiveDone,
+    [`${archiveTrace}_REJECTED`]: archiveErred,
+  },
+  initialState
+);

--- a/src/components/TracePage/ArchiveNotifier/index.css
+++ b/src/components/TracePage/ArchiveNotifier/index.css
@@ -14,26 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.TracePageHeader--titleRow {
-  align-items: center;
-  display: flex;
+.ArchiveNotifier--errorNotification {
+  position: absolute;
+  right: 0;
+  width: 650px;
 }
 
-.TracePageHeader--title {
-  margin: 0;
-  padding: 0.25rem 0.5rem;
+.ArchiveNotifier--errorIcon,
+.ArchiveNotifier--doneIcon {
+  font-size: 30px;
 }
 
-.TracePageHeader--title:hover {
-  background: #f5f5f5;
+.ArchiveNotifier--errorIcon {
+  color: #c00;
 }
 
-.TracePageHeader--overviewItems {
-  padding: 0 0.5rem 0.25rem 0.5rem;
-}
-
-.TracePageHeader--archiveIcon {
-  display: flex;
-  font-size: 1.2em;
-  margin-top: 0.15rem;
+.ArchiveNotifier--doneIcon {
+  color: teal;
 }

--- a/src/components/TracePage/ArchiveNotifier/index.js
+++ b/src/components/TracePage/ArchiveNotifier/index.js
@@ -1,0 +1,127 @@
+// @flow
+
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { Icon, notification } from 'antd';
+
+import ErrorMessage from '../../common/ErrorMessage';
+import type { TraceArchive } from '../../../types/archive';
+
+import './index.css';
+
+const NOTIFIED_PROGRESS = 'NOTIFIED_PROGRESS';
+const NOTIFIED_OUTCOME = 'NOTIFIED_OUTCOME';
+
+type NotifiedState = 'NOTIFIED_PROGRESS' | 'NOTIFIED_OUTCOME' | null;
+
+type Props = {
+  // eslint-disable-next-line react/no-unused-prop-types
+  archivedState: ?TraceArchive,
+  // eslint-disable-next-line react/no-unused-prop-types
+  acknowledge: () => void,
+};
+
+type State = {
+  notifiedState: NotifiedState,
+};
+
+function getNextNotifiedState(props: Props) {
+  const { archivedState } = props;
+  if (!archivedState) {
+    return null;
+  }
+  if (archivedState.isLoading) {
+    return NOTIFIED_PROGRESS;
+  }
+  return archivedState.isAcknowledged ? null : NOTIFIED_OUTCOME;
+}
+
+function updateNotification(oldState: NotifiedState, nextState: NotifiedState, props: Props) {
+  if (oldState === nextState) {
+    return;
+  }
+  if (oldState) {
+    notification.close(oldState);
+  }
+  if (nextState === NOTIFIED_PROGRESS) {
+    notification.info({
+      key: NOTIFIED_PROGRESS,
+      message: 'Archiving trace...',
+      icon: <Icon type="loading" />,
+      duration: 0,
+    });
+    return;
+  }
+  const { acknowledge, archivedState } = props;
+  if (nextState === NOTIFIED_OUTCOME) {
+    if (archivedState && archivedState.error) {
+      const error = typeof archivedState.error === 'string' ? archivedState.error : archivedState.error;
+      notification.warn({
+        key: NOTIFIED_OUTCOME,
+        className: 'ArchiveNotifier--errorNotification',
+        message: <ErrorMessage.Message error={error} wrap />,
+        description: <ErrorMessage.Details error={error} wrap />,
+        duration: null,
+        icon: <Icon type="clock-circle-o" className="ArchiveNotifier--errorIcon" />,
+        onClose: acknowledge,
+      });
+    } else if (archivedState && archivedState.isArchived) {
+      notification.success({
+        key: NOTIFIED_OUTCOME,
+        message: 'This trace has been archived.',
+        icon: <Icon type="clock-circle-o" className="ArchiveNotifier--doneIcon" />,
+        duration: null,
+        onClose: acknowledge,
+      });
+    } else {
+      throw new Error('Unexpected condition');
+    }
+  }
+}
+
+function processProps(notifiedState: NotifiedState, props: Props) {
+  const nxNotifiedState = getNextNotifiedState(props);
+  updateNotification(notifiedState, nxNotifiedState, props);
+  return nxNotifiedState;
+}
+
+export default class ArchiveNotifier extends React.PureComponent<Props, State> {
+  props: Props;
+
+  constructor(props: Props) {
+    super(props);
+    const notifiedState = processProps(null, props);
+    this.state = { notifiedState };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const notifiedState = processProps(this.state.notifiedState, nextProps);
+    if (this.state.notifiedState !== notifiedState) {
+      this.setState({ notifiedState });
+    }
+  }
+
+  componentWillUnmount() {
+    const { notifiedState } = this.state;
+    if (notifiedState) {
+      notification.close(notifiedState);
+    }
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/src/components/TracePage/TracePageHeader.css
+++ b/src/components/TracePage/TracePageHeader.css
@@ -33,7 +33,6 @@ limitations under the License.
 }
 
 .TracePageHeader--archiveIcon {
-  display: flex;
-  font-size: 1.2em;
-  margin-top: 0.15rem;
+  font-size: 1.78em;
+  margin-right: 0.15em;
 }

--- a/src/components/TracePage/TracePageHeader.js
+++ b/src/components/TracePage/TracePageHeader.js
@@ -36,6 +36,8 @@ type TracePageHeaderProps = {
   onSlimViewClicked: () => void,
   updateTextFilter: string => void,
   textFilter: ?string,
+  archiveButtonVisible: boolean,
+  onArchiveClicked: () => void,
   // these props are used by the `HEADER_ITEMS`
   // eslint-disable-next-line react/no-unused-prop-types
   timestamp: number,
@@ -84,6 +86,8 @@ export const HEADER_ITEMS = [
 
 export default function TracePageHeader(props: TracePageHeaderProps) {
   const {
+    archiveButtonVisible,
+    onArchiveClicked,
     duration,
     maxDepth,
     numSpans,
@@ -148,17 +152,12 @@ export default function TracePageHeader(props: TracePageHeaderProps) {
     <header>
       <div className="TracePageHeader--titleRow">
         <a className="ub-flex-auto ub-mr2" onClick={onSlimViewClicked} role="switch" aria-checked={!slimView}>
-          <h1 className="TracePageHeader--title">
+          <h1 className="TracePageHeader--title ub-flex ub-items-center">
             {slimView ? <IoChevronRight className="ub-mr2" /> : <IoChevronDown className="ub-mr2" />}
             {name || FALLBACK_TRACE_NAME}
           </h1>
         </a>
         <KeyboardShortcutsHelp className="ub-mr2" />
-        <Dropdown overlay={viewMenu}>
-          <Button className="ub-mr2">
-            View Options <Icon type="down" />
-          </Button>
-        </Dropdown>
         <div className="ub-mr2">
           <Input
             name="search"
@@ -168,6 +167,17 @@ export default function TracePageHeader(props: TracePageHeaderProps) {
             data-test={markers.IN_TRACE_SEARCH}
           />
         </div>
+        <Dropdown overlay={viewMenu}>
+          <Button className="ub-mr2">
+            View Options <Icon type="down" />
+          </Button>
+        </Dropdown>
+        {archiveButtonVisible && (
+          <Button className="ub-mr2 ub-flex" onClick={onArchiveClicked}>
+            <Icon type="clock-circle-o" className="TracePageHeader--archiveIcon" />
+            Archive Trace
+          </Button>
+        )}
       </div>
       {!slimView && <LabeledList className="TracePageHeader--overviewItems" items={overviewItems} />}
     </header>

--- a/src/components/TracePage/TracePageHeader.js
+++ b/src/components/TracePage/TracePageHeader.js
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { Button, Dropdown, Icon, Input, Menu } from 'antd';
 import IoChevronDown from 'react-icons/lib/io/chevron-down';
 import IoChevronRight from 'react-icons/lib/io/chevron-right';
+import IoIosFilingOutline from 'react-icons/lib/io/ios-filing-outline';
 import { Link } from 'react-router-dom';
 
 import * as markers from './TracePageHeader.markers';
@@ -173,8 +174,8 @@ export default function TracePageHeader(props: TracePageHeaderProps) {
           </Button>
         </Dropdown>
         {archiveButtonVisible && (
-          <Button className="ub-mr2 ub-flex" onClick={onArchiveClicked}>
-            <Icon type="clock-circle-o" className="TracePageHeader--archiveIcon" />
+          <Button className="ub-mr2 ub-flex ub-items-center" onClick={onArchiveClicked}>
+            <IoIosFilingOutline className="TracePageHeader--archiveIcon" />
             Archive Trace
           </Button>
         )}

--- a/src/components/TracePage/index.test.js
+++ b/src/components/TracePage/index.test.js
@@ -292,7 +292,11 @@ describe('<TracePage>', () => {
 
 describe('mapDispatchToProps()', () => {
   it('creates the actions correctly', () => {
-    expect(mapDispatchToProps(() => {})).toEqual({ fetchTrace: expect.any(Function) });
+    expect(mapDispatchToProps(() => {})).toEqual({
+      fetchTrace: expect.any(Function),
+      acknowledgeArchive: expect.any(Function),
+      archiveTrace: expect.any(Function),
+    });
   });
 });
 
@@ -307,6 +311,10 @@ describe('mapStateToProps()', () => {
           [id]: trace,
         },
       },
+      config: {
+        archiveEnabled: false,
+      },
+      archive: {},
     };
     const ownProps = {
       match: {
@@ -318,6 +326,8 @@ describe('mapStateToProps()', () => {
       id,
       trace,
       loading: state.trace.loading,
+      archiveEnabled: false,
+      archiveTraceState: undefined,
     });
   });
 });

--- a/src/components/common/ErrorMessage.css
+++ b/src/components/common/ErrorMessage.css
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 .ErrorMessage {
-  background: #f5f5f5;
-  border: 1px solid #e6e6e6;
   position: relative;
   word-break: break-word;
   word-wrap: break-word;
@@ -25,22 +23,42 @@ limitations under the License.
 .ErrorMessage--msg {
   color: #c00;
   margin: 0;
-  padding: 1rem;
+  padding-bottom: 1rem;
 }
 
 .ErrorMessage--details {
+  background: #f5f5f5;
+  border: 1px solid #e6e6e6;
   overflow: auto;
-  padding: 0 1rem 1rem 1rem;
+}
+
+.ErrorMessage--detailsTable {
+  min-width: 100%;
+}
+
+.ErrorMessage--detailItem:nth-child(2n) > .ErrorMessage--attr,
+.ErrorMessage--detailItem:nth-child(2n) > .ErrorMessage--value {
+  background-color: #f0f0f0;
+  border-bottom: 1px solid #e8e8e8;
+  border-top: 1px solid #e8e8e8;
+}
+
+/* dont have extra borders on the bottom row */
+.ErrorMessage--detailItem:last-child > .ErrorMessage--attr,
+.ErrorMessage--detailItem:last-child > .ErrorMessage--value {
+  border-bottom: none;
 }
 
 .ErrorMessage--attr {
-  padding-bottom: 0.5em;
-  padding-right: 1em;
+  color: rgba(0, 0, 0, 0.45);
+  padding: 0.5em;
   vertical-align: top;
   white-space: nowrap;
 }
 
 .ErrorMessage--value {
+  color: rgba(0, 0, 0, 0.8);
   font-family: monospace;
+  padding: 0.5em;
   white-space: pre;
 }

--- a/src/components/common/ErrorMessage.test.js
+++ b/src/components/common/ErrorMessage.test.js
@@ -32,14 +32,18 @@ describe('<ErrorMessage>', () => {
   });
 
   it('renders a message when passed a string', () => {
-    expect(wrapper.text()).toMatch(error);
+    const msg = wrapper.find('Message');
+    expect(msg.length).toBe(1);
+    expect(msg.shallow().text()).toMatch(error);
   });
 
   describe('rendering more complex errors', () => {
     it('renders the error message', () => {
       error = new Error('another-error');
       wrapper.setProps({ error });
-      expect(wrapper.text()).toMatch(error.message);
+      const msg = wrapper.find('Message');
+      expect(msg.length).toBe(1);
+      expect(msg.shallow().text()).toMatch(error.message);
     });
 
     it('renders HTTP related data from the error', () => {
@@ -52,11 +56,14 @@ describe('<ErrorMessage>', () => {
         httpBody: 'value-httpBody',
       };
       wrapper.setProps({ error });
+      const details = wrapper.find('Details');
+      expect(details.length).toBe(1);
+      const detailsWrapper = details.shallow();
       Object.keys(error).forEach(key => {
         if (key === 'message') {
           return;
         }
-        const errorAttr = wrapper.find(`ErrorAttr[value="${error[key]}"]`);
+        const errorAttr = detailsWrapper.find(`ErrorAttr[value="${error[key]}"]`);
         expect(errorAttr.length).toBe(1);
       });
     });

--- a/src/components/common/LoadingIndicator.css
+++ b/src/components/common/LoadingIndicator.css
@@ -14,8 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+@keyframes LoadingIndicator--colorAnim {
+  /*
+  rgb(0, 128, 128) == teal
+  rgba(0, 128, 128, 0.3) == #bedfdf
+  */
+  from {
+    color: #bedfdf;
+  }
+  to {
+    color: teal;
+  }
+}
+
 .LoadingIndicator {
+  animation: LoadingIndicator--colorAnim 1s infinite alternate;
   font-size: 36px;
+  /* outline / stroke the loading indicator */
+  text-shadow: -0.5px 0 rgba(0, 128, 128, 0.6), 0 0.5px rgba(0, 128, 128, 0.6), 0.5px 0 rgba(0, 128, 128, 0.6),
+    0 -0.5px rgba(0, 128, 128, 0.6);
 }
 
 .LoadingIndicator--centered {

--- a/src/constants/default-config.js
+++ b/src/constants/default-config.js
@@ -19,6 +19,7 @@ import { FALLBACK_DAG_MAX_NUM_SERVICES } from './index';
 export default deepFreeze(
   Object.defineProperty(
     {
+      archiveEnabled: false,
       dependencies: {
         dagMaxNumServices: FALLBACK_DAG_MAX_NUM_SERVICES,
         menuEnabled: true,

--- a/src/types/api-error.js
+++ b/src/types/api-error.js
@@ -14,22 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type ConfigMenuItem = {
-  label: string,
-  url: string,
-};
-
-export type ConfigMenuGroup = {
-  label: string,
-  items: ConfigMenuItem[],
-};
-
-export type Config = {
-  archiveEnabled: ?boolean,
-  dependencies?: { dagMaxServicesLen?: number, menuEnabled?: boolean },
-  tracking?: {
-    gaID: ?string,
-    trackErrors: ?boolean,
-  },
-  menu: (ConfigMenuGroup | ConfigMenuItem)[],
-};
+export type ApiError =
+  | string
+  | {
+      message: string,
+      httpStatus?: any,
+      httpStatusText?: string,
+      httpUrl?: string,
+      httpQuery?: string,
+      httpBody?: string,
+    };

--- a/src/types/archive.js
+++ b/src/types/archive.js
@@ -14,22 +14,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type ConfigMenuItem = {
-  label: string,
-  url: string,
+import type { ApiError } from './api-error';
+
+export type TraceArchive = {
+  isLoading?: boolean,
+  isArchived?: boolean,
+  isError?: boolean,
+  error?: ApiError,
+  isAcknowledged?: boolean,
 };
 
-export type ConfigMenuGroup = {
-  label: string,
-  items: ConfigMenuItem[],
-};
-
-export type Config = {
-  archiveEnabled: ?boolean,
-  dependencies?: { dagMaxServicesLen?: number, menuEnabled?: boolean },
-  tracking?: {
-    gaID: ?string,
-    trackErrors: ?boolean,
-  },
-  menu: (ConfigMenuGroup | ConfigMenuItem)[],
+export type TracesArchive = {
+  [string]: TraceArchive,
 };

--- a/src/utils/configure-store.js
+++ b/src/utils/configure-store.js
@@ -18,12 +18,14 @@ import { window } from 'global';
 
 import jaegerReducers from '../reducers';
 import * as jaegerMiddlewares from '../middlewares';
+import archiveReducer from '../components/TracePage/ArchiveNotifier/duck';
 import traceTimelineViewReducer from '../components/TracePage/TraceTimelineViewer/duck';
 
 export default function configureStore(history) {
   return createStore(
     combineReducers({
       ...jaegerReducers,
+      archive: archiveReducer,
       traceTimeline: traceTimelineViewReducer,
       router: routerReducer,
     }),

--- a/src/utils/generate-action-types.js
+++ b/src/utils/generate-action-types.js
@@ -27,7 +27,10 @@
  *                      to assign as the corresponding values.
  * @returns {{[string]: string}}
  */
-export default function generateActionTypes(commonPrefix: string, topLevelTypes: string[]) {
+export default function generateActionTypes(
+  commonPrefix: string,
+  topLevelTypes: string[]
+): { [string]: string } {
   const rv = {};
   topLevelTypes.forEach(type => {
     const fullType = `${commonPrefix}/${type}`;


### PR DESCRIPTION
Partially addresses #7.

## TODO

- ~Add a tooltip on the archive button that states it's for archiving a trace~
- [x] See about getting an icon that is more iconic of archiving

## Enabling Archiving

The archive functionality is hidden behind the UI config flag `archiveEnabled`, which is `false`, by default as archiving only works with Cassandra.

## Normal UX

Clicking the archive button raises a notification with a loading spinner.

When the HTTP call completes, the spinner notification is closed (if the user did not close it) and a second notification is raised showing the outcome. 

If the outcome is success, then a success message is shown.

If the outcome is an error, then error details are shown.

## Small Edge Case

The user should acknowledge the result notification (success or error). This is done by closing the notification. If the user doesn't close the notification but exits the trace view, the notification will be redisplayed if the user re-enters that trace detail (for that particular trace) during the session. The same applies if the user exits the trace view while the archive is in progress.

## Screens

### The archive button

<img width="544" alt="screen shot 2018-03-08 at 11 04 31 am" src="https://user-images.githubusercontent.com/2304337/37161413-a01f229c-22c0-11e8-8243-c8505f26eadf.png">

--------

### Button hover

<img width="541" alt="screen shot 2018-03-08 at 11 04 42 am" src="https://user-images.githubusercontent.com/2304337/37161425-a8fc8152-22c0-11e8-821f-390dfb9644c8.png">

--------

### In progress notification

<img width="1160" alt="02-in-progress" src="https://user-images.githubusercontent.com/2304337/37020795-1ba9ab12-20eb-11e8-8119-c0b949230bc1.png">

--------

### Success notification

<img width="1160" alt="03-success" src="https://user-images.githubusercontent.com/2304337/37020798-20f5e900-20eb-11e8-8990-70993dae4bad.png">

--------

### Error notification
Note: This error is shown just as an example of an error to show. This particular error should be very easy to avoid as the system administrator needs to simple keep archiving disabled if they're not using Cassandra.

Also, the error message styling (global) was tweaked a bit.

<img width="1160" alt="04-error-message" src="https://user-images.githubusercontent.com/2304337/37020807-26442912-20eb-11e8-950a-35f0d0571ccb.png">

--------

### Button is hidden due to UI config

<img width="1160" alt="05-button-disabled" src="https://user-images.githubusercontent.com/2304337/37020811-2a69ecf2-20eb-11e8-9cf1-c7c09cfc2224.png">