### PR TITLE
Process FOLLOWS_FROM spans in TraceView

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.js
@@ -43,6 +43,7 @@ describe('SpanTreeOffset', () => {
     ],
     spanID: ownSpanID,
   };
+
   const specialRootID = 'root';
   let props;
   let wrapper;
@@ -75,6 +76,35 @@ describe('SpanTreeOffset', () => {
       const indentGuides = wrapper.find('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(1);
       expect(indentGuides.prop('data-ancestor-id')).toBe(specialRootID);
+    });
+
+    it('renders one .SpanTreeOffset--indentGuide per ancestor span, plus one for entire trace, including FOLLOWS_FROM', () => {
+      props.span = {
+        hasChildren: false,
+        references: [
+          {
+            refType: 'FOLLOWS_FROM',
+            span: {
+              spanID: parentSpanID,
+              references: [
+                {
+                  refType: 'CHILD_OF',
+                  span: {
+                    spanID: rootSpanID,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        spanID: ownSpanID,
+      };
+      wrapper = shallow(<UnconnectedSpanTreeOffset {...props} />);
+      const indentGuides = wrapper.find('.SpanTreeOffset--indentGuide');
+      expect(indentGuides.length).toBe(3);
+      expect(indentGuides.at(0).prop('data-ancestor-id')).toBe(specialRootID);
+      expect(indentGuides.at(1).prop('data-ancestor-id')).toBe(rootSpanID);
+      expect(indentGuides.at(2).prop('data-ancestor-id')).toBe(parentSpanID);
     });
 
     it('renders one .SpanTreeOffset--indentGuide per ancestor span, plus one for entire trace', () => {


### PR DESCRIPTION
## Which problem is this PR solving?
- This fixes https://github.com/jaegertracing/jaeger-ui/issues/333

## Short description of the changes
- I noticed that there is FOLLOWS_FROM attributes on some spans that wasn't take into account when the indentation of the spans is computes on the TreeView.

Not sure if this is the proper way of handling this, I left two comments for two assumptions that I did. if some of the maintainers can review please. @tiffon @everett980 

Thanks!
