### PR TITLE
Deduplicate tags for spans

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.css
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2019 Uber Technologies, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,29 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.AccordianLogs {
-  border: 1px solid #d8d8d8;
-  position: relative;
-  margin-bottom: 0.25rem;
+.AccordianText--header {
+  cursor: pointer;
+  overflow: hidden;
+  padding: 0.25em 0.1em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.AccordianLogs--header {
-  background: #e4e4e4;
-  color: inherit;
-  display: block;
-  padding: 0.25rem 0.5rem;
-}
-
-.AccordianLogs--header:hover {
-  background: #dadada;
-}
-
-.AccordianLogs--content {
-  background: #f0f0f0;
-  border-top: 1px solid #d8d8d8;
-  padding: 0.5rem 0.5rem 0.25rem 0.5rem;
-}
-
-.AccordianLogs--footer {
-  color: #999;
+.AccordianText--header:hover {
+  background: #e8e8e8;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.test.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import AccordianText from './AccordianText';
+import TextList from './TextList';
+
+const warnings = ['Duplicated tag', 'Duplicated spanId'];
+
+describe('<AccordianText>', () => {
+  let wrapper;
+
+  const props = {
+    compact: false,
+    data: warnings,
+    highContrast: false,
+    isOpen: false,
+    label: 'le-label',
+    onToggle: jest.fn(),
+  };
+
+  beforeEach(() => {
+    wrapper = shallow(<AccordianText {...props} />);
+  });
+
+  it('renders without exploding', () => {
+    expect(wrapper).toBeDefined();
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders the label', () => {
+    const header = wrapper.find(`.AccordianText--header > strong`);
+    expect(header.length).toBe(1);
+    expect(header.text()).toBe(props.label);
+  });
+
+  it('renders the table instead of the summary when it is expanded', () => {
+    wrapper.setProps({ isOpen: true });
+    const table = wrapper.find(TextList);
+    expect(table.length).toBe(1);
+    expect(table.prop('data')).toBe(warnings);
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.test.js
@@ -46,10 +46,10 @@ describe('<AccordianText>', () => {
     expect(header.text()).toBe(props.label);
   });
 
-  it('renders the table instead of the summary when it is expanded', () => {
+  it('renders the content when it is expanded', () => {
     wrapper.setProps({ isOpen: true });
-    const table = wrapper.find(TextList);
-    expect(table.length).toBe(1);
-    expect(table.prop('data')).toBe(warnings);
+    const content = wrapper.find(TextList);
+    expect(content.length).toBe(1);
+    expect(content.prop('data')).toBe(warnings);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.tsx
@@ -24,15 +24,16 @@ import './AccordianText.css';
 type AccordianTextProps = {
   className?: string | TNil;
   data: string[];
+  headerClassName?: string | TNil;
   highContrast?: boolean;
   interactive?: boolean;
   isOpen: boolean;
-  label: string;
+  label: React.ReactNode;
   onToggle?: null | (() => void);
 };
 
 export default function AccordianText(props: AccordianTextProps) {
-  const { className, data, highContrast, interactive, isOpen, label, onToggle } = props;
+  const { className, data, headerClassName, highContrast, interactive, isOpen, label, onToggle } = props;
   const isEmpty = !Array.isArray(data) || !data.length;
   const iconCls = cx('u-align-icon', { 'AccordianKeyValues--emptyIcon': isEmpty });
   let arrow: React.ReactNode | null = null;
@@ -46,11 +47,12 @@ export default function AccordianText(props: AccordianTextProps) {
     };
   }
   return (
-    <div className={cx(className, 'u-tx-ellipsis')}>
+    <div className={className || ''}>
       <div
-        className={cx('AccordianText--header', {
+        className={cx('AccordianText--header', headerClassName, {
           'is-empty': isEmpty,
           'is-high-contrast': highContrast,
+          'is-open': isOpen,
         })}
         {...headerProps}
       >

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import cx from 'classnames';
+import IoIosArrowDown from 'react-icons/lib/io/ios-arrow-down';
+import IoIosArrowRight from 'react-icons/lib/io/ios-arrow-right';
+import TextList from './TextList';
+import { TNil } from '../../../../types';
+
+import './AccordianText.css';
+
+type AccordianTextProps = {
+  className?: string | TNil;
+  data: string[];
+  highContrast?: boolean;
+  interactive?: boolean;
+  isOpen: boolean;
+  label: string;
+  onToggle?: null | (() => void);
+};
+
+export default function AccordianText(props: AccordianTextProps) {
+  const { className, data, highContrast, interactive, isOpen, label, onToggle } = props;
+  const isEmpty = !Array.isArray(data) || !data.length;
+  const iconCls = cx('u-align-icon', { 'AccordianKeyValues--emptyIcon': isEmpty });
+  let arrow: React.ReactNode | null = null;
+  let headerProps: Object | null = null;
+  if (interactive) {
+    arrow = isOpen ? <IoIosArrowDown className={iconCls} /> : <IoIosArrowRight className={iconCls} />;
+    headerProps = {
+      'aria-checked': isOpen,
+      onClick: isEmpty ? null : onToggle,
+      role: 'switch',
+    };
+  }
+  return (
+    <div className={cx(className, 'u-tx-ellipsis')}>
+      <div
+        className={cx('AccordianText--header', {
+          'is-empty': isEmpty,
+          'is-high-contrast': highContrast,
+        })}
+        {...headerProps}
+      >
+        {arrow} <strong>{label}</strong> ({data.length})
+      </div>
+      {isOpen && <TextList data={data} />}
+    </div>
+  );
+}
+
+AccordianText.defaultProps = {
+  className: null,
+  highContrast: false,
+  interactive: true,
+  onToggle: null,
+};

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/DetailState.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/DetailState.tsx
@@ -21,11 +21,14 @@ export default class DetailState {
   isTagsOpen: boolean;
   isProcessOpen: boolean;
   logs: { isOpen: boolean; openedItems: Set<Log> };
+  isWarningsOpen: boolean;
 
   constructor(oldState?: DetailState) {
-    const { isTagsOpen, isProcessOpen, logs }: DetailState | Record<string, undefined> = oldState || {};
+    const { isTagsOpen, isProcessOpen, isWarningsOpen, logs }: DetailState | Record<string, undefined> =
+      oldState || {};
     this.isTagsOpen = Boolean(isTagsOpen);
     this.isProcessOpen = Boolean(isProcessOpen);
+    this.isWarningsOpen = Boolean(isWarningsOpen);
     this.logs = {
       isOpen: Boolean(logs && logs.isOpen),
       openedItems: logs && logs.openedItems ? new Set(logs.openedItems) : new Set(),
@@ -41,6 +44,12 @@ export default class DetailState {
   toggleProcess() {
     const next = new DetailState(this);
     next.isProcessOpen = !this.isProcessOpen;
+    return next;
+  }
+
+  toggleWarnings() {
+    const next = new DetailState(this);
+    next.isWarningsOpen = !this.isWarningsOpen;
     return next;
   }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
@@ -30,7 +30,7 @@ limitations under the License.
   margin: 0;
 }
 
-.TextList--List:nth-child(2n) > li {
+.TextList--List > li:nth-child(2n) {
   background: #f5f5f5;
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2019 Uber Technologies, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,29 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.AccordianLogs {
-  border: 1px solid #d8d8d8;
-  position: relative;
-  margin-bottom: 0.25rem;
+.TextList {
+  background: #fff;
+  max-height: 450px;
+  overflow: auto;
 }
 
-.AccordianLogs--header {
-  background: #e4e4e4;
-  color: inherit;
-  display: block;
+.TextList-body {
+  vertical-align: baseline;
+}
+
+.TextList--List {
+  width: 100%;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.TextList--List:nth-child(2n) > li {
+  background: #f5f5f5;
+}
+
+.TextList--List > li {
   padding: 0.25rem 0.5rem;
-}
-
-.AccordianLogs--header:hover {
-  background: #dadada;
-}
-
-.AccordianLogs--content {
-  background: #f0f0f0;
-  border-top: 1px solid #d8d8d8;
-  padding: 0.5rem 0.5rem 0.25rem 0.5rem;
-}
-
-.AccordianLogs--footer {
-  color: #999;
+  vertical-align: top;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 .TextList {
-  background: #fff;
   max-height: 450px;
   overflow: auto;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.css
@@ -19,10 +19,6 @@ limitations under the License.
   overflow: auto;
 }
 
-.TextList-body {
-  vertical-align: baseline;
-}
-
 .TextList--List {
   width: 100%;
   list-style: none;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.test.js
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import TextList from './TextList';
+
+describe('<TextList>', () => {
+  let wrapper;
+
+  const data = [{ key: 'span.kind', value: 'client' }, { key: 'omg', value: 'mos-def' }];
+
+  beforeEach(() => {
+    wrapper = shallow(<TextList data={data} />);
+  });
+
+  it('renders without exploding', () => {
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find('.TextList').length).toBe(1);
+  });
+
+  it('renders a table row for each data element', () => {
+    const trs = wrapper.find('li');
+    expect(trs.length).toBe(data.length);
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+import './TextList.css';
+
+type TextListProps = {
+  data: string[];
+};
+
+export default function TextList(props: TextListProps) {
+  const { data } = props;
+  return (
+    <div className="TextList u-simple-scrollbars">
+      <ul className="TextList--List ">
+        {data.map((row, i) => {
+          return (
+            // `i` is necessary in the key because row.key can repeat
+            // eslint-disable-next-line react/no-array-index-key
+            <li key={`${i}`}>{row}</li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
@@ -40,3 +40,21 @@ limitations under the License.
 .SpanDetail--debugValue:hover {
   color: #333;
 }
+.AccordianWarnings {
+  border: 1px solid #d8d8d8;
+}
+.AccordianWarnings > .AccordianText--header > strong {
+  color: #d36c08;
+}
+
+.AccordianWarnings > .AccordianText--header {
+  background: #fff7e6;
+  padding: 0.25rem 0.5rem;
+}
+
+.SpanDetail--warnIcon {
+  background: transparent;
+  color: #ffa500;
+  font-size: 1em;
+  margin-right: 0.2rem;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
@@ -41,20 +41,23 @@ limitations under the License.
   color: #333;
 }
 .AccordianWarnings {
-  border: 1px solid #d8d8d8;
+  background: #fafafa;
+  border: 1px solid #e4e4e4;
+  margin-bottom: 0.25rem;
 }
-.AccordianWarnings > .AccordianText--header > strong {
-  color: #d36c08;
-}
-
-.AccordianWarnings > .AccordianText--header {
+.AccordianWarnings--header {
   background: #fff7e6;
   padding: 0.25rem 0.5rem;
 }
 
-.SpanDetail--warnIcon {
-  background: transparent;
-  color: #ffa500;
-  font-size: 1em;
-  margin-right: 0.2rem;
+.AccordianWarnings--header:hover {
+  background: #ffe7ba;
+}
+
+.AccordianWarnings--header.is-open {
+  border-bottom: 1px solid #e8e8e8;
+}
+
+.AccordianWarnings--label {
+  color: #d36c08;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.js
@@ -20,6 +20,7 @@ import { shallow } from 'enzyme';
 
 import AccordianKeyValues from './AccordianKeyValues';
 import AccordianLogs from './AccordianLogs';
+import AccordianText from './AccordianText';
 import DetailState from './DetailState';
 import SpanDetail from './index';
 import { formatDuration } from '../utils';
@@ -46,6 +47,7 @@ describe('<SpanDetail>', () => {
     logsToggle: jest.fn(),
     processToggle: jest.fn(),
     tagsToggle: jest.fn(),
+    warningsToggle: jest.fn(),
   };
   span.logs = [
     {
@@ -57,6 +59,8 @@ describe('<SpanDetail>', () => {
       fields: [{ key: 'message', value: 'oh the next log message' }, { key: 'more', value: 'stuff' }],
     },
   ];
+
+  span.warnings = ['Warning 1', 'Warning 2'];
 
   beforeEach(() => {
     formatDuration.mockReset();
@@ -118,6 +122,15 @@ describe('<SpanDetail>', () => {
     accordianLogs.simulate('itemToggle', somethingUniq);
     expect(props.logsToggle).toHaveBeenLastCalledWith(span.spanID);
     expect(props.logItemToggle).toHaveBeenLastCalledWith(span.spanID, somethingUniq);
+  });
+
+  it('renders the warnings', () => {
+    const target = (
+      <AccordianText data={span.warnings} label="Warnings" isOpen={detailState.isWarningsOpen} />
+    );
+    expect(wrapper.containsMatchingElement(target)).toBe(true);
+    wrapper.find({ data: span.warnings }).simulate('toggle');
+    expect(props.warningsToggle).toHaveBeenLastCalledWith(span.spanID);
   });
 
   it('renders CopyIcon with deep link URL', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.js
@@ -20,7 +20,6 @@ import { shallow } from 'enzyme';
 
 import AccordianKeyValues from './AccordianKeyValues';
 import AccordianLogs from './AccordianLogs';
-import AccordianText from './AccordianText';
 import DetailState from './DetailState';
 import SpanDetail from './index';
 import { formatDuration } from '../utils';
@@ -125,11 +124,9 @@ describe('<SpanDetail>', () => {
   });
 
   it('renders the warnings', () => {
-    const target = (
-      <AccordianText data={span.warnings} label="Warnings" isOpen={detailState.isWarningsOpen} />
-    );
-    expect(wrapper.containsMatchingElement(target)).toBe(true);
-    wrapper.find({ data: span.warnings }).simulate('toggle');
+    const warningElm = wrapper.find({ data: span.warnings });
+    expect(warningElm.length).toBe(1);
+    warningElm.simulate('toggle');
     expect(props.warningsToggle).toHaveBeenLastCalledWith(span.spanID);
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -17,13 +17,14 @@ import { Divider } from 'antd';
 
 import AccordianKeyValues from './AccordianKeyValues';
 import AccordianLogs from './AccordianLogs';
+import AccordianText from './AccordianText';
 import DetailState from './DetailState';
 import { formatDuration } from '../utils';
 import CopyIcon from '../../../common/CopyIcon';
 import LabeledList from '../../../common/LabeledList';
 
 import { TNil } from '../../../../types';
-import { Log, Span, KeyValuePair, Link } from '../../../../types/trace';
+import { KeyValuePair, Link, Log, Span } from '../../../../types/trace';
 
 import './index.css';
 
@@ -36,6 +37,7 @@ type SpanDetailProps = {
   span: Span;
   tagsToggle: (spanID: string) => void;
   traceStartTime: number;
+  warningsToggle: (spanID: string) => void;
 };
 
 export default function SpanDetail(props: SpanDetailProps) {
@@ -48,9 +50,10 @@ export default function SpanDetail(props: SpanDetailProps) {
     span,
     tagsToggle,
     traceStartTime,
+    warningsToggle,
   } = props;
-  const { isTagsOpen, isProcessOpen, logs: logsState } = detailState;
-  const { operationName, process, duration, relativeStartTime, spanID, logs, tags } = span;
+  const { isTagsOpen, isProcessOpen, logs: logsState, isWarningsOpen } = detailState;
+  const { operationName, process, duration, relativeStartTime, spanID, logs, tags, warnings } = span;
   const overviewItems = [
     {
       key: 'svc',
@@ -111,6 +114,16 @@ export default function SpanDetail(props: SpanDetailProps) {
               onToggle={() => logsToggle(spanID)}
               onItemToggle={logItem => logItemToggle(spanID, logItem)}
               timestamp={traceStartTime}
+            />
+          )}
+        {warnings &&
+          warnings.length > 0 && (
+            <AccordianText
+              className="AccordianWarnings ub-mb1"
+              label="Warnings"
+              data={warnings}
+              isOpen={isWarningsOpen}
+              onToggle={() => warningsToggle(spanID)}
             />
           )}
         <small className="SpanDetail--debugInfo">

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -119,8 +119,9 @@ export default function SpanDetail(props: SpanDetailProps) {
         {warnings &&
           warnings.length > 0 && (
             <AccordianText
-              className="AccordianWarnings ub-mb1"
-              label="Warnings"
+              className="AccordianWarnings"
+              headerClassName="AccordianWarnings--header"
+              label={<span className="AccordianWarnings--label">Warnings</span>}
               data={warnings}
               isOpen={isWarningsOpen}
               onToggle={() => warningsToggle(spanID)}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -32,6 +32,7 @@ type SpanDetailRowProps = {
   logItemToggle: (spanID: string, log: Log) => void;
   logsToggle: (spanID: string) => void;
   processToggle: (spanID: string) => void;
+  warningsToggle: (spanID: string) => void;
   span: Span;
   tagsToggle: (spanID: string) => void;
   traceStartTime: number;
@@ -55,6 +56,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
       logItemToggle,
       logsToggle,
       processToggle,
+      warningsToggle,
       span,
       tagsToggle,
       traceStartTime,
@@ -81,6 +83,7 @@ export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProp
               logItemToggle={logItemToggle}
               logsToggle={logsToggle}
               processToggle={processToggle}
+              warningsToggle={warningsToggle}
               span={span}
               tagsToggle={tagsToggle}
               traceStartTime={traceStartTime}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -61,6 +61,7 @@ type TDispatchProps = {
   clearShouldScrollToFirstUiFindMatch: () => void;
   detailLogItemToggle: (spanID: string, log: Log) => void;
   detailLogsToggle: (spanID: string) => void;
+  detailWarningsToggle: (spanID: string) => void;
   detailProcessToggle: (spanID: string) => void;
   detailTagsToggle: (spanID: string) => void;
   detailToggle: (spanID: string) => void;
@@ -371,6 +372,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       detailLogItemToggle,
       detailLogsToggle,
       detailProcessToggle,
+      detailWarningsToggle,
       detailStates,
       detailTagsToggle,
       detailToggle,
@@ -393,6 +395,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           logItemToggle={detailLogItemToggle}
           logsToggle={detailLogsToggle}
           processToggle={detailProcessToggle}
+          warningsToggle={detailWarningsToggle}
           span={span}
           tagsToggle={detailTagsToggle}
           traceStartTime={trace.startTime}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
@@ -380,6 +380,13 @@ describe('TraceTimelineViewer/duck', () => {
         unchecked: new DetailState(),
         checked: baseDetail.toggleLogs(),
       },
+      {
+        msg: 'toggles warnings',
+        action: actions.detailWarningsToggle(id),
+        get: state => state.detailStates.get(id),
+        unchecked: new DetailState(),
+        checked: baseDetail.toggleWarnings(),
+      },
     ];
 
     beforeEach(() => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.tsx
@@ -68,6 +68,7 @@ export const actionTypes = generateActionTypes('@jaeger-ui/trace-timeline-viewer
   'DETAIL_PROCESS_TOGGLE',
   'DETAIL_LOGS_TOGGLE',
   'DETAIL_LOG_ITEM_TOGGLE',
+  'DETAIL_WARNINGS_TOGGLE',
   'EXPAND_ALL',
   'EXPAND_ONE',
   'FOCUS_UI_FIND_MATCHES',
@@ -87,6 +88,7 @@ const fullActions = createActions<TActionTypes>({
   [actionTypes.EXPAND_ALL]: () => ({}),
   [actionTypes.EXPAND_ONE]: (spans: Span[]) => ({ spans }),
   [actionTypes.DETAIL_PROCESS_TOGGLE]: (spanID: string) => ({ spanID }),
+  [actionTypes.DETAIL_WARNINGS_TOGGLE]: (spanID: string) => ({ spanID }),
   [actionTypes.DETAIL_TAGS_TOGGLE]: (spanID: string) => ({ spanID }),
   [actionTypes.DETAIL_TOGGLE]: (spanID: string) => ({ spanID }),
   [actionTypes.FOCUS_UI_FIND_MATCHES]: (trace: Trace, uiFind: string | TNil) => ({ trace, uiFind }),
@@ -237,7 +239,7 @@ function detailToggle(state: TTraceTimeline, { spanID }: TSpanIdValue) {
 }
 
 function detailSubsectionToggle(
-  subSection: 'tags' | 'process' | 'logs',
+  subSection: 'tags' | 'process' | 'logs' | 'warnings',
   state: TTraceTimeline,
   { spanID }: TSpanIdValue
 ) {
@@ -250,6 +252,8 @@ function detailSubsectionToggle(
     detailState = old.toggleTags();
   } else if (subSection === 'process') {
     detailState = old.toggleProcess();
+  } else if (subSection === 'warnings') {
+    detailState = old.toggleWarnings();
   } else {
     detailState = old.toggleLogs();
   }
@@ -261,6 +265,7 @@ function detailSubsectionToggle(
 const detailTagsToggle = detailSubsectionToggle.bind(null, 'tags');
 const detailProcessToggle = detailSubsectionToggle.bind(null, 'process');
 const detailLogsToggle = detailSubsectionToggle.bind(null, 'logs');
+const detailWarningsToggle = detailSubsectionToggle.bind(null, 'warnings');
 
 function detailLogItemToggle(state: TTraceTimeline, { spanID, logItem }: TSpanIdLogValue) {
   const old = state.detailStates.get(spanID);
@@ -299,6 +304,7 @@ export default handleActions(
     [actionTypes.DETAIL_LOGS_TOGGLE]: guardReducer(detailLogsToggle),
     [actionTypes.DETAIL_LOG_ITEM_TOGGLE]: guardReducer(detailLogItemToggle),
     [actionTypes.DETAIL_PROCESS_TOGGLE]: guardReducer(detailProcessToggle),
+    [actionTypes.DETAIL_WARNINGS_TOGGLE]: guardReducer(detailWarningsToggle),
     [actionTypes.DETAIL_TAGS_TOGGLE]: guardReducer(detailTagsToggle),
     [actionTypes.DETAIL_TOGGLE]: guardReducer(detailToggle),
     [actionTypes.EXPAND_ALL]: guardReducer(expandAll),

--- a/packages/jaeger-ui/src/types/trace.tsx
+++ b/packages/jaeger-ui/src/types/trace.tsx
@@ -54,6 +54,7 @@ export type SpanData = {
   logs: Array<Log>;
   tags: Array<KeyValuePair>;
   references: Array<SpanReference>;
+  warnings: Array<string> | null;
 };
 
 export type Span = SpanData & {


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

## Which problem is this PR solving?
- This solves issue: https://github.com/jaegertracing/jaeger/issues/1470, at least from the UI perspective, not sure if this is the best way.

## Short description of the changes
- I check for duplicated tags, and remove it (I left only one of them)
- Also has a boolean to indicate that span has duplicated tags so we can show a warning or something 

Screenshot of warning:

![Screenshot from 2019-05-03 12-29-02](https://user-images.githubusercontent.com/3799716/57156252-21762b00-6da3-11e9-87a1-22ed53787ee6.png)
