### PR TITLE
Fix typo in codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 coverage:
   status:
-    project:
+    patch:
       default:
         only_pulls: true


### PR DESCRIPTION
The previous PR applied the change to the wrong status check.

This is a change to the CI, not a functional change.