### PR TITLE
[WIP] Add links to make values in tags or log properties clickable

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.js
@@ -30,7 +30,7 @@ type AccordianKeyValuesProps = {
   highContrast?: boolean,
   isOpen: boolean,
   label: string,
-  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
   onToggle: () => void,
 };
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.js
@@ -30,6 +30,7 @@ type AccordianKeyValuesProps = {
   highContrast?: boolean,
   isOpen: boolean,
   label: string,
+  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
   onToggle: () => void,
 };
 
@@ -59,7 +60,7 @@ KeyValuesSummary.defaultProps = {
 };
 
 export default function AccordianKeyValues(props: AccordianKeyValuesProps) {
-  const { className, data, highContrast, isOpen, label, onToggle } = props;
+  const { className, data, highContrast, isOpen, label, linksGetter, onToggle } = props;
   const isEmpty = !Array.isArray(data) || !data.length;
   const iconCls = cx('u-align-icon', { 'AccordianKeyValues--emptyIcon': isEmpty });
   return (
@@ -80,7 +81,7 @@ export default function AccordianKeyValues(props: AccordianKeyValuesProps) {
         </strong>
         {!isOpen && <KeyValuesSummary data={data} />}
       </div>
-      {isOpen && <KeyValuesTable data={data} />}
+      {isOpen && <KeyValuesTable data={data} linksGetter={linksGetter} />}
     </div>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.js
@@ -21,21 +21,22 @@ import IoIosArrowRight from 'react-icons/lib/io/ios-arrow-right';
 
 import * as markers from './AccordianKeyValues.markers';
 import KeyValuesTable from './KeyValuesTable';
+import type { KeyValuePair, Link } from '../../../../types';
 
 import './AccordianKeyValues.css';
 
 type AccordianKeyValuesProps = {
   className?: ?string,
-  data: { key: string, value: any }[],
+  data: KeyValuePair[],
   highContrast?: boolean,
   isOpen: boolean,
   label: string,
-  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?(KeyValuePair[], number) => Link[],
   onToggle: () => void,
 };
 
 // export for tests
-export function KeyValuesSummary(props: { data?: { key: string, value: any }[] }) {
+export function KeyValuesSummary(props: { data?: KeyValuePair[] }) {
   const { data } = props;
   if (!Array.isArray(data) || !data.length) {
     return null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.js
@@ -27,7 +27,7 @@ import './AccordianLogs.css';
 
 type AccordianLogsProps = {
   isOpen: boolean,
-  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
   logs: Log[],
   onItemToggle: Log => void,
   onToggle: () => void,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.js
@@ -21,13 +21,13 @@ import IoIosArrowRight from 'react-icons/lib/io/ios-arrow-right';
 
 import AccordianKeyValues from './AccordianKeyValues';
 import { formatDuration } from '../utils';
-import type { Log } from '../../../../types';
+import type { Log, KeyValuePair, Link } from '../../../../types';
 
 import './AccordianLogs.css';
 
 type AccordianLogsProps = {
   isOpen: boolean,
-  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?(KeyValuePair[], number) => Link[],
   logs: Log[],
   onItemToggle: Log => void,
   onToggle: () => void,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.js
@@ -27,6 +27,7 @@ import './AccordianLogs.css';
 
 type AccordianLogsProps = {
   isOpen: boolean,
+  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
   logs: Log[],
   onItemToggle: Log => void,
   onToggle: () => void,
@@ -35,7 +36,7 @@ type AccordianLogsProps = {
 };
 
 export default function AccordianLogs(props: AccordianLogsProps) {
-  const { isOpen, logs, openedItems, onItemToggle, onToggle, timestamp } = props;
+  const { isOpen, linksGetter, logs, openedItems, onItemToggle, onToggle, timestamp } = props;
 
   return (
     <div className="AccordianLogs">
@@ -59,6 +60,7 @@ export default function AccordianLogs(props: AccordianLogsProps) {
               // compact
               highContrast
               isOpen={openedItems.has(log)}
+              linksGetter={linksGetter}
               data={log.fields || []}
               label={`${formatDuration(log.timestamp - timestamp)}`}
               onToggle={() => onItemToggle(log)}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -39,3 +39,13 @@ limitations under the License.
   white-space: pre;
   width: 125px;
 }
+
+.KeyValueTable--link {
+  display: block;
+  position: relative;
+}
+
+.KeyValueTable--linkIcon {
+  position: absolute;
+  right: 0px;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -40,6 +40,11 @@ limitations under the License.
   width: 125px;
 }
 
+.KeyValueTable--body > tr > td {
+  padding: 0.25rem 0.5rem;
+  vertical-align: top;
+}
+
 .KeyValueTable--linkIcon {
   vertical-align: middle;
   font-weight: bold;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -40,12 +40,7 @@ limitations under the License.
   width: 125px;
 }
 
-.KeyValueTable--link {
-  display: block;
-  position: relative;
-}
-
 .KeyValueTable--linkIcon {
-  position: absolute;
-  right: 0px;
+  vertical-align: middle;
+  font-weight: bold;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import * as React from 'react';
 import jsonMarkup from 'json-markup';
 import { Dropdown, Icon, Menu } from 'antd';
 
@@ -30,6 +30,24 @@ function parseIfJson(value) {
   } catch (_) {}
   return value;
 }
+
+const LinkValue = (props: { href: string, title?: string, children: React.Node }) => (
+  <a href={props.href} title={props.title} target="_blank" rel="noopener noreferrer">
+    {props.children} <Icon className="KeyValueTable--linkIcon" type="export" />
+  </a>
+);
+
+const linkValueList = (links: { url: string, text: string }[]) => (
+  <Menu>
+    {links.map(({ text, url }, index) => (
+      // `index` is necessary in the key because url can repeat
+      // eslint-disable-next-line react/no-array-index-key
+      <Menu.Item key={`${url}-${index}`}>
+        <LinkValue href={url}>{text}</LinkValue>
+      </Menu.Item>
+    ))}
+  </Menu>
+);
 
 type KeyValuesTableProps = {
   data: { key: string, value: any }[],
@@ -53,31 +71,15 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
             if (links && links.length === 1) {
               valueMarkup = (
                 <div>
-                  <a href={links[0].url} title={links[0].text} target="_blank" rel="noopener noreferrer">
-                    {jsonTable} <Icon className="KeyValueTable--linkIcon" type="export" />
-                  </a>
+                  <LinkValue href={links[0].url} title={links[0].text}>
+                    {jsonTable}
+                  </LinkValue>
                 </div>
               );
             } else if (links && links.length > 1) {
-              const menuItems = (
-                <Menu>
-                  {links.map((link, index) => {
-                    const { text, url } = link;
-                    return (
-                      // `index` is necessary in the key because url can repeat
-                      // eslint-disable-next-line react/no-array-index-key
-                      <Menu.Item key={`${url}-${index}`}>
-                        <a href={url} target="_blank" rel="noopener noreferrer">
-                          {text}
-                        </a>
-                      </Menu.Item>
-                    );
-                  })}
-                </Menu>
-              );
               valueMarkup = (
                 <div>
-                  <Dropdown overlay={menuItems} placement="bottomRight" trigger={['click']}>
+                  <Dropdown overlay={linkValueList(links)} placement="bottomRight" trigger={['click']}>
                     <a>
                       {jsonTable} <Icon className="KeyValueTable--linkIcon" type="profile" />
                     </a>
@@ -101,3 +103,5 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
     </div>
   );
 }
+
+KeyValuesTable.LinkValue = LinkValue;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
@@ -31,17 +31,6 @@ function parseIfJson(value) {
   return value;
 }
 
-function markupAsDiv(markup) {
-  // eslint-disable-next-line react/no-danger
-  return <div dangerouslySetInnerHTML={{ __html: markup }} />;
-}
-
-function markupAsSpan(markup) {
-  const spanMarkup = markup.replace(/^<div /i, '<span ').replace(/<\/div>$/i, '</span>');
-  // eslint-disable-next-line react/no-danger
-  return <span dangerouslySetInnerHTML={{ __html: spanMarkup }} />;
-}
-
 type KeyValuesTableProps = {
   data: { key: string, value: any }[],
   linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
@@ -54,14 +43,18 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
       <table className="u-width-100">
         <tbody className="KeyValueTable--body">
           {data.map((row, i) => {
-            const markup = jsonMarkup(parseIfJson(row.value));
+            const markup = {
+              __html: jsonMarkup(parseIfJson(row.value)),
+            };
+            // eslint-disable-next-line react/no-danger
+            const jsonTable = <div className="ub-inline-block" dangerouslySetInnerHTML={markup} />;
             const links = linksGetter ? linksGetter(data, i) : null;
             let valueMarkup;
             if (links && links.length === 1) {
               valueMarkup = (
                 <div>
                   <a href={links[0].url} title={links[0].text} target="_blank" rel="noopener noreferrer">
-                    {markupAsSpan(markup)} <Icon className="KeyValueTable--linkIcon" type="export" />
+                    {jsonTable} <Icon className="KeyValueTable--linkIcon" type="export" />
                   </a>
                 </div>
               );
@@ -86,13 +79,13 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                 <div>
                   <Dropdown overlay={menuItems} placement="bottomRight" trigger={['click']}>
                     <a>
-                      {markupAsSpan(markup)} <Icon className="KeyValueTable--linkIcon" type="profile" />
+                      {jsonTable} <Icon className="KeyValueTable--linkIcon" type="profile" />
                     </a>
                   </Dropdown>
                 </div>
               );
             } else {
-              valueMarkup = markupAsDiv(markup);
+              valueMarkup = jsonTable;
             }
             return (
               // `i` is necessary in the key because row.key can repeat

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
@@ -31,6 +31,22 @@ function parseIfJson(value) {
   return value;
 }
 
+function markupAsDiv(markup) {
+  // eslint-disable-next-line react/no-danger
+  return <div dangerouslySetInnerHTML={{ __html: markup }} />;
+}
+
+function markupAsSpan(markup) {
+  // eslint-disable-next-line react/no-danger
+  return (
+    <span
+      dangerouslySetInnerHTML={{
+        __html: markup.replace(/^<div /i, '<span ').replace(/<\/div>$/i, '</span>'),
+      }}
+    />
+  );
+}
+
 type KeyValuesTableProps = {
   data: { key: string, value: any }[],
   linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
@@ -43,24 +59,16 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
       <table className="u-width-100">
         <tbody className="KeyValueTable--body">
           {data.map((row, i) => {
-            const jsonTable = (
-              // eslint-disable-next-line react/no-danger
-              <div dangerouslySetInnerHTML={{ __html: jsonMarkup(parseIfJson(row.value)) }} />
-            );
-            let valueMarkup = jsonTable;
+            const markup = jsonMarkup(parseIfJson(row.value));
             const links = linksGetter ? linksGetter(data, i) : null;
+            let valueMarkup;
             if (links && links.length === 1) {
               valueMarkup = (
-                <a
-                  className="KeyValueTable--link"
-                  href={links[0].url}
-                  title={links[0].text}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Icon className="KeyValueTable--linkIcon" type="export" />
-                  {jsonTable}
-                </a>
+                <div>
+                  <a href={links[0].url} title={links[0].text} target="_blank" rel="noopener noreferrer">
+                    {markupAsSpan(markup)} <Icon className="KeyValueTable--linkIcon" type="export" />
+                  </a>
+                </div>
               );
             } else if (links && links.length > 1) {
               const menuItems = (
@@ -80,13 +88,16 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                 </Menu>
               );
               valueMarkup = (
-                <Dropdown overlay={menuItems} placement="bottomRight" trigger={['click']}>
-                  <a className="KeyValueTable--link">
-                    <Icon className="KeyValueTable--linkIcon" type="profile" />
-                    {jsonTable}
-                  </a>
-                </Dropdown>
+                <div>
+                  <Dropdown overlay={menuItems} placement="bottomRight" trigger={['click']}>
+                    <a>
+                      {markupAsSpan(markup)} <Icon className="KeyValueTable--linkIcon" type="profile" />
+                    </a>
+                  </Dropdown>
+                </div>
               );
+            } else {
+              valueMarkup = markupAsDiv(markup);
             }
             return (
               // `i` is necessary in the key because row.key can repeat

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
@@ -33,7 +33,7 @@ function parseIfJson(value) {
 
 type KeyValuesTableProps = {
   data: { key: string, value: any }[],
-  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
 };
 
 export default function KeyValuesTable(props: KeyValuesTableProps) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
@@ -37,14 +37,9 @@ function markupAsDiv(markup) {
 }
 
 function markupAsSpan(markup) {
+  const spanMarkup = markup.replace(/^<div /i, '<span ').replace(/<\/div>$/i, '</span>');
   // eslint-disable-next-line react/no-danger
-  return (
-    <span
-      dangerouslySetInnerHTML={{
-        __html: markup.replace(/^<div /i, '<span ').replace(/<\/div>$/i, '</span>'),
-      }}
-    />
-  );
+  return <span dangerouslySetInnerHTML={{ __html: spanMarkup }} />;
 }
 
 type KeyValuesTableProps = {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import jsonMarkup from 'json-markup';
+import { Dropdown, Icon, Menu } from 'antd';
 
 import './KeyValuesTable.css';
 
@@ -32,10 +33,11 @@ function parseIfJson(value) {
 
 type KeyValuesTableProps = {
   data: { key: string, value: any }[],
+  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
 };
 
 export default function KeyValuesTable(props: KeyValuesTableProps) {
-  const { data } = props;
+  const { data, linksGetter } = props;
   return (
     <div className="KeyValueTable u-simple-scrollbars">
       <table className="u-width-100">
@@ -45,12 +47,53 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
               // eslint-disable-next-line react/no-danger
               <div dangerouslySetInnerHTML={{ __html: jsonMarkup(parseIfJson(row.value)) }} />
             );
+            let valueMarkup = jsonTable;
+            const links = linksGetter ? linksGetter(data, i) : null;
+            if (links && links.length === 1) {
+              valueMarkup = (
+                <a
+                  className="KeyValueTable--link"
+                  href={links[0].url}
+                  title={links[0].text}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Icon className="KeyValueTable--linkIcon" type="export" />
+                  {jsonTable}
+                </a>
+              );
+            } else if (links && links.length > 1) {
+              const menuItems = (
+                <Menu>
+                  {links.map((link, index) => {
+                    const { text, url } = link;
+                    return (
+                      // `index` is necessary in the key because url can repeat
+                      // eslint-disable-next-line react/no-array-index-key
+                      <Menu.Item key={`${url}-${index}`}>
+                        <a href={url} target="_blank" rel="noopener noreferrer">
+                          {text}
+                        </a>
+                      </Menu.Item>
+                    );
+                  })}
+                </Menu>
+              );
+              valueMarkup = (
+                <Dropdown overlay={menuItems} placement="bottomRight" trigger={['click']}>
+                  <a className="KeyValueTable--link">
+                    <Icon className="KeyValueTable--linkIcon" type="profile" />
+                    {jsonTable}
+                  </a>
+                </Dropdown>
+              );
+            }
             return (
               // `i` is necessary in the key because row.key can repeat
               // eslint-disable-next-line react/no-array-index-key
               <tr key={`${row.key}-${i}`}>
                 <td className="KeyValueTable--keyColumn">{row.key}</td>
-                <td>{jsonTable}</td>
+                <td>{valueMarkup}</td>
               </tr>
             );
           })}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.js
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import jsonMarkup from 'json-markup';
 import { Dropdown, Icon, Menu } from 'antd';
+import type { KeyValuePair, Link } from '../../../../types';
 
 import './KeyValuesTable.css';
 
@@ -37,7 +38,7 @@ const LinkValue = (props: { href: string, title?: string, children: React.Node }
   </a>
 );
 
-const linkValueList = (links: { url: string, text: string }[]) => (
+const linkValueList = (links: Link[]) => (
   <Menu>
     {links.map(({ text, url }, index) => (
       // `index` is necessary in the key because url can repeat
@@ -50,8 +51,8 @@ const linkValueList = (links: { url: string, text: string }[]) => (
 );
 
 type KeyValuesTableProps = {
-  data: { key: string, value: any }[],
-  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
+  data: KeyValuePair[],
+  linksGetter: ?(KeyValuePair[], number) => Link[],
 };
 
 export default function KeyValuesTable(props: KeyValuesTableProps) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -14,6 +14,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Dropdown, Icon } from 'antd';
 
 import KeyValuesTable from './KeyValuesTable';
 
@@ -37,5 +38,61 @@ describe('<KeyValuesTable>', () => {
     trs.forEach((tr, i) => {
       expect(tr.find('.KeyValueTable--keyColumn').text()).toMatch(data[i].key);
     });
+  });
+
+  it('renders a single link correctly', () => {
+    wrapper.setProps({
+      linksGetter: (array, i) =>
+        array[i].key === 'span.kind'
+          ? [
+              {
+                url: `http://example.com/?kind=${encodeURIComponent(array[i].value)}`,
+                text: `More info about ${array[i].value}`,
+              },
+            ]
+          : [],
+    });
+
+    const anchor = wrapper.find('a');
+    expect(anchor).toHaveLength(1);
+    expect(anchor.prop('href')).toBe('http://example.com/?kind=client');
+    expect(anchor.prop('title')).toBe('More info about client');
+    expect(anchor.find(Icon)).toHaveLength(1);
+    expect(
+      anchor
+        .closest('tr')
+        .find('td')
+        .first()
+        .text()
+    ).toBe('span.kind');
+  });
+
+  it('renders multiple links correctly', () => {
+    wrapper.setProps({
+      linksGetter: (array, i) =>
+        array[i].key === 'span.kind'
+          ? [
+              { url: `http://example.com/1?kind=${encodeURIComponent(array[i].value)}`, text: 'Example 1' },
+              { url: `http://example.com/2?kind=${encodeURIComponent(array[i].value)}`, text: 'Example 2' },
+            ]
+          : [],
+    });
+    const dropdown = wrapper.find(Dropdown);
+    const menu = shallow(dropdown.prop('overlay'));
+    const anchors = menu.find('a');
+    expect(anchors).toHaveLength(2);
+    const firstAnchor = anchors.first();
+    expect(firstAnchor.prop('href')).toBe('http://example.com/1?kind=client');
+    expect(firstAnchor.text()).toBe('Example 1');
+    const secondAnchor = anchors.last();
+    expect(secondAnchor.prop('href')).toBe('http://example.com/2?kind=client');
+    expect(secondAnchor.text()).toBe('Example 2');
+    expect(
+      dropdown
+        .closest('tr')
+        .find('td')
+        .first()
+        .text()
+    ).toBe('span.kind');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Dropdown, Icon } from 'antd';
+import { Dropdown } from 'antd';
 
 import KeyValuesTable from './KeyValuesTable';
 
@@ -53,11 +53,10 @@ describe('<KeyValuesTable>', () => {
           : [],
     });
 
-    const anchor = wrapper.find('a');
+    const anchor = wrapper.find(KeyValuesTable.LinkValue);
     expect(anchor).toHaveLength(1);
     expect(anchor.prop('href')).toBe('http://example.com/?kind=client');
     expect(anchor.prop('title')).toBe('More info about client');
-    expect(anchor.find(Icon)).toHaveLength(1);
     expect(
       anchor
         .closest('tr')
@@ -79,14 +78,14 @@ describe('<KeyValuesTable>', () => {
     });
     const dropdown = wrapper.find(Dropdown);
     const menu = shallow(dropdown.prop('overlay'));
-    const anchors = menu.find('a');
+    const anchors = menu.find(KeyValuesTable.LinkValue);
     expect(anchors).toHaveLength(2);
     const firstAnchor = anchors.first();
     expect(firstAnchor.prop('href')).toBe('http://example.com/1?kind=client');
-    expect(firstAnchor.text()).toBe('Example 1');
+    expect(firstAnchor.children().text()).toBe('Example 1');
     const secondAnchor = anchors.last();
     expect(secondAnchor.prop('href')).toBe('http://example.com/2?kind=client');
-    expect(secondAnchor.text()).toBe('Example 2');
+    expect(secondAnchor.children().text()).toBe('Example 2');
     expect(
       dropdown
         .closest('tr')

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.js
@@ -22,13 +22,13 @@ import AccordianLogs from './AccordianLogs';
 import DetailState from './DetailState';
 import { formatDuration } from '../utils';
 import LabeledList from '../../../common/LabeledList';
-import type { Log, Span } from '../../../../types';
+import type { Log, Span, KeyValuePair, Link } from '../../../../types';
 
 import './index.css';
 
 type SpanDetailProps = {
   detailState: DetailState,
-  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?(KeyValuePair[], number) => Link[],
   logItemToggle: (string, Log) => void,
   logsToggle: string => void,
   processToggle: string => void,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.js
@@ -28,6 +28,7 @@ import './index.css';
 
 type SpanDetailProps = {
   detailState: DetailState,
+  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
   logItemToggle: (string, Log) => void,
   logsToggle: string => void,
   processToggle: string => void,
@@ -37,7 +38,16 @@ type SpanDetailProps = {
 };
 
 export default function SpanDetail(props: SpanDetailProps) {
-  const { detailState, logItemToggle, logsToggle, processToggle, span, tagsToggle, traceStartTime } = props;
+  const {
+    detailState,
+    linksGetter,
+    logItemToggle,
+    logsToggle,
+    processToggle,
+    span,
+    tagsToggle,
+    traceStartTime,
+  } = props;
   const { isTagsOpen, isProcessOpen, logs: logsState } = detailState;
   const { operationName, process, duration, relativeStartTime, spanID, logs, tags } = span;
   const overviewItems = [
@@ -73,6 +83,7 @@ export default function SpanDetail(props: SpanDetailProps) {
           <AccordianKeyValues
             data={tags}
             label="Tags"
+            linksGetter={linksGetter}
             isOpen={isTagsOpen}
             onToggle={() => tagsToggle(spanID)}
           />
@@ -81,6 +92,7 @@ export default function SpanDetail(props: SpanDetailProps) {
               className="ub-mb1"
               data={process.tags}
               label="Process"
+              linksGetter={linksGetter}
               isOpen={isProcessOpen}
               onToggle={() => processToggle(spanID)}
             />
@@ -89,6 +101,7 @@ export default function SpanDetail(props: SpanDetailProps) {
         {logs &&
           logs.length > 0 && (
             <AccordianLogs
+              linksGetter={linksGetter}
               logs={logs}
               isOpen={logsState.isOpen}
               openedItems={logsState.openedItems}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.js
@@ -28,7 +28,7 @@ import './index.css';
 
 type SpanDetailProps = {
   detailState: DetailState,
-  linksGetter: ({ key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?({ key: string, value: any }[], number) => { url: string, text: string }[],
   logItemToggle: (string, Log) => void,
   logsToggle: string => void,
   processToggle: string => void,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
@@ -20,7 +20,7 @@ import SpanDetail from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
 import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
-import type { Log, Span } from '../../../types';
+import type { Log, Span, KeyValuePair, Link } from '../../../types';
 
 import './SpanDetailRow.css';
 
@@ -30,7 +30,7 @@ type SpanDetailRowProps = {
   detailState: DetailState,
   onDetailToggled: string => void,
   isFilteredOut: boolean,
-  linksGetter: ?(number, { key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?(number, KeyValuePair[], number) => Link[],
   logItemToggle: (string, Log) => void,
   logsToggle: string => void,
   processToggle: string => void,
@@ -47,7 +47,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
     this.props.onDetailToggled(this.props.span.spanID);
   };
 
-  _linksGetter = (items: { key: string, value: any }[], itemIndex: number) => {
+  _linksGetter = (items: KeyValuePair[], itemIndex: number) => {
     const { linksGetter, spanIndex } = this.props;
     return linksGetter ? linksGetter(spanIndex, items, itemIndex) : [];
   };

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
@@ -58,7 +58,6 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
       columnDivision,
       detailState,
       isFilteredOut,
-      linksGetter,
       logItemToggle,
       logsToggle,
       processToggle,
@@ -84,7 +83,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
           <div className="detail-info-wrapper" style={{ borderTopColor: color }}>
             <SpanDetail
               detailState={detailState}
-              linksGetter={linksGetter ? this._linksGetter : null}
+              linksGetter={this._linksGetter}
               logItemToggle={logItemToggle}
               logsToggle={logsToggle}
               processToggle={processToggle}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
@@ -30,10 +30,12 @@ type SpanDetailRowProps = {
   detailState: DetailState,
   onDetailToggled: string => void,
   isFilteredOut: boolean,
+  linksGetter: (number, { key: string, value: any }[], number) => { url: string, text: string }[],
   logItemToggle: (string, Log) => void,
   logsToggle: string => void,
   processToggle: string => void,
   span: Span,
+  spanIndex: number,
   tagsToggle: string => void,
   traceStartTime: number,
 };
@@ -44,6 +46,9 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
   _detailToggle = () => {
     this.props.onDetailToggled(this.props.span.spanID);
   };
+
+  _linksGetter = (items: { key: string, value: any }[], itemIndex: number) =>
+    this.props.linksGetter(this.props.spanIndex, items, itemIndex);
 
   render() {
     const {
@@ -76,6 +81,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
           <div className="detail-info-wrapper" style={{ borderTopColor: color }}>
             <SpanDetail
               detailState={detailState}
+              linksGetter={this._linksGetter}
               logItemToggle={logItemToggle}
               logsToggle={logsToggle}
               processToggle={processToggle}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
@@ -30,7 +30,7 @@ type SpanDetailRowProps = {
   detailState: DetailState,
   onDetailToggled: string => void,
   isFilteredOut: boolean,
-  linksGetter: (number, { key: string, value: any }[], number) => { url: string, text: string }[],
+  linksGetter: ?(number, { key: string, value: any }[], number) => { url: string, text: string }[],
   logItemToggle: (string, Log) => void,
   logsToggle: string => void,
   processToggle: string => void,
@@ -47,8 +47,10 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
     this.props.onDetailToggled(this.props.span.spanID);
   };
 
-  _linksGetter = (items: { key: string, value: any }[], itemIndex: number) =>
-    this.props.linksGetter(this.props.spanIndex, items, itemIndex);
+  _linksGetter = (items: { key: string, value: any }[], itemIndex: number) => {
+    const { linksGetter, spanIndex } = this.props;
+    return linksGetter ? linksGetter(spanIndex, items, itemIndex) : [];
+  };
 
   render() {
     const {
@@ -56,6 +58,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
       columnDivision,
       detailState,
       isFilteredOut,
+      linksGetter,
       logItemToggle,
       logsToggle,
       processToggle,
@@ -81,7 +84,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
           <div className="detail-info-wrapper" style={{ borderTopColor: color }}>
             <SpanDetail
               detailState={detailState}
-              linksGetter={this._linksGetter}
+              linksGetter={linksGetter ? this._linksGetter : null}
               logItemToggle={logItemToggle}
               logsToggle={logsToggle}
               processToggle={processToggle}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
@@ -30,12 +30,11 @@ type SpanDetailRowProps = {
   detailState: DetailState,
   onDetailToggled: string => void,
   isFilteredOut: boolean,
-  linksGetter: ?(number, KeyValuePair[], number) => Link[],
+  linksGetter: ?(Span, KeyValuePair[], number) => Link[],
   logItemToggle: (string, Log) => void,
   logsToggle: string => void,
   processToggle: string => void,
   span: Span,
-  spanIndex: number,
   tagsToggle: string => void,
   traceStartTime: number,
 };
@@ -48,8 +47,8 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
   };
 
   _linksGetter = (items: KeyValuePair[], itemIndex: number) => {
-    const { linksGetter, spanIndex } = this.props;
-    return linksGetter ? linksGetter(spanIndex, items, itemIndex) : [];
+    const { linksGetter, span } = this.props;
+    return linksGetter ? linksGetter(span, items, itemIndex) : [];
   };
 
   render() {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
@@ -72,6 +72,7 @@ describe('<SpanDetailRow>', () => {
     const spanDetail = (
       <SpanDetail
         detailState={props.detailState}
+        linksGetter={null}
         logItemToggle={props.logItemToggle}
         logsToggle={props.logsToggle}
         processToggle={props.processToggle}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
@@ -27,11 +27,13 @@ describe('<SpanDetailRow>', () => {
     columnDivision: 0.5,
     detailState: new DetailState(),
     onDetailToggled: jest.fn(),
+    linksGetter: jest.fn(),
     isFilteredOut: false,
     logItemToggle: jest.fn(),
     logsToggle: jest.fn(),
     processToggle: jest.fn(),
     span: { spanID, depth: 3 },
+    spanIndex: 4,
     tagsToggle: jest.fn(),
     traceStartTime: 1000,
   };
@@ -40,6 +42,7 @@ describe('<SpanDetailRow>', () => {
 
   beforeEach(() => {
     props.onDetailToggled.mockReset();
+    props.linksGetter.mockReset();
     props.logItemToggle.mockReset();
     props.logsToggle.mockReset();
     props.processToggle.mockReset();
@@ -72,7 +75,7 @@ describe('<SpanDetailRow>', () => {
     const spanDetail = (
       <SpanDetail
         detailState={props.detailState}
-        linksGetter={null}
+        linksGetter={wrapper.instance()._linksGetter}
         logItemToggle={props.logItemToggle}
         logsToggle={props.logsToggle}
         processToggle={props.processToggle}
@@ -82,5 +85,17 @@ describe('<SpanDetailRow>', () => {
       />
     );
     expect(wrapper.contains(spanDetail)).toBe(true);
+  });
+
+  it('adds spanIndex when calling linksGetter', () => {
+    const spanDetail = wrapper.find(SpanDetail);
+    const linksGetter = spanDetail.prop('linksGetter');
+    const tags = [{ key: 'myKey', value: 'myValue' }];
+    const linksGetterResponse = {};
+    props.linksGetter.mockReturnValueOnce(linksGetterResponse);
+    const result = linksGetter(tags, 0);
+    expect(result).toBe(linksGetterResponse);
+    expect(props.linksGetter).toHaveBeenCalledTimes(1);
+    expect(props.linksGetter).toHaveBeenCalledWith(props.spanIndex, tags, 0);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
@@ -33,7 +33,6 @@ describe('<SpanDetailRow>', () => {
     logsToggle: jest.fn(),
     processToggle: jest.fn(),
     span: { spanID, depth: 3 },
-    spanIndex: 4,
     tagsToggle: jest.fn(),
     traceStartTime: 1000,
   };
@@ -87,7 +86,7 @@ describe('<SpanDetailRow>', () => {
     expect(wrapper.contains(spanDetail)).toBe(true);
   });
 
-  it('adds spanIndex when calling linksGetter', () => {
+  it('adds span when calling linksGetter', () => {
     const spanDetail = wrapper.find(SpanDetail);
     const linksGetter = spanDetail.prop('linksGetter');
     const tags = [{ key: 'myKey', value: 'myValue' }];
@@ -96,6 +95,6 @@ describe('<SpanDetailRow>', () => {
     const result = linksGetter(tags, 0);
     expect(result).toBe(linksGetterResponse);
     expect(props.linksGetter).toHaveBeenCalledTimes(1);
-    expect(props.linksGetter).toHaveBeenCalledWith(props.spanIndex, tags, 0);
+    expect(props.linksGetter).toHaveBeenCalledWith(props.span, tags, 0);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
@@ -31,6 +31,7 @@ import {
   isErrorSpan,
   spanContainsErredSpan,
 } from './utils';
+import getLinks from '../../../model/link-patterns';
 import type { Accessors } from '../ScrollManager';
 import type { Log, Span, Trace } from '../../../types';
 import colorGenerator from '../../../utils/color-generator';
@@ -264,10 +265,13 @@ export class VirtualizedTraceViewImpl extends React.PureComponent<VirtualizedTra
     return DEFAULT_HEIGHTS.detail;
   };
 
+  linksGetter = (spanIndex: number, items: { key: string, value: any }[], itemIndex: number) =>
+    getLinks(this.props.trace, spanIndex, items, itemIndex);
+
   renderRow = (key: string, style: Style, index: number, attrs: {}) => {
     const { isDetail, span, spanIndex } = this.rowStates[index];
     return isDetail
-      ? this.renderSpanDetailRow(span, key, style, attrs)
+      ? this.renderSpanDetailRow(span, spanIndex, key, style, attrs)
       : this.renderSpanBarRow(span, spanIndex, key, style, attrs);
   };
 
@@ -352,7 +356,7 @@ export class VirtualizedTraceViewImpl extends React.PureComponent<VirtualizedTra
     );
   }
 
-  renderSpanDetailRow(span: Span, key: string, style: Style, attrs: {}) {
+  renderSpanDetailRow(span: Span, spanIndex: number, key: string, style: Style, attrs: {}) {
     const { spanID } = span;
     const { serviceName } = span.process;
     const {
@@ -380,10 +384,12 @@ export class VirtualizedTraceViewImpl extends React.PureComponent<VirtualizedTra
           onDetailToggled={detailToggle}
           detailState={detailState}
           isFilteredOut={isFilteredOut}
+          linksGetter={this.linksGetter}
           logItemToggle={detailLogItemToggle}
           logsToggle={detailLogsToggle}
           processToggle={detailProcessToggle}
           span={span}
+          spanIndex={spanIndex}
           tagsToggle={detailTagsToggle}
           traceStartTime={trace.startTime}
         />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
@@ -265,13 +265,12 @@ export class VirtualizedTraceViewImpl extends React.PureComponent<VirtualizedTra
     return DEFAULT_HEIGHTS.detail;
   };
 
-  linksGetter = (spanIndex: number, items: KeyValuePair[], itemIndex: number) =>
-    getLinks(this.props.trace, spanIndex, items, itemIndex);
+  linksGetter = (span: Span, items: KeyValuePair[], itemIndex: number) => getLinks(span, items, itemIndex);
 
   renderRow = (key: string, style: Style, index: number, attrs: {}) => {
     const { isDetail, span, spanIndex } = this.rowStates[index];
     return isDetail
-      ? this.renderSpanDetailRow(span, spanIndex, key, style, attrs)
+      ? this.renderSpanDetailRow(span, key, style, attrs)
       : this.renderSpanBarRow(span, spanIndex, key, style, attrs);
   };
 
@@ -356,7 +355,7 @@ export class VirtualizedTraceViewImpl extends React.PureComponent<VirtualizedTra
     );
   }
 
-  renderSpanDetailRow(span: Span, spanIndex: number, key: string, style: Style, attrs: {}) {
+  renderSpanDetailRow(span: Span, key: string, style: Style, attrs: {}) {
     const { spanID } = span;
     const { serviceName } = span.process;
     const {
@@ -389,7 +388,6 @@ export class VirtualizedTraceViewImpl extends React.PureComponent<VirtualizedTra
           logsToggle={detailLogsToggle}
           processToggle={detailProcessToggle}
           span={span}
-          spanIndex={spanIndex}
           tagsToggle={detailTagsToggle}
           traceStartTime={trace.startTime}
         />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.js
@@ -33,7 +33,7 @@ import {
 } from './utils';
 import getLinks from '../../../model/link-patterns';
 import type { Accessors } from '../ScrollManager';
-import type { Log, Span, Trace } from '../../../types';
+import type { Log, Span, Trace, KeyValuePair } from '../../../types';
 import colorGenerator from '../../../utils/color-generator';
 
 import './VirtualizedTraceView.css';
@@ -265,7 +265,7 @@ export class VirtualizedTraceViewImpl extends React.PureComponent<VirtualizedTra
     return DEFAULT_HEIGHTS.detail;
   };
 
-  linksGetter = (spanIndex: number, items: { key: string, value: any }[], itemIndex: number) =>
+  linksGetter = (spanIndex: number, items: KeyValuePair[], itemIndex: number) =>
     getLinks(this.props.trace, spanIndex, items, itemIndex);
 
   renderRow = (key: string, style: Style, index: number, attrs: {}) => {

--- a/packages/jaeger-ui/src/constants/default-config.js
+++ b/packages/jaeger-ui/src/constants/default-config.js
@@ -24,6 +24,7 @@ export default deepFreeze(
         dagMaxNumServices: FALLBACK_DAG_MAX_NUM_SERVICES,
         menuEnabled: true,
       },
+      linkPatterns: [],
       tracking: {
         gaID: null,
         trackErrors: true,

--- a/packages/jaeger-ui/src/model/link-patterns.js
+++ b/packages/jaeger-ui/src/model/link-patterns.js
@@ -1,0 +1,183 @@
+// Copyright (c) 2017 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import _uniq from 'lodash/uniq';
+import { getConfigValue } from '../utils/config/get-config';
+
+const parameterRegExp = /\$\{([^{}]*)\}/;
+
+export function processTemplate(template, encodeFn) {
+  if (typeof template !== 'string') {
+    if (!template || !Array.isArray(template.parameters) || !(template.template instanceof Function)) {
+      throw new Error('Invalid template');
+    }
+    return template;
+  }
+  const templateSplit = template.split(parameterRegExp);
+  const templateSplitLength = templateSplit.length;
+  const parameters = [];
+  // odd indexes contain variable names
+  for (let i = 1; i < templateSplitLength; i += 2) {
+    const param = templateSplit[i];
+    let paramIndex = parameters.indexOf(param);
+    if (paramIndex === -1) {
+      paramIndex = parameters.length;
+      parameters.push(param);
+    }
+    templateSplit[i] = paramIndex;
+  }
+  return {
+    parameters,
+    template: (...args) => {
+      let text = '';
+      for (let i = 0; i < templateSplitLength; i++) {
+        if (i % 2 === 0) {
+          text += templateSplit[i];
+        } else {
+          text += encodeFn(args[templateSplit[i]]);
+        }
+      }
+      return text;
+    },
+  };
+}
+
+export function createTestFunction(entry) {
+  if (typeof entry === 'string') {
+    return arg => arg === entry;
+  }
+  if (Array.isArray(entry)) {
+    return arg => entry.indexOf(arg) > -1;
+  }
+  if (entry instanceof RegExp) {
+    return arg => entry.test(arg);
+  }
+  if (entry instanceof Function) {
+    return entry;
+  }
+  if (!entry) {
+    return () => true;
+  }
+  throw new Error(`Invalid value: ${entry}`);
+}
+
+const identity = a => a;
+
+export function processLinkPattern(pattern) {
+  try {
+    const url = processTemplate(pattern.url, encodeURIComponent);
+    const text = processTemplate(pattern.text, identity);
+    return {
+      object: pattern,
+      type: createTestFunction(pattern.type),
+      key: createTestFunction(pattern.key),
+      value: createTestFunction(pattern.value),
+      url,
+      text,
+      parameters: _uniq(url.parameters.concat(text.parameters)),
+    };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Ignoring invalid link pattern: ${error}`, pattern);
+    return null;
+  }
+}
+
+export function getParameterInArray(name, array) {
+  if (array) {
+    return array.find(entry => entry.key === name);
+  }
+  return null;
+}
+
+export function getParameterInAncestor(name, spans, startSpanIndex) {
+  let currentSpan = { depth: spans[startSpanIndex].depth + 1 };
+  for (let spanIndex = startSpanIndex; spanIndex >= 0; spanIndex--) {
+    const nextSpan = spans[spanIndex];
+    if (nextSpan.depth < currentSpan.depth) {
+      currentSpan = nextSpan;
+      const result =
+        getParameterInArray(name, currentSpan.tags) || getParameterInArray(name, currentSpan.process.tags);
+      if (result) {
+        return result;
+      }
+    }
+  }
+  return null;
+}
+
+export function callTemplate(template, data) {
+  return template.template(...template.parameters.map(param => data[param]));
+}
+
+export function computeLinks(linkPatterns, trace, spanIndex, items, itemIndex) {
+  const item = items[itemIndex];
+  const span = trace.spans[spanIndex];
+  let type = 'logs';
+  const processTags = span.process.tags === items;
+  if (processTags) {
+    type = 'process';
+  }
+  const spanTags = span.tags === items;
+  if (spanTags) {
+    type = 'tags';
+  }
+  const result = [];
+  linkPatterns.forEach(pattern => {
+    if (pattern.type(type) && pattern.key(item.key, item.value, type) && pattern.value(item.value)) {
+      let parameterValues = {};
+      pattern.parameters.every(parameter => {
+        let entry = getParameterInArray(parameter, items);
+        if (!entry && !processTags) {
+          // do not look in ancestors for process tags because the same object may appear in different places in the hierarchy
+          entry = getParameterInAncestor(parameter, trace.spans, spanIndex);
+        }
+        if (entry) {
+          parameterValues[parameter] = entry.value;
+          return true;
+        }
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Skipping link pattern, missing parameter ${parameter} for key ${item.key} in ${type}.`,
+          pattern.object
+        );
+        parameterValues = null;
+        return false;
+      });
+      if (parameterValues) {
+        result.push({
+          url: callTemplate(pattern.url, parameterValues),
+          text: callTemplate(pattern.text, parameterValues),
+        });
+      }
+    }
+  });
+  return result;
+}
+
+const linkPatterns = (getConfigValue('linkPatterns') || []).map(processLinkPattern).filter(value => !!value);
+const alreadyComputed = new WeakMap();
+
+export default function getLinks(trace, spanIndex, items, itemIndex) {
+  if (linkPatterns.length === 0) {
+    return [];
+  }
+  const item = items[itemIndex];
+  let result = alreadyComputed.get(item);
+  if (!result) {
+    result = computeLinks(linkPatterns, trace, spanIndex, items, itemIndex);
+    alreadyComputed.set(item, result);
+  }
+  return result;
+}

--- a/packages/jaeger-ui/src/model/link-patterns.js
+++ b/packages/jaeger-ui/src/model/link-patterns.js
@@ -18,7 +18,7 @@ import _uniq from 'lodash/uniq';
 import { getConfigValue } from '../utils/config/get-config';
 import type { Span, Trace, Link, KeyValuePair } from '../types';
 
-const parameterRegExp = /\$\{([^{}]*)\}/g;
+const parameterRegExp = /#\{([^{}]*)\}/g;
 
 type ProcessedTemplate = {
   parameters: string[],

--- a/packages/jaeger-ui/src/model/link-patterns.js
+++ b/packages/jaeger-ui/src/model/link-patterns.js
@@ -63,10 +63,10 @@ export function createTestFunction(entry) {
   if (entry instanceof RegExp) {
     return arg => entry.test(arg);
   }
-  if (entry instanceof Function) {
+  if (typeof entry === 'function') {
     return entry;
   }
-  if (!entry) {
+  if (entry == null) {
     return () => true;
   }
   throw new Error(`Invalid value: ${entry}`);

--- a/packages/jaeger-ui/src/model/link-patterns.js
+++ b/packages/jaeger-ui/src/model/link-patterns.js
@@ -98,7 +98,7 @@ export function getParameterInArray(name, array) {
   if (array) {
     return array.find(entry => entry.key === name);
   }
-  return null;
+  return undefined;
 }
 
 export function getParameterInAncestor(name, spans, startSpanIndex) {
@@ -114,7 +114,7 @@ export function getParameterInAncestor(name, spans, startSpanIndex) {
       }
     }
   }
-  return null;
+  return undefined;
 }
 
 export function callTemplate(template, data) {

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -233,47 +233,65 @@ describe('getParameterInAncestor()', () => {
       tags: [{ key: 'a', value: 'a0' }],
     },
   ];
+  spans[1].references = [
+    {
+      refType: 'CHILD_OF',
+      span: spans[0],
+    },
+  ];
+  spans[2].references = [
+    {
+      refType: 'CHILD_OF',
+      span: spans[0],
+    },
+  ];
+  spans[3].references = [
+    {
+      refType: 'CHILD_OF',
+      span: spans[2],
+    },
+  ];
 
   it('uses current span tags', () => {
-    expect(getParameterInAncestor('a', spans, 3)).toEqual({ key: 'a', value: 'a0' });
-    expect(getParameterInAncestor('a', spans, 2)).toEqual({ key: 'a', value: 'a2' });
-    expect(getParameterInAncestor('a', spans, 1)).toEqual({ key: 'a', value: 'a4' });
-    expect(getParameterInAncestor('a', spans, 0)).toEqual({ key: 'a', value: 'a6' });
+    expect(getParameterInAncestor('a', spans[3])).toEqual({ key: 'a', value: 'a0' });
+    expect(getParameterInAncestor('a', spans[2])).toEqual({ key: 'a', value: 'a2' });
+    expect(getParameterInAncestor('a', spans[1])).toEqual({ key: 'a', value: 'a4' });
+    expect(getParameterInAncestor('a', spans[0])).toEqual({ key: 'a', value: 'a6' });
   });
 
   it('uses current span process tags', () => {
-    expect(getParameterInAncestor('b', spans, 3)).toEqual({ key: 'b', value: 'b1' });
-    expect(getParameterInAncestor('d', spans, 2)).toEqual({ key: 'd', value: 'd3' });
-    expect(getParameterInAncestor('f', spans, 1)).toEqual({ key: 'f', value: 'f5' });
-    expect(getParameterInAncestor('h', spans, 0)).toEqual({ key: 'h', value: 'h7' });
+    expect(getParameterInAncestor('b', spans[3])).toEqual({ key: 'b', value: 'b1' });
+    expect(getParameterInAncestor('d', spans[2])).toEqual({ key: 'd', value: 'd3' });
+    expect(getParameterInAncestor('f', spans[1])).toEqual({ key: 'f', value: 'f5' });
+    expect(getParameterInAncestor('h', spans[0])).toEqual({ key: 'h', value: 'h7' });
   });
 
   it('uses parent span tags', () => {
-    expect(getParameterInAncestor('c', spans, 3)).toEqual({ key: 'c', value: 'c2' });
-    expect(getParameterInAncestor('e', spans, 2)).toEqual({ key: 'e', value: 'e6' });
-    expect(getParameterInAncestor('f', spans, 2)).toEqual({ key: 'f', value: 'f6' });
-    expect(getParameterInAncestor('g', spans, 2)).toEqual({ key: 'g', value: 'g6' });
-    expect(getParameterInAncestor('g', spans, 1)).toEqual({ key: 'g', value: 'g6' });
+    expect(getParameterInAncestor('c', spans[3])).toEqual({ key: 'c', value: 'c2' });
+    expect(getParameterInAncestor('e', spans[2])).toEqual({ key: 'e', value: 'e6' });
+    expect(getParameterInAncestor('f', spans[2])).toEqual({ key: 'f', value: 'f6' });
+    expect(getParameterInAncestor('g', spans[2])).toEqual({ key: 'g', value: 'g6' });
+    expect(getParameterInAncestor('g', spans[1])).toEqual({ key: 'g', value: 'g6' });
   });
 
   it('uses parent span process tags', () => {
-    expect(getParameterInAncestor('d', spans, 3)).toEqual({ key: 'd', value: 'd3' });
-    expect(getParameterInAncestor('h', spans, 2)).toEqual({ key: 'h', value: 'h7' });
-    expect(getParameterInAncestor('h', spans, 1)).toEqual({ key: 'h', value: 'h7' });
+    expect(getParameterInAncestor('d', spans[3])).toEqual({ key: 'd', value: 'd3' });
+    expect(getParameterInAncestor('h', spans[2])).toEqual({ key: 'h', value: 'h7' });
+    expect(getParameterInAncestor('h', spans[1])).toEqual({ key: 'h', value: 'h7' });
   });
 
   it('uses grand-parent span tags', () => {
-    expect(getParameterInAncestor('e', spans, 3)).toEqual({ key: 'e', value: 'e6' });
-    expect(getParameterInAncestor('f', spans, 3)).toEqual({ key: 'f', value: 'f6' });
-    expect(getParameterInAncestor('g', spans, 3)).toEqual({ key: 'g', value: 'g6' });
+    expect(getParameterInAncestor('e', spans[3])).toEqual({ key: 'e', value: 'e6' });
+    expect(getParameterInAncestor('f', spans[3])).toEqual({ key: 'f', value: 'f6' });
+    expect(getParameterInAncestor('g', spans[3])).toEqual({ key: 'g', value: 'g6' });
   });
 
   it('uses grand-parent process tags', () => {
-    expect(getParameterInAncestor('h', spans, 3)).toEqual({ key: 'h', value: 'h7' });
+    expect(getParameterInAncestor('h', spans[3])).toEqual({ key: 'h', value: 'h7' });
   });
 
   it('returns undefined when the entry cannot be found', () => {
-    expect(getParameterInAncestor('i', spans, 3)).toBeUndefined();
+    expect(getParameterInAncestor('i', spans[3])).toBeUndefined();
   });
 
   it('does not break if some tags are not defined', () => {
@@ -283,7 +301,7 @@ describe('getParameterInAncestor()', () => {
         process: {},
       },
     ];
-    expect(getParameterInAncestor('a', spansWithUndefinedTags, 0)).toBeUndefined();
+    expect(getParameterInAncestor('a', spansWithUndefinedTags[0])).toBeUndefined();
   });
 });
 
@@ -302,21 +320,25 @@ describe('computeLinks()', () => {
     },
   ].map(processLinkPattern);
 
-  const trace = {
-    spans: [
-      { depth: 0, process: {}, tags: [{ key: 'myKey', value: 'valueOfMyKey' }] },
-      { depth: 1, process: {}, logs: [{ fields: [{ key: 'myOtherKey', value: 'valueOfMy+Other+Key' }] }] },
-    ],
-  };
+  const spans = [
+    { depth: 0, process: {}, tags: [{ key: 'myKey', value: 'valueOfMyKey' }] },
+    { depth: 1, process: {}, logs: [{ fields: [{ key: 'myOtherKey', value: 'valueOfMy+Other+Key' }] }] },
+  ];
+  spans[1].references = [
+    {
+      refType: 'CHILD_OF',
+      span: spans[0],
+    },
+  ];
 
   it('correctly computes links', () => {
-    expect(computeLinks(linkPatterns, trace, 0, trace.spans[0].tags, 0)).toEqual([
+    expect(computeLinks(linkPatterns, spans[0], spans[0].tags, 0)).toEqual([
       {
         url: 'http://example.com/?myKey=valueOfMyKey',
         text: 'first link (valueOfMyKey)',
       },
     ]);
-    expect(computeLinks(linkPatterns, trace, 1, trace.spans[1].logs[0].fields, 0)).toEqual([
+    expect(computeLinks(linkPatterns, spans[1], spans[1].logs[0].fields, 0)).toEqual([
       {
         url: 'http://example.com/?myKey=valueOfMy%2BOther%2BKey&myKey=valueOfMyKey',
         text: 'second link (valueOfMy+Other+Key)',
@@ -335,9 +357,7 @@ describe('getLinks()', () => {
   ].map(processLinkPattern);
   const template = jest.spyOn(linkPatterns[0].url, 'template');
 
-  const trace = {
-    spans: [{ depth: 0, process: {}, tags: [{ key: 'mySpecialKey', value: 'valueOfMyKey' }] }],
-  };
+  const span = { depth: 0, process: {}, tags: [{ key: 'mySpecialKey', value: 'valueOfMyKey' }] };
 
   let cache;
 
@@ -349,21 +369,21 @@ describe('getLinks()', () => {
   it('does not access the cache if there is no link pattern', () => {
     cache.get = jest.fn();
     const getLinks = createGetLinks([], cache);
-    expect(getLinks(trace, 0, trace.spans[0].tags, 0)).toEqual([]);
+    expect(getLinks(span, span.tags, 0)).toEqual([]);
     expect(cache.get).not.toHaveBeenCalled();
   });
 
   it('returns the result from the cache', () => {
     const result = [];
-    cache.set(trace.spans[0].tags[0], result);
+    cache.set(span.tags[0], result);
     const getLinks = createGetLinks(linkPatterns, cache);
-    expect(getLinks(trace, 0, trace.spans[0].tags, 0)).toBe(result);
+    expect(getLinks(span, span.tags, 0)).toBe(result);
     expect(template).not.toHaveBeenCalled();
   });
 
   it('adds the result to the cache', () => {
     const getLinks = createGetLinks(linkPatterns, cache);
-    const result = getLinks(trace, 0, trace.spans[0].tags, 0);
+    const result = getLinks(span, span.tags, 0);
     expect(template).toHaveBeenCalledTimes(1);
     expect(result).toEqual([
       {
@@ -371,6 +391,6 @@ describe('getLinks()', () => {
         text: 'special key link (valueOfMyKey)',
       },
     ]);
-    expect(cache.get(trace.spans[0].tags[0])).toBe(result);
+    expect(cache.get(span.tags[0])).toBe(result);
   });
 });

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { processTemplate } from './link-patterns';
+import { processTemplate, createTestFunction } from './link-patterns';
 
 describe('processTemplate()', () => {
   it('correctly replaces variables', () => {
@@ -69,10 +69,72 @@ describe('processTemplate()', () => {
   });
 });
 
+describe('createTestFunction()', () => {
+  it('accepts a string', () => {
+    const testFn = createTestFunction('myValue');
+    expect(testFn('myValue')).toBe(true);
+    expect(testFn('myFirstValue')).toBe(false);
+    expect(testFn('mySecondValue')).toBe(false);
+    expect(testFn('otherValue')).toBe(false);
+  });
+
+  it('accepts an array', () => {
+    const testFn = createTestFunction(['myFirstValue', 'mySecondValue']);
+    expect(testFn('myValue')).toBe(false);
+    expect(testFn('myFirstValue')).toBe(true);
+    expect(testFn('mySecondValue')).toBe(true);
+    expect(testFn('otherValue')).toBe(false);
+  });
+
+  it('accepts a regular expression', () => {
+    const testFn = createTestFunction(/^my.*Value$/);
+    expect(testFn('myValue')).toBe(true);
+    expect(testFn('myFirstValue')).toBe(true);
+    expect(testFn('mySecondValue')).toBe(true);
+    expect(testFn('otherValue')).toBe(false);
+  });
+
+  it('accepts a function', () => {
+    const mockCallback = jest.fn();
+    mockCallback
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+    const testFn = createTestFunction(mockCallback);
+    expect(testFn('myValue')).toBe(true);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenCalledWith('myValue');
+    expect(testFn('myFirstValue')).toBe(false);
+    expect(mockCallback).toHaveBeenCalledTimes(2);
+    expect(mockCallback).toHaveBeenCalledWith('myFirstValue');
+    expect(testFn('mySecondValue')).toBe(true);
+    expect(mockCallback).toHaveBeenCalledTimes(3);
+    expect(mockCallback).toHaveBeenCalledWith('mySecondValue');
+    expect(testFn('otherValue')).toBe(false);
+    expect(mockCallback).toHaveBeenCalledTimes(4);
+    expect(mockCallback).toHaveBeenCalledWith('otherValue');
+  });
+
+  it('accepts undefined', () => {
+    const testFn = createTestFunction();
+    expect(testFn('myValue')).toBe(true);
+    expect(testFn('myFirstValue')).toBe(true);
+    expect(testFn('mySecondValue')).toBe(true);
+    expect(testFn('otherValue')).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    expect(() => createTestFunction({})).toThrow();
+    expect(() => createTestFunction(true)).toThrow();
+    expect(() => createTestFunction(false)).toThrow();
+    expect(() => createTestFunction(0)).toThrow();
+    expect(() => createTestFunction(5)).toThrow();
+  });
+});
+
 // TODO:
 /*
-describe('createTestFunction()', () => {});
-
 describe('processLinkPattern()', () => {});
 
 describe('getParameterInArray()', () => {});
@@ -82,4 +144,6 @@ describe('getParameterInAncestor()', () => {});
 describe('callTemplate()', () => {});
 
 describe('computeLinks()', () => {});
+
+describe('getLinks()', () => {});
 */

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -25,8 +25,7 @@ import {
 describe('processTemplate()', () => {
   it('correctly replaces variables', () => {
     const processedTemplate = processTemplate(
-      // eslint-disable-next-line no-template-curly-in-string
-      'this is a test with ${oneVariable}${anotherVariable} and the same ${oneVariable}',
+      'this is a test with #{oneVariable}#{anotherVariable} and the same #{oneVariable}',
       a => a
     );
     expect(processedTemplate.parameters).toEqual(['oneVariable', 'anotherVariable']);
@@ -37,8 +36,7 @@ describe('processTemplate()', () => {
 
   it('correctly uses the encoding function', () => {
     const processedTemplate = processTemplate(
-      // eslint-disable-next-line no-template-curly-in-string
-      'this is a test with ${oneVariable}${anotherVariable} and the same ${oneVariable}',
+      'this is a test with #{oneVariable}#{anotherVariable} and the same #{oneVariable}',
       e => `/${e}\\`
     );
     expect(processedTemplate.parameters).toEqual(['oneVariable', 'anotherVariable']);
@@ -294,17 +292,13 @@ describe('computeLinks()', () => {
     {
       type: 'tags',
       key: 'myKey',
-      // eslint-disable-next-line no-template-curly-in-string
-      url: 'http://example.com/?myKey=${myKey}',
-      // eslint-disable-next-line no-template-curly-in-string
-      text: 'first link (${myKey})',
+      url: 'http://example.com/?myKey=#{myKey}',
+      text: 'first link (#{myKey})',
     },
     {
       key: 'myOtherKey',
-      // eslint-disable-next-line no-template-curly-in-string
-      url: 'http://example.com/?myKey=${myOtherKey}&myKey=${myKey}',
-      // eslint-disable-next-line no-template-curly-in-string
-      text: 'second link (${myOtherKey})',
+      url: 'http://example.com/?myKey=#{myOtherKey}&myKey=#{myKey}',
+      text: 'second link (#{myOtherKey})',
     },
   ].map(processLinkPattern);
 
@@ -335,10 +329,8 @@ describe('getLinks()', () => {
   const linkPatterns = [
     {
       key: 'mySpecialKey',
-      // eslint-disable-next-line no-template-curly-in-string
-      url: 'http://example.com/?mySpecialKey=${mySpecialKey}',
-      // eslint-disable-next-line no-template-curly-in-string
-      text: 'special key link (${mySpecialKey})',
+      url: 'http://example.com/?mySpecialKey=#{mySpecialKey}',
+      text: 'special key link (#{mySpecialKey})',
     },
   ].map(processLinkPattern);
   const template = jest.spyOn(linkPatterns[0].url, 'template');

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { processTemplate, createTestFunction } from './link-patterns';
+import { processTemplate, createTestFunction, getParameterInArray } from './link-patterns';
 
 describe('processTemplate()', () => {
   it('correctly replaces variables', () => {
@@ -133,11 +133,27 @@ describe('createTestFunction()', () => {
   });
 });
 
+describe('getParameterInArray()', () => {
+  const data = [{ key: 'mykey', value: 'ok' }, { key: 'otherkey', value: 'v' }];
+
+  it('returns an entry that is present', () => {
+    expect(getParameterInArray('mykey', data)).toBe(data[0]);
+    expect(getParameterInArray('otherkey', data)).toBe(data[1]);
+  });
+
+  it('returns undefined when the entry cannot be found', () => {
+    expect(getParameterInArray('myotherkey', data)).toBeUndefined();
+  });
+
+  it('returns undefined when there is no array', () => {
+    expect(getParameterInArray('otherkey')).toBeUndefined();
+    expect(getParameterInArray('otherkey', null)).toBeUndefined();
+  });
+});
+
 // TODO:
 /*
 describe('processLinkPattern()', () => {});
-
-describe('getParameterInArray()', () => {});
 
 describe('getParameterInAncestor()', () => {});
 

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -1,0 +1,85 @@
+// Copyright (c) 2017 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { processTemplate } from './link-patterns';
+
+describe('processTemplate()', () => {
+  it('correctly replaces variables', () => {
+    const processedTemplate = processTemplate(
+      // eslint-disable-next-line no-template-curly-in-string
+      'this is a test with ${oneVariable}${anotherVariable} and the same ${oneVariable}',
+      a => a
+    );
+    expect(processedTemplate.parameters).toEqual(['oneVariable', 'anotherVariable']);
+    expect(processedTemplate.template('MYFIRSTVAR', 'SECOND')).toBe(
+      'this is a test with MYFIRSTVARSECOND and the same MYFIRSTVAR'
+    );
+  });
+
+  it('correctly uses the encoding function', () => {
+    const processedTemplate = processTemplate(
+      // eslint-disable-next-line no-template-curly-in-string
+      'this is a test with ${oneVariable}${anotherVariable} and the same ${oneVariable}',
+      e => `/${e}\\`
+    );
+    expect(processedTemplate.parameters).toEqual(['oneVariable', 'anotherVariable']);
+    expect(processedTemplate.template('MYFIRSTVAR', 'SECOND')).toBe(
+      'this is a test with /MYFIRSTVAR\\/SECOND\\ and the same /MYFIRSTVAR\\'
+    );
+  });
+
+  it('correctly returns the same object when passing an already processed template', () => {
+    const alreadyProcessed = {
+      parameters: ['b'],
+      template: b => `a${b}c`,
+    };
+    const processedTemplate = processTemplate(alreadyProcessed, a => a);
+    expect(processedTemplate).toBe(alreadyProcessed);
+  });
+
+  it('reports an error when passing an object that does not look like an already processed template', () => {
+    expect(() =>
+      processTemplate(
+        {
+          template: b => `a${b}c`,
+        },
+        a => a
+      )
+    ).toThrow();
+    expect(() =>
+      processTemplate(
+        {
+          parameters: ['b'],
+        },
+        a => a
+      )
+    ).toThrow();
+    expect(() => processTemplate({}, a => a)).toThrow();
+  });
+});
+
+// TODO:
+/*
+describe('createTestFunction()', () => {});
+
+describe('processLinkPattern()', () => {});
+
+describe('getParameterInArray()', () => {});
+
+describe('getParameterInAncestor()', () => {});
+
+describe('callTemplate()', () => {});
+
+describe('computeLinks()', () => {});
+*/

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -17,6 +17,7 @@ import {
   createTestFunction,
   getParameterInArray,
   getParameterInAncestor,
+  callTemplate,
 } from './link-patterns';
 
 describe('processTemplate()', () => {
@@ -276,11 +277,27 @@ describe('getParameterInAncestor()', () => {
   });
 });
 
+describe('callTemplate()', () => {
+  it('correctly calls the template', () => {
+    const template = {
+      parameters: ['myKey', 'otherKey'],
+      template: jest.fn(),
+    };
+    template.template.mockReturnValue('ok');
+    expect(
+      callTemplate(template, {
+        otherKey: 'valueForOtherKey',
+        myKey: 'forMyKey',
+      })
+    ).toBe('ok');
+    expect(template.template).toHaveBeenCalledTimes(1);
+    expect(template.template).toHaveBeenCalledWith('forMyKey', 'valueForOtherKey');
+  });
+});
+
 // TODO:
 /*
 describe('processLinkPattern()', () => {});
-
-describe('callTemplate()', () => {});
 
 describe('computeLinks()', () => {});
 

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -17,7 +17,6 @@ import {
   createTestFunction,
   getParameterInArray,
   getParameterInAncestor,
-  callTemplate,
   processLinkPattern,
   computeLinks,
 } from './link-patterns';
@@ -30,7 +29,7 @@ describe('processTemplate()', () => {
       a => a
     );
     expect(processedTemplate.parameters).toEqual(['oneVariable', 'anotherVariable']);
-    expect(processedTemplate.template('MYFIRSTVAR', 'SECOND')).toBe(
+    expect(processedTemplate.template({ oneVariable: 'MYFIRSTVAR', anotherVariable: 'SECOND' })).toBe(
       'this is a test with MYFIRSTVARSECOND and the same MYFIRSTVAR'
     );
   });
@@ -42,25 +41,30 @@ describe('processTemplate()', () => {
       e => `/${e}\\`
     );
     expect(processedTemplate.parameters).toEqual(['oneVariable', 'anotherVariable']);
-    expect(processedTemplate.template('MYFIRSTVAR', 'SECOND')).toBe(
+    expect(processedTemplate.template({ oneVariable: 'MYFIRSTVAR', anotherVariable: 'SECOND' })).toBe(
       'this is a test with /MYFIRSTVAR\\/SECOND\\ and the same /MYFIRSTVAR\\'
     );
   });
 
+  /*
+  // kept on ice until #123 is implemented:
+
   it('correctly returns the same object when passing an already processed template', () => {
     const alreadyProcessed = {
       parameters: ['b'],
-      template: b => `a${b}c`,
+      template: data => `a${data.b}c`,
     };
     const processedTemplate = processTemplate(alreadyProcessed, a => a);
     expect(processedTemplate).toBe(alreadyProcessed);
   });
 
+  */
+
   it('reports an error when passing an object that does not look like an already processed template', () => {
     expect(() =>
       processTemplate(
         {
-          template: b => `a${b}c`,
+          template: data => `a${data.b}c`,
         },
         a => a
       )
@@ -94,6 +98,9 @@ describe('createTestFunction()', () => {
     expect(testFn('otherValue')).toBe(false);
   });
 
+  /*
+  // kept on ice until #123 is implemented:
+
   it('accepts a regular expression', () => {
     const testFn = createTestFunction(/^my.*Value$/);
     expect(testFn('myValue')).toBe(true);
@@ -123,6 +130,8 @@ describe('createTestFunction()', () => {
     expect(mockCallback).toHaveBeenCalledTimes(4);
     expect(mockCallback).toHaveBeenCalledWith('otherValue');
   });
+
+  */
 
   it('accepts undefined', () => {
     const testFn = createTestFunction();
@@ -276,24 +285,6 @@ describe('getParameterInAncestor()', () => {
       },
     ];
     expect(getParameterInAncestor('a', spansWithUndefinedTags, 0)).toBeUndefined();
-  });
-});
-
-describe('callTemplate()', () => {
-  it('correctly calls the template', () => {
-    const template = {
-      parameters: ['myKey', 'otherKey'],
-      template: jest.fn(),
-    };
-    template.template.mockReturnValue('ok');
-    expect(
-      callTemplate(template, {
-        otherKey: 'valueForOtherKey',
-        myKey: 'forMyKey',
-      })
-    ).toBe('ok');
-    expect(template.template).toHaveBeenCalledTimes(1);
-    expect(template.template).toHaveBeenCalledWith('forMyKey', 'valueForOtherKey');
   });
 });
 

--- a/packages/jaeger-ui/src/model/span.js
+++ b/packages/jaeger-ui/src/model/span.js
@@ -1,0 +1,27 @@
+// @flow
+
+// Copyright (c) 2017 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Span } from '../types';
+
+/**
+ * Searches the span.references to find 'CHILD_OF' reference type or returns null.
+ * @param  {Span} span The span whose parent is to be returned.
+ * @return {Span|null} The parent span if there is one, null otherwise.
+ */
+export function getParent(span: Span) {
+  const parentRef = span.references ? span.references.find(ref => ref.refType === 'CHILD_OF') : null;
+  return parentRef ? parentRef.span : null;
+}

--- a/packages/jaeger-ui/src/model/transform-trace-data.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.js
@@ -21,6 +21,21 @@ import type { Process, Span, SpanData, Trace, TraceData } from '../types';
 
 type SpanWithProcess = SpanData & { process: Process };
 
+export function addSpanReferences(spans: Span[]) {
+  const spansMap = new Map();
+  spans.forEach(span => spansMap.set(span.spanID, span));
+  spans.forEach(span => {
+    span.references.forEach(ref => {
+      const refSpan = spansMap.get(ref.spanID);
+      if (refSpan) {
+        // eslint-disable-next-line no-param-reassign
+        ref.span = refSpan;
+      }
+    });
+  });
+  return spans;
+}
+
 /**
  * NOTE: Mutates `data` - Transform the HTTP response data into the form the app
  * generally requires.
@@ -101,6 +116,9 @@ export default function transfromTraceData(data: TraceData & { spans: SpanWithPr
       traceID: span.traceID,
     });
   });
+
+  addSpanReferences(spans);
+
   return {
     spans,
     traceID,

--- a/packages/jaeger-ui/src/types/index.js
+++ b/packages/jaeger-ui/src/types/index.js
@@ -40,6 +40,8 @@ export type Process = {
 
 export type SpanReference = {
   refType: 'CHILD_OF' | 'FOLLOWS_FROM',
+  // eslint-disable-next-line no-use-before-define
+  span: Span,
   spanID: string,
   traceID: string,
 };

--- a/packages/jaeger-ui/src/types/index.js
+++ b/packages/jaeger-ui/src/types/index.js
@@ -41,7 +41,7 @@ export type Process = {
 export type SpanReference = {
   refType: 'CHILD_OF' | 'FOLLOWS_FROM',
   // eslint-disable-next-line no-use-before-define
-  span: Span,
+  span: ?Span,
   spanID: string,
   traceID: string,
 };

--- a/packages/jaeger-ui/src/types/index.js
+++ b/packages/jaeger-ui/src/types/index.js
@@ -18,9 +18,14 @@
  * All timestamps are in microseconds
  */
 
-type KeyValuePair = {
+export type KeyValuePair = {
   key: string,
   value: any,
+};
+
+export type Link = {
+  url: string,
+  text: string,
 };
 
 export type Log = {


### PR DESCRIPTION
This pull request contains an implementation of the feature described in #216.

It allows to define in the configuration some patterns so that the values of keys from the `Tags`, `Process` and `Logs` sections become clickable links that open the configured URL.

This has to be configured in the new `linkPatterns` property. For example:

```json
{
  "linkPatterns": [{
    "type": "process",
    "key": "jaeger.version",
    "url": "https://github.com/jaegertracing/jaeger-client-go/releases/tag/#{jaeger.version}",
    "text": "Information about Jaeger release #{jaeger.version}"
  }]
}
```

When this is declared in the configuration, every time the `jaeger.version` key appears in the `process` section, the value of that key will be displayed as a clickable link, with an icon on the right to show that the value is clickable, for example:

![jaeger link](https://user-images.githubusercontent.com/1152706/42288023-66439c8c-7fb9-11e8-9eba-e46063ed8a09.png)


If several patterns match the same tag, clicking on the value will display a popup with all the links:

![jaeger multiple links](https://user-images.githubusercontent.com/1152706/42288044-72eb6064-7fb9-11e8-8ef0-78d1350d2cc3.png)


Links are opened in a new window or tab.

In the configuration of a link, there are two kinds of properties:
- test properties: they determine whether the link should be displayed. These properties can contain a string or an array of strings specifying the possible values of that property that lead to the display of the link. All test properties must match for the link to be displayed. If a test property is not defined, it is considered to match.
  - `type` (possible values: `process`, `logs` or `tags`)
  - `key`
  - `value`
- template properties: they determine the url and text of the link. They are simple templates where each occurrence of `#{key}` is replaced by the value of the given `key`.
  - `url`: each replacement in the URL is wrapped in a call to `encodeURIComponent`
  - `text`: if there is only one link, the text of the link is displayed as a tooltip, if there are multiple links the text is displayed in the popup menu

  Template properties can depend on the value of the following keys:
  - for type `process`, only the keys in the current process can be used
  - for other types, the search order is the following:
    - for type `logs`: the keys present in the log  
    - the keys of the tags or process in the span on which the log or tag being rendered can be found
    - the keys of the tags or process in the parent span according to the CHILD_OF hierarchy
    - other parents in the CHILD_OF hierarchy...


**Commented extra features**

Note that this PR originally also implemented the following possibilities that rely on the implementation of #123 (which allows the use of any JS expression instead of only JSON in the configuration). Those features have been commented in the code of the PR.
- test properties can contain functions or regular expressions instead of containing only strings or arrays of strings
- template properties can be implemented as an object containing two properties:
  - parameters: an array of strings specifying which keys are needed
  - template: a function that receives as its only argument an object with the keys declared in the `parameters` array and returns the url or the text of the link

For example, once #123 is implemented and the corresponding code is uncommented, the previous example can also be configured in the following equivalent way (using functions):

```js
const JAEGER_CONFIG = {
  linkPatterns: [{
    type: (type) => type === "process",
    key: (key) => key === "jaeger.version",
    url: {
      parameters: ["jaeger.version"],
      template: data => `https://github.com/jaegertracing/jaeger-client-go/releases/tag/${encodeURIComponent(data["jaeger.version"])}`
    },
    text: {
      parameters: ["jaeger.version"],
      template: data => `Information about Jaeger release ${data["jaeger.version"]}`
    }
  }]
}
```

Thank you in advance for your comments.
