### PR TITLE
Fix a typo in transform-trace-data.js

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.js
@@ -26,7 +26,7 @@ type SpanWithProcess = SpanData & { process: Process };
  * NOTE: Mutates `data` - Transform the HTTP response data into the form the app
  * generally requires.
  */
-export default function transfromTraceData(data: TraceData & { spans: SpanWithProcess[] }): ?Trace {
+export default function transformTraceData(data: TraceData & { spans: SpanWithProcess[] }): ?Trace {
   let { traceID } = data;
   if (!traceID) {
     return null;


### PR DESCRIPTION
## Short description of the changes
- I think there is a typo in the name `transfromTraceData` this PR fixes that, changes it to `transformTraceData`