### PR TITLE
Embedded components (SearchTraces and Tracepage )

### DIFF
--- a/packages/jaeger-ui/src/components/App/Page.js
+++ b/packages/jaeger-ui/src/components/App/Page.js
@@ -20,7 +20,7 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import type { Location } from 'react-router-dom';
 import { withRouter } from 'react-router-dom';
-
+import { isEmbed } from '../../utils/embedded';
 import TopNav from './TopNav';
 import { trackPageView } from '../../utils/tracking';
 
@@ -56,10 +56,12 @@ export class PageImpl extends React.Component<Props> {
       <div>
         <Helmet title="Jaeger UI" />
         <Layout>
-          <Header className="Page--topNav">
-            <TopNav />
-          </Header>
-          <Content className="Page--content">{this.props.children}</Content>
+          {!isEmbed(this.props.search) && (
+            <Header className="Page--topNav">
+              <TopNav />
+            </Header>
+          )}
+          <Content className={!isEmbed(this.props.search) && 'Page--content'}>{this.props.children}</Content>
         </Layout>
       </div>
     );

--- a/packages/jaeger-ui/src/components/App/Page.test.js
+++ b/packages/jaeger-ui/src/components/App/Page.test.js
@@ -61,4 +61,23 @@ describe('<Page>', () => {
     wrapper.setProps(props);
     expect(trackPageView.mock.calls).toEqual([[props.pathname, props.search]]);
   });
