### PR TITLE
Iterating on codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,32 @@
+# Everything is the default except coverage.status.patch.default.only_pulls
 coverage:
   status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: null
+        base: auto
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
     patch:
       default:
+        # basic
+        target: auto
+        threshold: null
+        base: auto
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        # the main change:
         only_pulls: true
+        flags: null
+        paths: null


### PR DESCRIPTION
## Which problem is this PR solving?

Inadvertently removed all codecov status checks from master in a previous PR.

## Short description of the changes

This adds `project` and `patch` based on the default config with the change that `patch.default.only_pulls` is set to `true`.
