### PR TITLE
Hide child status icon on SpanTreeOffset used in SpanDetailRow component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
@@ -65,7 +65,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
     return (
       <TimelineRow className="detail-row">
         <TimelineRow.Cell width={columnDivision}>
-          <SpanTreeOffset span={span} />
+          <SpanTreeOffset span={span} showChildrenStatus={false} />
           <span>
             <span
               className="detail-row-expanded-accent"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.js
@@ -65,7 +65,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
     return (
       <TimelineRow className="detail-row">
         <TimelineRow.Cell width={columnDivision}>
-          <SpanTreeOffset span={span} showChildrenStatus={false} />
+          <SpanTreeOffset span={span} showChildrenIcon={false} />
           <span>
             <span
               className="detail-row-expanded-accent"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
@@ -63,7 +63,7 @@ describe('<SpanDetailRow>', () => {
   });
 
   it('renders the span tree offset', () => {
-    const spanTreeOffset = <SpanTreeOffset span={props.span} showChildrenStatus={false} />;
+    const spanTreeOffset = <SpanTreeOffset span={props.span} showChildrenIcon={false} />;
     expect(wrapper.contains(spanTreeOffset)).toBe(true);
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
@@ -63,7 +63,7 @@ describe('<SpanDetailRow>', () => {
   });
 
   it('renders the span tree offset', () => {
-    const spanTreeOffset = <SpanTreeOffset span={props.span} />;
+    const spanTreeOffset = <SpanTreeOffset span={props.span} showChildrenStatus={false} />;
     expect(wrapper.contains(spanTreeOffset)).toBe(true);
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.js
@@ -37,7 +37,7 @@ type SpanTreeOffsetPropsType = {
   onClick: ?() => void,
   removeHoverIndentGuideId: string => void,
   span: Span,
-  showChildrenStatus: boolean => void,
+  showChildrenStatus: boolean,
 };
 
 export class UnconnectedSpanTreeOffset extends React.PureComponent<SpanTreeOffsetPropsType> {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.js
@@ -37,6 +37,7 @@ type SpanTreeOffsetPropsType = {
   onClick: ?() => void,
   removeHoverIndentGuideId: string => void,
   span: Span,
+  showChildrenStatus: boolean => void,
 };
 
 export class UnconnectedSpanTreeOffset extends React.PureComponent<SpanTreeOffsetPropsType> {
@@ -46,6 +47,7 @@ export class UnconnectedSpanTreeOffset extends React.PureComponent<SpanTreeOffse
   static defaultProps = {
     childrenVisible: false,
     onClick: null,
+    showChildrenStatus: true,
   };
 
   constructor(props: SpanTreeOffsetPropsType) {
@@ -105,10 +107,11 @@ export class UnconnectedSpanTreeOffset extends React.PureComponent<SpanTreeOffse
   };
 
   render() {
-    const { childrenVisible, onClick, span } = this.props;
+    const { showChildrenStatus, childrenVisible, onClick, span } = this.props;
     const { hasChildren, spanID } = span;
     const wrapperProps = hasChildren ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
-    const icon = hasChildren && (childrenVisible ? <IoIosArrowDown /> : <IoChevronRight />);
+    const icon =
+      showChildrenStatus && hasChildren && (childrenVisible ? <IoIosArrowDown /> : <IoChevronRight />);
     return (
       <span className={`SpanTreeOffset ${hasChildren ? 'is-parent' : ''}`} {...wrapperProps}>
         {this.ancestorIds.map(ancestorId => (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.js
@@ -37,7 +37,7 @@ type SpanTreeOffsetPropsType = {
   onClick: ?() => void,
   removeHoverIndentGuideId: string => void,
   span: Span,
-  showChildrenStatus: boolean,
+  showChildrenIcon: boolean,
 };
 
 export class UnconnectedSpanTreeOffset extends React.PureComponent<SpanTreeOffsetPropsType> {
@@ -47,7 +47,7 @@ export class UnconnectedSpanTreeOffset extends React.PureComponent<SpanTreeOffse
   static defaultProps = {
     childrenVisible: false,
     onClick: null,
-    showChildrenStatus: true,
+    showChildrenIcon: true,
   };
 
   constructor(props: SpanTreeOffsetPropsType) {
@@ -107,11 +107,11 @@ export class UnconnectedSpanTreeOffset extends React.PureComponent<SpanTreeOffse
   };
 
   render() {
-    const { showChildrenStatus, childrenVisible, onClick, span } = this.props;
+    const { showChildrenIcon, childrenVisible, onClick, span } = this.props;
     const { hasChildren, spanID } = span;
     const wrapperProps = hasChildren ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
     const icon =
-      showChildrenStatus && hasChildren && (childrenVisible ? <IoIosArrowDown /> : <IoChevronRight />);
+      showChildrenIcon && hasChildren && (childrenVisible ? <IoIosArrowDown /> : <IoChevronRight />);
     return (
       <span className={`SpanTreeOffset ${hasChildren ? 'is-parent' : ''}`} {...wrapperProps}>
         {this.ancestorIds.map(ancestorId => (


### PR DESCRIPTION

## Which problem is this PR solving?
- This PR fixes https://github.com/jaegertracing/jaeger-ui/issues/328

## Short description of the changes
- Just hide the icon (chevron or arrow down) when `SpanTreeOfset` is used for indent `SpanDetailsRow
`