### PR TITLE
Add popover and prevent submit if duration params are invalid (#244)

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -38,9 +38,12 @@ import './SearchForm.css';
 const FormItem = Form.Item;
 const Option = Select.Option;
 
-const AdaptedInput = reduxFormFieldAdapter(Input);
-const AdaptedSelect = reduxFormFieldAdapter(Select);
-const AdaptedVirtualSelect = reduxFormFieldAdapter(VirtSelect, option => (option ? option.value : null));
+const AdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input, isValidatedInput: true });
+const AdaptedSelect = reduxFormFieldAdapter({ AntInputComponent: Select });
+const AdaptedVirtualSelect = reduxFormFieldAdapter({
+  AntInputComponent: VirtSelect,
+  onChangeAdapter: option => (option ? option.value : null),
+});
 
 export function getUnixTimeStampInMSFromForm({ startDate, startDateTime, endDate, endDateTime }) {
   const start = `${startDate} ${startDateTime}`;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -74,6 +74,17 @@ export function traceIDsToQuery(traceIDs) {
   return traceIDs.split(',');
 }
 
+export const placeholderDurationFields = 'e.g. 1.2s, 100ms, 500us';
+export function validateDurationFields(value) {
+  if (!value) return undefined;
+  return /\d[\d\\.]*(us|ms|s|m|h)$/.test(value)
+    ? undefined
+    : {
+        content: `Please enter a number followed by a duration unit, ${placeholderDurationFields}`,
+        title: 'Please match the requested format.',
+      };
+}
+
 export function convertQueryParamsToFormDates({ start, end }) {
   let queryStartDate;
   let queryStartDateTime;
@@ -155,6 +166,7 @@ export class SearchFormImpl extends React.PureComponent {
   render() {
     const {
       handleSubmit,
+      invalid,
       selectedLookback,
       selectedService = '-',
       services,
@@ -323,13 +335,20 @@ export class SearchFormImpl extends React.PureComponent {
           <Field
             name="minDuration"
             component={AdaptedInput}
-            placeholder="e.g. 1.2s, 100ms, 500us"
+            placeholder={placeholderDurationFields}
             props={{ disabled }}
+            validate={validateDurationFields}
           />
         </FormItem>
 
         <FormItem label="Max Duration">
-          <Field name="maxDuration" component={AdaptedInput} placeholder="e.g. 1.1s" props={{ disabled }} />
+          <Field
+            name="maxDuration"
+            component={AdaptedInput}
+            placeholder={placeholderDurationFields}
+            props={{ disabled }}
+            validate={validateDurationFields}
+          />
         </FormItem>
 
         <FormItem label="Limit Results">
@@ -342,7 +361,11 @@ export class SearchFormImpl extends React.PureComponent {
           />
         </FormItem>
 
-        <Button htmlType="submit" disabled={disabled || noSelectedService} data-test={markers.SUBMIT_BTN}>
+        <Button
+          htmlType="submit"
+          disabled={disabled || noSelectedService || invalid}
+          data-test={markers.SUBMIT_BTN}
+        >
           Find Traces
         </Button>
       </Form>
@@ -352,6 +375,7 @@ export class SearchFormImpl extends React.PureComponent {
 
 SearchFormImpl.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
+  invalid: PropTypes.boolean,
   submitting: PropTypes.bool,
   services: PropTypes.arrayOf(
     PropTypes.shape({
@@ -364,6 +388,7 @@ SearchFormImpl.propTypes = {
 };
 
 SearchFormImpl.defaultProps = {
+  invalid: false,
   services: [],
   submitting: false,
   selectedService: null,

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -38,12 +38,13 @@ import './SearchForm.css';
 const FormItem = Form.Item;
 const Option = Select.Option;
 
-const AdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input, isValidatedInput: true });
+const AdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input });
 const AdaptedSelect = reduxFormFieldAdapter({ AntInputComponent: Select });
 const AdaptedVirtualSelect = reduxFormFieldAdapter({
   AntInputComponent: VirtSelect,
   onChangeAdapter: option => (option ? option.value : null),
 });
+const ValidatedAdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input, isValidatedInput: true });
 
 export function getUnixTimeStampInMSFromForm({ startDate, startDateTime, endDate, endDateTime }) {
   const start = `${startDate} ${startDateTime}`;
@@ -337,7 +338,7 @@ export class SearchFormImpl extends React.PureComponent {
         <FormItem label="Min Duration">
           <Field
             name="minDuration"
-            component={AdaptedInput}
+            component={ValidatedAdaptedInput}
             placeholder={placeholderDurationFields}
             props={{ disabled }}
             validate={validateDurationFields}
@@ -347,7 +348,7 @@ export class SearchFormImpl extends React.PureComponent {
         <FormItem label="Max Duration">
           <Field
             name="maxDuration"
-            component={AdaptedInput}
+            component={ValidatedAdaptedInput}
             placeholder={placeholderDurationFields}
             props={{ disabled }}
             validate={validateDurationFields}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -375,7 +375,7 @@ export class SearchFormImpl extends React.PureComponent {
 
 SearchFormImpl.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
-  invalid: PropTypes.boolean,
+  invalid: PropTypes.bool,
   submitting: PropTypes.bool,
   services: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
@@ -29,6 +29,7 @@ import {
   submitForm,
   traceIDsToQuery,
   SearchFormImpl as SearchForm,
+  validateDurationFields,
 } from './SearchForm';
 import * as markers from './SearchForm.markers';
 
@@ -274,6 +275,36 @@ describe('<SearchForm>', () => {
     wrapper = shallow(<SearchForm {...defaultProps} selectedService="svcA" />);
     btn = wrapper.find(`[data-test="${markers.SUBMIT_BTN}"]`);
     expect(btn.prop('disabled')).toBeFalsy();
+  });
+
+  it('disables the submit button when the form has invalid data', () => {
+    wrapper = shallow(<SearchForm {...defaultProps} selectedService="svcA" />);
+    let btn = wrapper.find(`[data-test="${markers.SUBMIT_BTN}"]`);
+    // If this test fails on the following expect statement, this may be a false negative caused by a separate
+    // regression.
+    expect(btn.prop('disabled')).toBeFalsy();
+    wrapper.setProps({ invalid: true });
+    btn = wrapper.find(`[data-test="${markers.SUBMIT_BTN}"]`);
+    expect(btn.prop('disabled')).toBeTruthy();
+  });
+});
+
+describe('validation', () => {
+  it('should return `undefined` if the value is falsy', () => {
+    expect(validateDurationFields('')).toBeUndefined();
+    expect(validateDurationFields(null)).toBeUndefined();
+    expect(validateDurationFields(undefined)).toBeUndefined();
+  });
+
+  it('should return Popover-compliant error object if the value is a populated string that does not adhere to expected format', () => {
+    expect(validateDurationFields('100')).toEqual({
+      content: 'Please enter a number followed by a duration unit, e.g. 1.2s, 100ms, 500us',
+      title: 'Please match the requested format.',
+    });
+  });
+
+  it('should return `undefined` if the value is a populated string that adheres to expected format', () => {
+    expect(validateDurationFields('100ms')).toBeUndefined();
   });
 });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -61,7 +61,7 @@ function SelectSortImpl() {
   return (
     <label>
       Sort:{' '}
-      <Field name="sortBy" component={reduxFormFieldAdapter(Select)}>
+      <Field name="sortBy" component={reduxFormFieldAdapter({ AntInputComponent: Select })}>
         <Option value={orderBy.MOST_RECENT}>Most Recent</Option>
         <Option value={orderBy.LONGEST_FIRST}>Longest First</Option>
         <Option value={orderBy.SHORTEST_FIRST}>Shortest First</Option>

--- a/packages/jaeger-ui/src/utils/__snapshots__/redux-form-field-adapter.test.js.snap
+++ b/packages/jaeger-ui/src/utils/__snapshots__/redux-form-field-adapter.test.js.snap
@@ -1,6 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reduxFormFieldAdapter should render Popover as invisible if there is an error but the field has not been touched 1`] = `
+exports[`reduxFormFieldAdapter not validated input should render as expected 1`] = `
+<Input
+  className=""
+  disabled={false}
+  meta={
+    Object {
+      "active": false,
+      "error": null,
+    }
+  }
+  onBlur={null}
+  onChange={[Function]}
+  onFocus={null}
+  prefixCls="ant-input"
+  type="text"
+  value="inputValue"
+/>
+`;
+
+exports[`reduxFormFieldAdapter validate input should render Popover as invisible if there is an error but the field is active 1`] = `
 <Popover
   content="error content"
   mouseEnterDelay={0.1}
@@ -14,15 +33,15 @@ exports[`reduxFormFieldAdapter should render Popover as invisible if there is an
   visible={false}
 >
   <Input
-    className=""
+    className="AdaptedReduxFormField--isValidatedInput"
     disabled={false}
     meta={
       Object {
+        "active": true,
         "error": Object {
           "content": "error content",
           "title": "error title",
         },
-        "touched": false,
       }
     }
     onBlur={[Function]}
@@ -34,7 +53,7 @@ exports[`reduxFormFieldAdapter should render Popover as invisible if there is an
 </Popover>
 `;
 
-exports[`reduxFormFieldAdapter should render Popover as visible if there is an error and the field has been touched 1`] = `
+exports[`reduxFormFieldAdapter validate input should render Popover as visible if there is an error and the field is not active 1`] = `
 <Popover
   content="error content"
   mouseEnterDelay={0.1}
@@ -48,15 +67,15 @@ exports[`reduxFormFieldAdapter should render Popover as visible if there is an e
   visible={true}
 >
   <Input
-    className="is-invalid"
+    className="is-invalid AdaptedReduxFormField--isValidatedInput"
     disabled={false}
     meta={
       Object {
+        "active": false,
         "error": Object {
           "content": "error content",
           "title": "error title",
         },
-        "touched": true,
       }
     }
     onBlur={[Function]}
@@ -68,7 +87,7 @@ exports[`reduxFormFieldAdapter should render Popover as visible if there is an e
 </Popover>
 `;
 
-exports[`reduxFormFieldAdapter should render as expected when there is not an error 1`] = `
+exports[`reduxFormFieldAdapter validate input should render as expected when there is not an error 1`] = `
 <Popover
   mouseEnterDelay={0.1}
   mouseLeaveDelay={0.1}
@@ -80,12 +99,12 @@ exports[`reduxFormFieldAdapter should render as expected when there is not an er
   visible={false}
 >
   <Input
-    className=""
+    className="AdaptedReduxFormField--isValidatedInput"
     disabled={false}
     meta={
       Object {
+        "active": false,
         "error": null,
-        "touched": false,
       }
     }
     onBlur={[Function]}

--- a/packages/jaeger-ui/src/utils/__snapshots__/redux-form-field-adapter.test.js.snap
+++ b/packages/jaeger-ui/src/utils/__snapshots__/redux-form-field-adapter.test.js.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reduxFormFieldAdapter should render Popover as invisible if there is an error but the field has not been touched 1`] = `
+<Popover
+  content="error content"
+  mouseEnterDelay={0.1}
+  mouseLeaveDelay={0.1}
+  overlayStyle={Object {}}
+  placement="bottomLeft"
+  prefixCls="ant-popover"
+  title="error title"
+  transitionName="zoom-big"
+  trigger="hover"
+  visible={false}
+>
+  <Input
+    className=""
+    disabled={false}
+    meta={
+      Object {
+        "error": Object {
+          "content": "error content",
+          "title": "error title",
+        },
+        "touched": false,
+      }
+    }
+    onBlur={[Function]}
+    onChange={[Function]}
+    prefixCls="ant-input"
+    type="text"
+    value="inputValue"
+  />
+</Popover>
+`;
+
+exports[`reduxFormFieldAdapter should render Popover as visible if there is an error and the field has been touched 1`] = `
+<Popover
+  content="error content"
+  mouseEnterDelay={0.1}
+  mouseLeaveDelay={0.1}
+  overlayStyle={Object {}}
+  placement="bottomLeft"
+  prefixCls="ant-popover"
+  title="error title"
+  transitionName="zoom-big"
+  trigger="hover"
+  visible={true}
+>
+  <Input
+    className="is-invalid"
+    disabled={false}
+    meta={
+      Object {
+        "error": Object {
+          "content": "error content",
+          "title": "error title",
+        },
+        "touched": true,
+      }
+    }
+    onBlur={[Function]}
+    onChange={[Function]}
+    prefixCls="ant-input"
+    type="text"
+    value="inputValue"
+  />
+</Popover>
+`;
+
+exports[`reduxFormFieldAdapter should render as expected when there is not an error 1`] = `
+<Popover
+  mouseEnterDelay={0.1}
+  mouseLeaveDelay={0.1}
+  overlayStyle={Object {}}
+  placement="bottomLeft"
+  prefixCls="ant-popover"
+  transitionName="zoom-big"
+  trigger="hover"
+  visible={false}
+>
+  <Input
+    className=""
+    disabled={false}
+    meta={
+      Object {
+        "error": null,
+        "touched": false,
+      }
+    }
+    onBlur={[Function]}
+    onChange={[Function]}
+    prefixCls="ant-input"
+    type="text"
+    value="inputValue"
+  />
+</Popover>
+`;

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.css
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.css
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2018 Uber Technologies, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-input.ant-input.is-invalid {
-  border: rgba(255, 0, 0, 0.5) 1px solid;
-  background-color: rgba(255, 0, 0, 0.1);
+.AdaptedReduxFormField--isValidatedInput.is-invalid {
+  background: #fff9f8;
+  border: 1px solid #c00;
 }

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.css
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.css
@@ -1,0 +1,20 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+input.ant-input.is-invalid {
+  border: rgba(255, 0, 0, 0.5) 1px solid;
+  background-color: rgba(255, 0, 0, 0.1);
+}

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.js
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.js
@@ -20,25 +20,39 @@ import * as React from 'react';
 
 import './redux-form-field-adapter.css';
 
-export default function reduxFormFieldAdapter(
+export default function reduxFormFieldAdapter({
+  AntInputComponent,
+  onChangeAdapter,
+  isValidatedInput = false,
+}: {
   AntInputComponent: Class<React.Component<*, *>>,
-  onChangeAdapter: () => void
-) {
+  onChangeAdapter: () => void,
+  isValidatedInput: boolean,
+}) {
   return function _reduxFormFieldAdapter(props: any) {
-    // inputRest includes necessary props such as onBlur and value
-    const { input: { onChange, ...inputRest }, children, ...rest } = props;
-    const isInvalid = rest.meta.touched && !!rest.meta.error;
-    return (
+    const { input: { onBlur, onChange, onFocus, value }, children, ...rest } = props;
+    const isInvalid = !rest.meta.active && Boolean(rest.meta.error);
+    const content = (
+      <AntInputComponent
+        className={cx({
+          'is-invalid': isInvalid,
+          'AdaptedReduxFormField--isValidatedInput': isValidatedInput,
+        })}
+        onBlur={isValidatedInput ? onBlur : null}
+        onFocus={isValidatedInput ? onFocus : null}
+        onChange={onChangeAdapter ? (...args) => onChange(onChangeAdapter(...args)) : onChange}
+        value={value}
+        {...rest}
+      >
+        {children}
+      </AntInputComponent>
+    );
+    return isValidatedInput ? (
       <Popover placement={'bottomLeft'} visible={isInvalid} {...rest.meta.error}>
-        <AntInputComponent
-          className={cx({ 'is-invalid': isInvalid })}
-          onChange={onChangeAdapter ? (...args) => onChange(onChangeAdapter(...args)) : onChange}
-          {...inputRest}
-          {...rest}
-        >
-          {children}
-        </AntInputComponent>
+        {content}
       </Popover>
+    ) : (
+      content
     );
   };
 }

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.js
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.js
@@ -48,7 +48,7 @@ export default function reduxFormFieldAdapter({
       </AntInputComponent>
     );
     return isValidatedInput ? (
-      <Popover placement={'bottomLeft'} visible={isInvalid} {...rest.meta.error}>
+      <Popover placement="bottomLeft" visible={isInvalid} {...rest.meta.error}>
         {content}
       </Popover>
     ) : (

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.js
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.js
@@ -14,22 +14,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Popover } from 'antd';
+import cx from 'classnames';
 import * as React from 'react';
+
+import './redux-form-field-adapter.css';
 
 export default function reduxFormFieldAdapter(
   AntInputComponent: Class<React.Component<*, *>>,
   onChangeAdapter: () => void
 ) {
   return function _reduxFormFieldAdapter(props: any) {
-    const { input: { value, onChange }, children, ...rest } = props;
+    // inputRest includes necessary props such as onBlur and value
+    const { input: { onChange, ...inputRest }, children, ...rest } = props;
+    const isInvalid = rest.meta.touched && !!rest.meta.error;
     return (
-      <AntInputComponent
-        value={value}
-        onChange={onChangeAdapter ? (...args) => onChange(onChangeAdapter(...args)) : onChange}
-        {...rest}
-      >
-        {children}
-      </AntInputComponent>
+      <Popover placement={'bottomLeft'} visible={isInvalid} {...rest.meta.error}>
+        <AntInputComponent
+          className={cx({ 'is-invalid': isInvalid })}
+          onChange={onChangeAdapter ? (...args) => onChange(onChangeAdapter(...args)) : onChange}
+          {...inputRest}
+          {...rest}
+        >
+          {children}
+        </AntInputComponent>
+      </Popover>
     );
   };
 }

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.test.js
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.test.js
@@ -19,7 +19,6 @@ import React from 'react';
 import reduxFormFieldAdapter from './redux-form-field-adapter';
 
 describe('reduxFormFieldAdapter', () => {
-  const AdaptedInput = reduxFormFieldAdapter(Input);
   const input = {
     onChange: function onChange() {},
     onBlur: function onBlur() {},
@@ -34,27 +33,38 @@ describe('reduxFormFieldAdapter', () => {
   beforeEach(() => {
     meta = {
       error: null,
-      touched: false,
+      active: false,
     };
   });
 
-  it('should render as expected when there is not an error', () => {
-    const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
-    expect(wrapper).toMatchSnapshot();
+  describe('not validated input', () => {
+    const AdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input });
+    it('should render as expected', () => {
+      const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
-  it('should render Popover as invisible if there is an error but the field has not been touched', () => {
-    meta.error = error;
-    const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
-    expect(wrapper.find(Popover).prop('visible')).toBeFalsy();
-    expect(wrapper).toMatchSnapshot();
-  });
+  describe('validate input', () => {
+    const AdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input, isValidatedInput: true });
+    it('should render as expected when there is not an error', () => {
+      const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+      expect(wrapper).toMatchSnapshot();
+    });
 
-  it('should render Popover as visible if there is an error and the field has been touched', () => {
-    meta.error = error;
-    meta.touched = true;
-    const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
-    expect(wrapper.find(Popover).prop('visible')).toBeTruthy();
-    expect(wrapper).toMatchSnapshot();
+    it('should render Popover as invisible if there is an error but the field is active', () => {
+      meta.error = error;
+      meta.active = true;
+      const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+      expect(wrapper.find(Popover).prop('visible')).toBeFalsy();
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render Popover as visible if there is an error and the field is not active', () => {
+      meta.error = error;
+      const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+      expect(wrapper.find(Popover).prop('visible')).toBeTruthy();
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.test.js
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.test.js
@@ -19,18 +19,19 @@ import React from 'react';
 import reduxFormFieldAdapter from './redux-form-field-adapter';
 
 describe('reduxFormFieldAdapter', () => {
-  const input = {
-    onChange: function onChange() {},
-    onBlur: function onBlur() {},
-    value: 'inputValue',
-  };
   const error = {
     content: 'error content',
     title: 'error title',
   };
+  let input;
   let meta;
 
   beforeEach(() => {
+    input = {
+      onChange: function onChange() {},
+      onBlur: function onBlur() {},
+      value: 'inputValue',
+    };
     meta = {
       error: null,
       active: false,
@@ -65,6 +66,30 @@ describe('reduxFormFieldAdapter', () => {
       const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
       expect(wrapper.find(Popover).prop('visible')).toBeTruthy();
       expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe('onChangeAdapter', () => {
+    it('should use input.onChange when adapter is not provided', () => {
+      const AdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input });
+      const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+      expect(wrapper.find(Input).prop('onChange')).toBe(input.onChange);
+    });
+
+    it('should call input.onChange with result of adapter when adapter is provided', () => {
+      const onChangeMockInput = 'onChangeMockInput';
+      const onChangeAdapterMockReturnValue = 'onChangeAdapterMockReturnValue';
+      const onChangeAdapter = jest.fn().mockReturnValue(onChangeAdapterMockReturnValue);
+      const onChangeSpy = jest.fn();
+      input.onChange = onChangeSpy;
+      const AdaptedInput = reduxFormFieldAdapter({ AntInputComponent: Input, onChangeAdapter });
+      const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+
+      const renderedOnChangeFn = wrapper.find(Input).prop('onChange');
+      expect(renderedOnChangeFn).not.toBe(input.onChange);
+      renderedOnChangeFn(onChangeMockInput);
+      expect(onChangeAdapter).toHaveBeenCalledWith(onChangeMockInput);
+      expect(onChangeSpy).toHaveBeenCalledWith(onChangeAdapterMockReturnValue);
     });
   });
 });

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.test.js
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.test.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Input, Popover } from 'antd';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import reduxFormFieldAdapter from './redux-form-field-adapter';
+
+describe('reduxFormFieldAdapter', () => {
+  const AdaptedInput = reduxFormFieldAdapter(Input);
+  const input = {
+    onChange: function onChange() {},
+    onBlur: function onBlur() {},
+    value: 'inputValue',
+  };
+  const error = {
+    content: 'error content',
+    title: 'error title',
+  };
+  let meta;
+
+  beforeEach(() => {
+    meta = {
+      error: null,
+      touched: false,
+    };
+  });
+
+  it('should render as expected when there is not an error', () => {
+    const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render Popover as invisible if there is an error but the field has not been touched', () => {
+    meta.error = error;
+    const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+    expect(wrapper.find(Popover).prop('visible')).toBeFalsy();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render Popover as visible if there is an error and the field has been touched', () => {
+    meta.error = error;
+    meta.touched = true;
+    const wrapper = shallow(<AdaptedInput input={input} meta={meta} />);
+    expect(wrapper.find(Popover).prop('visible')).toBeTruthy();
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?
- Duration fields without units result in an error, this PR adds popovers when these fields lack units and prevents submit (#244 )

## Short description of the changes
If the user times in an invalid duration, a popover is displayed to indicate that units are necessary. The submit button is disabled if any fields are invalid. To avoid jumping on the user as soon as the start typing, the popover is not visible until the user has blurred. After the user has blurred, the popover is visible as long as the field is invalid, even if the field becomes focused again.

![244 invalid popover](https://user-images.githubusercontent.com/3471184/50316345-38ffe780-0484-11e9-87ed-0a0290edbbd6.gif)

