### PR TITLE
Fix plexus start and prepublishOnly npm scripts

### DIFF
--- a/packages/plexus/package.json
+++ b/packages/plexus/package.json
@@ -57,9 +57,9 @@
     "build":
       "NODE_ENV=production npm-run-all -ln --serial _tasks/clean/* _tasks/bundle-worker --parallel _tasks/build/**",
     "coverage": "echo 'NO TESTS YET'",
-    "prepublishOnly": "$npm_execpath build",
+    "prepublishOnly": "yarn build",
     "start":
-      "NODE_ENV='development' npm-run-all -ln --serial _tasks/clean/worker --parallel '_tasks/bundle-worker --watch' _tasks/dev-server",
+      "NODE_ENV='development' npm-run-all -ln --serial _tasks/clean/worker _tasks/bundle-worker --parallel '_tasks/bundle-worker --watch' _tasks/dev-server",
     "test": "echo 'NO TESTS YET'"
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fix #376.

## Short description of the changes

Fix to the `start` and `prepublishOnly` plexus npm scripts.
