### PR TITLE
Preparing release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,22 @@
 # Releases
 
-## Next (Unreleased)
+## v1.0.2 (March 3, 2019)
 
 ### Enhancements
 
-* **Trace detail:** Log Markers on Spans ([Fix #119](https://github.com/jaegertracing/jaeger-ui/issues/119)) ([@sfriberg](https://github.com/sfriberg) in [#309](https://github.com/jaegertracing/jaeger-ui/pull/309))
+* **Trace detail:** Log Markers on spans ([Fix #119](https://github.com/jaegertracing/jaeger-ui/issues/119)) ([@sfriberg](https://github.com/sfriberg) in [#309](https://github.com/jaegertracing/jaeger-ui/pull/309))
 
 * **Search:** Load trace(s) from a JSON file ([Fix #214](https://github.com/jaegertracing/jaeger-ui/issues/214)) ([@yuribit](https://github.com/yuribit) in [#327](https://github.com/jaegertracing/jaeger-ui/pull/327))
+
+### Fixes
+
+* **Trace detail:** Hide child status icon on SpanTreeOffset used in SpanDetailRow component ([Fix #328](https://github.com/jaegertracing/jaeger-ui/issues/328)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#334](https://github.com/jaegertracing/jaeger-ui/pull/334))
+
+* **Data munging:** Optimize tree walk to avoid too depth function call stack ([Fix #320](https://github.com/jaegertracing/jaeger-ui/issues/320)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#326](https://github.com/jaegertracing/jaeger-ui/pull/326))
+
+### Chores & Maintenance
+
+* **Code quality:** Fix a typo in transform-trace-data.js ([@bhavin192](https://github.com/bhavin192) in [#332](https://github.com/jaegertracing/jaeger-ui/pull/332))
 
 ## v1.0.1 (February 15, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Releases
 
-## v1.0.2 (March 3, 2019)
+## v1.1.0 (March 3, 2019)
 
 ### Enhancements
 
@@ -12,7 +12,7 @@
 
 * **Trace detail:** Hide child status icon on SpanTreeOffset used in SpanDetailRow component ([Fix #328](https://github.com/jaegertracing/jaeger-ui/issues/328)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#334](https://github.com/jaegertracing/jaeger-ui/pull/334))
 
-* **Data munging:** Optimize tree walk to avoid too depth function call stack ([Fix #320](https://github.com/jaegertracing/jaeger-ui/issues/320)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#326](https://github.com/jaegertracing/jaeger-ui/pull/326))
+* **Data munging:** Optimize tree walk to avoid excessive function call depth ([Fix #320](https://github.com/jaegertracing/jaeger-ui/issues/320)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#326](https://github.com/jaegertracing/jaeger-ui/pull/326))
 
 ### Chores & Maintenance
 

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "jaeger-ui",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "src/index.js",
   "license": "Apache-2.0",
   "homepage": ".",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "jaeger-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.js",
   "license": "Apache-2.0",
   "homepage": ".",

--- a/scripts/get-changelog.js
+++ b/scripts/get-changelog.js
@@ -43,7 +43,7 @@ function compareMergedDates(a, b) {
 }
 
 function getPrData(document) {
-  const wrapper = document.querySelector('[aria-label="Issues"]');
+  const wrapper = document.querySelector('[aria-label="Issues"][role="group"]');
   const issues = [].slice.call(wrapper.querySelectorAll('.js-issue-row'));
   const okIssues = issues.filter(elm => !elm.querySelector('[aria-label*="Closed"]'));
   return okIssues.map(getData);


### PR DESCRIPTION
Also, fix a CSS selector in `./scripts/get-changelog.js`.

-----

### Note

The version is being changed from `v1.0.2` to `v1.1.0` to be consistent with sermver, so the branch name is no longer accurate.