### PR TITLE
Update lodash to 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "rxjs-compat": "6.4.0",
     "typescript": "3.3.3333"
   },
+  "resolutions": {
+    "**/lodash": "4.17.11"
+  },
   "workspaces": {
     "packages": ["packages/*"],
     "nohoist": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7728,13 +7728,9 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.x, "lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.16.5, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+lodash@4.17.11, lodash@4.x, "lodash@>=3.5 <5", lodash@^3.10.0, lodash@^4.15.0, lodash@^4.16.5, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-
-lodash@^3.10.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 logfmt@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
Uses `yarn`'s [selective resolutions](https://yarnpkg.com/en/docs/selective-version-resolutions) to pin all uses of `lodash` to `4.17.11`.