### PR TITLE
Wrap span tag values

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -22,7 +22,7 @@ limitations under the License.
   line-height: 17px;
   font-size: 13px;
   font-family: monospace;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 .json-markup-key {
   font-weight: bold;


### PR DESCRIPTION
## Which problem is this PR solving?
Long tag values are difficult to read as they are rendered in a scroll box.

## Short description of the changes
Wrap the tag value instead.

From

![image](https://user-images.githubusercontent.com/6265378/58903603-d28a2100-86d3-11e9-8fc7-94dc5b3670a4.png)

to

![image](https://user-images.githubusercontent.com/6265378/58903538-b1c1cb80-86d3-11e9-9691-cbf52780693d.png)

Signed-off-by: Elan Kugelmass <epkugelmass@gmail.com>
