### PR TITLE
[Non-functional change] Update prettier and re-format

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -42,10 +42,10 @@ This applies ESLint to the repo, as a whole. The TypeScript linting has a distin
 
 This is an amalgamation of linting scripts that run to make sure things are all-good. It's run in CI (travis) and as part of a pre-commit hook.
 
-* `prettier-lint`
-* `tsc-lint`
-* `eslint`
-* `check-license`
+- `prettier-lint`
+- `tsc-lint`
+- `eslint`
+- `check-license`
 
 #### `prepare`
 
@@ -91,15 +91,15 @@ Used to configure the `tsc-lint` script and, in theory, the IDE (such as VS Code
 
 A few notable [compiler settings](http://www.typescriptlang.org/docs/handbook/compiler-options.html):
 
-* `lib`
-  * [es2017](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.es2017.d.ts)
-  * [dom](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
-  * [dom.iterable](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.iterable.d.ts)
-  * [webworker](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.webworker.d.ts)
-* `skipLibCheck` - Maybe worth reevaluating in the future
-* `strict` - Important
-* `noEmit` - We're using this for linting, after all
-* `include` - We've included `./typgings` here because it turned out to be a lot simpler than configuring `types`, `typeRoots` and `paths`
+- `lib`
+  - [es2017](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.es2017.d.ts)
+  - [dom](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
+  - [dom.iterable](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.iterable.d.ts)
+  - [webworker](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.webworker.d.ts)
+- `skipLibCheck` - Maybe worth reevaluating in the future
+- `strict` - Important
+- `noEmit` - We're using this for linting, after all
+- `include` - We've included `./typgings` here because it turned out to be a lot simpler than configuring `types`, `typeRoots` and `paths`
 
 ## `typings/{custom.d.ts, index.d.ts}`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,102 +4,102 @@
 
 ### Enhancements
 
-* **Trace detail:** Limit the thickness of spans in the minimap ([@rubenvp8510](https://github.com/rubenvp8510) in [#372](https://github.com/jaegertracing/jaeger-ui/pull/372))
+- **Trace detail:** Limit the thickness of spans in the minimap ([@rubenvp8510](https://github.com/rubenvp8510) in [#372](https://github.com/jaegertracing/jaeger-ui/pull/372))
 
-* **UI find:** Scroll to first match on load or on press of new locate icon ([@everett980](https://github.com/everett980) in [#367](https://github.com/jaegertracing/jaeger-ui/pull/367))
+- **UI find:** Scroll to first match on load or on press of new locate icon ([@everett980](https://github.com/everett980) in [#367](https://github.com/jaegertracing/jaeger-ui/pull/367))
 
-* **UI find:** Move filter state to query param and highlight filter matches on graphs ([@everett980](https://github.com/everett980) in [#310](https://github.com/jaegertracing/jaeger-ui/pull/310))
+- **UI find:** Move filter state to query param and highlight filter matches on graphs ([@everett980](https://github.com/everett980) in [#310](https://github.com/jaegertracing/jaeger-ui/pull/310))
 
-* **Search:** Improve display of long operation names in Operations list ([@kinghuang](https://github.com/kinghuang) in [#351](https://github.com/jaegertracing/jaeger-ui/pull/351))
+- **Search:** Improve display of long operation names in Operations list ([@kinghuang](https://github.com/kinghuang) in [#351](https://github.com/jaegertracing/jaeger-ui/pull/351))
 
 ### Fixes
 
-* **Search:** Fix "containig" typo ([@yurishkuro](https://github.com/yurishkuro) in [#363](https://github.com/jaegertracing/jaeger-ui/pull/363))
+- **Search:** Fix "containig" typo ([@yurishkuro](https://github.com/yurishkuro) in [#363](https://github.com/jaegertracing/jaeger-ui/pull/363))
 
-* **Trace detail:** Fixes dragging on the minimap in trace timeline ([Fix #354](https://github.com/jaegertracing/jaeger-ui/issues/354)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#357](https://github.com/jaegertracing/jaeger-ui/pull/357))
+- **Trace detail:** Fixes dragging on the minimap in trace timeline ([Fix #354](https://github.com/jaegertracing/jaeger-ui/issues/354)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#357](https://github.com/jaegertracing/jaeger-ui/pull/357))
 
-* **Trace detail:** Remove extra vertical scrollbar in trace timeline view ([Fix #241](https://github.com/jaegertracing/jaeger-ui/issues/241)) in ([@tiffon](https://github.com/tiffon) in [#350](https://github.com/jaegertracing/jaeger-ui/pull/350))
+- **Trace detail:** Remove extra vertical scrollbar in trace timeline view ([Fix #241](https://github.com/jaegertracing/jaeger-ui/issues/241)) in ([@tiffon](https://github.com/tiffon) in [#350](https://github.com/jaegertracing/jaeger-ui/pull/350))
 
-* **Trace detail:** Process FOLLOWS_FROM spans for indent guides in TraceView ([Fix #333](https://github.com/jaegertracing/jaeger-ui/issues/333)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#335](https://github.com/jaegertracing/jaeger-ui/pull/335))
+- **Trace detail:** Process FOLLOWS_FROM spans for indent guides in TraceView ([Fix #333](https://github.com/jaegertracing/jaeger-ui/issues/333)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#335](https://github.com/jaegertracing/jaeger-ui/pull/335))
 
-* **Dev docs:** Replace the wrong link for signing commits ([@sosiska](https://github.com/sosiska) in [#346](https://github.com/jaegertracing/jaeger-ui/pull/346))
+- **Dev docs:** Replace the wrong link for signing commits ([@sosiska](https://github.com/sosiska) in [#346](https://github.com/jaegertracing/jaeger-ui/pull/346))
 
 ### Chores & Maintenance
 
-* **TypeScript:** Convert from Flow to Typescript for Jaeger-UI ([@everett980](https://github.com/everett980) in [#359](https://github.com/jaegertracing/jaeger-ui/pull/359))
+- **TypeScript:** Convert from Flow to Typescript for Jaeger-UI ([@everett980](https://github.com/everett980) in [#359](https://github.com/jaegertracing/jaeger-ui/pull/359))
 
-* **TypeScript:** Export plexus type declarations, remove Neutrino ([@tiffon](https://github.com/tiffon) in [#348](https://github.com/jaegertracing/jaeger-ui/pull/348))
+- **TypeScript:** Export plexus type declarations, remove Neutrino ([@tiffon](https://github.com/tiffon) in [#348](https://github.com/jaegertracing/jaeger-ui/pull/348))
 
-* **TypeScript:** Shift plexus to TypeScript (from flowtypes) (Contributes to [#306](https://github.com/jaegertracing/jaeger-ui/issues/306)) ([@tiffon](https://github.com/tiffon) in [#331](https://github.com/jaegertracing/jaeger-ui/pull/331))
+- **TypeScript:** Shift plexus to TypeScript (from flowtypes) (Contributes to [#306](https://github.com/jaegertracing/jaeger-ui/issues/306)) ([@tiffon](https://github.com/tiffon) in [#331](https://github.com/jaegertracing/jaeger-ui/pull/331))
 
-* **Jaeger UI codebase:** Use memoize-one instead of bespoke solutions ([@rubenvp8510](https://github.com/rubenvp8510) in [#353](https://github.com/jaegertracing/jaeger-ui/pull/353))
+- **Jaeger UI codebase:** Use memoize-one instead of bespoke solutions ([@rubenvp8510](https://github.com/rubenvp8510) in [#353](https://github.com/jaegertracing/jaeger-ui/pull/353))
 
-* **Jaeger UI codebase:** Update lodash to 4.17.11 ([@tiffon](https://github.com/tiffon) in [#343](https://github.com/jaegertracing/jaeger-ui/pull/343))
+- **Jaeger UI codebase:** Update lodash to 4.17.11 ([@tiffon](https://github.com/tiffon) in [#343](https://github.com/jaegertracing/jaeger-ui/pull/343))
 
 ## v1.1.0 (March 3, 2019)
 
 ### Enhancements
 
-* **Trace detail:** Log Markers on spans ([Fix #119](https://github.com/jaegertracing/jaeger-ui/issues/119)) ([@sfriberg](https://github.com/sfriberg) in [#309](https://github.com/jaegertracing/jaeger-ui/pull/309))
+- **Trace detail:** Log Markers on spans ([Fix #119](https://github.com/jaegertracing/jaeger-ui/issues/119)) ([@sfriberg](https://github.com/sfriberg) in [#309](https://github.com/jaegertracing/jaeger-ui/pull/309))
 
-* **Search:** Load trace(s) from a JSON file ([Fix #214](https://github.com/jaegertracing/jaeger-ui/issues/214)) ([@yuribit](https://github.com/yuribit) in [#327](https://github.com/jaegertracing/jaeger-ui/pull/327))
+- **Search:** Load trace(s) from a JSON file ([Fix #214](https://github.com/jaegertracing/jaeger-ui/issues/214)) ([@yuribit](https://github.com/yuribit) in [#327](https://github.com/jaegertracing/jaeger-ui/pull/327))
 
 ### Fixes
 
-* **Trace detail:** Hide child status icon on SpanTreeOffset used in SpanDetailRow component ([Fix #328](https://github.com/jaegertracing/jaeger-ui/issues/328)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#334](https://github.com/jaegertracing/jaeger-ui/pull/334))
+- **Trace detail:** Hide child status icon on SpanTreeOffset used in SpanDetailRow component ([Fix #328](https://github.com/jaegertracing/jaeger-ui/issues/328)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#334](https://github.com/jaegertracing/jaeger-ui/pull/334))
 
-* **Data munging:** Optimize tree walk to avoid excessive function call depth ([Fix #320](https://github.com/jaegertracing/jaeger-ui/issues/320)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#326](https://github.com/jaegertracing/jaeger-ui/pull/326))
+- **Data munging:** Optimize tree walk to avoid excessive function call depth ([Fix #320](https://github.com/jaegertracing/jaeger-ui/issues/320)) ([@rubenvp8510](https://github.com/rubenvp8510) in [#326](https://github.com/jaegertracing/jaeger-ui/pull/326))
 
 ### Chores & Maintenance
 
-* **Code quality:** Fix a typo in transform-trace-data.js ([@bhavin192](https://github.com/bhavin192) in [#332](https://github.com/jaegertracing/jaeger-ui/pull/332))
+- **Code quality:** Fix a typo in transform-trace-data.js ([@bhavin192](https://github.com/bhavin192) in [#332](https://github.com/jaegertracing/jaeger-ui/pull/332))
 
 ## v1.0.1 (February 15, 2019)
 
 ### Fixes
 
-* **Trace detail:** Fix [#323](https://github.com/jaegertracing/jaeger-ui/issues/323) - Browser back button of trace page not working if plot is clicked ([@tacigar](https://github.com/tacigar) in [#324](https://github.com/jaegertracing/jaeger-ui/pull/324))
+- **Trace detail:** Fix [#323](https://github.com/jaegertracing/jaeger-ui/issues/323) - Browser back button of trace page not working if plot is clicked ([@tacigar](https://github.com/tacigar) in [#324](https://github.com/jaegertracing/jaeger-ui/pull/324))
 
-* **Search:** Fix [#325](https://github.com/jaegertracing/jaeger-ui/issues/325) - JS errors on search form dropdowns ([@tiffon](https://github.com/tiffon) in [#329](https://github.com/jaegertracing/jaeger-ui/pull/329))
+- **Search:** Fix [#325](https://github.com/jaegertracing/jaeger-ui/issues/325) - JS errors on search form dropdowns ([@tiffon](https://github.com/tiffon) in [#329](https://github.com/jaegertracing/jaeger-ui/pull/329))
 
 ## v1.0.0 (January 18, 2019)
 
 ### Enhancements
 
-* **Embedded mode:** Revisions to search and trace detail embed mode ([@tiffon](https://github.com/tiffon) in [#286](https://github.com/jaegertracing/jaeger-ui/pull/286))
+- **Embedded mode:** Revisions to search and trace detail embed mode ([@tiffon](https://github.com/tiffon) in [#286](https://github.com/jaegertracing/jaeger-ui/pull/286))
 
-  * This release establishes our commitment to the `uiEmbed=v0` API
-  * A big thanks to [@aljesusg](https://github.com/aljesusg) for getting this off the ground in [#263](https://github.com/jaegertracing/jaeger-ui/pull/263)! :tada:
+  - This release establishes our commitment to the `uiEmbed=v0` API
+  - A big thanks to [@aljesusg](https://github.com/aljesusg) for getting this off the ground in [#263](https://github.com/jaegertracing/jaeger-ui/pull/263)! :tada:
 
-* **Trace detail:** Add a tree view (aka Trace Graph) to the TracePage ([@copa2](https://github.com/copa2) in [#276](https://github.com/jaegertracing/jaeger-ui/pull/276))
+- **Trace detail:** Add a tree view (aka Trace Graph) to the TracePage ([@copa2](https://github.com/copa2) in [#276](https://github.com/jaegertracing/jaeger-ui/pull/276))
 
-  * Stability: Experimental – See [#293](https://github.com/jaegertracing/jaeger-ui/issues/293) for discussion.
-  * Big thanks to [@copa2](https://github.com/copa2) for the contribution! :tada:
-  * **We would love to hear feedback!**
+  - Stability: Experimental – See [#293](https://github.com/jaegertracing/jaeger-ui/issues/293) for discussion.
+  - Big thanks to [@copa2](https://github.com/copa2) for the contribution! :tada:
+  - **We would love to hear feedback!**
 
-* **Trace detail:** Add a copy icon to entries in KeyValuesTable ([#204](https://github.com/jaegertracing/jaeger-ui/issues/204)) ([@everett980](https://github.com/everett980) in [#292](https://github.com/jaegertracing/jaeger-ui/pull/292))
+- **Trace detail:** Add a copy icon to entries in KeyValuesTable ([#204](https://github.com/jaegertracing/jaeger-ui/issues/204)) ([@everett980](https://github.com/everett980) in [#292](https://github.com/jaegertracing/jaeger-ui/pull/292))
 
-* **Trace detail:** Add a Button to Reset Viewing Layer Zoom ([#215](https://github.com/jaegertracing/jaeger-ui/issues/215)) ([@everett980](https://github.com/everett980) in [#290](https://github.com/jaegertracing/jaeger-ui/pull/290))
+- **Trace detail:** Add a Button to Reset Viewing Layer Zoom ([#215](https://github.com/jaegertracing/jaeger-ui/issues/215)) ([@everett980](https://github.com/everett980) in [#290](https://github.com/jaegertracing/jaeger-ui/pull/290))
 
-* **Trace detail:** Add indent guides to trace timeline view ([#172](https://github.com/jaegertracing/jaeger-ui/issues/172)) ([@everett980](https://github.com/everett980) in [#297](https://github.com/jaegertracing/jaeger-ui/pull/297))
+- **Trace detail:** Add indent guides to trace timeline view ([#172](https://github.com/jaegertracing/jaeger-ui/issues/172)) ([@everett980](https://github.com/everett980) in [#297](https://github.com/jaegertracing/jaeger-ui/pull/297))
 
-* **Search:** Add popover and prevent submit if duration params are invalid ([#244](https://github.com/jaegertracing/jaeger-ui/issues/244)) ([@everett980](https://github.com/everett980) in [#291](https://github.com/jaegertracing/jaeger-ui/pull/291))
+- **Search:** Add popover and prevent submit if duration params are invalid ([#244](https://github.com/jaegertracing/jaeger-ui/issues/244)) ([@everett980](https://github.com/everett980) in [#291](https://github.com/jaegertracing/jaeger-ui/pull/291))
 
-* **Trace comparison:** Add link to timeline view from comparison view and selection ([@everett980](https://github.com/everett980) in [#313](https://github.com/jaegertracing/jaeger-ui/pull/313))
+- **Trace comparison:** Add link to timeline view from comparison view and selection ([@everett980](https://github.com/everett980) in [#313](https://github.com/jaegertracing/jaeger-ui/pull/313))
 
-* **Trace DAGs:** Add the ability to copy node data in the Trace Graph and Trace Comparison views ([@everett980](https://github.com/everett980) in [#312](https://github.com/jaegertracing/jaeger-ui/pull/312))
+- **Trace DAGs:** Add the ability to copy node data in the Trace Graph and Trace Comparison views ([@everett980](https://github.com/everett980) in [#312](https://github.com/jaegertracing/jaeger-ui/pull/312))
 
-* **Menu configuration:** Ability to open additional menu links in same tab (Resolves [#275](https://github.com/jaegertracing/jaeger-ui/issues/275)) ([@zablvit](https://github.com/zablvit) in [#278](https://github.com/jaegertracing/jaeger-ui/pull/278))
+- **Menu configuration:** Ability to open additional menu links in same tab (Resolves [#275](https://github.com/jaegertracing/jaeger-ui/issues/275)) ([@zablvit](https://github.com/zablvit) in [#278](https://github.com/jaegertracing/jaeger-ui/pull/278))
 
 ### Fixes
 
-* **Trace detail:** Fix [#269](https://github.com/jaegertracing/jaeger-ui/issues/269) - Fix column resizer overlays trace header ([@tiffon](https://github.com/tiffon) in [#280](https://github.com/jaegertracing/jaeger-ui/pull/280))
+- **Trace detail:** Fix [#269](https://github.com/jaegertracing/jaeger-ui/issues/269) - Fix column resizer overlays trace header ([@tiffon](https://github.com/tiffon) in [#280](https://github.com/jaegertracing/jaeger-ui/pull/280))
 
 ### Chores & Maintenance
 
-* **Dev docs:** Update a few links to the new website ([@ledor473](https://github.com/ledor473) in [#287](https://github.com/jaegertracing/jaeger-ui/pull/287))
+- **Dev docs:** Update a few links to the new website ([@ledor473](https://github.com/ledor473) in [#287](https://github.com/jaegertracing/jaeger-ui/pull/287))
 
-* **Jaeger UI codebase:** Update create-react-app to 2.1.2 ([@tiffon](https://github.com/tiffon) in [#302](https://github.com/jaegertracing/jaeger-ui/pull/302))
+- **Jaeger UI codebase:** Update create-react-app to 2.1.2 ([@tiffon](https://github.com/tiffon) in [#302](https://github.com/jaegertracing/jaeger-ui/pull/302))
 
 ## Changes released in Jaeger 1.8.2 and earlier
 
@@ -133,79 +133,79 @@ These changes are listed in chronological order by the date they were merged int
 
 ### [#221](https://github.com/jaegertracing/jaeger-ui/pull/221) Timeline Expand and Collapse Features
 
-* Partially addresses [#160](https://github.com/jaegertracing/jaeger-ui/issues/160) - Heuristics for collapsing spans
+- Partially addresses [#160](https://github.com/jaegertracing/jaeger-ui/issues/160) - Heuristics for collapsing spans
 
 ### [#191](https://github.com/jaegertracing/jaeger-ui/pull/191) Add GA event tracking for actions in trace view
 
-* Partially addresses [#157](https://github.com/jaegertracing/jaeger-ui/issues/157) - Enhanced Google Analytics integration
+- Partially addresses [#157](https://github.com/jaegertracing/jaeger-ui/issues/157) - Enhanced Google Analytics integration
 
 ### [#198](https://github.com/jaegertracing/jaeger-ui/pull/198) Use `<base>` and config webpack at runtime to allow path prefix
 
-* Fix [#42](https://github.com/jaegertracing/jaeger-ui/issues/42) - No support for Jaeger behind a reverse proxy
+- Fix [#42](https://github.com/jaegertracing/jaeger-ui/issues/42) - No support for Jaeger behind a reverse proxy
 
 ### [#195](https://github.com/jaegertracing/jaeger-ui/pull/195) Handle Error stored in redux trace.traces
 
-* Fix [#166](https://github.com/jaegertracing/jaeger-ui/issues/166) - JS error on search page after viewing 404 trace
+- Fix [#166](https://github.com/jaegertracing/jaeger-ui/issues/166) - JS error on search page after viewing 404 trace
 
 ### [#192](https://github.com/jaegertracing/jaeger-ui/pull/192) Change fallback trace name to be more informative
 
-* Fix [#190](https://github.com/jaegertracing/jaeger-ui/issues/190) - Change `cannot-find-trace-name` to `trace-without-root-span`
+- Fix [#190](https://github.com/jaegertracing/jaeger-ui/issues/190) - Change `cannot-find-trace-name` to `trace-without-root-span`
 
 ### [#189](https://github.com/jaegertracing/jaeger-ui/pull/189) Track JS errors in GA
 
-* Fix [#39](https://github.com/jaegertracing/jaeger-ui/issues/39) - Log js client side errors in our server side logs
+- Fix [#39](https://github.com/jaegertracing/jaeger-ui/issues/39) - Log js client side errors in our server side logs
 
 ### [#179](https://github.com/jaegertracing/jaeger-ui/pull/179) Resolve perf issues on the search page
 
-* Fix [#178](https://github.com/jaegertracing/jaeger-ui/issues/178) - Performance regression - Search page
+- Fix [#178](https://github.com/jaegertracing/jaeger-ui/issues/178) - Performance regression - Search page
 
 ### [#169](https://github.com/jaegertracing/jaeger-ui/pull/169) Use Ant Design instead of Semantic UI
 
-* Fix [#164](https://github.com/jaegertracing/jaeger-ui/issues/164) - Use Ant Design instead of Semantic UI
-* Fix [#165](https://github.com/jaegertracing/jaeger-ui/issues/165) - Search results are shown without a date
-* Fix [#69](https://github.com/jaegertracing/jaeger-ui/issues/69) - Missing endpoints in jaeger ui dropdown
+- Fix [#164](https://github.com/jaegertracing/jaeger-ui/issues/164) - Use Ant Design instead of Semantic UI
+- Fix [#165](https://github.com/jaegertracing/jaeger-ui/issues/165) - Search results are shown without a date
+- Fix [#69](https://github.com/jaegertracing/jaeger-ui/issues/69) - Missing endpoints in jaeger ui dropdown
 
 ### [#168](https://github.com/jaegertracing/jaeger-ui/pull/168) Fix 2 digit lookback (12h, 24h) parsing
 
-* Fix [#167](https://github.com/jaegertracing/jaeger-ui/issues/167) - 12 and 24 hour search lookbacks not converted to start timestamp correctly
+- Fix [#167](https://github.com/jaegertracing/jaeger-ui/issues/167) - 12 and 24 hour search lookbacks not converted to start timestamp correctly
 
 ### [#162](https://github.com/jaegertracing/jaeger-ui/pull/162) Only JSON.parse JSON strings in tags/logs values
 
-* Fix [#146](https://github.com/jaegertracing/jaeger-ui/issues/146) - Tags with string type displayed as integers in UI, bigint js problem
+- Fix [#146](https://github.com/jaegertracing/jaeger-ui/issues/146) - Tags with string type displayed as integers in UI, bigint js problem
 
 ### [#161](https://github.com/jaegertracing/jaeger-ui/pull/161) Add timezone tooltip to custom lookback form-field
 
-* Fix [#154](https://github.com/jaegertracing/jaeger-ui/issues/154) - Explain time zone of the lookback parameter
+- Fix [#154](https://github.com/jaegertracing/jaeger-ui/issues/154) - Explain time zone of the lookback parameter
 
 ### [#153](https://github.com/jaegertracing/jaeger-ui/pull/153) Add View Option for raw/unadjusted trace
 
-* Fix [#152](https://github.com/jaegertracing/jaeger-ui/issues/152) - Add View Option for raw/unadjusted trace
+- Fix [#152](https://github.com/jaegertracing/jaeger-ui/issues/152) - Add View Option for raw/unadjusted trace
 
 ### [#147](https://github.com/jaegertracing/jaeger-ui/pull/147) Use logfmt for search tag input format
 
-* Fix [#145](https://github.com/jaegertracing/jaeger-ui/issues/145) - Support logfmt for tags text input in the search form
-* Fix [#11](https://github.com/jaegertracing/jaeger-ui/issues/11) - Document allowed operators on tag search
+- Fix [#145](https://github.com/jaegertracing/jaeger-ui/issues/145) - Support logfmt for tags text input in the search form
+- Fix [#11](https://github.com/jaegertracing/jaeger-ui/issues/11) - Document allowed operators on tag search
 
 ### [#143](https://github.com/jaegertracing/jaeger-ui/pull/143) Add a config value for the DAG cutoff
 
-* Fix [#130](https://github.com/jaegertracing/jaeger-ui/issues/130) - Why maximum dependency length is set to 100 in DAG?
+- Fix [#130](https://github.com/jaegertracing/jaeger-ui/issues/130) - Why maximum dependency length is set to 100 in DAG?
 
 ### [#141](https://github.com/jaegertracing/jaeger-ui/pull/141) `package.json#proxy` should proxy all `/api` requests
 
-* Fix [#139](https://github.com/jaegertracing/jaeger-ui/issues/139) - Anyone konw how to open 16686 port?
+- Fix [#139](https://github.com/jaegertracing/jaeger-ui/issues/139) - Anyone konw how to open 16686 port?
 
 ### [#140](https://github.com/jaegertracing/jaeger-ui/pull/140) Encode service names in API calls
 
-* Fix [#138](https://github.com/jaegertracing/jaeger-ui/issues/138) - Cannot find operations if there is '/' char in serviceName
+- Fix [#138](https://github.com/jaegertracing/jaeger-ui/issues/138) - Cannot find operations if there is '/' char in serviceName
 
 ### [#136](https://github.com/jaegertracing/jaeger-ui/pull/136) Fix endless trace HTTP requests
 
-* Fix [#128](https://github.com/jaegertracing/jaeger-ui/issues/128) - When trace id is invalid, Jaeger UI send this request forever
+- Fix [#128](https://github.com/jaegertracing/jaeger-ui/issues/128) - When trace id is invalid, Jaeger UI send this request forever
 
 ### [#134](https://github.com/jaegertracing/jaeger-ui/pull/134) Fix trace name resolution
 
-* Fix [#117](https://github.com/jaegertracing/jaeger-ui/issues/117) - traceName relies on traceID to equal spanID
-* Fix [#129](https://github.com/jaegertracing/jaeger-ui/issues/129) - ¯*( ツ )*/¯ is not very clear
+- Fix [#117](https://github.com/jaegertracing/jaeger-ui/issues/117) - traceName relies on traceID to equal spanID
+- Fix [#129](https://github.com/jaegertracing/jaeger-ui/issues/129) - ¯*( ツ )*/¯ is not very clear
 
 ### [#133](https://github.com/jaegertracing/jaeger-ui/pull/133) Better HTTP error messages
 
@@ -215,11 +215,11 @@ These changes are listed in chronological order by the date they were merged int
 
 ### [#118](https://github.com/jaegertracing/jaeger-ui/pull/118) Handle `FOLLOWS_FROM` reference type
 
-* Fix [#115](https://github.com/jaegertracing/jaeger-ui/issues/115) - Rendering traces with spans containing a 'FOLLOWS_FROM' reference seems broken
+- Fix [#115](https://github.com/jaegertracing/jaeger-ui/issues/115) - Rendering traces with spans containing a 'FOLLOWS_FROM' reference seems broken
 
 ### [#110](https://github.com/jaegertracing/jaeger-ui/pull/110) Fix browser back button not working correctly
 
-* Fix [#94](https://github.com/jaegertracing/jaeger-ui/issues/94) - Browser back button not working correctly
+- Fix [#94](https://github.com/jaegertracing/jaeger-ui/issues/94) - Browser back button not working correctly
 
 ### [#107](https://github.com/jaegertracing/jaeger-ui/pull/107) Embed UI config
 
@@ -229,20 +229,20 @@ The query service can embed custom UI configuration into `index.html`, speeding 
 
 ### [#93](https://github.com/jaegertracing/jaeger-ui/pull/93) Keyboard shortcuts and minimap UX
 
-* Fix [#89](https://github.com/uber/jaeger-ui/issues/89) - [trace view] Drag and release on timeline header row zooms into respective range
-* Fix [#23](https://github.com/uber/jaeger-ui/issues/23) - [trace view] Navigate and zoom via minimap
-* Fix [#22](https://github.com/uber/jaeger-ui/issues/22) - [trace view] Pan and zoom via keyboard shortcuts
+- Fix [#89](https://github.com/uber/jaeger-ui/issues/89) - [trace view] Drag and release on timeline header row zooms into respective range
+- Fix [#23](https://github.com/uber/jaeger-ui/issues/23) - [trace view] Navigate and zoom via minimap
+- Fix [#22](https://github.com/uber/jaeger-ui/issues/22) - [trace view] Pan and zoom via keyboard shortcuts
 
 ### [#84](https://github.com/jaegertracing/jaeger-ui/pull/84) Improve search dropdowns
 
-* Fix [#79](https://github.com/uber/jaeger-ui/issues/79) - Sort services and operations operations (case insensitive)
-* Fix [#31](https://github.com/uber/jaeger-ui/issues/31) - Filter options based on contains instead of starts with
-* Fix [#30](https://github.com/uber/jaeger-ui/issues/30) - Filter options based on case insensitive match
+- Fix [#79](https://github.com/uber/jaeger-ui/issues/79) - Sort services and operations operations (case insensitive)
+- Fix [#31](https://github.com/uber/jaeger-ui/issues/31) - Filter options based on contains instead of starts with
+- Fix [#30](https://github.com/uber/jaeger-ui/issues/30) - Filter options based on case insensitive match
 
 ### [#78](https://github.com/jaegertracing/jaeger-ui/pull/78) Custom menu via /api/config with project links as defaults
 
-* Fix [#44](https://github.com/uber/jaeger-ui/issues/44) - Add configurable, persistent links to the header
-* **Support for this is WIP in query service**
+- Fix [#44](https://github.com/uber/jaeger-ui/issues/44) - Add configurable, persistent links to the header
+- **Support for this is WIP in query service**
 
 ### [#81](https://github.com/jaegertracing/jaeger-ui/pull/81) Fix Google Analytics tracking
 
@@ -254,23 +254,23 @@ The query service can embed custom UI configuration into `index.html`, speeding 
 
 ### [#68](https://github.com/jaegertracing/jaeger-ui/pull/68) Virtualized scrolling for trace detail view
 
-* Performance improved for initial loading, expanding span details, text search and scrolling
+- Performance improved for initial loading, expanding span details, text search and scrolling
 
 ### [#53](https://github.com/jaegertracing/jaeger-ui/pull/53) Refactor trace detail
 
-* Partial fix for [#42](https://github.com/uber/jaeger-ui/issues/42) - Support URL prefix via homepage in package.json
-* Scatterplot dots are sized based on number of spans
-* Scatterplot dots mouseover shows trace name
-* Clicking span detail left column collapses detail
-* Clicking anywhere left of parent span name toggles children visibility
-* Clip or hide span bars when zoomed in (instead of flush left)
-* Label on span bars no longer off-screen
-* Full width of the header is clickable for tags, process, and logs headers (instead of header text, only)
-* Horizontal scrolling for wide content (e.g. long log values) (Fix [#58](https://github.com/uber/jaeger-ui/issues/58))
-* Tall content scrolls via entire table instead of single table cell
-* Fix [#55](https://github.com/uber/jaeger-ui/issues/55) - Some tags were not being rendered due to clashing keys (observed in a log message)
-* Fix [jaegertracing/jaeger#326](https://github.com/jaegertracing/jaeger/issues/326) - extraneous scrollbars in trace views
-* Ticks in span graph made to match trace detail (in number and formatting)
-* Fix [#49](https://github.com/uber/jaeger-ui/issues/42) - Span position in graph doesn't not match its position in the detail
+- Partial fix for [#42](https://github.com/uber/jaeger-ui/issues/42) - Support URL prefix via homepage in package.json
+- Scatterplot dots are sized based on number of spans
+- Scatterplot dots mouseover shows trace name
+- Clicking span detail left column collapses detail
+- Clicking anywhere left of parent span name toggles children visibility
+- Clip or hide span bars when zoomed in (instead of flush left)
+- Label on span bars no longer off-screen
+- Full width of the header is clickable for tags, process, and logs headers (instead of header text, only)
+- Horizontal scrolling for wide content (e.g. long log values) (Fix [#58](https://github.com/uber/jaeger-ui/issues/58))
+- Tall content scrolls via entire table instead of single table cell
+- Fix [#55](https://github.com/uber/jaeger-ui/issues/55) - Some tags were not being rendered due to clashing keys (observed in a log message)
+- Fix [jaegertracing/jaeger#326](https://github.com/jaegertracing/jaeger/issues/326) - extraneous scrollbars in trace views
+- Ticks in span graph made to match trace detail (in number and formatting)
+- Fix [#49](https://github.com/uber/jaeger-ui/issues/42) - Span position in graph doesn't not match its position in the detail
 
 ### [Changes from before 2017-08-23 are not logged here](https://www.youtube.com/watch?v=NoAzpa1x7jU&feature=youtu.be&t=107)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,17 +16,17 @@ _Before making any significant changes, please [open an issue](https://github.co
 
 Once we've discussed your changes and you've got your code ready, make sure that tests are passing and open your pull request. Your PR is most likely to be accepted if it:
 
-* Includes tests for new functionality.
-* References the original issue in description, e.g. "Resolves #123".
-* Has a [good commit message](https://chris.beams.io/posts/git-commit/):
-  * Separate subject from body with a blank line
-  * Limit the subject line to 50 characters
-  * Capitalize the subject line
-  * Do not end the subject line with a period
-  * Use the imperative mood in the subject line
-  * Wrap the body at 72 characters
-  * Use the body to explain _what_ and _why_ instead of _how_
-* Each commit must be signed by the author ([see below](#sign-your-work)).
+- Includes tests for new functionality.
+- References the original issue in description, e.g. "Resolves #123".
+- Has a [good commit message](https://chris.beams.io/posts/git-commit/):
+  - Separate subject from body with a blank line
+  - Limit the subject line to 50 characters
+  - Capitalize the subject line
+  - Do not end the subject line with a period
+  - Use the imperative mood in the subject line
+  - Wrap the body at 72 characters
+  - Use the body to explain _what_ and _why_ instead of _how_
+- Each commit must be signed by the author ([see below](#sign-your-work)).
 
 ## License
 
@@ -121,18 +121,18 @@ Finally, we generally adhere to the [Airbnb Style Guide](https://github.com/airb
 # Cutting a Jaeger UI release
 
 1. Determine the version for the release.
-   * Follow [semver.org](https://semver.org) to determine the new version for Jaeger UI.
-     * Review all changes since the last release to determine how, if at all, any externally facing APIs are impacted. This includes, but is not limited to, the UI config and URL routes such as deep-linking and configuring the embedded mode.
-   * Preface the version with a "v", e.g. `v1.0.0`.
+   - Follow [semver.org](https://semver.org) to determine the new version for Jaeger UI.
+     - Review all changes since the last release to determine how, if at all, any externally facing APIs are impacted. This includes, but is not limited to, the UI config and URL routes such as deep-linking and configuring the embedded mode.
+   - Preface the version with a "v", e.g. `v1.0.0`.
 1. Create and merge, per approval, a PR which preps the release.
    1. The PR title should match the format "Preparing release vX.Y.Z".
    1. CHANGELOG.md
-      * Change the version of the current release from "Next (unreleased)" to "vX.Y.Z (Month D, YYYY)" where "vX.Y.Z" is the semver for this release.
-      * Make sure all relevant changes made since the last release are present and listed under the current release. [`scripts/get-changelog.js`](https://github.com/jaegertracing/jaeger-ui/blob/52780c897f21131472de9b81c96ebd63853917ee/scripts/get-changelog.js) might be useful.
-      * If necessary, add a note detailing any impact to externally facing APIs.
+      - Change the version of the current release from "Next (unreleased)" to "vX.Y.Z (Month D, YYYY)" where "vX.Y.Z" is the semver for this release.
+      - Make sure all relevant changes made since the last release are present and listed under the current release. [`scripts/get-changelog.js`](https://github.com/jaegertracing/jaeger-ui/blob/52780c897f21131472de9b81c96ebd63853917ee/scripts/get-changelog.js) might be useful.
+      - If necessary, add a note detailing any impact to externally facing APIs.
    1. Update `packages/jaeger-ui/package.json#version` to refer to the version being released.
 1. Create a GitHub release.
-   * The tag and release must refer to the commit created when the PR from the previous step was merged.
-   * The tag name for the GitHub release should be the version for the release. It should include the "v", e.g. `v1.0.0`.
-   * The title of the release match the format "Jaeger UI vX.Y.Z".
-   * Copy the new CHANGELOG.md section into the release notes.
+   - The tag and release must refer to the commit created when the PR from the previous step was merged.
+   - The tag name for the GitHub release should be the version for the release. It should include the "v", e.g. `v1.0.0`.
+   - The title of the release match the format "Jaeger UI vX.Y.Z".
+   - Copy the new CHANGELOG.md section into the release notes.

--- a/package.json
+++ b/package.json
@@ -22,16 +22,19 @@
     "jsdom": "13.2.0",
     "lerna": "3.13.0",
     "npm-run-all": "4.1.5",
-    "prettier": "1.10.2",
+    "prettier": "1.18.2",
     "rxjs-compat": "6.4.0",
     "typescript": "3.3.3333"
   },
   "resolutions": {
     "**/lodash": "4.17.11",
+    "**/prettier": "1.18.2",
     "**/cheerio/parse5": "4.0.0"
   },
   "workspaces": {
-    "packages": ["packages/*"],
+    "packages": [
+      "packages/*"
+    ],
     "nohoist": [
       "**/customize-cra",
       "**/customize-cra/**",
@@ -45,15 +48,11 @@
     "build": "lerna run build",
     "check-license": "./scripts/check-license.sh",
     "coverage": "lerna run coverage",
-    "eslint":
-      "eslint --cache 'scripts/*.{js,ts,tsx}' 'packages/*/src/**/*.{js,ts,tsx}' 'packages/*/*.{js,ts,tsx}'",
+    "eslint": "eslint --cache 'scripts/*.{js,ts,tsx}' 'packages/*/src/**/*.{js,ts,tsx}' 'packages/*/*.{js,ts,tsx}'",
     "lint": "npm-run-all -ln --parallel prettier-lint tsc-lint eslint check-license",
     "prepare": "lerna run --stream --sort prepublishOnly",
-    "prettier-comment": "https://github.com/yarnpkg/yarn/issues/6300",
-    "prettier":
-      "./node_modules/prettier/bin-prettier.js --write '{.,scripts}/*.{js,json,md,ts,tsx}' 'packages/*/{src,demo/src}/**/!(layout.worker.bundled|react-vis).{css,js,json,md,ts,tsx}' 'packages/*/*.{css,js,json,md,ts,tsx}'",
-    "prettier-lint":
-      "./node_modules/prettier/bin-prettier.js --list-different '{.,scripts}/*.{js,json,md,ts,tsx}' 'packages/*/{src,demo/src}/**/!(layout.worker.bundled|react-vis).{css,js,json,md,ts,tsx}' 'packages/*/*.{css,js,json,md,ts,tsx}'",
+    "prettier": "prettier --write '{.,scripts}/*.{js,json,md,ts,tsx}' 'packages/*/{src,demo/src}/**/!(layout.worker.bundled|react-vis).{css,js,json,md,ts,tsx}' 'packages/*/*.{css,js,json,md,ts,tsx}'",
+    "prettier-lint": "prettier --list-different '{.,scripts}/*.{js,json,md,ts,tsx}' 'packages/*/{src,demo/src}/**/!(layout.worker.bundled|react-vis).{css,js,json,md,ts,tsx}' 'packages/*/*.{css,js,json,md,ts,tsx}'",
     "test": "lerna run test",
     "tsc-lint": "tsc --build",
     "tsc-lint-debug": "tsc --listFiles",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -100,8 +100,7 @@
     "analyze": "source-map-explorer build/static/js/main.*",
     "build": "REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) react-app-rewired build",
     "coverage": "yarn run test -- --coverage",
-    "start:ga-debug":
-      "REACT_APP_GA_DEBUG=1 REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) react-app-rewired start",
+    "start:ga-debug": "REACT_APP_GA_DEBUG=1 REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) react-app-rewired start",
     "start": "react-app-rewired start",
     "test-dev": "react-app-rewired test --env=jsdom",
     "test": "CI=1 react-app-rewired test --env=jsdom --color"
@@ -115,5 +114,10 @@
       "!src/demo/**/*.js"
     ]
   },
-  "browserslist": [">0.5%", "not dead", "not ie <= 11", "not op_mini all"]
+  "browserslist": [
+    ">0.5%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.js
@@ -131,4 +131,7 @@ export function mapDispatchToProps(dispatch) {
   return { fetchDependencies };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DependencyGraphPageImpl);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DependencyGraphPageImpl);

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -611,7 +611,10 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(
   reduxForm({
     form: 'searchSideBar',
   })(SearchFormImpl)

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
@@ -91,7 +91,7 @@ export default class ResultItemTitle extends React.PureComponent<Props> {
           />
         )}
         {/* TODO: Shouldn't need cast */}
-        <WrapperComponent {...wrapperProps as { [key: string]: any; to: string }}>
+        <WrapperComponent {...(wrapperProps as { [key: string]: any; to: string })}>
           <span
             className="ResultItemTitle--durationBar"
             style={{ width: `${durationPercent || DEFAULT_DURATION_PERCENT}%` }}

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -115,7 +115,9 @@ export class SearchTracePageImpl extends Component {
             {showErrors && (
               <div className="js-test-error-message">
                 <h2>There was an error querying for traces:</h2>
-                {errors.map(err => <ErrorMessage key={err.message} error={err} />)}
+                {errors.map(err => (
+                  <ErrorMessage key={err.message} error={err} />
+                ))}
               </div>
             )}
             {!showErrors && (
@@ -282,4 +284,7 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchTracePageImpl);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SearchTracePageImpl);

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.js
@@ -314,10 +314,10 @@ describe('TraceDiff', () => {
 
     // This test may false negative if previous tests are failing
     it('builds tracesData Map from cohort and state.trace.traces', () => {
-      const { tracesData, cohort: { length: expectedSize } } = mapStateToProps(
-        makeTestReduxState(),
-        getOwnProps()
-      );
+      const {
+        tracesData,
+        cohort: { length: expectedSize },
+      } = mapStateToProps(makeTestReduxState(), getOwnProps());
       defaultCohortIds.forEach(id => {
         expect(tracesData.get(id)).toEqual({
           id,

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/drawNode.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/drawNode.tsx
@@ -68,7 +68,7 @@ export class DiffNode extends React.PureComponent<Props> {
             {isSame ? null : (
               <td className={`DiffNode--metricCell ${className}`}>
                 <span className="DiffNode--metricSymbol">{chgSign}</span>
-                {a === 0 || b === 0 ? 100 : abs((a - b) / max(a, b) * 100).toFixed(0)}
+                {a === 0 || b === 0 ? 100 : abs(((a - b) / max(a, b)) * 100).toFixed(0)}
                 <span className="DiffNode--metricSymbol">%</span>
               </td>
             )}

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/CohortTable.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/CohortTable.test.js
@@ -148,7 +148,12 @@ describe('CohortTable', () => {
   it('renders TraceName fragment when given complete data', () => {
     const traceNameColumnRenderer = getRowRenderer('traceName');
     const testTrace = cohort[0];
-    const { id, error, state, data: { traceName } } = testTrace;
+    const {
+      id,
+      error,
+      state,
+      data: { traceName },
+    } = testTrace;
     const renderedTraceNameColumn = shallow(
       // traceNameRenderer returns a React Fragment, wrapper div helps enzyme
       <div>{traceNameColumnRenderer('unused argument', testTrace)}</div>

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceDiffHeader.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceDiffHeader.tsx
@@ -75,15 +75,13 @@ export default class TraceDiffHeader extends React.PureComponent<Props, State> {
       id: aId = undefined,
       state: aState = undefined,
       error: aError = undefined,
-    } =
-      a || {};
+    } = a || {};
     const {
       data: bData = undefined,
       id: bId = undefined,
       state: bState = undefined,
       error: bError = undefined,
-    } =
-      b || {};
+    } = b || {};
     const selection: Record<string, { label: 'A' | 'B' }> = {};
     if (aId) selection[aId] = { label: 'A' };
     if (bId) selection[bId] = { label: 'B' };

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.tsx
@@ -98,9 +98,9 @@ export function calculateTraceDag(trace: Trace): TraceDag<TSumSpan> {
       count: n.members.length,
       errors: numErrors,
       time: ntime,
-      percent: 100 / trace.duration * ntime,
+      percent: (100 / trace.duration) * ntime,
       selfTime: stime,
-      percentSelfTime: 100 / ntime * stime,
+      percentSelfTime: (100 / ntime) * stime,
     };
     // eslint-disable-next-line no-param-reassign
     n.data = nd;

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/GraphTicks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/GraphTicks.tsx
@@ -25,7 +25,7 @@ export default function GraphTicks(props: GraphTicksProps) {
   const ticks = [];
   // i starts at 1, limit is `i < numTicks` so the first and last ticks aren't drawn
   for (let i = 1; i < numTicks; i++) {
-    const x = `${i / numTicks * 100}%`;
+    const x = `${(i / numTicks) * 100}%`;
     ticks.push(<line className="GraphTick" x1={x} y1="0%" x2={x} y2="100%" key={i / numTicks} />);
   }
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/render-into-canvas.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/render-into-canvas.test.js
@@ -135,9 +135,9 @@ describe('renderIntoCanvas()', () => {
           const color = expectedColors[i].output;
           const fillStyle = `rgba(${color.concat(ITEM_ALPHA).join()})`;
           const height = Math.min(MAX_ITEM_HEIGHT, Math.max(MIN_ITEM_HEIGHT, cHeight / items.length));
-          const width = valueWidth / totalValueWidth * getCanvasWidth();
-          const x = valueOffset / totalValueWidth * getCanvasWidth();
-          const y = cHeight / items.length * i;
+          const width = (valueWidth / totalValueWidth) * getCanvasWidth();
+          const x = (valueOffset / totalValueWidth) * getCanvasWidth();
+          const y = (cHeight / items.length) * i;
           return { fillStyle, height, width, x, y };
         }),
       ];
@@ -181,9 +181,9 @@ describe('renderIntoCanvas()', () => {
           const color = expectedColors[i].output;
           const fillStyle = `rgba(${color.concat(ITEM_ALPHA).join()})`;
           const height = MIN_ITEM_HEIGHT;
-          const width = Math.max(MIN_ITEM_WIDTH, valueWidth / totalValueWidth * getCanvasWidth());
-          const x = valueOffset / totalValueWidth * getCanvasWidth();
-          const y = MAX_TOTAL_HEIGHT / items.length * i;
+          const width = Math.max(MIN_ITEM_WIDTH, (valueWidth / totalValueWidth) * getCanvasWidth());
+          const x = (valueOffset / totalValueWidth) * getCanvasWidth();
+          const y = (MAX_TOTAL_HEIGHT / items.length) * i;
           return { fillStyle, height, width, x, y };
         }),
       ];

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -45,8 +45,8 @@ export default function renderIntoCanvas(
   ctx.fillRect(0, 0, cWidth, cHeight);
   for (let i = 0; i < items.length; i++) {
     const { valueWidth, valueOffset, serviceName } = items[i];
-    const x = valueOffset / totalValueWidth * cWidth;
-    let width = valueWidth / totalValueWidth * cWidth;
+    const x = (valueOffset / totalValueWidth) * cWidth;
+    let width = (valueWidth / totalValueWidth) * cWidth;
     if (width < MIN_ITEM_WIDTH) {
       width = MIN_ITEM_WIDTH;
     }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -199,15 +199,14 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
         )}
       </div>
       {summaryItems && <LabeledList className="TracePageHeader--overviewItems" items={summaryItems} />}
-      {!hideMap &&
-        !slimView && (
-          <SpanGraph
-            trace={trace}
-            viewRange={viewRange}
-            updateNextViewRangeTime={updateNextViewRangeTime}
-            updateViewRangeTime={updateViewRangeTime}
-          />
-        )}
+      {!hideMap && !slimView && (
+        <SpanGraph
+          trace={trace}
+          viewRange={viewRange}
+          updateNextViewRangeTime={updateNextViewRangeTime}
+          updateViewRangeTime={updateViewRangeTime}
+        />
+      )}
     </header>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ListView/Positions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ListView/Positions.tsx
@@ -192,6 +192,6 @@ export default class Positions {
       return known | 0;
     }
     // eslint-disable-next-line no-bitwise
-    return (known / (this.lastI + 1) * this.heights.length) | 0;
+    return ((known / (this.lastI + 1)) * this.heights.length) | 0;
   }
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -89,7 +89,12 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
       traceStartTime,
       span,
     } = this.props;
-    const { duration, hasChildren: isParent, operationName, process: { serviceName } } = span;
+    const {
+      duration,
+      hasChildren: isParent,
+      operationName,
+      process: { serviceName },
+    } = span;
     const label = formatDuration(duration);
     const viewBounds = getViewedBounds(span.startTime, span.startTime + span.duration);
     const viewStart = viewBounds.start;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -104,29 +104,27 @@ export default function SpanDetail(props: SpanDetailProps) {
             />
           )}
         </div>
-        {logs &&
-          logs.length > 0 && (
-            <AccordianLogs
-              linksGetter={linksGetter}
-              logs={logs}
-              isOpen={logsState.isOpen}
-              openedItems={logsState.openedItems}
-              onToggle={() => logsToggle(spanID)}
-              onItemToggle={logItem => logItemToggle(spanID, logItem)}
-              timestamp={traceStartTime}
-            />
-          )}
-        {warnings &&
-          warnings.length > 0 && (
-            <AccordianText
-              className="AccordianWarnings"
-              headerClassName="AccordianWarnings--header"
-              label={<span className="AccordianWarnings--label">Warnings</span>}
-              data={warnings}
-              isOpen={isWarningsOpen}
-              onToggle={() => warningsToggle(spanID)}
-            />
-          )}
+        {logs && logs.length > 0 && (
+          <AccordianLogs
+            linksGetter={linksGetter}
+            logs={logs}
+            isOpen={logsState.isOpen}
+            openedItems={logsState.openedItems}
+            onToggle={() => logsToggle(spanID)}
+            onItemToggle={logItem => logItemToggle(spanID, logItem)}
+            timestamp={traceStartTime}
+          />
+        )}
+        {warnings && warnings.length > 0 && (
+          <AccordianText
+            className="AccordianWarnings"
+            headerClassName="AccordianWarnings--header"
+            label={<span className="AccordianWarnings--label">Warnings</span>}
+            data={warnings}
+            isOpen={isWarningsOpen}
+            onToggle={() => warningsToggle(spanID)}
+          />
+        )}
         <small className="SpanDetail--debugInfo">
           <span className="SpanDetail--debugLabel" data-label="SpanID:" /> {spanID}
           <CopyIcon

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -137,4 +137,7 @@ export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchPro
   return { addHoverIndentGuideId, removeHoverIndentGuideId };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(UnconnectedSpanTreeOffset);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(UnconnectedSpanTreeOffset);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.tsx
@@ -34,7 +34,7 @@ export default function Ticks(props: TicksProps) {
     labels = [];
     const viewingDuration = (endTime || 0) - (startTime || 0);
     for (let i = 0; i < numTicks; i++) {
-      const durationAtTick = (startTime || 0) + i / (numTicks - 1) * viewingDuration;
+      const durationAtTick = (startTime || 0) + (i / (numTicks - 1)) * viewingDuration;
       labels.push(formatDuration(durationAtTick));
     }
   }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -443,5 +443,8 @@ export default withRouter(
     TDispatchProps,
     TVirtualizedTraceViewOwnProps,
     ReduxState
-  >(mapStateToProps, mapDispatchToProps)(VirtualizedTraceViewImpl)
+  >(
+    mapStateToProps,
+    mapDispatchToProps
+  )(VirtualizedTraceViewImpl)
 );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -124,4 +124,7 @@ function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
   return { setSpanNameColumnWidth, expandAll, expandOne, collapseAll, collapseOne };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TraceTimelineViewerImpl);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TraceTimelineViewerImpl);

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -431,4 +431,7 @@ export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchPro
   return { acknowledgeArchive, archiveTrace, fetchTrace, focusUiFindMatches };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TracePageImpl);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TracePageImpl);

--- a/packages/jaeger-ui/src/middlewares/track.tsx
+++ b/packages/jaeger-ui/src/middlewares/track.tsx
@@ -36,4 +36,4 @@ function trackingMiddleware(store: Store<ReduxState>) {
   };
 }
 
-export default (isGaEnabled ? trackingMiddleware : undefined);
+export default isGaEnabled ? trackingMiddleware : undefined;

--- a/packages/jaeger-ui/src/selectors/span.js
+++ b/packages/jaeger-ui/src/selectors/span.js
@@ -24,7 +24,10 @@ export const getSpanTimestamp = span => span.startTime;
 export const getSpanProcessId = span => span.processID;
 export const getSpanReferences = span => span.references || [];
 export const getSpanReferenceByType = createSelector(
-  createSelector(({ span }) => span, getSpanReferences),
+  createSelector(
+    ({ span }) => span,
+    getSpanReferences
+  ),
   ({ type }) => type,
   (references, type) => references.find(ref => ref.refType === type)
 );
@@ -46,7 +49,10 @@ export const getSpanProcess = span => {
   return span.process;
 };
 
-export const getSpanServiceName = createSelector(getSpanProcess, getProcessServiceName);
+export const getSpanServiceName = createSelector(
+  getSpanProcess,
+  getProcessServiceName
+);
 
 export const filterSpansForTimestamps = createSelector(
   ({ spans }) => spans,
@@ -67,14 +73,16 @@ export const filterSpansForText = createSelector(
       .map(({ original }) => original)
 );
 
-const getTextFilterdSpansAsMap = createSelector(filterSpansForText, matchingSpans =>
-  matchingSpans.reduce(
-    (obj, span) => ({
-      ...obj,
-      [getSpanId(span)]: span,
-    }),
-    {}
-  )
+const getTextFilterdSpansAsMap = createSelector(
+  filterSpansForText,
+  matchingSpans =>
+    matchingSpans.reduce(
+      (obj, span) => ({
+        ...obj,
+        [getSpanId(span)]: span,
+      }),
+      {}
+    )
 );
 
 export const highlightSpansForTextFilter = createSelector(

--- a/packages/jaeger-ui/src/selectors/trace.js
+++ b/packages/jaeger-ui/src/selectors/trace.js
@@ -42,8 +42,9 @@ const getSpanWithProcess = createSelector(
   })
 );
 
-export const getTraceSpansAsMap = createSelector(getTraceSpans, spans =>
-  spans.reduce((map, span) => map.set(getSpanId(span), span), new Map())
+export const getTraceSpansAsMap = createSelector(
+  getTraceSpans,
+  spans => spans.reduce((map, span) => map.set(getSpanId(span), span), new Map())
 );
 
 export const TREE_ROOT_ID = '__root__';
@@ -106,24 +107,32 @@ export const hydrateSpansWithProcesses = trace => {
   };
 };
 
-export const getTraceSpanCount = createSelector(getTraceSpans, spans => spans.length);
-
-export const getTraceTimestamp = createSelector(getTraceSpans, spans =>
-  spans.reduce(
-    (prevTimestamp, span) =>
-      prevTimestamp ? Math.min(prevTimestamp, getSpanTimestamp(span)) : getSpanTimestamp(span),
-    null
-  )
+export const getTraceSpanCount = createSelector(
+  getTraceSpans,
+  spans => spans.length
 );
 
-export const getTraceDuration = createSelector(getTraceSpans, getTraceTimestamp, (spans, timestamp) =>
-  spans.reduce(
-    (prevDuration, span) =>
-      prevDuration
-        ? Math.max(getSpanTimestamp(span) - timestamp + getSpanDuration(span), prevDuration)
-        : getSpanDuration(span),
-    null
-  )
+export const getTraceTimestamp = createSelector(
+  getTraceSpans,
+  spans =>
+    spans.reduce(
+      (prevTimestamp, span) =>
+        prevTimestamp ? Math.min(prevTimestamp, getSpanTimestamp(span)) : getSpanTimestamp(span),
+      null
+    )
+);
+
+export const getTraceDuration = createSelector(
+  getTraceSpans,
+  getTraceTimestamp,
+  (spans, timestamp) =>
+    spans.reduce(
+      (prevDuration, span) =>
+        prevDuration
+          ? Math.max(getSpanTimestamp(span) - timestamp + getSpanDuration(span), prevDuration)
+          : getSpanDuration(span),
+      null
+    )
 );
 
 export const getTraceEndTimestamp = createSelector(
@@ -141,22 +150,36 @@ export const getParentSpan = createSelector(
       .sort((spanA, spanB) => numberSortComparator(getSpanTimestamp(spanA), getSpanTimestamp(spanB)))[0]
 );
 
-export const getTraceDepth = createSelector(getTraceSpanIdsAsTree, spanTree => spanTree.depth - 1);
+export const getTraceDepth = createSelector(
+  getTraceSpanIdsAsTree,
+  spanTree => spanTree.depth - 1
+);
 
 export const getSpanDepthForTrace = createSelector(
-  createSelector(state => state.trace, getTraceSpanIdsAsTree),
-  createSelector(state => state.span, getSpanId),
+  createSelector(
+    state => state.trace,
+    getTraceSpanIdsAsTree
+  ),
+  createSelector(
+    state => state.span,
+    getSpanId
+  ),
   (node, spanID) => node.getPath(spanID).length - 1
 );
 
-export const getTraceServices = createSelector(getTraceProcesses, processes =>
-  Object.keys(processes).reduce(
-    (services, processID) => services.add(getProcessServiceName(processes[processID])),
-    new Set()
-  )
+export const getTraceServices = createSelector(
+  getTraceProcesses,
+  processes =>
+    Object.keys(processes).reduce(
+      (services, processID) => services.add(getProcessServiceName(processes[processID])),
+      new Set()
+    )
 );
 
-export const getTraceServiceCount = createSelector(getTraceServices, services => services.size);
+export const getTraceServiceCount = createSelector(
+  getTraceServices,
+  services => services.size
+);
 
 // establish constants to determine how math should be handled
 // for nanosecond-to-millisecond conversions.
@@ -178,7 +201,10 @@ export const formatDurationForUnit = createSelector(
 
 export const formatDurationForTrace = createSelector(
   ({ duration }) => duration,
-  createSelector(({ trace }) => trace, getDurationFormatterForTrace),
+  createSelector(
+    ({ trace }) => trace,
+    getDurationFormatterForTrace
+  ),
   (duration, formatter) => formatter(duration)
 );
 
@@ -190,16 +216,25 @@ export const getSortedSpans = createSelector(
     [...spans].sort((spanA, spanB) => dir * comparator(selector(spanA, trace), selector(spanB, trace)))
 );
 
-const getTraceSpansByHierarchyPosition = createSelector(getTraceSpanIdsAsTree, tree => {
-  const hierarchyPositionMap = new Map();
-  let i = 0;
-  tree.walk(spanID => hierarchyPositionMap.set(spanID, i++));
-  return hierarchyPositionMap;
-});
+const getTraceSpansByHierarchyPosition = createSelector(
+  getTraceSpanIdsAsTree,
+  tree => {
+    const hierarchyPositionMap = new Map();
+    let i = 0;
+    tree.walk(spanID => hierarchyPositionMap.set(spanID, i++));
+    return hierarchyPositionMap;
+  }
+);
 
 export const getTreeSizeForTraceSpan = createSelector(
-  createSelector(state => state.trace, getTraceSpanIdsAsTree),
-  createSelector(state => state.span, getSpanId),
+  createSelector(
+    state => state.trace,
+    getTraceSpanIdsAsTree
+  ),
+  createSelector(
+    state => state.span,
+    getSpanId
+  ),
   (tree, spanID) => {
     const node = tree.find(spanID);
     if (!node) {
@@ -210,14 +245,20 @@ export const getTreeSizeForTraceSpan = createSelector(
 );
 
 export const getSpanHierarchySortPositionForTrace = createSelector(
-  createSelector(({ trace }) => trace, getTraceSpansByHierarchyPosition),
+  createSelector(
+    ({ trace }) => trace,
+    getTraceSpansByHierarchyPosition
+  ),
   ({ span }) => span,
   (hierarchyPositionMap, span) => hierarchyPositionMap.get(getSpanId(span))
 );
 
 export const getTraceName = createSelector(
   createSelector(
-    createSelector(hydrateSpansWithProcesses, getParentSpan),
+    createSelector(
+      hydrateSpansWithProcesses,
+      getParentSpan
+    ),
     createStructuredSelector({
       name: getSpanName,
       serviceName: getSpanServiceName,
@@ -228,7 +269,10 @@ export const getTraceName = createSelector(
 
 export const omitCollapsedSpans = createSelector(
   ({ spans }) => spans,
-  createSelector(({ trace }) => trace, getTraceSpanIdsAsTree),
+  createSelector(
+    ({ trace }) => trace,
+    getTraceSpanIdsAsTree
+  ),
   ({ collapsed }) => collapsed,
   (spans, tree, collapse) => {
     const hiddenSpanIds = collapse.reduce((result, collapsedSpanId) => {

--- a/packages/jaeger-ui/src/utils/DraggableManager/README.md
+++ b/packages/jaeger-ui/src/utils/DraggableManager/README.md
@@ -4,8 +4,8 @@ In the `src/utils/DraggableManager/demo` folder there is a small project that de
 
 The demo contains two components:
 
-* `DividerDemo`, which occupies the top half of the web page
-* `RegionDemo`, which occupies the bottom half of the web page, as shown in the GIF, below
+- `DividerDemo`, which occupies the top half of the web page
+- `RegionDemo`, which occupies the bottom half of the web page, as shown in the GIF, below
 
 ![GIF of Demo](demo/demo-ux.gif)
 
@@ -19,16 +19,16 @@ What we do with that information is up to us. This is mentioned because you need
 
 DraggableManager instances provide three (and a half) conveniences:
 
-* Handle mouse events related to dragging.
-* Maps `MouseEvent.clientX` from the [client area](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX) to the local context (yielding `x` (pixels) and `value` (0 -> 1, e.g, `x/width`)).
-* Maintains a sense of state in terms of whether or not the subject DOM element is being dragged. For example, it fires `onMouseMove` callbacks when not being dragged and `onDragMove` when being dragged.
-* Two other minor conveniences (relating to window events)
+- Handle mouse events related to dragging.
+- Maps `MouseEvent.clientX` from the [client area](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX) to the local context (yielding `x` (pixels) and `value` (0 -> 1, e.g, `x/width`)).
+- Maintains a sense of state in terms of whether or not the subject DOM element is being dragged. For example, it fires `onMouseMove` callbacks when not being dragged and `onDragMove` when being dragged.
+- Two other minor conveniences (relating to window events)
 
 And, DraggableManager instances have two (or three) primary requirements:
 
-* Mouse events need to be piped into it
-* The `getBounds()` constructor parameter must be provided
-* At least some of the callbacks need to be handled
+- Mouse events need to be piped into it
+- The `getBounds()` constructor parameter must be provided
+- At least some of the callbacks need to be handled
 
 ## Conveniences
 
@@ -36,10 +36,10 @@ And, DraggableManager instances have two (or three) primary requirements:
 
 For the purposes of handling mouse events related to the intended dragging functionality, DraggableManager instances expose the following methods (among others):
 
-* `handleMouseEnter`
-* `handleMouseMove`
-* `handleMouseLeave`
-* `handleMouseDown`
+- `handleMouseEnter`
+- `handleMouseMove`
+- `handleMouseLeave`
+- `handleMouseDown`
 
 To use a DraggableManager instance, relevant mouse events should be piped to the above handlers:
 
@@ -77,12 +77,12 @@ In other words, DraggableManager instances convert the data to the relevant cont
 
 The callbacks for DraggableManager instances are:
 
-* onMouseEnter
-* onMouseLeave
-* onMouseMove
-* onDragStart
-* onDragMove
-* onDragEnd
+- onMouseEnter
+- onMouseLeave
+- onMouseMove
+- onDragStart
+- onDragMove
+- onDragEnd
 
 Implicit in the breakdown of the callbacks is the notion that `onDrag*` callbacks are fired when dragging and `onMouse*` callbacks are issued, otherwise.
 
@@ -173,8 +173,8 @@ In the other scenario, `RegionDemo`, we care about showing the red vertical line
 
 The `RegionDemo` is a bit more involved, so, to break down how we handle the callbacks... First, we store the following state (in the parent element, incidentally):
 
-* `regionCursor` is where we draw the cursor indicator (a red vertical line, in the demo).
-* `regionDragging` represents the start (at index `0`) and current position (at index `1`) of the region currently being dragged.
+- `regionCursor` is where we draw the cursor indicator (a red vertical line, in the demo).
+- `regionDragging` represents the start (at index `0`) and current position (at index `1`) of the region currently being dragged.
 
 ```
 {
@@ -185,21 +185,21 @@ The `RegionDemo` is a bit more involved, so, to break down how we handle the cal
 
 Then, we handle the callbacks as follows:
 
-* `onMouseMove`
-  * Set `regionCursor` to `value`
-  * This allows us to draw the red vertical line at the cursor
-* `onMouseLeave`
-  * Set `regionCursor` to `null`
-  * So we know not to draw the red vertical line
-* `onDragStart`
-  * Set `regionDragging` to `[value, value]`
-  * This allows us to draw the dragging region
-* `onDragMove`
-  * Set `regionDragging` to `[regionDragging[0], value]`
-  * Again, for drawing the dragging region. We keep `regionDragging[0]` as-is so we always know where the drag started
-* `onDragEnd`
-  * Set `regionDragging` to `null`, set `regionCursor` to `value`
-  * Setting `regionDragging` to `null` lets us know not to draw the region, and setting `regionCursor` lets us know to draw the cursor right where the user left off
+- `onMouseMove`
+  - Set `regionCursor` to `value`
+  - This allows us to draw the red vertical line at the cursor
+- `onMouseLeave`
+  - Set `regionCursor` to `null`
+  - So we know not to draw the red vertical line
+- `onDragStart`
+  - Set `regionDragging` to `[value, value]`
+  - This allows us to draw the dragging region
+- `onDragMove`
+  - Set `regionDragging` to `[regionDragging[0], value]`
+  - Again, for drawing the dragging region. We keep `regionDragging[0]` as-is so we always know where the drag started
+- `onDragEnd`
+  - Set `regionDragging` to `null`, set `regionCursor` to `value`
+  - Setting `regionDragging` to `null` lets us know not to draw the region, and setting `regionCursor` lets us know to draw the cursor right where the user left off
 
 This is a contrived demo, so `onDragEnd` is kind of boring... Usually we would do something more interesting with the final `x` or `value`.
 

--- a/packages/jaeger-ui/src/utils/date.tsx
+++ b/packages/jaeger-ui/src/utils/date.tsx
@@ -34,7 +34,7 @@ export const DEFAULT_MS_PRECISION = Math.log10(ONE_MILLISECOND);
  * @return {number} 0-100 percentage
  */
 export function getPercentageOfDuration(duration: number, totalDuration: number) {
-  return duration / totalDuration * 100;
+  return (duration / totalDuration) * 100;
 }
 
 const quantizeDuration = (duration: number, floatPrecision: number, conversionFactor: number) =>

--- a/packages/jaeger-ui/src/utils/plexus/set-on-graph.test.js
+++ b/packages/jaeger-ui/src/utils/plexus/set-on-graph.test.js
@@ -33,11 +33,11 @@ describe('Set on graph utils', () => {
     });
 
     it('calculates style object with outline width one third larger if zoomTransform.k is .5', () => {
-      expect(getComputedWidth(0.5)).toBe(4 / 3 * SIZE_IDENTITY);
+      expect(getComputedWidth(0.5)).toBe((4 / 3) * SIZE_IDENTITY);
     });
 
     it('calculates style object with outline width two thirds larger if zoomTransform.k is .33', () => {
-      expect(getComputedWidth(0.33)).toBe(5 / 3 * SIZE_IDENTITY);
+      expect(getComputedWidth(0.33)).toBe((5 / 3) * SIZE_IDENTITY);
     });
 
     it('calculates style object with outline width twice as large if zoomTransform.k is .25', () => {

--- a/packages/jaeger-ui/src/utils/redux-form-field-adapter.tsx
+++ b/packages/jaeger-ui/src/utils/redux-form-field-adapter.tsx
@@ -30,7 +30,11 @@ export default function reduxFormFieldAdapter({
   isValidatedInput: boolean;
 }) {
   return function _reduxFormFieldAdapter(props: any) {
-    const { input: { onBlur, onChange, onFocus, value }, children, ...rest } = props;
+    const {
+      input: { onBlur, onChange, onFocus, value },
+      children,
+      ...rest
+    } = props;
     const isInvalid = !rest.meta.active && Boolean(rest.meta.error);
     const content = (
       <AntInputComponent

--- a/packages/jaeger-ui/src/utils/tracking/README.md
+++ b/packages/jaeger-ui/src/utils/tracking/README.md
@@ -8,25 +8,25 @@ The page-view tracking is pretty basic, so details aren't provided. The GA track
 
 The following fields are sent for each GA session:
 
-* [Application Name](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#appName)
-  * Set to `Jaeger UI`
-* [Application ID](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#appId)
-  * Set to `github.com/jaegertracing/jaeger-ui`
-* [Application Version](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#appVersion)
-  * Example: `0.0.1 | github.com/jaegertracing/jaeger-ui | 8c50c6c | 2f +2 -12 | master`
-  * A dynamic value set to: `<version> | <git remote> | <short SHA> | <diff shortstat> | <branch name>`
-  * Truncated to 96 characters
-  * **version** - `package.json#version`
-  * **git remote** - `git remote get-url --push origin`, normalized
-  * **short SHA** - `git branch --points-at HEAD --format="%(objectname:short)"`
-  * **diff shortstat** - A compacted `git diff-index --shortstat HEAD`
-    * E.g. `2f +3 -4 5?`
-    * 2 modified files, having
-    * 3 insertions and
-    * 4 deletions
-    * 5 untracked files
-  * **branch name** - `$ git branch --points-at HEAD --format="%(refname:short)"`
-    * `(detached)` is used when HEAD is detached because the SHA is already noted
+- [Application Name](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#appName)
+  - Set to `Jaeger UI`
+- [Application ID](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#appId)
+  - Set to `github.com/jaegertracing/jaeger-ui`
+- [Application Version](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#appVersion)
+  - Example: `0.0.1 | github.com/jaegertracing/jaeger-ui | 8c50c6c | 2f +2 -12 | master`
+  - A dynamic value set to: `<version> | <git remote> | <short SHA> | <diff shortstat> | <branch name>`
+  - Truncated to 96 characters
+  - **version** - `package.json#version`
+  - **git remote** - `git remote get-url --push origin`, normalized
+  - **short SHA** - `git branch --points-at HEAD --format="%(objectname:short)"`
+  - **diff shortstat** - A compacted `git diff-index --shortstat HEAD`
+    - E.g. `2f +3 -4 5?`
+    - 2 modified files, having
+    - 3 insertions and
+    - 4 deletions
+    - 5 untracked files
+  - **branch name** - `$ git branch --points-at HEAD --format="%(refname:short)"`
+    - `(detached)` is used when HEAD is detached because the SHA is already noted
 
 ## Error Tracking
 
@@ -36,33 +36,33 @@ Raven.js is used to capture error data ([GitHub](https://github.com/getsentry/ra
 
 For every error we learn of, two GA calls are issued:
 
-* An [exception](https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions)
-* An [event](https://developers.google.com/analytics/devguides/collection/analyticsjs/events)
+- An [exception](https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions)
+- An [event](https://developers.google.com/analytics/devguides/collection/analyticsjs/events)
 
 GA exception tracking is pretty minimal, allowing just a [150 byte string](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#exDescription). So, in addition to the exception, an event with additional data is also issued.
 
-* [Category](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory) - The page type the error occurred on
-* [Action](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventAction) - Error information with a compacted stack trace (sans sourcemaps, at this time)
-* [Label](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel) - A compact form of the breadcrumbs
-* [Value](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue) - The duration of the session when the error occurred (in seconds)
+- [Category](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventCategory) - The page type the error occurred on
+- [Action](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventAction) - Error information with a compacted stack trace (sans sourcemaps, at this time)
+- [Label](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventLabel) - A compact form of the breadcrumbs
+- [Value](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue) - The duration of the session when the error occurred (in seconds)
 
 #### Event: Category - Which Page
 
 The category indicates which type of page the error occurred on, and will be one of the following:
 
-* `jaeger/home/error` - The site root
-* `jaeger/search/error` - The search page
-* `jaeger/trace/error` - The trace page
-* `jaeger/dependencies/error` - The Dependencies page
+- `jaeger/home/error` - The site root
+- `jaeger/search/error` - The search page
+- `jaeger/trace/error` - The trace page
+- `jaeger/dependencies/error` - The Dependencies page
 
 #### Event: Action - Error Info
 
 The action contains:
 
-* The error message (truncated to 149 characters)
-* A compact form of the git status (SHA and diff shortstat)
-* The page URL with the origin and path-prefix removed (truncated to 50 characters)
-* A compact form of the stack trace (without the benefit of sourcemaps, at this time)
+- The error message (truncated to 149 characters)
+- A compact form of the git status (SHA and diff shortstat)
+- The page URL with the origin and path-prefix removed (truncated to 50 characters)
+- A compact form of the stack trace (without the benefit of sourcemaps, at this time)
 
 For example, the following error:
 
@@ -103,11 +103,11 @@ Note: The git status is determined when the build is generated or when `yarn sta
 
 The label contains:
 
-* The error message (truncated to 149 characters)
-* The type of page the error occurred on
-* The duration, in seconds, of the session when the error occurred
-* A compact form of the git status (SHA and diff shortstat)
-* A compact form of breadcrumbs, with older entries preceding newer entries
+- The error message (truncated to 149 characters)
+- The type of page the error occurred on
+- The duration, in seconds, of the session when the error occurred
+- A compact form of the git status (SHA and diff shortstat)
+- A compact form of breadcrumbs, with older entries preceding newer entries
 
 For example, the following label:
 
@@ -132,56 +132,56 @@ cc{.SpanTreeOffset.is-parent >.SpanTreeOffset--iconWrapper}
 
 Indicates:
 
-* `! Houston...` - The error message is `Error: Houston we have a problem`
-* `trace` - The error occurred on the trace page
-* `18` - The error occurred 18 seconds into the session
-* `8c50c6c 2f +34 -56 1?` - The build was generated from commit `8c50c6c` with two modified files and one untracked file
-* The sequence of events indicated by the breadcrumbs is (oldest to most recent):
-  * On the first page of the session
-    * `[tr|404]` - A HTTP call to fetch a trace returned a `404` status code
-  * `sr` - Next, on the search page
-    * `[svc]` - The services were fetched with a `200` status code
-    * `[op]` - The operations for a service were fetched with a `200` status code
-    * `c` - 1 click
-    * `i` - 1 text input
-    * `c` - 1 click
-  * `sd` - Next, on a search page showing results
-    * `[sr]` - A HTTP call to execute a search returned a `200` status code
-    * `c3` - 3 click UI interactions
-  * `tr` - Next, on a trace page
-    * `cc` - 2 clicks
-      * `c{.SpanTree...}` - The second click is the last UI breadcrumb, so it is shown with a CSS selector related to the click event target. The CSS selector is "related" instead of "identifying" because it's been simplified.
-    * `! test-sentry` - An error with the message `Error: test-sentry`
-    * The error being tracked occurred — implicit as the next event
+- `! Houston...` - The error message is `Error: Houston we have a problem`
+- `trace` - The error occurred on the trace page
+- `18` - The error occurred 18 seconds into the session
+- `8c50c6c 2f +34 -56 1?` - The build was generated from commit `8c50c6c` with two modified files and one untracked file
+- The sequence of events indicated by the breadcrumbs is (oldest to most recent):
+  - On the first page of the session
+    - `[tr|404]` - A HTTP call to fetch a trace returned a `404` status code
+  - `sr` - Next, on the search page
+    - `[svc]` - The services were fetched with a `200` status code
+    - `[op]` - The operations for a service were fetched with a `200` status code
+    - `c` - 1 click
+    - `i` - 1 text input
+    - `c` - 1 click
+  - `sd` - Next, on a search page showing results
+    - `[sr]` - A HTTP call to execute a search returned a `200` status code
+    - `c3` - 3 click UI interactions
+  - `tr` - Next, on a trace page
+    - `cc` - 2 clicks
+      - `c{.SpanTree...}` - The second click is the last UI breadcrumb, so it is shown with a CSS selector related to the click event target. The CSS selector is "related" instead of "identifying" because it's been simplified.
+    - `! test-sentry` - An error with the message `Error: test-sentry`
+    - The error being tracked occurred — implicit as the next event
 
 The cryptic encoding for the breadcrumbs is used to fit as much of the event history into the 500 characters as possible. It might turn out that fewer events with more details is preferable. In which case, the payload will be adjusted. For now, the encoding is:
 
-* `[sym]` - A fetch to `sym` resulted in a `200` status code, possible values for `sym` are:
-  * `svc` - Fetch the services for the search page
-  * `op` - Fetch the operations for a service
-  * `sr` - Execute a search
-  * `tr` - Fetch a trace
-  * `dp` - Fetch the dependency data
-  * `??` - Unknown fetch (should not happen)
-* `[sym|NNN]` - The status code was `NNN`, omitted for `200` status codes
-* `\n\nsym\n` - Navigation to `sym`
-  * Page navigation tokens are on their own line and have an empty line above them, e.g. empty lines separate events that occurred on different pages
-  * `sym` indicates the type of page, valid values are:
-    * `dp` - Dependencies page
-    * `tr` - Trace page
-    * `sd` - Search page with search results
-    * `sr` - Search page
-    * `rt` - The root page
-    * `??` - Uknown page (should not happen)
-* `c` or `i` - Indicates a user interaction
-  * `c` is click
-  * `i` is input
-  * `cN` - Indicates `c` occurred `N` consecutive times, e.g. 3 clicks would be `c3` and `i2` is two input breadcrumbs
-  * `c{selector}` - Indicates `c` was the last UI breadcrumb, and the CSS selector `selector` describes the event target
-    * Takes for the form `i{selector}` for input events
-* `! <some message>` - A previous error that was tracked, truncated to 58 characters
-  * The first occurrence of `/error/i` is removed
-  * The first `:` is replaced with `!`
+- `[sym]` - A fetch to `sym` resulted in a `200` status code, possible values for `sym` are:
+  - `svc` - Fetch the services for the search page
+  - `op` - Fetch the operations for a service
+  - `sr` - Execute a search
+  - `tr` - Fetch a trace
+  - `dp` - Fetch the dependency data
+  - `??` - Unknown fetch (should not happen)
+- `[sym|NNN]` - The status code was `NNN`, omitted for `200` status codes
+- `\n\nsym\n` - Navigation to `sym`
+  - Page navigation tokens are on their own line and have an empty line above them, e.g. empty lines separate events that occurred on different pages
+  - `sym` indicates the type of page, valid values are:
+    - `dp` - Dependencies page
+    - `tr` - Trace page
+    - `sd` - Search page with search results
+    - `sr` - Search page
+    - `rt` - The root page
+    - `??` - Uknown page (should not happen)
+- `c` or `i` - Indicates a user interaction
+  - `c` is click
+  - `i` is input
+  - `cN` - Indicates `c` occurred `N` consecutive times, e.g. 3 clicks would be `c3` and `i2` is two input breadcrumbs
+  - `c{selector}` - Indicates `c` was the last UI breadcrumb, and the CSS selector `selector` describes the event target
+    - Takes for the form `i{selector}` for input events
+- `! <some message>` - A previous error that was tracked, truncated to 58 characters
+  - The first occurrence of `/error/i` is removed
+  - The first `:` is replaced with `!`
 
 ### [Sentry](https://github.com/getsentry) Is Not Being Used
 
@@ -191,12 +191,12 @@ Using Sentry is currently under consideration. In the meantime, errors can be tr
 
 You get a lot for free when using Raven.js:
 
-* [Breadcrumbs](https://docs.sentry.io/learn/breadcrumbs/), which include:
-  * [`fetch`](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L1242) HTTP requests
-  * [Previous errors](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L1872)
-  * Some [UI events](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L870) (click and input)
-  * [URL changes](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L945)
-* Stack traces are [normalized](https://github.com/getsentry/raven-js/blob/f8eec063c95f70d8978f895284946bd278748d97/vendor/TraceKit/tracekit.js)
-* Some global handlers are added
+- [Breadcrumbs](https://docs.sentry.io/learn/breadcrumbs/), which include:
+  - [`fetch`](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L1242) HTTP requests
+  - [Previous errors](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L1872)
+  - Some [UI events](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L870) (click and input)
+  - [URL changes](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L945)
+- Stack traces are [normalized](https://github.com/getsentry/raven-js/blob/f8eec063c95f70d8978f895284946bd278748d97/vendor/TraceKit/tracekit.js)
+- Some global handlers are added
 
 Implementing the above from scratch would require substantial effort. Meanwhile, Raven.js is well tested.

--- a/packages/plexus/BUILD.md
+++ b/packages/plexus/BUILD.md
@@ -8,15 +8,15 @@ There are three build scenarios and one pre-step common to all of them.
 
 Pre-step:
 
-* Bundle `./src/LayoutManager/layout.worker.tsx` to a UMD module which can initialize a `WebWorker` from a `Blob` URL
+- Bundle `./src/LayoutManager/layout.worker.tsx` to a UMD module which can initialize a `WebWorker` from a `Blob` URL
 
 Build scenarios:
 
-* Production ES modules
-  * **This is the project's default export as `./lib/index.js`.** This build is not bundled and therefore does not use Webpack.
-* Production UMD module
-* Webpack dev server
-  * Runs `./demo/src/index.tsx` which has a few example graphs.
+- Production ES modules
+  - **This is the project's default export as `./lib/index.js`.** This build is not bundled and therefore does not use Webpack.
+- Production UMD module
+- Webpack dev server
+  - Runs `./demo/src/index.tsx` which has a few example graphs.
 
 The pre-step, which they all require, is to bundle `./src/LayoutManager/layout.worker.tsx` via the `worker-loader` Webpack loader.
 
@@ -30,9 +30,9 @@ The production ES module build is not bundled and therefore does not use Webpack
 
 Webpack is used to:
 
-* Bundle `./src/LayoutManager/layout.worker.tsx` so we can have a `WebWorker` without forcing folks to deal with an additional JavaScript asset
-* Bundle the production UMD module
-* Run the Webpack dev server during development
+- Bundle `./src/LayoutManager/layout.worker.tsx` so we can have a `WebWorker` without forcing folks to deal with an additional JavaScript asset
+- Bundle the production UMD module
+- Run the Webpack dev server during development
 
 `./webpack-factory.js` is used to generate the Webpack configurations for each scenario.
 
@@ -72,20 +72,20 @@ class LayoutWorker extends Worker { ... }
 
 ### Scripts
 
-* `build` — Generates the UMD bundle and ES module production builds
-* `prepublishOnly` — Executed after `yarn install` is run in the project root; runs the `build` script
-* `start` — Starts the Webpack dev server and watches all files, including `layout.worker`
+- `build` — Generates the UMD bundle and ES module production builds
+- `prepublishOnly` — Executed after `yarn install` is run in the project root; runs the `build` script
+- `start` — Starts the Webpack dev server and watches all files, including `layout.worker`
 
 The `_tasks/*` scripts are not intended to be run, directly.
 
-* `_tasks/clean/*`
-  * Remove generated files
-* `_tasks/bundle-worker`
-  * Generates the `layout.worker` UMD bundle
-* `_tasks/build/*`
-  * Generates the production ES and UMD builds
-* `_tasks/dev-server`
-  * Starts the Webpack dev server
+- `_tasks/clean/*`
+  - Remove generated files
+- `_tasks/bundle-worker`
+  - Generates the `layout.worker` UMD bundle
+- `_tasks/build/*`
+  - Generates the production ES and UMD builds
+- `_tasks/dev-server`
+  - Starts the Webpack dev server
 
 ### Dependencies (dev and otherwise)
 

--- a/packages/plexus/package.json
+++ b/packages/plexus/package.json
@@ -4,7 +4,10 @@
   "version": "0.2.0",
   "description": "Directed Graph React component",
   "main": "lib/index.js",
-  "files": ["lib", "dist"],
+  "files": [
+    "lib",
+    "dist"
+  ],
   "devDependencies": {
     "@babel/cli": "7.2.3",
     "@babel/core": "7.3.4",
@@ -54,12 +57,10 @@
     "_tasks/clean/worker": "rimraf src/LayoutManager/layout.worker*js*",
     "_tasks/bundle-worker": "webpack --mode $NODE_ENV --config webpack.layout-worker.config.js",
     "_tasks/dev-server": "webpack-dev-server --mode $NODE_ENV --config webpack.dev.config.js",
-    "build":
-      "NODE_ENV=production npm-run-all -ln --serial _tasks/clean/* _tasks/bundle-worker --parallel _tasks/build/**",
+    "build": "NODE_ENV=production npm-run-all -ln --serial _tasks/clean/* _tasks/bundle-worker --parallel _tasks/build/**",
     "coverage": "echo 'NO TESTS YET'",
     "prepublishOnly": "$npm_execpath build",
-    "start":
-      "NODE_ENV='development' npm-run-all -ln --serial _tasks/clean/worker --parallel '_tasks/bundle-worker --watch' _tasks/dev-server",
+    "start": "NODE_ENV='development' npm-run-all -ln --serial _tasks/clean/worker --parallel '_tasks/bundle-worker --watch' _tasks/dev-server",
     "test": "echo 'NO TESTS YET'"
   }
 }

--- a/packages/plexus/src/DirectedGraph/DirectedGraph.tsx
+++ b/packages/plexus/src/DirectedGraph/DirectedGraph.tsx
@@ -308,33 +308,29 @@ export default class DirectedGraph<T> extends React.PureComponent<
 
     return (
       <div {...rootProps} ref={this.rootRef}>
-        {layoutGraph &&
-          haveEdges && (
-            <EdgesContainer {...edgesContainerProps} height={height} width={width}>
-              <EdgeArrowDef
-                id={this.arrowId}
-                scaleDampener={arrowScaleDampener}
-                zoomScale={zoomEnabled && zoomTransform ? zoomTransform.k : null}
-              />
-              <g transform={zoomEnabled ? getZoomAttr(zoomTransform) : undefined}>{this._renderEdges()}</g>
-            </EdgesContainer>
-          )}
-        <div {...nodesContainerProps}>{this._renderVertices()}</div>
-        {zoomEnabled &&
-          minimapEnabled &&
-          layoutGraph &&
-          rootElm && (
-            <MiniMap
-              className={minimapClassName}
-              classNamePrefix={classNamePrefix}
-              contentHeight={height}
-              contentWidth={width}
-              viewAll={this._resetZoom}
-              viewportHeight={rootElm.clientHeight}
-              viewportWidth={rootElm.clientWidth}
-              {...zoomTransform}
+        {layoutGraph && haveEdges && (
+          <EdgesContainer {...edgesContainerProps} height={height} width={width}>
+            <EdgeArrowDef
+              id={this.arrowId}
+              scaleDampener={arrowScaleDampener}
+              zoomScale={zoomEnabled && zoomTransform ? zoomTransform.k : null}
             />
-          )}
+            <g transform={zoomEnabled ? getZoomAttr(zoomTransform) : undefined}>{this._renderEdges()}</g>
+          </EdgesContainer>
+        )}
+        <div {...nodesContainerProps}>{this._renderVertices()}</div>
+        {zoomEnabled && minimapEnabled && layoutGraph && rootElm && (
+          <MiniMap
+            className={minimapClassName}
+            classNamePrefix={classNamePrefix}
+            contentHeight={height}
+            contentWidth={width}
+            viewAll={this._resetZoom}
+            viewportHeight={rootElm.clientHeight}
+            viewportWidth={rootElm.clientWidth}
+            {...zoomTransform}
+          />
+        )}
       </div>
     );
   }

--- a/packages/plexus/src/DirectedGraph/MiniMap.tsx
+++ b/packages/plexus/src/DirectedGraph/MiniMap.tsx
@@ -36,9 +36,9 @@ const LENGTH_TARGET_PX = 80;
 function getMapSize(props: TProps) {
   const { contentHeight: ch, contentWidth: cw } = props;
   if (ch > cw) {
-    return { height: LENGTH_TARGET_PX, width: LENGTH_TARGET_PX * cw / ch };
+    return { height: LENGTH_TARGET_PX, width: (LENGTH_TARGET_PX * cw) / ch };
   }
-  return { height: LENGTH_TARGET_PX * ch / cw, width: LENGTH_TARGET_PX };
+  return { height: (LENGTH_TARGET_PX * ch) / cw, width: LENGTH_TARGET_PX };
 }
 
 function getViewTransform(props: TProps, displaySize: { width: number; height: number }) {

--- a/packages/plexus/src/DirectedGraph/builtins/PureEdges.tsx
+++ b/packages/plexus/src/DirectedGraph/builtins/PureEdges.tsx
@@ -33,7 +33,7 @@ export default class PureEdges extends React.PureComponent<TProps> {
         key={`${edge.edge.from}\v${edge.edge.to}`}
         pathPoints={edge.pathPoints}
         markerEnd={arrowIriRef}
-        {...setOnEdgePath && setOnEdgePath(edge.edge)}
+        {...(setOnEdgePath && setOnEdgePath(edge.edge))}
       />
     ));
   }

--- a/packages/plexus/src/DirectedGraph/builtins/PureNodes.tsx
+++ b/packages/plexus/src/DirectedGraph/builtins/PureNodes.tsx
@@ -39,7 +39,7 @@ export default class PureNodes<T> extends React.PureComponent<TProps<T>> {
         classNamePrefix={classNamePrefix}
         labelFactory={getNodeLabel}
         vertex={v}
-        {...setOnNode && setOnNode(v)}
+        {...(setOnNode && setOnNode(v))}
       />
     ));
   }
@@ -58,7 +58,7 @@ export default class PureNodes<T> extends React.PureComponent<TProps<T>> {
         vertex={lv.vertex}
         left={lv.left}
         top={lv.top}
-        {...setOnNode && setOnNode(lv.vertex)}
+        {...(setOnNode && setOnNode(lv.vertex))}
       />
     ));
   }

--- a/packages/plexus/src/DirectedGraph/prop-factories/scaledStrokeWidth.tsx
+++ b/packages/plexus/src/DirectedGraph/prop-factories/scaledStrokeWidth.tsx
@@ -39,7 +39,7 @@ export default function scaledStrokeWidth(graphState: TDirectedGraphState) {
   } else if (k < THRESHOLD_MAX) {
     props = PROPS_MAX;
   } else {
-    const strokeWidth = (STROKE_MIN + STROKE_SPREAD * (THRESHOLD_MIN - k) / THRESHOLD_SPREAD).toFixed(1);
+    const strokeWidth = (STROKE_MIN + (STROKE_SPREAD * (THRESHOLD_MIN - k)) / THRESHOLD_SPREAD).toFixed(1);
     props = cache[strokeWidth] || (cache[strokeWidth] = { style: { strokeWidth } });
   }
   lastK = k;

--- a/packages/plexus/src/DirectedGraph/transform-utils.tsx
+++ b/packages/plexus/src/DirectedGraph/transform-utils.tsx
@@ -32,7 +32,7 @@ function boundValue(min: number, max: number, value: number) {
 function getFittedScale(width: number, height: number, viewWidth: number, viewHeight: number) {
   return Math.max(
     SCALE_MIN,
-    Math.min((1 - SCALE_MARGIN) * viewWidth / width, (1 - SCALE_MARGIN) * viewHeight / height, SCALE_MAX)
+    Math.min(((1 - SCALE_MARGIN) * viewWidth) / width, ((1 - SCALE_MARGIN) * viewHeight) / height, SCALE_MAX)
   );
 }
 

--- a/packages/plexus/src/LayoutManager/dot/convPlain.tsx
+++ b/packages/plexus/src/LayoutManager/dot/convPlain.tsx
@@ -70,7 +70,10 @@ function parseNumbers(
 function parseGraph(str: string, startIndex: number): { end: number; graph: TLayoutGraph } {
   // skip "graph "
   const i = startIndex + 6;
-  const { values: [scale, width], end: widthEnd } = parseNumbers(2, str, i);
+  const {
+    values: [scale, width],
+    end: widthEnd,
+  } = parseNumbers(2, str, i);
   const { value: height, end } = parseNumber(str, widthEnd + 1, '\n');
   return {
     end,

--- a/packages/plexus/src/LayoutManager/getLayout.tsx
+++ b/packages/plexus/src/LayoutManager/getLayout.tsx
@@ -61,7 +61,13 @@ function getVerticesValidity(
   let warn: TVerticesValidity | void;
 
   for (let i = 0; i < output.length; i++) {
-    const { vertex: { key }, height, left, top, width } = output[i];
+    const {
+      vertex: { key },
+      height,
+      left,
+      top,
+      width,
+    } = output[i];
     const src = inputHash[String(key)];
     if (!src) {
       return { validity: EValidity.Error, message: `Extra vertex found: ${key}` };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9807,13 +9807,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
-
-prettier@^1.14.2, prettier@^1.14.3:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+prettier@1.18.2, prettier@^1.14.2, prettier@^1.14.3:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-bytes@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, an outdated version of prettier is used for formatting and pre-commit linting. This causes issues when upgrading packages that use a newer version of prettier; the newer version is used instead, which conflates the upgrade (and is inconsistent with the specification of the outdated package). 

## Short description of the changes

This PR updates prettier to the latest and forces all packages using prettier to use it. Prettier is then run on the code-base, which has some different default formatting than the older version, resulting in formatting changes.

The main changes are in package.json and yarn.lock. The other changes are formatting updates.
