### PR TITLE
Fix CollapseOne action

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.js
@@ -138,7 +138,9 @@ export function collapseOne(state, { payload }) {
   const childrenHiddenIDs = spans.reduce((res, curSpan) => {
     if (nearestCollapsedAncestor && curSpan.depth <= nearestCollapsedAncestor.depth) {
       res.add(nearestCollapsedAncestor.spanID);
-      nearestCollapsedAncestor = curSpan;
+      if (curSpan.hasChildren) {
+        nearestCollapsedAncestor = curSpan;
+      }
     } else if (curSpan.hasChildren && !res.has(curSpan.spanID)) {
       nearestCollapsedAncestor = curSpan;
     }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
@@ -135,12 +135,14 @@ describe('TraceTimelineViewer/duck', () => {
     // --- 2
     // - 3
     // --- 4
+    // - 5
     const spans = [
       { spanID: 0, depth: 0, hasChildren: true },
       { spanID: 1, depth: 1, hasChildren: true },
       { spanID: 2, depth: 2, hasChildren: false },
       { spanID: 3, depth: 1, hasChildren: true },
       { spanID: 4, depth: 2, hasChildren: false },
+      { spanID: 5, depth: 1, hasChildren: false },
     ];
 
     const oneSpanCollapsed = new Set([1]);


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves #229 

## Short description of the changes
`nearestCollapsedAncestor` should always have children otherwise in some particular cases (see test) it will be incorrectly added to `childrenHiddenIDs`.