### PR TITLE
Optimize tree walk to avoid too depth function call stack.

### DIFF
--- a/packages/jaeger-ui/src/utils/TreeNode.js
+++ b/packages/jaeger-ui/src/utils/TreeNode.js
@@ -83,7 +83,18 @@ export default class TreeNode {
   }
 
   walk(fn, depth = 0) {
-    TreeNode.iterFunction(fn, depth)(this);
-    this.children.forEach(child => child.walk(fn, depth + 1));
+    const nodeStack = [];
+    let actualDepth = depth;
+    nodeStack.push({ node: this, depth: actualDepth });
+    while (nodeStack.length) {
+      const { node, depth: nodeDepth } = nodeStack.pop();
+      fn(node.value, node, nodeDepth);
+      actualDepth = nodeDepth + 1;
+      let i = node.children.length - 1;
+      while (i >= 0) {
+        nodeStack.push({ node: node.children[i], depth: actualDepth });
+        i--;
+      }
+    }
   }
 }

--- a/packages/jaeger-ui/src/utils/TreeNode.test.js
+++ b/packages/jaeger-ui/src/utils/TreeNode.test.js
@@ -264,3 +264,30 @@ it('walk() should iterate over every item once in the right order', () => {
 
   treeRoot.walk(value => expect(value).toBe(++i));
 });
+
+it('walk() should iterate over every item and compute the right deep on each node', () => {
+  /**
+   *     C0
+   *    /
+   *   B0 – C1
+   *  /
+   * A – B1 – C2
+   *      \
+   *      C3 – D
+   */
+
+  const nodeA = new TreeNode('A');
+  const nodeB0 = new TreeNode('B0');
+  const nodeB1 = new TreeNode('B1');
+  const nodeC3 = new TreeNode('C3');
+  const depthMap = { A: 0, B0: 1, B1: 1, C0: 2, C1: 2, C2: 2, C3: 2, D: 3 };
+  nodeA.addChild(nodeB0);
+  nodeA.addChild(nodeB0);
+  nodeA.addChild(nodeB1);
+  nodeB0.addChild('C0');
+  nodeB0.addChild('C1');
+  nodeB1.addChild('C2');
+  nodeB1.addChild(nodeC3);
+  nodeC3.addChild('D');
+  nodeA.walk((value, node, depth) => expect(depth).toBe(depthMap[value]));
+});


### PR DESCRIPTION

## Which problem is this PR solving?
- This Resolves https://github.com/jaegertracing/jaeger-ui/issues/320

## Short description of the changes
- After taking a look a the Issue and run the test code mentioned in the issue, it seems like the UI is freezing on the tree walk method when the tree is too depth. After did some tests I think that the "recursive" function calling could be the problem.

I did some tests and it seems to behave better with an iterative walk algorithm. This partially solves the problem, because the render of too many components is slow. We could probably need to impose a limit on the depth (But at least now is not freezing anymore)

