### PR TITLE
Improve display of long operation names in Operations list

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -215,7 +215,7 @@ export class SearchFormImpl extends React.PureComponent {
             props={{
               clearable: false,
               disabled: disabled || noSelectedService,
-              options: ['all'].concat(opsForSvc).map(v => ({ label: v, value: v })),
+              options: ['all'].concat(opsForSvc).map(v => ({ label: v, value: v, title: v })),
               required: true,
             }}
           />

--- a/packages/jaeger-ui/src/components/common/VirtSelect.css
+++ b/packages/jaeger-ui/src/components/common/VirtSelect.css
@@ -40,6 +40,7 @@ limitations under the License.
   display: flex;
   align-items: center;
   padding: 0 0.5rem;
+  white-space: nowrap;
 }
 
 .VirtSelect--option.is-focused {


### PR DESCRIPTION
## Which problem is this PR solving?

Services like Traefik can generate really long operation names. These names wrap in the Operation search list, making options unreadable. This PR improves the display of really long operation names in the list.

Resolves #349

## Short description of the changes

* Set `white-space: nowrap` on `.VirtSelect--option` elements.
* Pass operation name as the `title` for select options, so that the full value of really long operation names can be seen.

![image](https://user-images.githubusercontent.com/27340/54625657-5158b180-4a35-11e9-9281-7df8c0a6172d.png)
