### PR TITLE
Fix GA filter category copy-paste

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/index.track.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.track.tsx
@@ -18,7 +18,7 @@ import { trackEvent } from '../../utils/tracking';
 
 // export for tests
 export const CATEGORY_RANGE = 'jaeger/ux/trace/range';
-export const CATEGORY_FILTER = 'jaeger/ux/trace/range';
+export const CATEGORY_FILTER = 'jaeger/ux/trace/filter';
 
 // export for tests
 export const ACTION_FILTER_SET = 'set';


### PR DESCRIPTION
We aren't yet using the GA Event Categories (just the Event Action), but as we do more GA tracking we may want to, and before that point this should be updated.