### PR TITLE
Add an ESLint rule requiring the names of interfaces to be prefixed with "I"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       rules: {
         'no-unused-vars': 0,
+        '@typescript-eslint/interface-name-prefix': ['error', 'always'],
         '@typescript-eslint/no-unused-vars': 1,
       },
     },

--- a/packages/jaeger-ui/src/components/TracePage/ScrollManager.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/ScrollManager.tsx
@@ -37,7 +37,7 @@ export type Accessors = {
   mapSpanIndexToRowIndex: (spanIndex: number) => number;
 };
 
-interface Scroller {
+interface IScroller {
   scrollTo: (rowIndex: number) => void;
   // TODO arg names throughout
   scrollBy: (rowIndex: number, opt?: boolean) => void;
@@ -55,7 +55,7 @@ interface Scroller {
  * @returns {{ isHidden: boolean, parentIds: Set<string> }}
  */
 function isSpanHidden(span: Span, childrenAreHidden: Set<string>, spansMap: Map<string, Span | TNil>) {
-  const parentIDs = new Set();
+  const parentIDs = new Set<string>();
   let { references }: { references: SpanReference[] | TNil } = span;
   let parentID: undefined | string;
   const checkRef = (ref: SpanReference) => {
@@ -87,10 +87,10 @@ function isSpanHidden(span: Span, childrenAreHidden: Set<string>, spansMap: Map<
  */
 export default class ScrollManager {
   _trace: Trace | TNil;
-  _scroller: Scroller;
+  _scroller: IScroller;
   _accessors: Accessors | TNil;
 
-  constructor(trace: Trace | TNil, scroller: Scroller) {
+  constructor(trace: Trace | TNil, scroller: IScroller) {
     this._trace = trace;
     this._scroller = scroller;
     this._accessors = undefined;

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/ViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/ViewingLayer.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 
 import GraphTicks from './GraphTicks';
 import Scrubber from './Scrubber';
-import { TUpdateViewRangeTimeFunction, ViewRange, ViewRangeTimeUpdate } from '../../types';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../../types';
 import { TNil } from '../../../../types';
 import DraggableManager, {
   DraggableBounds,
@@ -33,7 +33,7 @@ type ViewingLayerProps = {
   numTicks: number;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
-  viewRange: ViewRange;
+  viewRange: IViewRange;
 };
 
 type ViewingLayerState = {

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/index.tsx
@@ -17,7 +17,7 @@ import * as React from 'react';
 import CanvasSpanGraph from './CanvasSpanGraph';
 import TickLabels from './TickLabels';
 import ViewingLayer from './ViewingLayer';
-import { TUpdateViewRangeTimeFunction, ViewRange, ViewRangeTimeUpdate } from '../../types';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../../types';
 import { Span, Trace } from '../../../../types/trace';
 
 const DEFAULT_HEIGHT = 60;
@@ -26,7 +26,7 @@ const TIMELINE_TICK_INTERVAL = 4;
 type SpanGraphProps = {
   height?: number;
   trace: Trace;
-  viewRange: ViewRange;
+  viewRange: IViewRange;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   updateNextViewRangeTime: (nextUpdate: ViewRangeTimeUpdate) => void;
 };

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -26,7 +26,7 @@ import AltViewOptions from './AltViewOptions';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 import SpanGraph from './SpanGraph';
 import TracePageSearchBar from './TracePageSearchBar';
-import { TUpdateViewRangeTimeFunction, ViewRange, ViewRangeTimeUpdate } from '../types';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../types';
 import LabeledList from '../../common/LabeledList';
 import NewWindowIcon from '../../common/NewWindowIcon';
 import TraceName from '../../common/TraceName';
@@ -61,7 +61,7 @@ type TracePageHeaderEmbedProps = {
   traceGraphView: boolean;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
-  viewRange: ViewRange;
+  viewRange: IViewRange;
 };
 
 export const HEADER_ITEMS = [

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -19,7 +19,7 @@ import TimelineColumnResizer from './TimelineColumnResizer';
 import TimelineViewingLayer from './TimelineViewingLayer';
 import Ticks from '../Ticks';
 import TimelineRow from '../TimelineRow';
-import { TUpdateViewRangeTimeFunction, ViewRangeTime, ViewRangeTimeUpdate } from '../../types';
+import { TUpdateViewRangeTimeFunction, IViewRangeTime, ViewRangeTimeUpdate } from '../../types';
 
 import './TimelineHeaderRow.css';
 
@@ -34,7 +34,7 @@ type TimelineHeaderRowProps = {
   onExpandOne: () => void;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
-  viewRangeTime: ViewRangeTime;
+  viewRangeTime: IViewRangeTime;
 };
 
 export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -15,7 +15,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 
-import { TUpdateViewRangeTimeFunction, ViewRangeTime, ViewRangeTimeUpdate } from '../../types';
+import { TUpdateViewRangeTimeFunction, IViewRangeTime, ViewRangeTimeUpdate } from '../../types';
 import { TNil } from '../../../../types';
 import DraggableManager, { DraggableBounds, DraggingUpdate } from '../../../../utils/DraggableManager';
 
@@ -30,7 +30,7 @@ type TimelineViewingLayerProps = {
   boundsInvalidator: any | null | undefined;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
-  viewRangeTime: ViewRangeTime;
+  viewRangeTime: IViewRangeTime;
 };
 
 type TDraggingLeftLayout = {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineRow.tsx
@@ -16,19 +16,19 @@ import * as React from 'react';
 
 import './TimelineRow.css';
 
-type TimelineRowProps = {
+type TTimelineRowProps = {
   children: React.ReactNode;
   className?: string;
 };
 
-interface TimelineRowCellProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ITimelineRowCellProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   className?: string;
   width: number;
   style?: Object;
 }
 
-export default function TimelineRow(props: TimelineRowProps) {
+export default function TimelineRow(props: TTimelineRowProps) {
   const { children, className = '', ...rest } = props;
   return (
     <div className={`flex-row ${className}`} {...rest}>
@@ -41,7 +41,7 @@ TimelineRow.defaultProps = {
   className: '',
 };
 
-function TimelineRowCell(props: TimelineRowCellProps) {
+function TimelineRowCell(props: ITimelineRowCellProps) {
   const { children, className = '', width, style, ...rest } = props;
   const widthPercent = `${width * 100}%`;
   const mergedStyle = { ...style, flexBasis: widthPercent, maxWidth: widthPercent };

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -21,7 +21,7 @@ import TimelineHeaderRow from './TimelineHeaderRow';
 import VirtualizedTraceView from './VirtualizedTraceView';
 import { merge as mergeShortcuts } from '../keyboard-shortcuts';
 import { Accessors } from '../ScrollManager';
-import { TUpdateViewRangeTimeFunction, ViewRange, ViewRangeTimeUpdate } from '../types';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../types';
 import { TNil, ReduxState } from '../../../types';
 import { Span, Trace } from '../../../types/trace';
 
@@ -43,7 +43,7 @@ type TProps = TDispatchProps & {
   trace: Trace;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
-  viewRange: ViewRange;
+  viewRange: IViewRange;
 };
 
 const NUM_TICKS = 5;

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -41,7 +41,7 @@ import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
 import TracePageHeader from './TracePageHeader';
 import TraceTimelineViewer from './TraceTimelineViewer';
 import { actions as timelineActions } from './TraceTimelineViewer/duck';
-import { TUpdateViewRangeTimeFunction, ViewRange, ViewRangeTimeUpdate } from './types';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from './types';
 import { getLocation, getUrl } from './url';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
@@ -87,7 +87,7 @@ type TState = {
   headerHeight: number | TNil;
   slimView: boolean;
   traceGraphView: boolean;
-  viewRange: ViewRange;
+  viewRange: IViewRange;
 };
 
 // export for tests

--- a/packages/jaeger-ui/src/components/TracePage/types.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/types.tsx
@@ -14,34 +14,34 @@
 
 import { TNil } from '../../types';
 
-interface TimeCursorUpdate {
+interface ITimeCursorUpdate {
   cursor: number | TNil;
 }
 
-interface TimeReframeUpdate {
+interface ITimeReframeUpdate {
   reframe: {
     anchor: number;
     shift: number;
   };
 }
 
-interface TimeShiftEndUpdate {
+interface ITimeShiftEndUpdate {
   shiftEnd: number;
 }
 
-interface TimeShiftStartUpdate {
+interface ITimeShiftStartUpdate {
   shiftStart: number;
 }
 
 export type TUpdateViewRangeTimeFunction = (start: number, end: number, trackSrc?: string) => void;
 
 export type ViewRangeTimeUpdate =
-  | TimeCursorUpdate
-  | TimeReframeUpdate
-  | TimeShiftEndUpdate
-  | TimeShiftStartUpdate;
+  | ITimeCursorUpdate
+  | ITimeReframeUpdate
+  | ITimeShiftEndUpdate
+  | ITimeShiftStartUpdate;
 
-export interface ViewRangeTime {
+export interface IViewRangeTime {
   current: [number, number];
   cursor?: number | TNil;
   reframe?: {
@@ -52,6 +52,6 @@ export interface ViewRangeTime {
   shiftStart?: number;
 }
 
-export interface ViewRange {
-  time: ViewRangeTime;
+export interface IViewRange {
+  time: IViewRangeTime;
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Make it an error to have an interface without `I` instead of the current functionality which is to error if it is prefixed with an `I`.

## Short description of the changes

Add an eslint rule and rename existing interfaces.
