### PR TITLE
Validate when tags and/or references fields are arrays.

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.tsx
+++ b/packages/jaeger-ui/src/model/transform-trace-data.tsx
@@ -15,10 +15,8 @@
 import _isEqual from 'lodash/isEqual';
 
 import { getTraceSpanIdsAsTree } from '../selectors/trace';
-import { KeyValuePair, Process, Span, SpanData, Trace, TraceData } from '../types/trace';
+import { KeyValuePair, Span, SpanData, Trace, TraceData } from '../types/trace';
 import TreeNode from '../utils/TreeNode';
-
-type SpanWithProcess = SpanData & { process: Process };
 
 function deduplicateTags(spanTags: Array<KeyValuePair>) {
   const warningsHash: Map<string, string> = new Map<string, string>();
@@ -38,7 +36,7 @@ function deduplicateTags(spanTags: Array<KeyValuePair>) {
  * NOTE: Mutates `data` - Transform the HTTP response data into the form the app
  * generally requires.
  */
-export default function transformTraceData(data: TraceData & { spans: SpanWithProcess[] }): Trace | null {
+export default function transformTraceData(data: TraceData & { spans: SpanData[] }): Trace | null {
   let { traceID } = data;
   if (!traceID) {
     return null;
@@ -48,14 +46,14 @@ export default function transformTraceData(data: TraceData & { spans: SpanWithPr
   let traceEndTime = 0;
   let traceStartTime = Number.MAX_SAFE_INTEGER;
   const spanIdCounts = new Map();
-  const spanMap = new Map<string, SpanWithProcess>();
+  const spanMap = new Map<string, Span>();
   // filter out spans with empty start times
   // eslint-disable-next-line no-param-reassign
   data.spans = data.spans.filter(span => Boolean(span.startTime));
 
   const max = data.spans.length;
   for (let i = 0; i < max; i++) {
-    const span = data.spans[i];
+    const span: Span = data.spans[i] as Span;
     const { startTime, duration, processID } = span;
     //
     let spanID = span.spanID;
@@ -107,9 +105,11 @@ export default function transformTraceData(data: TraceData & { spans: SpanWithPr
     span.relativeStartTime = span.startTime - traceStartTime;
     span.depth = depth - 1;
     span.hasChildren = node.children.length > 0;
+    span.warnings = span.warnings || [];
+    span.tags = span.tags || [];
+    span.references = span.references || [];
     const tagsInfo = deduplicateTags(span.tags);
     span.tags = tagsInfo.tags;
-    span.warnings = span.warnings || [];
     span.warnings = span.warnings.concat(tagsInfo.warnings);
     span.references.forEach(ref => {
       const refSpan = spanMap.get(ref.spanID) as Span;

--- a/packages/jaeger-ui/src/types/trace.tsx
+++ b/packages/jaeger-ui/src/types/trace.tsx
@@ -52,9 +52,9 @@ export type SpanData = {
   startTime: number;
   duration: number;
   logs: Array<Log>;
-  tags: Array<KeyValuePair>;
-  references: Array<SpanReference>;
-  warnings: Array<string> | null;
+  tags?: Array<KeyValuePair>;
+  references?: Array<SpanReference>;
+  warnings?: Array<string> | null;
 };
 
 export type Span = SpanData & {
@@ -62,6 +62,9 @@ export type Span = SpanData & {
   hasChildren: boolean;
   process: Process;
   relativeStartTime: number;
+  tags: NonNullable<SpanData['tags']>;
+  references: NonNullable<SpanData['references']>;
+  warnings: NonNullable<SpanData['warnings']>;
 };
 
 export type TraceData = {


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

## Which problem is this PR solving?
- Not sure if this can happens when is coming from the query Rest API, but I did tests with JSON files while I was investigating https://github.com/jaegertracing/jaeger-ui/issues/381 and it can happens there, (Of course it could be a bad format in the JSON). This does not solve https://github.com/jaegertracing/jaeger-ui/issues/381 but could help. 


## Short description of the changes
- Just validate those cases.
