### PR TITLE
Validate when there is no query but a JSON file is loaded

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -46,7 +46,7 @@ type SearchResultsProps = {
   hideGraph: boolean,
   loading: boolean,
   maxTraceDuration: number,
-  queryOfResults: SearchQuery,
+  queryOfResults?: SearchQuery,
   showStandaloneLink: boolean,
   skipMessage?: boolean,
   traces: TraceSummary[],
@@ -84,7 +84,7 @@ export const sortFormSelector = formValueSelector('traceResultsSort');
 export default class SearchResults extends React.PureComponent<SearchResultsProps> {
   props: SearchResultsProps;
 
-  static defaultProps = { skipMessage: false };
+  static defaultProps = { skipMessage: false, queryOfResults: undefined };
 
   toggleComparison = (traceID: string, remove: boolean) => {
     const { cohortAddTrace, cohortRemoveTrace } = this.props;
@@ -132,7 +132,7 @@ export default class SearchResults extends React.PureComponent<SearchResultsProp
       );
     }
     const cohortIds = new Set(diffCohort.map(datum => datum.id));
-    const searchUrl = getUrl(stripEmbeddedState(queryOfResults));
+    const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
     return (
       <div>
         <div>

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -71,7 +71,7 @@ export class SearchTracePageImpl extends Component {
 
   goToTrace = traceID => {
     const { queryOfResults } = this.props;
-    const searchUrl = getUrl(stripEmbeddedState(queryOfResults));
+    const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
     this.props.history.push(getTraceLocation(traceID, { fromSearch: searchUrl }));
   };
 


### PR DESCRIPTION


## Which problem is this PR solving?
- I had an issue when I tried to load a JSON file, the UI throws an error about undefined variable. The only way I was managed to work with it, is doing a search first and then I can load my JSON file.

## Short description of the changes
- Just validate if the URL does not have a searchQuery.