+
+  describe('Page embedded', () => {
+    beforeEach(() => {
+      trackPageView.mockReset();
+      props = {
+        pathname: String(Math.random()),
+        search: 'embed=v0&hideGraph',
+      };
+      wrapper = mount(<Page {...props} />);
+    });
+
+    it('does not explode', () => {
+      expect(wrapper).toBeDefined();
+    });
+
+    it('does not render Header', () => {
+      expect(wrapper.find('Header').length).toBe(0);
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.js
@@ -36,6 +36,7 @@ type Props = {
   linkTo: string,
   toggleComparison: string => void,
   trace: Trace,
+  disableComparision: boolean,
 };
 
 const isErrorTag = ({ key, value }) => key === 'error' && (value === true || value === 'true');
@@ -44,7 +45,14 @@ export default class ResultItem extends React.PureComponent<Props> {
   props: Props;
 
   render() {
-    const { durationPercent, isInDiffCohort, linkTo, toggleComparison, trace } = this.props;
+    const {
+      disableComparision,
+      durationPercent,
+      isInDiffCohort,
+      linkTo,
+      toggleComparison,
+      trace,
+    } = this.props;
     const { duration, services, startTime, spans, traceName, traceID } = trace;
     const mDate = moment(startTime / 1000);
     const timeStr = mDate.format('h:mm:ss a');
@@ -61,6 +69,7 @@ export default class ResultItem extends React.PureComponent<Props> {
           toggleComparison={toggleComparison}
           traceID={traceID}
           traceName={traceName}
+          disableComparision={disableComparision}
         />
         <Link to={linkTo}>
           <Row>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.js
@@ -37,6 +37,7 @@ type Props = {
   toggleComparison: (string, boolean) => void,
   traceID: string,
   traceName: string,
+  disableComparision?: boolean,
 };
 
 export default class ResultItemTitle extends React.PureComponent<Props> {
@@ -64,6 +65,7 @@ export default class ResultItemTitle extends React.PureComponent<Props> {
       state,
       traceID,
       traceName,
+      disableComparision,
     } = this.props;
     let WrapperComponent = 'div';
     const wrapperProps: { [string]: string } = { className: 'ResultItemTitle--item ub-flex-auto' };
@@ -74,12 +76,14 @@ export default class ResultItemTitle extends React.PureComponent<Props> {
     const isErred = state === fetchedState.ERROR;
     return (
       <div className="ResultItemTitle">
-        <Checkbox
-          className="ResultItemTitle--item ub-flex-none"
-          checked={!isErred && isInDiffCohort}
-          disabled={isErred}
-          onChange={this.toggleComparison}
-        />
+        {!disableComparision && (
+          <Checkbox
+            className="ResultItemTitle--item ub-flex-none"
+            checked={!isErred && isInDiffCohort}
+            disabled={isErred}
+            onChange={this.toggleComparison}
+          />
+        )}
         <WrapperComponent {...wrapperProps}>
           <span className="ResultItemTitle--durationBar" style={{ width: `${durationPercent}%` }} />
           {duration != null && <span className="ub-right ub-relative">{formatDuration(duration)}</span>}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Select } from 'antd';
+import { Select, Button } from 'antd';
 import { Field, reduxForm, formValueSelector } from 'redux-form';
 
 import DiffSelection from './DiffSelection';
@@ -27,6 +27,7 @@ import * as orderBy from '../../../model/order-by';
 import { getPercentageOfDuration } from '../../../utils/date';
 import prefixUrl from '../../../utils/prefix-url';
 import reduxFormFieldAdapter from '../../../utils/redux-form-field-adapter';
+import { VERSION_API } from '../../../utils/embedded';
 
 import type { FetchedTrace } from '../../../types';
 
@@ -37,7 +38,10 @@ type SearchResultsProps = {
   cohortRemoveTrace: string => void,
   diffCohort: FetchedTrace[],
   goToTrace: string => void,
+  embed?: boolean,
+  hideGraph?: boolean,
   loading: boolean,
+  getSearchURL: () => string,
   maxTraceDuration: number,
   skipMessage?: boolean,
   traces: TraceSummary[],
@@ -85,8 +89,20 @@ export default class SearchResults extends React.PureComponent<SearchResultsProp
   };
 
   render() {
-    const { loading, diffCohort, skipMessage, traces } = this.props;
-    const diffSelection = <DiffSelection toggleComparison={this.toggleComparison} traces={diffCohort} />;
+    const {
+      loading,
+      diffCohort,
+      skipMessage,
+      traces,
+      goToTrace,
+      embed,
+      hideGraph,
+      getSearchURL,
+      maxTraceDuration,
+    } = this.props;
+    const diffSelection = !embed && (
+      <DiffSelection toggleComparison={this.toggleComparison} traces={diffCohort} />
+    );
     if (loading) {
       return (
         <React.Fragment>
@@ -107,28 +123,41 @@ export default class SearchResults extends React.PureComponent<SearchResultsProp
         </React.Fragment>
       );
     }
-    const { goToTrace, maxTraceDuration } = this.props;
     const cohortIds = new Set(diffCohort.map(datum => datum.id));
     return (
       <div>
         <div>
           <div className="SearchResults--header">
-            <div className="ub-p3">
-              <ScatterPlot
-                data={traces.map(t => ({
-                  x: t.startTime,
-                  y: t.duration,
-                  traceID: t.traceID,
-                  size: t.spans.length,
-                  name: t.traceName,
-                }))}
-                onValueClick={t => {
-                  goToTrace(t.traceID);
-                }}
-              />
-            </div>
+            {!hideGraph && (
+              <div className="ub-p3">
+                <ScatterPlot
+                  data={traces.map(t => ({
+                    x: t.startTime,
+                    y: t.duration,
+                    traceID: t.traceID,
+                    size: t.spans.length,
+                    name: t.traceName,
+                  }))}
+                  onValueClick={t => {
+                    goToTrace(t.traceID);
+                  }}
+                />
+              </div>
+            )}
             <div className="SearchResults--headerOverview">
               <SelectSort />
+              {embed && (
+                <label className="ub-right">
+                  <Button
+                    className="ub-mr2 ub-items-center"
+                    icon="export"
+                    target="_blank"
+                    href={getSearchURL()}
+                  >
+                    View Results
+                  </Button>
+                </label>
+              )}
               <h2 className="ub-m0">
                 {traces.length} Trace{traces.length > 1 && 's'}
               </h2>
@@ -143,9 +172,16 @@ export default class SearchResults extends React.PureComponent<SearchResultsProp
                 <ResultItem
                   durationPercent={getPercentageOfDuration(trace.duration, maxTraceDuration)}
                   isInDiffCohort={cohortIds.has(trace.traceID)}
-                  linkTo={prefixUrl(`/trace/${trace.traceID}`)}
+                  linkTo={prefixUrl(
+                    embed
+                      ? `/trace/${trace.traceID}?embed=${VERSION_API}&fromSearch=${encodeURIComponent(
+                          getSearchURL()
+                        )}`
+                      : `/trace/${trace.traceID}`
+                  )}
                   toggleComparison={this.toggleComparison}
                   trace={trace}
+                  disableComparision={embed}
                 />
               </li>
             ))}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
@@ -19,6 +19,7 @@ import SearchResults from './';
 import * as markers from './index.markers';
 import ResultItem from './ResultItem';
 import ScatterPlot from './ScatterPlot';
+import DiffSelection from './DiffSelection.js';
 import LoadingIndicator from '../../common/LoadingIndicator';
 
 describe('<SearchResults>', () => {
@@ -46,6 +47,16 @@ describe('<SearchResults>', () => {
   it('shows a loading indicator if loading traces', () => {
     wrapper.setProps({ loading: true });
     expect(wrapper.find(LoadingIndicator).length).toBe(1);
+  });
+
+  it('hide scatter plot if queryparam hideGraph', () => {
+    wrapper.setProps({ hideGraph: true });
+    expect(wrapper.find(ScatterPlot).length).toBe(0);
+  });
+
+  it('hide DiffSelection if is an embedded component', () => {
+    wrapper.setProps({ embed: true, getSearchURL: () => 'SEARCH_URL' });
+    expect(wrapper.find(DiffSelection).length).toBe(0);
   });
 
   describe('search finished with results', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -66,8 +66,7 @@ export class SearchTracePageImpl extends Component {
   };
 
   getSearchURL = () => {
-    const urlQuery = this.props.query;
-    delete urlQuery.embed;
+    const { embed: _, ...urlQuery } = this.props.query;
     return `/search?${queryString.stringify(urlQuery)}`;
   };
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -30,6 +30,7 @@ import { fetchedState } from '../../constants';
 import { sortTraces } from '../../model/search';
 import getLastXformCacher from '../../utils/get-last-xform-cacher';
 import prefixUrl from '../../utils/prefix-url';
+import { isEmbed } from '../../utils/embedded';
 
 import './index.css';
 import JaegerLogo from '../../img/jaeger-logo.svg';
@@ -60,7 +61,14 @@ export class SearchTracePageImpl extends Component {
   }
 
   goToTrace = traceID => {
-    this.props.history.push(prefixUrl(`/trace/${traceID}`));
+    const url = this.props.embed ? `/trace/${traceID}?embed` : `/trace/${traceID}`;
+    this.props.history.push(prefixUrl(url));
+  };
+
+  getSearchURL = () => {
+    const urlQuery = this.props.query;
+    delete urlQuery.embed;
+    return `/search?${queryString.stringify(urlQuery)}`;
   };
 
   render() {
@@ -75,6 +83,8 @@ export class SearchTracePageImpl extends Component {
       maxTraceDuration,
       services,
       traceResults,
+      embed,
+      hideGraph,
     } = this.props;
     const hasTraceResults = traceResults && traceResults.length > 0;
     const showErrors = errors && !loadingTraces;
@@ -82,13 +92,15 @@ export class SearchTracePageImpl extends Component {
     return (
       <div>
         <Row>
-          <Col span={6} className="SearchTracePage--column">
-            <div className="SearchTracePage--find">
-              <h2>Find Traces</h2>
-              {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
-            </div>
-          </Col>
-          <Col span={18} className="SearchTracePage--column">
+          {!embed && (
+            <Col span={6} className="SearchTracePage--column">
+              <div className="SearchTracePage--find">
+                <h2>Find Traces</h2>
+                {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
+              </div>
+            </Col>
+          )}
+          <Col span={!embed ? 18 : 24} className="SearchTracePage--column">
             {showErrors && (
               <div className="js-test-error-message">
                 <h2>There was an error querying for traces:</h2>
@@ -104,17 +116,21 @@ export class SearchTracePageImpl extends Component {
                 cohortRemoveTrace={cohortRemoveTrace}
                 diffCohort={diffCohort}
                 skipMessage={isHomepage}
+                getSearchURL={this.getSearchURL}
                 traces={traceResults}
+                embed={embed}
+                hideGraph={hideGraph}
               />
             )}
-            {showLogo && (
-              <img
-                className="SearchTracePage--logo js-test-logo"
-                alt="presentation"
-                src={JaegerLogo}
-                width="400"
-              />
-            )}
+            {showLogo &&
+              !embed && (
+                <img
+                  className="SearchTracePage--logo js-test-logo"
+                  alt="presentation"
+                  src={JaegerLogo}
+                  width="400"
+                />
+              )}
           </Col>
         </Row>
       </div>
@@ -123,7 +139,10 @@ export class SearchTracePageImpl extends Component {
 }
 
 SearchTracePageImpl.propTypes = {
+  query: PropTypes.object,
   isHomepage: PropTypes.bool,
+  embed: PropTypes.bool,
+  hideGraph: PropTypes.bool,
   // eslint-disable-next-line react/forbid-prop-types
   traceResults: PropTypes.array,
   diffCohort: PropTypes.array,
@@ -196,6 +215,7 @@ const stateServicesXformer = getLastXformCacher(stateServices => {
 // export to test
 export function mapStateToProps(state) {
   const query = queryString.parse(state.router.location.search);
+  const { hideGraph } = queryString.parse(state.router.location.search);
   const isHomepage = !Object.keys(query).length;
   const { traces, maxDuration, traceError, loadingTraces } = stateTraceXformer(state.trace);
   const diffCohort = stateTraceDiffXformer(state.trace, state.traceDiff);
@@ -210,7 +230,10 @@ export function mapStateToProps(state) {
   const sortBy = sortFormSelector(state, 'sortBy');
   const traceResults = sortedTracesXformer(traces, sortBy);
   return {
+    query,
     diffCohort,
+    embed: isEmbed(state.router.location.search),
+    hideGraph: hideGraph !== undefined,
     isHomepage,
     loadingServices,
     loadingTraces,

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import queryString from 'query-string';
+
 jest.mock('redux-form', () => {
   function reduxForm() {
     return component => component;
@@ -48,6 +50,7 @@ describe('<SearchTracePage>', () => {
     traceResults = [{ traceID: 'a', spans: [], processes: {} }, { traceID: 'b', spans: [], processes: {} }];
     props = {
       traceResults,
+      embed: false,
       isHomepage: false,
       loadingServices: false,
       loadingTraces: false,
@@ -80,6 +83,12 @@ describe('<SearchTracePage>', () => {
     store.get = oldFn;
   });
 
+  it('return the searchpath if call getSearchURL', () => {
+    const query = "end=1542906238737000&limit=20&lookback=1h&maxDuration&minDuration&service=productpage&start=1542902638737000"
+    wrapper = mount(<SearchTracePage {...props} query={query}/>);
+    expect(wrapper.instance().getSearchURL()).toBe(`/search?${queryString.stringify(query)}`);
+  });
+
   it('shows a loading indicator if loading services', () => {
     wrapper.setProps({ loadingServices: true });
     expect(wrapper.find(LoadingIndicator).length).toBe(1);
@@ -99,6 +108,16 @@ describe('<SearchTracePage>', () => {
   it('shows the logo prior to searching', () => {
     wrapper.setProps({ isHomepage: true, traceResults: [] });
     expect(wrapper.find('.js-test-logo').length).toBe(1);
+  });
+
+  it('hide SearchForm if is embed', () => {
+    wrapper.setProps({ embed: true });
+    expect(wrapper.find(SearchForm).length).toBe(0);
+  });
+
+  it('hide logo if is embed', () => {
+    wrapper.setProps({ embed: true });
+    expect(wrapper.find('.js-test-logo').length).toBe(0);
   });
 });
 
@@ -140,6 +159,9 @@ describe('mapStateToProps()', () => {
     expect(diffCohort[0].data.traceID).toBe(trace.traceID);
 
     expect(rest).toEqual({
+      embed: false,
+      hideGraph: false,
+      query: {},
       isHomepage: true,
       // the redux-form `formValueSelector` mock returns `null` for "sortBy"
       sortTracesBy: null,

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader.css
@@ -19,7 +19,15 @@ limitations under the License.
   display: flex;
 }
 
-.TracePageHeader--title {
+.TracePageHeader--titleRowEmbed {
+  align-items: center;
+  background-color: #ececec;
+  border-bottom: 1px solid #d8d8d8;
+  display: flex;
+}
+
+.TracePageHeader--title,
+.TracePageHeader--titleEmbed {
   margin: 0;
   padding: 0.25rem 0.5rem;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeaderEmbed.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeaderEmbed.test.js
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { TracePageHeaderEmbedFn as TracePageHeaderEmbed, HEADER_ITEMS } from './TracePageHeaderEmbed';
+import LabeledList from '../common/LabeledList';
+
+describe('<TracePageHeaderEmbed>', () => {
+  const defaultProps = {
+    traceID: 'some-trace-id',
+    name: 'some-trace-name',
+    textFilter: '',
+    updateTextFilter: () => {},
+  };
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<TracePageHeaderEmbed {...defaultProps} />);
+  });
+
+  it('renders a <header />', () => {
+    expect(wrapper.find('header').length).toBe(1);
+  });
+
+  it('renders an empty <div> if no traceID is present', () => {
+    wrapper = mount(<TracePageHeaderEmbed {...defaultProps} traceID={null} />);
+    expect(wrapper.children().length).toBe(0);
+  });
+
+  it('renders the trace title', () => {
+    const h1 = wrapper.find('h1').first();
+    expect(h1.contains(defaultProps.name)).toBeTruthy();
+  });
+
+  it('renders the header items', () => {
+    wrapper.find('.horizontal .item').forEach((item, i) => {
+      expect(item.contains(HEADER_ITEMS[i].title)).toBeTruthy();
+      expect(item.contains(HEADER_ITEMS[i].renderer(defaultProps.trace))).toBeTruthy();
+    });
+  });
+
+  it('show details if queryparam enableDetails', () => {
+    wrapper.setProps({ enableDetails: true });
+    expect(wrapper.find(LabeledList).length).toBe(1);
+  });
+
+});

--- a/packages/jaeger-ui/src/utils/embedded/index.js
+++ b/packages/jaeger-ui/src/utils/embedded/index.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import queryString from 'query-string';
+
+export const VERSION_API = 'v0';
+
+export function isEmbed(query: string) {
+  const { embed } = queryString.parse(query);
+  if (embed === VERSION_API) {
+    return true;
+  }
+  return false;
+}

--- a/packages/jaeger-ui/src/utils/embedded/index.test.js
+++ b/packages/jaeger-ui/src/utils/embedded/index.test.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as embedded from './index';
+
+describe('isEmbed', () => {
+  it('query request a embed component', () => {
+    const query = 'embed=v0&hideGraph&mapCollapsed';
+    expect(embedded.isEmbed(query)).toBeTruthy();
+  });
+
+  it('query request a embed component with an icorrect version', () => {
+    const query = 'embed=v1&hideGraph&mapCollapsed';
+    expect(embedded.isEmbed(query)).toBeFalsy();
+  });
+
+  it('query not request a embed component', () => {
+    const query = 'hideGraph&mapCollapsed';
+    expect(embedded.isEmbed(query)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Related issue : https://github.com/jaegertracing/jaeger-ui/issues/248

The point is make a PoC about how whould this look .

We have here 2 uses of cases:

- Show the results of a search
![results](https://user-images.githubusercontent.com/3019213/46605033-6cbfa800-caf8-11e8-8999-3627f007f1f2.png)

- Show a Trace
![trace](https://user-images.githubusercontent.com/3019213/46605027-64676d00-caf8-11e8-90e9-05301064d285.png)


So I added query param called **embed**, with this params the top navigation and search are removed.
**See demo GIF**

![embed_components](https://user-images.githubusercontent.com/3019213/46604968-371abf00-caf8-11e8-9c17-04a8ac02ba86.gif)


# How works ? pass **embed** like a query param

# TracePage View
![trace](https://user-images.githubusercontent.com/3019213/48301215-86368400-e4ea-11e8-8ddd-f32fe3606896.gif)

- **minimap** option
- **details** option

# SearchTraces View
![search](https://user-images.githubusercontent.com/3019213/48301216-86cf1a80-e4ea-11e8-8e91-ede8c70fa9db.gif)

- **disableComparision** option
- **hideGraph** option


