### PR TITLE
Add Import json from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * **Trace detail:** Log Markers on Spans ([Fix #119](https://github.com/jaegertracing/jaeger-ui/issues/119)) ([@sfriberg](https://github.com/sfriberg) in [#309](https://github.com/jaegertracing/jaeger-ui/pull/309))
 
+* **Search:** Load trace(s) from a JSON file ([Fix #214](https://github.com/jaegertracing/jaeger-ui/issues/214)) ([@yuribit](https://github.com/yuribit) in [#327](https://github.com/jaegertracing/jaeger-ui/pull/327))
+
 ## v1.0.1 (February 15, 2019)
 
 ### Fixes

--- a/packages/jaeger-ui/src/actions/file-reader-api.js
+++ b/packages/jaeger-ui/src/actions/file-reader-api.js
@@ -1,0 +1,25 @@
+// @flow
+
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createAction } from 'redux-actions';
+import fileReader from '../utils/fileReader';
+
+// eslint-disable-next-line import/prefer-default-export
+export const loadJsonTraces = createAction(
+  '@FILE_READER_API/LOAD_JSON',
+  fileList => fileReader.readJsonFile(fileList),
+  fileList => ({ fileList })
+);

--- a/packages/jaeger-ui/src/actions/file-reader-api.test.js
+++ b/packages/jaeger-ui/src/actions/file-reader-api.test.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import sinon from 'sinon';
+import isPromise from 'is-promise';
+
+import * as fileReaderActions from './file-reader-api';
+import fileReader from '../utils/fileReader';
+
+it('loadJsonTraces should return a promise', () => {
+  const fileList = { data: {}, filename: 'whatever' };
+
+  const { payload } = fileReaderActions.loadJsonTraces(fileList);
+  expect(isPromise(payload)).toBeTruthy();
+});
+
+it('loadJsonTraces should call readJsonFile', () => {
+  const fileList = { data: {}, filename: 'whatever' };
+  const mock = sinon.mock(fileReader);
+  const called = mock
+    .expects('readJsonFile')
+    .once()
+    .withExactArgs(fileList);
+  fileReaderActions.loadJsonTraces(fileList);
+  expect(called.verify()).toBeTruthy();
+  mock.restore();
+});

--- a/packages/jaeger-ui/src/actions/file-reader-api.test.js
+++ b/packages/jaeger-ui/src/actions/file-reader-api.test.js
@@ -23,6 +23,8 @@ it('loadJsonTraces should return a promise', () => {
 
   const { payload } = fileReaderActions.loadJsonTraces(fileList);
   expect(isPromise(payload)).toBeTruthy();
+  // prevent the unhandled rejection warnings
+  payload.catch(() => {});
 });
 
 it('loadJsonTraces should call readJsonFile', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.js
@@ -1,0 +1,36 @@
+// @flow
+
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { Upload, Icon } from 'antd';
+
+const Dragger = Upload.Dragger;
+
+type FileLoaderProps = {
+  loadJsonTraces: (fileList: FileList) => void,
+};
+
+export default function FileLoader(props: FileLoaderProps) {
+  return (
+    <Dragger accept=".json" customRequest={props.loadJsonTraces} multiple>
+      <p className="ant-upload-drag-icon">
+        <Icon type="file-add" />
+      </p>
+      <p className="ant-upload-text">Click or drag files to this area.</p>
+      <p className="ant-upload-hint">Support JSON files containig one or more traces.</p>
+    </Dragger>
+  );
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.test.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import FileLoader from './FileLoader';
+
+describe('<FileLoader />', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<FileLoader loadJsonTrace={jest.fn()} />);
+  });
+
+  it('matches the snapshot', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/__snapshots__/FileLoader.test.js.snap
+++ b/packages/jaeger-ui/src/components/SearchTracePage/__snapshots__/FileLoader.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FileLoader /> matches the snapshot 1`] = `
+<Dragger
+  accept=".json"
+  multiple={true}
+>
+  <p
+    className="ant-upload-drag-icon"
+  >
+    <Icon
+      type="file-add"
+    />
+  </p>
+  <p
+    className="ant-upload-text"
+  >
+    Click or drag files to this area.
+  </p>
+  <p
+    className="ant-upload-hint"
+  >
+    Support JSON files containig one or more traces.
+  </p>
+</Dragger>
+`;

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -15,7 +15,7 @@
 /* eslint-disable react/require-default-props */
 
 import React, { Component } from 'react';
-import { Col, Row } from 'antd';
+import { Col, Row, Tabs } from 'antd';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import { connect } from 'react-redux';
@@ -26,6 +26,7 @@ import SearchForm from './SearchForm';
 import SearchResults, { sortFormSelector } from './SearchResults';
 import { isSameQuery, getUrl } from './url';
 import * as jaegerApiActions from '../../actions/jaeger-api';
+import * as fileReaderActions from '../../actions/file-reader-api';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
 import { getLocation as getTraceLocation } from '../TracePage/url';
@@ -34,9 +35,12 @@ import { fetchedState } from '../../constants';
 import { sortTraces } from '../../model/search';
 import getLastXformCacher from '../../utils/get-last-xform-cacher';
 import { stripEmbeddedState } from '../../utils/embedded-url';
+import FileLoader from './FileLoader';
 
 import './index.css';
 import JaegerLogo from '../../img/jaeger-logo.svg';
+
+const TabPane = Tabs.TabPane;
 
 // export for tests
 export class SearchTracePageImpl extends Component {
@@ -85,6 +89,7 @@ export class SearchTracePageImpl extends Component {
       services,
       traceResults,
       queryOfResults,
+      loadJsonTraces,
     } = this.props;
     const hasTraceResults = traceResults && traceResults.length > 0;
     const showErrors = errors && !loadingTraces;
@@ -95,8 +100,14 @@ export class SearchTracePageImpl extends Component {
           {!embedded && (
             <Col span={6} className="SearchTracePage--column">
               <div className="SearchTracePage--find">
-                <h2>Find Traces</h2>
-                {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
+                <Tabs size="large">
+                  <TabPane tab="Find Traces" key="searchForm">
+                    {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
+                  </TabPane>
+                  <TabPane tab="JSON File" key="fileLoader">
+                    <FileLoader loadJsonTraces={loadJsonTraces} />
+                  </TabPane>
+                </Tabs>
               </div>
             </Col>
           )}
@@ -177,6 +188,7 @@ SearchTracePageImpl.propTypes = {
       message: PropTypes.string,
     })
   ),
+  loadJsonTraces: PropTypes.func,
 };
 
 const stateTraceXformer = getLastXformCacher(stateTrace => {
@@ -257,6 +269,7 @@ function mapDispatchToProps(dispatch) {
     jaegerApiActions,
     dispatch
   );
+  const { loadJsonTraces } = bindActionCreators(fileReaderActions, dispatch);
   const { cohortAddTrace, cohortRemoveTrace } = bindActionCreators(traceDiffActions, dispatch);
   return {
     cohortAddTrace,
@@ -265,6 +278,7 @@ function mapDispatchToProps(dispatch) {
     fetchServiceOperations,
     fetchServices,
     searchTraces,
+    loadJsonTraces,
   };
 }
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -101,7 +101,7 @@ export class SearchTracePageImpl extends Component {
             <Col span={6} className="SearchTracePage--column">
               <div className="SearchTracePage--find">
                 <Tabs size="large">
-                  <TabPane tab="Find Traces" key="searchForm">
+                  <TabPane tab="Search" key="searchForm">
                     {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
                   </TabPane>
                   <TabPane tab="JSON File" key="fileLoader">

--- a/packages/jaeger-ui/src/utils/fileReader.js
+++ b/packages/jaeger-ui/src/utils/fileReader.js
@@ -1,0 +1,34 @@
+// @flow
+
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const fileReader = {
+  readJsonFile(fileList: { file: File }) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === 'string') {
+          return resolve(JSON.parse(reader.result));
+        }
+        return reject('Invalid result type');
+      };
+      reader.onerror = reject;
+      reader.onabort = reject;
+      reader.readAsText(fileList.file);
+    });
+  },
+};
+
+export default fileReader;

--- a/packages/jaeger-ui/src/utils/fileReader.js
+++ b/packages/jaeger-ui/src/utils/fileReader.js
@@ -19,14 +19,31 @@ const fileReader = {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => {
-        if (typeof reader.result === 'string') {
-          return resolve(JSON.parse(reader.result));
+        if (typeof reader.result !== 'string') {
+          reject(new Error('Invalid result type'));
+          return;
         }
-        return reject('Invalid result type');
+        try {
+          resolve(JSON.parse(reader.result));
+        } catch (error) {
+          reject(new Error(`Error parsing JSON: ${error.message}`));
+        }
       };
-      reader.onerror = reject;
-      reader.onabort = reject;
-      reader.readAsText(fileList.file);
+      reader.onerror = () => {
+        // eslint-disable-next-line no-console
+        const errMessage = reader.error ? `: ${String(reader.error)}` : '';
+        reject(new Error(`Error reading the JSON file${errMessage}`));
+      };
+      reader.onabort = () => {
+        // eslint-disable-next-line no-console
+        reject(new Error(`Reading the JSON file has been aborted`));
+      };
+      try {
+        reader.readAsText(fileList.file);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        reject(new Error(`Error reading the JSON file: ${error.message}`));
+      }
     });
   },
 };

--- a/packages/jaeger-ui/src/utils/fileReader.test.js
+++ b/packages/jaeger-ui/src/utils/fileReader.test.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import isPromise from 'is-promise';
+import sinon from 'sinon';
+
+import fileReader from './fileReader.js';
+
+it('readJsonFile returns a promise', () => {
+  const fileList = { data: {}, filename: 'whatever' };
+
+  const promise = fileReader.readJsonFile(fileList);
+  expect(isPromise(promise)).toBeTruthy();
+});
+
+it('readJsonFile fails to load a fail', async () => {
+  expect.assertions(1);
+  const fileList = { data: {}, filename: 'whatever' };
+  try {
+    await fileReader.readJsonFile(fileList);
+  } catch (e) {
+    expect(true).toBeTruthy();
+  }
+});
+
+it('readJsonFile fails when fileList is wrong', async () => {
+  expect.assertions(2);
+
+  const mock = sinon.mock(window);
+  const called = mock.expects('FileReader').once();
+  const fileList = {
+    action: '',
+    filename: 'file',
+    file: { uid: '1234' },
+    data: {},
+    headers: {},
+    withCredentials: false,
+  };
+
+  try {
+    await fileReader.readJsonFile(fileList);
+  } catch (e) {
+    expect(true).toBeTruthy();
+    expect(called.verify()).toBeTruthy();
+  }
+  mock.restore();
+});


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #214 

## Short description of the changes
- The UI will not throw any exception in case the request for /services fails. In this way the UI can be used even if the server is offline / not reachable.
- The search trace page has two tabs, the first one contains the old form (1st screenshot) while the second tab contains a simple file uploader (2nd screenshot).

<img width="1438" alt="screen shot 2019-02-08 at 2 55 31 pm" src="https://user-images.githubusercontent.com/1260900/52510836-7cd4ba80-2bb2-11e9-875a-2df6a1d9b87b.png">
<img width="1439" alt="screen shot 2019-02-08 at 2 56 01 pm" src="https://user-images.githubusercontent.com/1260900/52510837-7d6d5100-2bb2-11e9-9b95-4faa0a2eb7b7.png">
