### PR TITLE
Remove patch check from master branch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        only_pulls: true


### PR DESCRIPTION
## Which problem is this PR solving?

<img width="826" alt="Screen Shot 2019-07-16 at 5 24 22 PM" src="https://user-images.githubusercontent.com/2304337/61332470-4dc21500-a7f2-11e9-8dcf-edc61a19ba2f.png">


Currently if a PR that's merged to master has less than 90% coverage the Jaeger UI repo shows up as failing some checks even if the coverage for the project is above 90%.

This PR endeavor to remove the `patch` check from the master branch.

## Short description of the changes

Add a `.codecov.yml` config file and configure to only apply the patch check to pull requests.
