### PR TITLE
Initial components for supporting layers of graph elements in plexus

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "url": "https://github.com/jaegertracing/jaeger-ui.git"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "1.4.1",
+    "@typescript-eslint/eslint-plugin": "1.12.0",
+    "@typescript-eslint/parser": "1.12.0",
+    "@typescript-eslint/typescript-estree": "1.12.0",
     "babel-eslint": "10.0.1",
     "eslint": "5.14.1",
     "eslint-config-airbnb": "17.1.0",
@@ -24,7 +26,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "1.18.2",
     "rxjs-compat": "6.4.0",
-    "typescript": "3.3.3333"
+    "typescript": "3.5.3"
   },
   "resolutions": {
     "**/cheerio/parse5": "4.0.0",

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
@@ -31,7 +31,7 @@ export function matches(path: string) {
   return Boolean(matchPath(path, ROUTE_MATCHER));
 }
 
-export function getUrl(query?: Object | null | undefined) {
+export function getUrl(query?: { [key: string]: unknown } | null | undefined) {
   const search = query ? `?${queryString.stringify(query)}` : '';
   return prefixUrl(`/search${search}`);
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.tsx
@@ -168,7 +168,7 @@ function childrenToggle(state: TTraceTimeline, { spanID }: TSpanIdValue): TTrace
 }
 
 export function expandAll(state: TTraceTimeline): TTraceTimeline {
-  const childrenHiddenIDs = new Set();
+  const childrenHiddenIDs = new Set<string>();
   return { ...state, childrenHiddenIDs };
 }
 
@@ -181,7 +181,7 @@ export function collapseAll(state: TTraceTimeline, { spans }: TSpansValue) {
       res.add(s.spanID);
     }
     return res;
-  }, new Set());
+  }, new Set<string>());
   return { ...state, childrenHiddenIDs };
 }
 

