### PR TITLE
Use correct duration format for scatter plot

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.test.js
+++ b/packages/jaeger-ui/src/api/jaeger.test.js
@@ -28,7 +28,7 @@ import fetchMock from 'isomorphic-fetch';
 import traceGenerator from '../demo/trace-generators';
 import JaegerAPI, { getMessageFromError } from './jaeger';
 
-const generatedTraces = traceGenerator.traces({ traces: 5 });
+const generatedTraces = traceGenerator.traces({ numberOfTraces: 5 });
 
 it('fetchTrace() should fetch with the id', () => {
   fetchMock.mockClear();

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.js
@@ -37,7 +37,7 @@ function ScatterPlotImpl(props) {
         height={200}
       >
         <XAxis title="Time" tickTotal={4} tickFormat={t => moment(t).format('hh:mm:ss a')} />
-        <YAxis title="Duration" tickTotal={3} tickFormat={t => formatDuration(t, 'milliseconds')} />
+        <YAxis title="Duration" tickTotal={3} tickFormat={t => formatDuration(t)} />
         <MarkSeries
           sizeRange={[3, 10]}
           opacity={0.5}


### PR DESCRIPTION
Fix #253.

>Trace duration unit in scatterplot is always 'seconds'