### PR TITLE
Raise real ddg request

### DIFF
--- a/packages/jaeger-ui/src/actions/jaeger-api.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.js
@@ -15,8 +15,6 @@
 import { createAction } from 'redux-actions';
 import JaegerAPI from '../api/jaeger';
 
-import * as paths from '../model/ddg/sample-paths.test.resources';
-
 export const fetchTrace = createAction(
   '@JAEGER_API/FETCH_TRACE',
   id => JaegerAPI.fetchTrace(id),
@@ -49,23 +47,9 @@ export const fetchServiceOperations = createAction(
   serviceName => ({ serviceName })
 );
 
-function tempTestFetch() {
-  let resolve;
-  const promise = new Promise(res => {
-    resolve = res;
-  });
-  setTimeout(() => {
-    /* istanbul ignore next */
-    resolve([paths.simplePath, paths.almostDoubleFocalPath]);
-  }, 1000);
-  return promise;
-}
-
 export const fetchDeepDependencyGraph = createAction(
   '@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH',
-  // Temporary mock used until backend is available, TODO revert & re-enable test
-  // query => JaegerAPI.fetchDeepDependencyGraph(query),
-  tempTestFetch,
+  query => JaegerAPI.fetchDeepDependencyGraph(query),
   query => ({ query })
 );
 

--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -72,6 +72,7 @@ function getJSON(url, options = {}) {
 }
 
 export const DEFAULT_API_ROOT = prefixUrl('/api/');
+export const ANALYTICS_ROOT = prefixUrl('/analytics/');
 export const DEFAULT_DEPENDENCY_LOOKBACK = moment.duration(1, 'weeks').asMilliseconds();
 
 const JaegerAPI = {
@@ -80,7 +81,7 @@ const JaegerAPI = {
     return getJSON(`${this.apiRoot}archive/${id}`, { method: 'POST' });
   },
   fetchDeepDependencyGraph(query) {
-    return getJSON(`${this.apiRoot}deep-dependency-graph`, { query });
+    return getJSON(`${ANALYTICS_ROOT}v1/dependencies`, { query });
   },
   fetchDependencies(endTs = new Date().getTime(), lookback = DEFAULT_DEPENDENCY_LOOKBACK) {
     return getJSON(`${this.apiRoot}dependencies`, { query: { endTs, lookback } });

--- a/packages/jaeger-ui/src/api/jaeger.test.js
+++ b/packages/jaeger-ui/src/api/jaeger.test.js
@@ -27,7 +27,12 @@ import fetchMock from 'isomorphic-fetch';
 import queryString from 'query-string';
 
 import traceGenerator from '../demo/trace-generators';
-import JaegerAPI, { getMessageFromError, DEFAULT_API_ROOT, DEFAULT_DEPENDENCY_LOOKBACK } from './jaeger';
+import JaegerAPI, {
+  getMessageFromError,
+  DEFAULT_API_ROOT,
+  DEFAULT_DEPENDENCY_LOOKBACK,
+  ANALYTICS_ROOT,
+} from './jaeger';
 
 const defaultOptions = {
   credentials: 'same-origin',
@@ -48,7 +53,7 @@ describe('fetchDeepDependencyGraph', () => {
     const query = { service: 'serviceName', start: 400, end: 800 };
     JaegerAPI.fetchDeepDependencyGraph(query);
     expect(fetchMock).toHaveBeenLastCalledWith(
-      `${DEFAULT_API_ROOT}deep-dependency-graph?${queryString.stringify(query)}`,
+      `${ANALYTICS_ROOT}v1/dependencies?${queryString.stringify(query)}`,
       defaultOptions
     );
   });

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph.test.js
@@ -17,12 +17,12 @@ import { shallow } from 'enzyme';
 import { DirectedGraph, LayoutManager } from '@jaegertracing/plexus';
 
 import Graph from './Graph';
-import { focalPayloadElem, simplePath } from '../../model/ddg/sample-paths.test.resources';
+import { focalPayloadElem, simplePath, wrap } from '../../model/ddg/sample-paths.test.resources';
 import transformDdgData from '../../model/ddg/transformDdgData';
 import GraphModel from '../../model/ddg/Graph';
 
 describe('<Graph />', () => {
-  const ddgModel = transformDdgData([simplePath], focalPayloadElem);
+  const ddgModel = transformDdgData([simplePath].map(wrap), focalPayloadElem);
   const props = {
     ddgModel,
     visEncoding: '3',

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/index.test.js
@@ -20,14 +20,15 @@ import {
   longSimplePath,
   shortPath,
   simplePath,
+  wrap,
 } from '../../../../model/ddg/sample-paths.test.resources';
 import transformDdgData from '../../../../model/ddg/transformDdgData';
 import * as codec from '../../../../model/ddg/visibility-codec';
 import HopsSelector from '.';
 
 describe('HopsSelector', () => {
-  const { distanceToPathElems } = transformDdgData([longSimplePath, simplePath], focalPayloadElem);
-  const { distanceToPathElems: shortPathElems } = transformDdgData([shortPath], focalPayloadElem);
+  const { distanceToPathElems } = transformDdgData([longSimplePath, simplePath].map(wrap), focalPayloadElem);
+  const { distanceToPathElems: shortPathElems } = transformDdgData([shortPath].map(wrap), focalPayloadElem);
 
   describe('without visEncoding', () => {
     it('renders hops within two hops as full and others as empty', () => {

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -56,10 +56,11 @@ type TProps = TDispatchProps & TReduxProps & TOwnProps;
 // export for tests
 export class DeepDependencyGraphPageImpl extends Component<TProps> {
   static fetchModelIfStale(props: TProps) {
-    const { fetchDeepDependencyGraph, graphState = null } = props;
-    // TEMP
-    if (!graphState) {
-      fetchDeepDependencyGraph({ service: 'focalService', operation: 'focalOperation', start: 0, end: 0 });
+    const { fetchDeepDependencyGraph, graphState = null, urlState } = props;
+    const { service, operation } = urlState;
+    // backend temporarily requires service and operation
+    if (!graphState && service && operation) {
+      fetchDeepDependencyGraph({ service, operation, start: 0, end: 0 });
     }
   }
 
@@ -154,16 +155,13 @@ export class DeepDependencyGraphPageImpl extends Component<TProps> {
 // export for tests
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
   const urlState = getUrlState(ownProps.location.search);
-  const graphState = _get(state, [
-    'deepDependencyGraph',
-    stateKey({ service: 'focalService', operation: 'focalOperation', start: 0, end: 0 }),
-  ]);
-  // skip using the URL until services and operations are wired up
-  // const { service, operation, start, end } = urlState;
-  // let graphState: TDdgStateEntry | undefined;
-  // if (service && start && end) {
-  //   graphState = _get(state, ['deepDependencyGraph', stateKey({ service, operation, start, end })]);
-  // }
+  const { service, operation } = urlState;
+  let graphState: TDdgStateEntry | undefined;
+  // backend temporarily requires service and operation
+  // if (service) {
+  if (service && operation) {
+    graphState = _get(state, ['deepDependencyGraph', stateKey({ service, operation, start: 0, end: 0 })]);
+  }
   return {
     graphState,
     urlState,

--- a/packages/jaeger-ui/src/model/ddg/Graph.test.js
+++ b/packages/jaeger-ui/src/model/ddg/Graph.test.js
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { convergentPaths, focalPayloadElem, simplePath } from './sample-paths.test.resources';
+import { convergentPaths, focalPayloadElem, simplePath, wrap } from './sample-paths.test.resources';
 import transformDdgData from './transformDdgData';
 
 import Graph from './Graph';
 import { encode } from './visibility-codec';
 
 describe('Graph', () => {
-  const convergentModel = transformDdgData(convergentPaths, focalPayloadElem);
-  const simpleModel = transformDdgData([simplePath], focalPayloadElem);
+  const convergentModel = transformDdgData(convergentPaths.map(wrap), focalPayloadElem);
+  const simpleModel = transformDdgData([simplePath].map(wrap), focalPayloadElem);
 
   /**
    * This function takes in a Graph and validates the structure based on the expected vertices.

--- a/packages/jaeger-ui/src/model/ddg/sample-paths.test.resources.js
+++ b/packages/jaeger-ui/src/model/ddg/sample-paths.test.resources.js
@@ -88,3 +88,5 @@ export const convergentPaths = [
   [firstPayloadElem, focalPayloadElem, midPayloadElem, afterPayloadElem, lastPayloadElem],
   [firstPayloadElem, focalPayloadElem, divergentPayloadElem, afterPayloadElem, lastPayloadElem],
 ];
+
+export const wrap = path => ({ path });

--- a/packages/jaeger-ui/src/model/ddg/transformDdgData.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformDdgData.test.js
@@ -25,7 +25,10 @@ describe('transform ddg data', () => {
     const focalPayloadElemArgument = ignoreFocalOperation
       ? { service: focalPayloadElem.service }
       : focalPayloadElem;
-    const { paths, services, visIdxToPathElem } = transformDdgData(payload, focalPayloadElemArgument);
+    const { paths, services, visIdxToPathElem } = transformDdgData(
+      payload.map(testResources.wrap),
+      focalPayloadElemArgument
+    );
 
     // Validate all services and operations are captured
     expect(new Set(services.keys())).toEqual(new Set(_map(_flatten(payload), 'service')));
@@ -121,11 +124,11 @@ describe('transform ddg data', () => {
       almostDoubleFocalPath,
     } = testResources;
     const { visIdxToPathElem: presortedPathsVisIdxToPathElem } = transformDdgData(
-      [simplePath, doubleFocalPath, almostDoubleFocalPath, longSimplePath],
+      [simplePath, doubleFocalPath, almostDoubleFocalPath, longSimplePath].map(testResources.wrap),
       focalPayloadElem
     );
     const { visIdxToPathElem: unsortedPathsVisIdxToPathElem } = transformDdgData(
-      [longSimplePath, almostDoubleFocalPath, simplePath, doubleFocalPath],
+      [longSimplePath, almostDoubleFocalPath, simplePath, doubleFocalPath].map(testResources.wrap),
       focalPayloadElem
     );
 
@@ -163,7 +166,7 @@ describe('transform ddg data', () => {
   it('throws an error if a path lacks the focalPayloadElem', () => {
     const { simplePath, noFocalPath, doubleFocalPath, focalPayloadElem } = testResources;
     expect(() =>
-      transformDdgData([simplePath, noFocalPath, doubleFocalPath], focalPayloadElem)
+      transformDdgData([simplePath, noFocalPath, doubleFocalPath].map(testResources.wrap), focalPayloadElem)
     ).toThrowError();
   });
 });

--- a/packages/jaeger-ui/src/model/ddg/transformDdgData.tsx
+++ b/packages/jaeger-ui/src/model/ddg/transformDdgData.tsx
@@ -33,7 +33,7 @@ export default function transformDdgData(
   const pathCompareValues: Map<TDdgPayloadEntry[], string> = new Map();
 
   const paths = payload
-    .slice()
+    .map(({ path }) => path)
     .sort((a, b) => {
       let aCompareValue = pathCompareValues.get(a);
       if (!aCompareValue) {

--- a/packages/jaeger-ui/src/model/ddg/types.tsx
+++ b/packages/jaeger-ui/src/model/ddg/types.tsx
@@ -25,7 +25,9 @@ export type TDdgPayloadEntry = {
   service: string;
 };
 
-export type TDdgPayload = TDdgPayloadEntry[][];
+export type TDdgPayload = {
+  path: TDdgPayloadEntry[];
+}[];
 
 export type TDdgService = {
   name: string;

--- a/packages/jaeger-ui/src/model/ddg/visibility-codec.test.js
+++ b/packages/jaeger-ui/src/model/ddg/visibility-codec.test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { encode, decode, encodeDistance } from './visibility-codec';
-import { focalPayloadElem, longSimplePath, shortPath, simplePath } from './sample-paths.test.resources';
+import { focalPayloadElem, longSimplePath, shortPath, simplePath, wrap } from './sample-paths.test.resources';
 import transformDdgData from './transformDdgData';
 
 describe('visibility-codec', () => {
@@ -57,8 +57,8 @@ describe('visibility-codec', () => {
   });
 
   describe('encodeDistance', () => {
-    const ddgModel = transformDdgData([longSimplePath, simplePath], focalPayloadElem);
-    const shortModel = transformDdgData([shortPath], focalPayloadElem);
+    const ddgModel = transformDdgData([longSimplePath, simplePath].map(wrap), focalPayloadElem);
+    const shortModel = transformDdgData([shortPath].map(wrap), focalPayloadElem);
 
     /**
      * Creates a visibility encoding containing all indices between two specified hops, inclusive, except

--- a/packages/jaeger-ui/src/setupProxy.js
+++ b/packages/jaeger-ui/src/setupProxy.js
@@ -26,4 +26,14 @@ module.exports = function setupProxy(app) {
       xfwd: true,
     })
   );
+  app.use(
+    proxy('/analytics', {
+      target: 'http://localhost:16686',
+      logLevel: 'silent',
+      secure: false,
+      changeOrigin: true,
+      ws: true,
+      xfwd: true,
+    })
+  );
 };

--- a/packages/jaeger-ui/tsconfig.lint.json
+++ b/packages/jaeger-ui/tsconfig.lint.json
@@ -29,8 +29,6 @@
     "src/actions/jaeger-api.js",
     "src/api/jaeger.js",
     "src/components/SearchTracePage/SearchResults/ResultItem.markers.js",
-    // TODO: remove the next line when the fetchDeepDependencyGraph action is live
-    "src/model/ddg/sample-paths.test.resources.js",
     "src/model/order-by.js",
     "src/model/trace-viewer.js",
     "src/selectors/process.js",


### PR DESCRIPTION
This PR removes the consumption of `sample-paths.test.resources.js` and instead raises the request to jaeger-query to get a DDG.

The structure of the DDG payload is slightly different now, so tests were updated to provide this new structure and a super simple `map` was added to `transformDdgData`.