--- a/packages/jaeger-ui/src/model/link-patterns.tsx
+++ b/packages/jaeger-ui/src/model/link-patterns.tsx
@@ -36,7 +36,7 @@ type ProcessedLinkPattern = {
 };
 
 function getParamNames(str: string) {
-  const names = new Set();
+  const names = new Set<string>();
   str.replace(parameterRegExp, (match, name) => {
     names.add(name);
     return match;

--- a/packages/jaeger-ui/src/model/trace-dag/DenseTrace.tsx
+++ b/packages/jaeger-ui/src/model/trace-dag/DenseTrace.tsx
@@ -48,7 +48,7 @@ function convSpans(spans: Span[]) {
       service,
       span,
       tags,
-      children: new Set(),
+      children: new Set<string>(),
       skipToChild: false,
     };
     const parent = parentID && map.get(parentID);

--- a/packages/jaeger-ui/tsconfig.lint.json
+++ b/packages/jaeger-ui/tsconfig.lint.json
@@ -36,6 +36,7 @@
     "src/selectors/process.js",
     "src/selectors/span.js",
     "src/selectors/trace.js",
-    "src/utils/sort.js"
+    "src/utils/sort.js",
+    "src/utils/TreeNode.js"
   ]
 }

--- a/packages/plexus/demo/src/index.css
+++ b/packages/plexus/demo/src/index.css
@@ -42,6 +42,7 @@ html {
   box-shadow: 0 0 7px 1px rgba(0, 0, 0, 0.4);
   cursor: pointer;
   padding: 0.8em 1.25em;
+  white-space: nowrap;
 }
 
 .DemoGraph--node:hover {

--- a/packages/plexus/demo/src/index.tsx
+++ b/packages/plexus/demo/src/index.tsx
@@ -16,10 +16,12 @@ import * as React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { render } from 'react-dom';
 
-import largeDg, { getNodeLabel as getLargeNodeLabel } from './data-large';
+import largeDag, { getNodeLabel as getLargeNodeLabel } from './data-large';
 import { edges as dagEdges, vertices as dagVertices } from './data-dag';
 import { colored as colorData, getColorNodeLabel, setOnColorEdge, setOnColorNode } from './data-small';
 import { DirectedGraph, LayoutManager } from '../../src';
+import LayeredDigraph from '../../src/LayeredDigraph';
+import { classNameIsSmall as layeredClassNameIsSmall } from '../../src/LayeredDigraph/props-factories';
 import { TVertex } from '../../src/types';
 
 import './index.css';
@@ -36,6 +38,35 @@ const setOnNode = (vertex: TVertex) => ({
 function Demo() {
   return (
     <div>
+      <h1>LayeredDigraph</h1>
+      <div>
+        <div className="DemoGraph">
+          <LayeredDigraph
+            zoom
+            minimap
+            className="DemoGraph--dag"
+            layoutManager={new LayoutManager({ useDotEdges: true })}
+            minimapClassName="Demo--miniMap"
+            setOnGraph={layeredClassNameIsSmall}
+            measurableNodesKey="nodes"
+            layers={[
+              {
+                key: 'nodes-layers',
+                html: true,
+                layers: [
+                  {
+                    setOnNode,
+                    key: 'nodes',
+                    measurable: true,
+                    nodeRender: getLargeNodeLabel,
+                  },
+                ],
+              },
+            ]}
+            {...largeDag}
+          />
+        </div>
+      </div>
       <h1>Directed graph with cycles - dot edges</h1>
       <div>
         <div className="DemoGraph">
@@ -49,7 +80,7 @@ function Demo() {
             minimapClassName="Demo--miniMap"
             setOnNode={setOnNode}
             setOnRoot={classNameIsSmall}
-            {...largeDg}
+            {...largeDag}
           />
         </div>
       </div>
@@ -66,7 +97,7 @@ function Demo() {
             minimapClassName="Demo--miniMap"
             setOnNode={setOnNode}
             setOnRoot={classNameIsSmall}
-            {...largeDg}
+            {...largeDag}
           />
         </div>
       </div>
@@ -89,7 +120,7 @@ function Demo() {
             minimapClassName="Demo--miniMap"
             setOnNode={setOnNode}
             setOnRoot={classNameIsSmall}
-            {...largeDg}
+            {...largeDag}
           />
         </div>
       </div>

--- a/packages/plexus/demo/src/index.tsx
+++ b/packages/plexus/demo/src/index.tsx
@@ -25,6 +25,7 @@ import { classNameIsSmall as layeredClassNameIsSmall } from '../../src/LayeredDi
 import { TVertex } from '../../src/types';
 
 import './index.css';
+import { ELayerType } from '../../src/LayeredDigraph/types';
 
 const { classNameIsSmall } = DirectedGraph.propsFactories;
 
@@ -52,7 +53,7 @@ function Demo() {
             layers={[
               {
                 key: 'nodes-layers',
-                html: true,
+                layerType: ELayerType.Html,
                 layers: [
                   {
                     setOnNode,
@@ -61,6 +62,30 @@ function Demo() {
                     nodeRender: getLargeNodeLabel,
                   },
                 ],
+              },
+            ]}
+            {...largeDag}
+          />
+        </div>
+      </div>
+      <h1>LayeredDigraph with standalone layers</h1>
+      <div>
+        <div className="DemoGraph">
+          <LayeredDigraph
+            zoom
+            minimap
+            className="DemoGraph--dag"
+            layoutManager={new LayoutManager({ useDotEdges: true })}
+            minimapClassName="Demo--miniMap"
+            setOnGraph={layeredClassNameIsSmall}
+            measurableNodesKey="nodes"
+            layers={[
+              {
+                setOnNode,
+                key: 'nodes',
+                layerType: 'html',
+                measurable: true,
+                nodeRender: getLargeNodeLabel,
               },
             ]}
             {...largeDag}

--- a/packages/plexus/src/LayeredDigraph/HtmlLayersGroup.tsx
+++ b/packages/plexus/src/LayeredDigraph/HtmlLayersGroup.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+import MeasurableNodesLayer from './MeasurableNodesLayer';
+import { TExposedGraphState, THtmlLayersGroup } from './types';
+import { assignMergeCss, getProps } from './utils';
+import { TSizeVertex } from '../types';
+import ZoomManager from '../ZoomManager';
+
+type TProps<T = {}, U = {}> = Omit<THtmlLayersGroup<T, U>, 'html' | 'key'> & {
+  classNamePrefix?: string;
+  graphState: TExposedGraphState<T, U>;
+  setSizeVertices: (senderKey: string, sizeVertices: TSizeVertex<T>[]) => void;
+};
+
+export default class HtmlLayersGroup<T = {}, U = {}> extends React.PureComponent<TProps<T, U>> {
+  private renderLayers() {
+    const { classNamePrefix, layers, graphState, setSizeVertices } = this.props;
+    return layers.map(layer => {
+      if (layer.nodeRender && layer.measurable) {
+        const { key, setOnContainer, setOnNode, nodeRender } = layer;
+        return (
+          <MeasurableNodesLayer<T, U>
+            key={key}
+            html
+            nodeRender={nodeRender}
+            setOnNode={setOnNode}
+            graphState={graphState}
+            senderKey={key}
+            setSizeVertices={setSizeVertices}
+            classNamePrefix={classNamePrefix || undefined}
+            setOnContainer={setOnContainer}
+          />
+        );
+      }
+      throw new Error('Not implemented');
+    });
+  }
+
+  render() {
+    const { classNamePrefix, graphState, setOnContainer } = this.props;
+
+    const { zoomTransform } = graphState;
+
+    const containerProps = assignMergeCss(getProps(setOnContainer, graphState), {
+      style: {
+        ...ZoomManager.getZoomStyle(zoomTransform),
+        position: 'absolute',
+        top: 0,
+        left: 0,
+      },
+      className: `${classNamePrefix} ${classNamePrefix}-LayeredDigraph--HtmlLayersGroup`,
+    });
+    return <div {...containerProps}>{this.renderLayers()}</div>;
+  }
+}

--- a/packages/plexus/src/LayeredDigraph/HtmlLayersGroup.tsx
+++ b/packages/plexus/src/LayeredDigraph/HtmlLayersGroup.tsx
@@ -15,12 +15,12 @@
 import * as React from 'react';
 
 import MeasurableNodesLayer from './MeasurableNodesLayer';
-import { TExposedGraphState, THtmlLayersGroup } from './types';
+import { TExposedGraphState, THtmlLayersGroup, ELayerType } from './types';
 import { assignMergeCss, getProps } from './utils';
 import { TSizeVertex } from '../types';
 import ZoomManager from '../ZoomManager';
 
-type TProps<T = {}, U = {}> = Omit<THtmlLayersGroup<T, U>, 'html' | 'key'> & {
+type TProps<T = {}, U = {}> = Omit<THtmlLayersGroup<T, U>, 'layerType' | 'key'> & {
   classNamePrefix?: string;
   graphState: TExposedGraphState<T, U>;
   setSizeVertices: (senderKey: string, sizeVertices: TSizeVertex<T>[]) => void;
@@ -35,13 +35,13 @@ export default class HtmlLayersGroup<T = {}, U = {}> extends React.PureComponent
         return (
           <MeasurableNodesLayer<T, U>
             key={key}
-            html
+            layerType={ELayerType.Html}
             nodeRender={nodeRender}
             setOnNode={setOnNode}
             graphState={graphState}
             senderKey={key}
             setSizeVertices={setSizeVertices}
-            classNamePrefix={classNamePrefix || undefined}
+            classNamePrefix={classNamePrefix}
             setOnContainer={setOnContainer}
           />
         );

--- a/packages/plexus/src/LayeredDigraph/MeasurableHtmlNode.tsx
+++ b/packages/plexus/src/LayeredDigraph/MeasurableHtmlNode.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 20179sUber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+import { TMeasurableNodeProps } from './types';
+import { assignMergeCss, getProps } from './utils';
+
+export default class MeasurableHtmlNode<T = {}> extends React.PureComponent<TMeasurableNodeProps<T>> {
+  static defaultProps = {
+    hidden: false,
+  };
+
+  wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
+
+  measure() {
+    const { current } = this.wrapperRef;
+    if (!current) {
+      return { height: 0, width: 0 };
+    }
+    return {
+      height: current.offsetHeight,
+      width: current.offsetWidth,
+    };
+  }
+
+  render() {
+    const { classNamePrefix, hidden, nodeRender, renderUtils, setOnNode, vertex, layoutVertex } = this.props;
+    const { left = null, top = null } = layoutVertex || {};
+    const props = assignMergeCss(getProps(setOnNode, vertex, renderUtils, layoutVertex), {
+      className: `${classNamePrefix}-Node`,
+      style: {
+        position: 'absolute',
+        transform: left == null || top == null ? undefined : `translate(${left}px,${top}px)`,
+        visibility: hidden ? 'hidden' : undefined,
+      },
+    });
+    return (
+      <div ref={this.wrapperRef} {...props}>
+        {nodeRender(vertex, renderUtils, layoutVertex)}
+      </div>
+    );
+  }
+}

--- a/packages/plexus/src/LayeredDigraph/MeasurableNodesLayer.tsx
+++ b/packages/plexus/src/LayeredDigraph/MeasurableNodesLayer.tsx
@@ -1,0 +1,162 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+import MeasurableHtmlNode from './MeasurableHtmlNode';
+import {
+  TExposedGraphState,
+  TElemType,
+  TSetOnContainer,
+  TMeasurableNodeRenderer,
+  ELayoutPhase,
+} from './types';
+import { assignMergeCss, getProps } from './utils';
+import { TSizeVertex, TVertex } from '../types';
+import { TOneOfTwo } from '../types/TOneOf';
+
+type TProps<T = {}, U = {}> = TElemType &
+  Omit<TMeasurableNodeRenderer<T>, 'measurable'> &
+  TSetOnContainer<T, U> & {
+    classNamePrefix?: string;
+    graphState: TExposedGraphState<T, U>;
+    senderKey: string;
+    setSizeVertices: (senderKey: string, sizeVertices: TSizeVertex<T>[]) => void;
+  };
+
+type TState<T> = TOneOfTwo<
+  {
+    htmlNodeRefs: React.RefObject<MeasurableHtmlNode<T>>[];
+  },
+  {
+    svgNodeRefs: React.RefObject<any>[];
+  }
+> & {
+  vertices: TVertex<T>[];
+};
+
+function createRefs<T>(length: number) {
+  const rv: React.RefObject<T>[] = [];
+  for (let i = 0; i < length; i++) {
+    rv.push(React.createRef<T>());
+  }
+  return rv;
+}
+
+// TODO - parameterize to handle SVG too
+export default class MeasurableNodesLayer<T = {}, U = {}> extends React.PureComponent<
+  TProps<T, U>,
+  TState<T>
+> {
+  static getDerivedStateFromProps<T>(nextProps: TProps<T>, prevState: TState<T>) {
+    const { vertices } = nextProps.graphState;
+    const { vertices: stVertices } = prevState;
+    if (vertices === stVertices) {
+      return null;
+    }
+    return {
+      vertices,
+      htmlNodeRefs: createRefs<MeasurableHtmlNode<T>>(vertices.length),
+    };
+  }
+
+  constructor(props: TProps<T, U>) {
+    super(props);
+    const { graphState, html } = props;
+    if (html) {
+      const { vertices } = graphState;
+      this.state = {
+        vertices,
+        htmlNodeRefs: createRefs<MeasurableHtmlNode<T>>(vertices.length),
+      };
+    } else {
+      // props.svg === true
+      throw new Error('Not implemented');
+    }
+  }
+
+  componentDidMount() {
+    this.measureNodes();
+  }
+
+  componentDidUpdate() {
+    this.measureNodes();
+  }
+
+  private measureNodes() {
+    const { layoutPhase, vertices } = this.props.graphState;
+    if (layoutPhase !== ELayoutPhase.CalcSizes) {
+      return;
+    }
+    const { htmlNodeRefs } = this.state;
+    if (!htmlNodeRefs) {
+      return;
+    }
+    const sizeVertices: TSizeVertex<T>[] = [];
+    htmlNodeRefs.forEach((ref, i) => {
+      const { current } = ref;
+      if (current) {
+        sizeVertices.push({
+          ...current.measure(),
+          vertex: vertices[i],
+        });
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(`Invalid ref state: current is ${current}`);
+      }
+    });
+    const { senderKey, setSizeVertices } = this.props;
+    setSizeVertices(senderKey, sizeVertices);
+  }
+
+  // TODO - parameterize to handle SVG too
+  private renderVertices(htmlNodeRefs: React.RefObject<MeasurableHtmlNode<T>>[]) {
+    const {
+      classNamePrefix,
+      graphState: { layoutVertices, renderUtils, vertices },
+      nodeRender,
+      setOnNode,
+    } = this.props;
+    return vertices.map((vertex, i) => (
+      <MeasurableHtmlNode<T>
+        key={vertex.key}
+        classNamePrefix={classNamePrefix}
+        ref={htmlNodeRefs[i]}
+        hidden={!layoutVertices}
+        nodeRender={nodeRender}
+        renderUtils={renderUtils}
+        vertex={vertex}
+        layoutVertex={layoutVertices && layoutVertices[i]}
+        setOnNode={setOnNode}
+      />
+    ));
+  }
+
+  render() {
+    const { htmlNodeRefs } = this.state;
+    if (htmlNodeRefs) {
+      const { classNamePrefix, graphState, setOnContainer } = this.props;
+      const containerProps = assignMergeCss(getProps(setOnContainer, graphState), {
+        style: {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+        },
+        className: `${classNamePrefix} ${classNamePrefix}-LayeredDigraph--MeasurableNodesLayer`,
+      });
+      return <div {...containerProps}>{this.renderVertices(htmlNodeRefs)}</div>;
+    }
+    return null;
+  }
+}

--- a/packages/plexus/src/LayeredDigraph/index.tsx
+++ b/packages/plexus/src/LayeredDigraph/index.tsx
@@ -1,0 +1,217 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+import HtmlLayersGroup from './HtmlLayersGroup';
+import {
+  ELayoutPhase,
+  TExposedGraphState,
+  TFromGraphStateFn,
+  TLayer,
+  TPropsFactory,
+  TRendererUtils,
+} from './types';
+import { assignMergeCss, getProps } from './utils';
+import { classNameIsSmall, scaledStrokeWidth } from './props-factories';
+// TODO(joe): don't use stuff in ../DirectedGraph
+import MiniMap from '../DirectedGraph/MiniMap';
+import LayoutManager from '../LayoutManager';
+import ZoomManager, { zoomIdentity, ZoomTransform } from '../ZoomManager';
+import { TCancelled, TEdge, TLayoutDone, TSizeVertex, TVertex } from '../types';
+
+type TLayeredDigraphState<T = {}, U = {}> = Omit<TExposedGraphState<T, U>, 'renderUtils'> & {
+  sizeVertices: TSizeVertex<T>[] | null;
+};
+
+type TLayeredDigraphProps<T = {}, U = {}> = TPropsFactory<'setOnGraph', TFromGraphStateFn<T, U>> & {
+  className?: string;
+  classNamePrefix?: string;
+  edges: TEdge<U>[];
+  // require atleast one layer
+  layers: [TLayer, ...TLayer[]];
+  layoutManager: LayoutManager;
+  measurableNodesKey: string;
+  minimap?: boolean;
+  minimapClassName?: string;
+  style?: React.CSSProperties;
+  vertices: TVertex<T>[];
+  zoom?: boolean;
+};
+
+const WRAPPER_STYLE_ZOOM = {
+  height: '100%',
+  overflow: 'hidden',
+  position: 'relative',
+  width: '100%',
+};
+
+const WRAPPER_STYLE = {
+  position: 'relative',
+};
+
+let idCounter = 0;
+
+export default class LayeredDigraph<T = {}, U = {}> extends React.PureComponent<
+  TLayeredDigraphProps<T, U>,
+  TLayeredDigraphState<T, U>
+> {
+  renderUtils: TRendererUtils;
+
+  static propsFactories = {
+    classNameIsSmall,
+    scaledStrokeWidth,
+  };
+
+  static defaultProps = {
+    className: '',
+    classNamePrefix: 'plexus',
+    minimap: false,
+    minimapClassName: '',
+    zoom: false,
+  };
+
+  state: TLayeredDigraphState<T, U> = {
+    edges: [],
+    layoutEdges: null,
+    layoutGraph: null,
+    layoutPhase: ELayoutPhase.NoData,
+    layoutVertices: null,
+    sizeVertices: null,
+    vertices: [],
+    zoomTransform: zoomIdentity,
+  };
+
+  baseId = `plexus--LayeredDigraph--${idCounter++}`;
+
+  rootRef: React.RefObject<HTMLDivElement> = React.createRef();
+
+  zoomManager: ZoomManager | null = null;
+
+  constructor(props: TLayeredDigraphProps<T, U>) {
+    super(props);
+    const { edges, vertices, zoom: zoomEnabled } = props;
+    if (Array.isArray(edges) && edges.length && Array.isArray(vertices) && vertices.length) {
+      this.state.layoutPhase = ELayoutPhase.CalcSizes;
+      this.state.edges = edges;
+      this.state.vertices = vertices;
+    }
+    if (zoomEnabled) {
+      this.zoomManager = new ZoomManager(this.onZoomUpdated);
+    } else {
+      this.zoomManager = null;
+    }
+    this.renderUtils = {
+      getLocalId: this.getLocalId,
+      getZoomTransform: this.getZoomTransform,
+    };
+  }
+
+  componentDidMount() {
+    const { current } = this.rootRef;
+    if (current && this.zoomManager) {
+      this.zoomManager.setElement(current);
+    }
+  }
+
+  getLocalId = (name: string) => `${this.baseId}--${name}`;
+
+  getZoomTransform = () => this.state.zoomTransform;
+
+  private setSizeVertices = (senderKey: string, sizeVertices: TSizeVertex<T>[]) => {
+    const { edges, layoutManager, measurableNodesKey: expectedKey } = this.props;
+    if (senderKey !== expectedKey) {
+      const values = `expected ${JSON.stringify(expectedKey)}, recieved ${JSON.stringify(senderKey)}`;
+      throw new Error(`Key mismatch for measuring nodes; ${values}`);
+    }
+    this.setState({ sizeVertices });
+    const { layout } = layoutManager.getLayout(edges, sizeVertices);
+    // const { positions, layout } = layoutManager.getLayout(edges, sizeVertices);
+    // positions.then(this._onPositionsDone);
+    layout.then(this.onLayoutDone);
+    this.setState({ sizeVertices, layoutPhase: ELayoutPhase.CalcPositions });
+  };
+
+  private renderLayers() {
+    const { classNamePrefix, layers: topLayers } = this.props;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { sizeVertices, ...partialGraphState } = this.state;
+    const graphState = {
+      ...partialGraphState,
+      renderUtils: this.renderUtils,
+    };
+    return topLayers.map(layer => {
+      if (layer.layers && layer.html && !layer.nodeRender) {
+        const { key, layers, setOnContainer } = layer;
+        return (
+          <HtmlLayersGroup<T, U>
+            key={key}
+            graphState={graphState}
+            layers={layers}
+            classNamePrefix={classNamePrefix}
+            setOnContainer={setOnContainer}
+            setSizeVertices={this.setSizeVertices}
+          />
+        );
+      }
+      throw new Error('Not implemented');
+    });
+  }
+
+  private onZoomUpdated = (zoomTransform: ZoomTransform) => {
+    this.setState({ zoomTransform });
+  };
+
+  private onLayoutDone = (result: TCancelled | TLayoutDone) => {
+    if (result.isCancelled) {
+      return;
+    }
+    const { edges: layoutEdges, graph: layoutGraph, vertices: layoutVertices } = result;
+    this.setState({ layoutEdges, layoutGraph, layoutVertices, layoutPhase: ELayoutPhase.Done });
+    if (this.zoomManager) {
+      this.zoomManager.setContentSize(layoutGraph);
+    }
+  };
+
+  render() {
+    const {
+      className,
+      classNamePrefix,
+      minimap: minimapEnabled,
+      minimapClassName,
+      setOnGraph,
+      style,
+    } = this.props;
+    const rootProps = assignMergeCss(
+      { className, style },
+      getProps(setOnGraph, { ...this.state, renderUtils: this.renderUtils }),
+      {
+        style: this.zoomManager ? WRAPPER_STYLE_ZOOM : WRAPPER_STYLE,
+        className: `${classNamePrefix} ${classNamePrefix}-LayeredDigraph`,
+      }
+    );
+    return (
+      <div {...rootProps} ref={this.rootRef}>
+        {this.renderLayers()}
+        {minimapEnabled && this.zoomManager && (
+          <MiniMap
+            className={minimapClassName}
+            classNamePrefix={classNamePrefix}
+            {...this.zoomManager.getProps()}
+          />
+        )}
+      </div>
+    );
+  }
+}

--- a/packages/plexus/src/LayeredDigraph/index.tsx
+++ b/packages/plexus/src/LayeredDigraph/index.tsx
@@ -15,6 +15,8 @@
 import * as React from 'react';
 
 import HtmlLayersGroup from './HtmlLayersGroup';
+import MeasurableNodesLayer from './MeasurableNodesLayer';
+import { classNameIsSmall, scaledStrokeWidth } from './props-factories';
 import {
   ELayoutPhase,
   TExposedGraphState,
@@ -22,9 +24,9 @@ import {
   TLayer,
   TPropsFactory,
   TRendererUtils,
+  ELayerType,
 } from './types';
 import { assignMergeCss, getProps } from './utils';
-import { classNameIsSmall, scaledStrokeWidth } from './props-factories';
 // TODO(joe): don't use stuff in ../DirectedGraph
 import MiniMap from '../DirectedGraph/MiniMap';
 import LayoutManager from '../LayoutManager';
@@ -152,19 +154,47 @@ export default class LayeredDigraph<T = {}, U = {}> extends React.PureComponent<
       renderUtils: this.renderUtils,
     };
     return topLayers.map(layer => {
-      if (layer.layers && layer.html && !layer.nodeRender) {
-        const { key, layers, setOnContainer } = layer;
+      const { layerType, key, layers, setOnContainer } = layer;
+      if (layers) {
+        if (layerType === ELayerType.Html) {
+          return (
+            <HtmlLayersGroup<T, U>
+              key={key}
+              graphState={graphState}
+              layers={layers}
+              classNamePrefix={classNamePrefix}
+              setOnContainer={setOnContainer}
+              setSizeVertices={this.setSizeVertices}
+            />
+          );
+        }
+        // svg group layer
+        throw new Error('Not implemented');
+      }
+      const { edges } = layer;
+      if (edges) {
+        // edges standalone layer
+        throw new Error('Not implemented');
+      }
+      if (layer.measurable) {
+        // standalone measurable Nodes Layer
+        const { nodeRender, setOnNode } = layer;
         return (
-          <HtmlLayersGroup<T, U>
+          <MeasurableNodesLayer<T, U>
             key={key}
-            graphState={graphState}
-            layers={layers}
+            standalone
             classNamePrefix={classNamePrefix}
+            graphState={graphState}
+            layerType={layer.layerType}
+            nodeRender={nodeRender}
+            senderKey={key}
             setOnContainer={setOnContainer}
+            setOnNode={setOnNode}
             setSizeVertices={this.setSizeVertices}
           />
         );
       }
+      // regular nodes layer
       throw new Error('Not implemented');
     });
   }

--- a/packages/plexus/src/LayeredDigraph/props-factories.tsx
+++ b/packages/plexus/src/LayeredDigraph/props-factories.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TExposedGraphState } from './types';
+
+export const scaledStrokeWidth = (() => {
+  // define via an IIFE to sequester consts
+  const STROKE_MAX = 4.2;
+  const STROKE_MIN = 2;
+  const STROKE_SPREAD = STROKE_MAX - STROKE_MIN;
+  const PROPS_MAX = { style: { strokeWidth: STROKE_MAX.toFixed(1) } };
+  const PROPS_MIN = { style: { strokeWidth: STROKE_MIN.toFixed(1) } };
+
+  const THRESHOLD_MAX = 0.1;
+  const THRESHOLD_MIN = 0.6;
+  const THRESHOLD_SPREAD = THRESHOLD_MIN - THRESHOLD_MAX;
+
+  const cache: { [key: string]: { style: { strokeWidth: string } } } = {};
+  let lastK = -Number.MIN_VALUE;
+  let lastProps = PROPS_MIN;
+
+  // eslint-disable-next-line no-shadow
+  function scaledStrokeWidth<T = {}, U = {}>(graphState: TExposedGraphState<T, U>) {
+    const { k = 1 } = graphState.zoomTransform || {};
+    if (k === lastK) {
+      return lastProps;
+    }
+    let props = lastProps;
+    if (k > THRESHOLD_MIN) {
+      props = PROPS_MIN;
+    } else if (k < THRESHOLD_MAX) {
+      props = PROPS_MAX;
+    } else {
+      const strokeWidth = (STROKE_MIN + (STROKE_SPREAD * (THRESHOLD_MIN - k)) / THRESHOLD_SPREAD).toFixed(1);
+      props = cache[strokeWidth] || (cache[strokeWidth] = { style: { strokeWidth } });
+    }
+    lastK = k;
+    lastProps = props;
+    return props;
+  }
+
+  return scaledStrokeWidth;
+})();
+
+export const classNameIsSmall = (() => {
+  // define via an IIFE to sequester consts
+  const SCALE_THRESHOLD_SMALL = 0.29;
+
+  // eslint-disable-next-line no-shadow
+  function classNameIsSmall<T = {}, U = {}>(graphState: TExposedGraphState<T, U>) {
+    const { k = 1 } = graphState.zoomTransform || {};
+    if (k <= SCALE_THRESHOLD_SMALL) {
+      return { className: 'is-small' };
+    }
+    return null;
+  }
+
+  return classNameIsSmall;
+})();

--- a/packages/plexus/src/LayeredDigraph/types.tsx
+++ b/packages/plexus/src/LayeredDigraph/types.tsx
@@ -26,6 +26,12 @@ export enum ELayoutPhase {
   Done = 'Done',
 }
 
+export type TLayerType = 'html' | 'svg';
+export enum ELayerType {
+  Html = 'html',
+  Svg = 'svg',
+}
+
 export type TRendererUtils = {
   getLocalId: (name: string) => string;
   getZoomTransform: () => ZoomTransform;
@@ -64,8 +70,6 @@ export type TSetOnContainer<T = {}, U = {}> = TPropsFactory<'setOnContainer', TF
 
 type TKeyed = { key: string };
 
-export type TElemType = TOneOfTwo<{ html: true }, { svg: true }>;
-
 export type TNodeRenderFn<T = {}> = (vertex: TVertex<T>, utils: TRendererUtils) => React.ReactNode;
 
 export type TMeasurableNodeRenderFn<T = {}> = (
@@ -91,7 +95,9 @@ type TNodesLayer<T = {}, U = {}> = TKeyed &
   TOneOfTwo<TNodeRenderer<T>, TMeasurableNodeRenderer<T>> &
   TSetOnContainer<T, U>;
 
-type TStandaloneNodesLayer<T = {}, U = {}> = TNodesLayer<T, U> & TElemType;
+type TStandaloneNodesLayer<T = {}, U = {}> = TNodesLayer<T, U> & {
+  layerType: TLayerType;
+};
 
 type TMarkerDef<T = {}, U = {}> = TKeyed & {
   type: React.Component;
@@ -105,20 +111,20 @@ type TEdgesLayer<T = {}, U = {}> = TKeyed &
     setOnEdge?: TSetProps<(edges: TLayoutEdge<U>, utils: TRendererUtils) => TAnyProps | null>;
   };
 
-type TStandaloneEdgesLayer<T = {}, U = {}> = TEdgesLayer<T, U> &
-  TElemType & {
-    defs?: TMarkerDef<T, U>[];
-  };
+type TStandaloneEdgesLayer<T = {}, U = {}> = TEdgesLayer<T, U> & {
+  layerType: TLayerType;
+  defs?: TMarkerDef<T, U>[];
+};
 
 export type THtmlLayersGroup<T = {}, U = {}> = TKeyed &
   TSetOnContainer<T, U> & {
-    html: true;
+    layerType: Extract<TLayerType, 'html'>;
     layers: TOneOfTwo<TNodesLayer<T, U>, TEdgesLayer<T, U>>[];
   };
 
 type TSvgLayersGroup<T = {}, U = {}> = TKeyed &
   TSetOnContainer<T, U> & {
-    svg: true;
+    layerType: Extract<TLayerType, 'svg'>;
     defs?: TMarkerDef<T, U>[];
     layers: TOneOfTwo<TNodesLayer<T, U>, TEdgesLayer<T, U>>[];
   };

--- a/packages/plexus/src/LayeredDigraph/types.tsx
+++ b/packages/plexus/src/LayeredDigraph/types.tsx
@@ -26,6 +26,22 @@ export enum ELayoutPhase {
   Done = 'Done',
 }
 
+export type TRendererUtils = {
+  getLocalId: (name: string) => string;
+  getZoomTransform: () => ZoomTransform;
+};
+
+export type TExposedGraphState<T = {}, U = {}> = {
+  edges: TEdge<U>[];
+  layoutEdges: TLayoutEdge<U>[] | null;
+  layoutGraph: TLayoutGraph | null;
+  layoutPhase: ELayoutPhase;
+  layoutVertices: TLayoutVertex<T>[] | null;
+  renderUtils: TRendererUtils;
+  vertices: TVertex<T>[];
+  zoomTransform: ZoomTransform;
+};
+
 export type TAnyProps = Record<string, unknown> & {
   className?: string;
   style?: React.CSSProperties;
@@ -38,33 +54,13 @@ export type TSetProps<TFactoryFn extends TPropFactoryFn> =
   | TFactoryFn
   | (TAnyProps | TFactoryFn)[];
 
-// TODO(joe): consider getting rid of this type
-// type TAesthetics = {
-//   className?: string;
-//   style?: React.CSSProperties;
-// };
-
-export type TRendererUtils = {
-  getLocalId: (name: string) => string;
-  getZoomTransform: () => ZoomTransform;
-};
-
-export type TExposedGraphState<T = {}, U = {}> = {
-  edges: TEdge<U>[];
-  zoomTransform: ZoomTransform;
-  layoutEdges: TLayoutEdge<U>[] | null;
-  layoutGraph: TLayoutGraph | null;
-  layoutPhase: ELayoutPhase;
-  layoutVertices: TLayoutVertex<T>[] | null;
-  renderUtils: TRendererUtils;
-  vertices: TVertex<T>[];
-};
-
 export type TFromGraphStateFn<T = {}, U = {}> = (input: TExposedGraphState<T, U>) => TAnyProps | null;
 
-export type TSetOnContainer<T = {}, U = {}> = {
-  setOnContainer?: TSetProps<TFromGraphStateFn<T, U>>;
+export type TPropsFactory<PropNames extends string, FactoryFn extends TPropFactoryFn> = {
+  [K in PropNames]?: TSetProps<FactoryFn>;
 };
+
+export type TSetOnContainer<T = {}, U = {}> = TPropsFactory<'setOnContainer', TFromGraphStateFn<T, U>>;
 
 type TKeyed = { key: string };
 
@@ -114,17 +110,17 @@ type TStandaloneEdgesLayer<T = {}, U = {}> = TEdgesLayer<T, U> &
     defs?: TMarkerDef<T, U>[];
   };
 
-type THtmlLayersGroup<T = {}, U = {}> = TKeyed &
+export type THtmlLayersGroup<T = {}, U = {}> = TKeyed &
   TSetOnContainer<T, U> & {
     html: true;
-    layers: (TNodesLayer<T, U> | TEdgesLayer<T, U>)[];
+    layers: TOneOfTwo<TNodesLayer<T, U>, TEdgesLayer<T, U>>[];
   };
 
 type TSvgLayersGroup<T = {}, U = {}> = TKeyed &
   TSetOnContainer<T, U> & {
     svg: true;
     defs?: TMarkerDef<T, U>[];
-    layers: (TNodesLayer<T, U> | TEdgesLayer<T, U>)[];
+    layers: TOneOfTwo<TNodesLayer<T, U>, TEdgesLayer<T, U>>[];
   };
 
 export type TLayer<T = {}, U = {}> = TOneOfFour<
@@ -134,8 +130,8 @@ export type TLayer<T = {}, U = {}> = TOneOfFour<
   TStandaloneEdgesLayer<T, U>
 >;
 
-export type TMeasurableNodeProps<T = {}> = Pick<TMeasurableNodeRenderer<T>, 'nodeRender' | 'setOnNode'> & {
-  classNamePrefix: string;
+export type TMeasurableNodeProps<T = {}> = Omit<TMeasurableNodeRenderer<T>, 'measurable'> & {
+  classNamePrefix?: string;
   hidden?: boolean;
   layoutVertex: TLayoutVertex<T> | null;
   renderUtils: TRendererUtils;

--- a/packages/plexus/src/LayeredDigraph/utils.tsx
+++ b/packages/plexus/src/LayeredDigraph/utils.tsx
@@ -13,9 +13,26 @@
 // limitations under the License.
 
 import { TPropFactoryFn, TSetProps } from './types';
-import { assignMergeCss } from '../DirectedGraph/prop-factories/mergePropSetters';
 
-// eslint-disable-next-line import/prefer-default-export
+function reduce(a: Record<string, any>, b: Record<string, any>) {
+  // eslint-disable-next-line prefer-const
+  let { className, style, ...rest } = a;
+  const { className: bClassName, style: bStyle, ...bRest } = b;
+  // merge className props
+  if (bClassName) {
+    className = className ? `${className} ${bClassName}` : bClassName;
+  }
+  // merge style props
+  if (bStyle && typeof bStyle === 'object') {
+    style = style ? { ...style, ...bStyle } : bStyle;
+  }
+  return { className, style, ...rest, ...bRest };
+}
+
+export function assignMergeCss(...objs: Record<string, any>[]) {
+  return objs.reduce(reduce);
+}
+
 export function getProps<TFactoryFn extends TPropFactoryFn>(
   propSpec: TSetProps<TFactoryFn> | void,
   ...args: Parameters<TFactoryFn>

--- a/packages/plexus/src/types/TOneOf.tsx
+++ b/packages/plexus/src/types/TOneOf.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type TOneOf<A, B, C = {}, D = {}, E = {}> =
+type TOneOf<A, B, C = {}, D = {}, E = {}> =
   | { [P in Exclude<keyof (B & C & D & E), keyof A>]?: null } & A
   | { [P in Exclude<keyof (A & C & D & E), keyof B>]?: null } & B
   | { [P in Exclude<keyof (A & B & D & E), keyof C>]?: null } & C

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,6 +1511,11 @@
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@types/deep-freeze/-/deep-freeze-0.1.1.tgz#0e1ee6ceee06f51baeb663deec0bb7780bd72827"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/history@*", "@types/history@^4.7.2":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
@@ -1638,26 +1643,39 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
 
-"@typescript-eslint/eslint-plugin@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.4.1.tgz#f752a6888a957fd411c7bcada11884c4257d374a"
+"@typescript-eslint/eslint-plugin@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.12.0.tgz#96b4e08b5f998a198b8414508b1a289f9e8c549a"
+  integrity sha512-J/ZTZF+pLNqjXBGNfq5fahsoJ4vJOkYbitWPavA05IrZ7BXUaf4XWlhUB/ic1lpOGTRpLWF+PLAePjiHp6dz8g==
   dependencies:
-    "@typescript-eslint/parser" "1.4.1"
-    "@typescript-eslint/typescript-estree" "1.4.1"
-    requireindex "^1.2.0"
+    "@typescript-eslint/experimental-utils" "1.12.0"
+    eslint-utils "^1.3.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
     tsutils "^3.7.0"
 
-"@typescript-eslint/parser@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.4.1.tgz#a7cd1a41722da6a37088ea90c0009ea56a27a372"
+"@typescript-eslint/experimental-utils@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.12.0.tgz#98417ee2e0c6fe8d1e50d934a6535d9c0f4277b6"
+  integrity sha512-s0soOTMJloytr9GbPteMLNiO2HvJ+qgQkRNplABXiVw6vq7uQRvidkby64Gqt/nA7pys74HksHwRULaB/QRVyw==
   dependencies:
-    "@typescript-eslint/typescript-estree" "1.4.1"
+    "@typescript-eslint/typescript-estree" "1.12.0"
     eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.12.0.tgz#9965895ec4745578185965d63f21510f93a3f35a"
+  integrity sha512-0uzbaa9ZLCA5yMWJywnJJ7YVENKGWVUhJDV5UrMoldC5HoI54W5kkdPhTfmtFKpPFp93MIwmJj0/61ztvmz5Dw==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.12.0"
+    "@typescript-eslint/typescript-estree" "1.12.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/typescript-estree@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.1.tgz#6ca30b1770db0aee62b92a1c4ac5eaabc332c116"
+"@typescript-eslint/typescript-estree@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.12.0.tgz#d8dd0a7cffb5e3c0c3e98714042d83e316dfc9a9"
+  integrity sha512-nwN6yy//XcVhFs0ZyU+teJHB8tbCm7AIA8mu6E2r5hu6MajwYBY3Uwop7+rPZWUN/IUOHpL8C+iUPMDVYUU3og==
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
@@ -11113,10 +11131,6 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requireindex@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -12381,7 +12395,12 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.3.3333, typescript@^3.3.3333:
+typescript@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
+typescript@^3.3.3333:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
 


### PR DESCRIPTION
## Which problem is this PR solving?

Adding the first couple of components for supporting layers of graph elements in plexus.

## Short description of the changes

Add `LayeredDigraph`, `HtmlLayersGroup`, `MeasurableNodesLayer` and `MeasurableHtmlNode` to plexus.

Also, update TypeScript to `3.5.3`.

From the demo:

```tsx
<LayeredDigraph
  zoom
  minimap
  className="DemoGraph--dag"
  layoutManager={new LayoutManager({ useDotEdges: true })}
  minimapClassName="Demo--miniMap"
  setOnGraph={layeredClassNameIsSmall}
  measurableNodesKey="nodes"
  layers={[
    {
      key: 'nodes-layers',
      html: true,
      layers: [
        {
          setOnNode,
          key: 'nodes',
          measurable: true,
          nodeRender: getLargeNodeLabel,
        },
      ],
    },
  ]}
  {...largeDag}
/>
```

### TODO:

- [x] Allow `MeasurableNodesLayer` as a standalone layer, i.e. not as a layer within a `HtmlLayersGroup`

### Node layout comparison

**↓ `LayeredDigraph`** (component under development)

<img width="827" alt="Screen Shot 2019-07-16 at 7 53 47 PM" src="https://user-images.githubusercontent.com/2304337/61337833-ec577180-a804-11e9-9504-2896a2af369d.png">

----

**↓ `DirectedGraph`** (the current component)

<img width="809" alt="Screen Shot 2019-07-16 at 7 54 37 PM" src="https://user-images.githubusercontent.com/2304337/61337843-f4171600-a804-11e9-974d-9eacc450fdb4.png">
