### PR TITLE
[Embed] Fix hideGraph queryParam with not embedded component

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -128,7 +128,7 @@ export default class SearchResults extends React.PureComponent<SearchResultsProp
       <div>
         <div>
           <div className="SearchResults--header">
-            {!hideGraph && (
+            {(!embed || !hideGraph) && (
               <div className="ub-p3">
                 <ScatterPlot
                   data={traces.map(t => ({

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
@@ -50,7 +50,7 @@ describe('<SearchResults>', () => {
   });
 
   it('hide scatter plot if queryparam hideGraph', () => {
-    wrapper.setProps({ hideGraph: true });
+    wrapper.setProps({ hideGraph: true, embed: true, getSearchURL: () => 'SEARCH_URL' });
     expect(wrapper.find(ScatterPlot).length).toBe(0);
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?
- When you use the search traces with the embed and hideGraph option the view results button don't how the result expected, instead of the full results in Jaeger, the ScatterPlot is missed
![no_graph](https://user-images.githubusercontent.com/3019213/49172563-b92da400-f341-11e8-9ba5-a838f090df42.gif)


## Short description of the changes
- Show the scatterPlot in the search traces when the user come from embed view.
![yes_graph](https://user-images.githubusercontent.com/3019213/49172571-bcc12b00-f341-11e8-9227-b618864911da.gif)
