### PR TITLE
Use plexus digraph in jaeger

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.css
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.css
@@ -41,15 +41,11 @@ limitations under the License.
 
 .TraceDiffGraph--dag {
   transition: background 0.5s ease;
-  stroke-width: 1.2;
+  stroke-width: 0.9;
 }
 
 .TraceDiffGraph--dag.is-uiFind-mode {
   background: #ddd;
-}
-
-.TraceDiffGraph--dag.is-small {
-  stroke-width: 0.7;
 }
 
 /* Find within diff */
@@ -65,48 +61,4 @@ limitations under the License.
   border: 1px solid #aaa;
   border-radius: 0;
   box-shadow: 0 0 2px 2px #ccc;
-}
-
-/* DAG minimap */
-
-.TraceDiffGraph--miniMap {
-  align-items: flex-end;
-  bottom: 1rem;
-  display: flex;
-  left: 1rem;
-  position: absolute;
-  z-index: 1;
-}
-
-.TraceDiffGraph--miniMap > .plexus-MiniMap--item {
-  border: 1px solid #777;
-  background: #999;
-  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
-  margin-right: 1rem;
-  position: relative;
-}
-
-.TraceDiffGraph--miniMap > .plexus-MiniMap--map {
-  /* dynamic widht, height */
-  box-sizing: content-box;
-  cursor: not-allowed;
-}
-
-.TraceDiffGraph--miniMap .plexus-MiniMap--mapActive {
-  /* dynamic: width, height, transform */
-  background: #ccc;
-  position: absolute;
-}
-
-.TraceDiffGraph--miniMap > .plexus-MiniMap--button {
-  background: #ccc;
-  color: #888;
-  cursor: pointer;
-  font-size: 1.6em;
-  line-height: 0;
-  padding: 0.1rem;
-}
-
-.TraceDiffGraph--miniMap > .plexus-MiniMap--button:hover {
-  background: #ddd;
 }

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
@@ -614,20 +614,20 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
 <Popover
   content={
     <table
-      className="DiffNode is-same is-ui-find-match"
+      className="DiffNode is-same"
     >
       <tbody
         className="DiffNode--body"
       >
         <tr>
           <td
-            className="DiffNode--metricCell is-same is-ui-find-match"
+            className="DiffNode--metricCell is-same"
             rowSpan={2}
           >
             100
           </td>
           <td
-            className="DiffNode--labelCell is-same is-ui-find-match"
+            className="DiffNode--labelCell is-same"
           >
             <strong>
               serviceName
@@ -643,7 +643,7 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
         </tr>
         <tr>
           <td
-            className="DiffNode--labelCell is-same is-ui-find-match"
+            className="DiffNode--labelCell is-same"
           >
             operationName
           </td>
@@ -653,7 +653,7 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
   }
   mouseEnterDelay={0.25}
   mouseLeaveDelay={0.1}
-  overlayClassName="DiffNode--popover is-same is-ui-find-match"
+  overlayClassName="DiffNode--popover is-same"
   overlayStyle={Object {}}
   placement="top"
   prefixCls="ant-popover"
@@ -661,20 +661,20 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
   trigger="hover"
 >
   <table
-    className="DiffNode is-same is-ui-find-match"
+    className="DiffNode is-same"
   >
     <tbody
       className="DiffNode--body"
     >
       <tr>
         <td
-          className="DiffNode--metricCell is-same is-ui-find-match"
+          className="DiffNode--metricCell is-same"
           rowSpan={2}
         >
           100
         </td>
         <td
-          className="DiffNode--labelCell is-same is-ui-find-match"
+          className="DiffNode--labelCell is-same"
         >
           <strong>
             serviceName
@@ -690,7 +690,7 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
       </tr>
       <tr>
         <td
-          className="DiffNode--labelCell is-same is-ui-find-match"
+          className="DiffNode--labelCell is-same"
         >
           operationName
         </td>

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.css
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.css
@@ -22,11 +22,6 @@ limitations under the License.
   white-space: nowrap;
 }
 
-.DiffNode.is-ui-find-match {
-  outline: inherit;
-  outline-color: #fff3d7;
-}
-
 .DiffNode.is-changed {
   color: var(--tx-color-title);
 }
@@ -55,10 +50,6 @@ limitations under the License.
 
 .TraceDiffGraph--dag.is-small .DiffNode--body {
   opacity: 0;
-}
-
-.DiffNode--popover .DiffNode.is-ui-find-match {
-  outline: #fff3d7 solid 3px;
 }
 
 .DiffNode--metricCell {

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.js
@@ -15,11 +15,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import drawNodeGenerator, { DiffNode } from './drawNode';
+import renderNode, { DiffNode } from './renderNode';
 
 describe('drawNode', () => {
   const operation = 'operationName';
   const service = 'serviceName';
+
   describe('diffNode', () => {
     const defaultCount = 100;
     const props = {
@@ -65,7 +66,7 @@ describe('drawNode', () => {
     });
   });
 
-  describe('drawNode function', () => {
+  describe('renderNode()', () => {
     const dataKey = 'data-key';
     const dataValue = 'data-value';
     const key = 'vertex key';
@@ -81,16 +82,10 @@ describe('drawNode', () => {
     };
 
     it('extracts values from vertex.data', () => {
-      const drawNodeResult = drawNodeGenerator(new Set())(vertex);
-      expect(drawNodeResult.props[dataKey]).toBe(dataValue);
-      expect(drawNodeResult.props.isUiFindMatch).toBe(false);
-      expect(drawNodeResult.props.operation).toBe(operation);
-      expect(drawNodeResult.props.service).toBe(service);
-    });
-
-    it('passes isUiFindMatch as true if key is in set', () => {
-      const drawNodeResult = drawNodeGenerator(new Set([key]))(vertex);
-      expect(drawNodeResult.props.isUiFindMatch).toBe(true);
+      const node = renderNode(vertex);
+      expect(node.props[dataKey]).toBe(dataValue);
+      expect(node.props.operation).toBe(operation);
+      expect(node.props.service).toBe(service);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.tsx
@@ -15,17 +15,18 @@
 import * as React from 'react';
 import { Popover } from 'antd';
 import cx from 'classnames';
+import { TLayoutVertex } from '@jaegertracing/plexus/lib/types';
 
+import EmphasizedNode from '../../common/EmphasizedNode';
 import CopyIcon from '../../common/CopyIcon';
 import { DiffCounts } from '../../../model/trace-dag/types';
 import TDagVertex from '../../../model/trace-dag/types/TDagVertex';
 
-import './drawNode.css';
+import './renderNode.css';
 
 type Props = {
   a: number;
   b: number;
-  isUiFindMatch: boolean;
   operation: string;
   service: string;
 };
@@ -35,7 +36,7 @@ const max = Math.max;
 
 export class DiffNode extends React.PureComponent<Props> {
   render() {
-    const { a, b, isUiFindMatch, operation, service } = this.props;
+    const { a, b, operation, service } = this.props;
     const isSame = a === b;
     const className = cx({
       'is-same': isSame,
@@ -44,7 +45,6 @@ export class DiffNode extends React.PureComponent<Props> {
       'is-added': a === 0,
       'is-less': a > b && b > 0,
       'is-removed': b === 0,
-      'is-ui-find-match': isUiFindMatch,
     });
     const chgSign = a < b ? '+' : '-';
     const table = (
@@ -86,13 +86,16 @@ export class DiffNode extends React.PureComponent<Props> {
   }
 }
 
-function drawNode(vertex: TDagVertex<DiffCounts>, keys: Set<number | string>) {
+export default function renderNode(vertex: TDagVertex<DiffCounts>) {
   const { data, operation, service } = vertex.data;
-  return <DiffNode {...data} isUiFindMatch={keys.has(vertex.key)} operation={operation} service={service} />;
+  return <DiffNode {...data} operation={operation} service={service} />;
 }
 
-export default function drawNodeGenerator(keys: Set<number | string>) {
-  return function drawVertex(vertex: TDagVertex<DiffCounts>) {
-    return drawNode(vertex, keys);
+export function getNodeEmphasisRenderer(keys: Set<string>) {
+  return function drawEmphasizedNode(lv: TLayoutVertex<any>) {
+    if (!keys.has(lv.vertex.key)) {
+      return null;
+    }
+    return <EmphasizedNode height={lv.height} width={lv.width} />;
   };
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.css
@@ -16,10 +16,20 @@ limitations under the License.
 
 .OpNode {
   width: 100%;
-  border: 1px solid #111;
+  background: #fff;
   cursor: pointer;
   white-space: nowrap;
   border-collapse: separate;
+}
+
+.OpNode--popoverContent {
+  border: 1px solid #bbb;
+}
+
+.OpNode--vectorBorder {
+  box-sizing: content-box;
+  stroke: rgba(0, 0, 0, 0.4);
+  stroke-width: 2;
 }
 
 .OpNode td,
@@ -36,8 +46,8 @@ limitations under the License.
   outline: #fff3d7 solid 3px;
 }
 
-.OpMode--mode-service {
-  background: #bbb;
+.OpNode--legendNode {
+  background: #096dd9;
 }
 
 .OpNode--mode-time {
@@ -63,6 +73,28 @@ limitations under the License.
 .OpNode--service {
   display: flex;
   justify-content: space-between;
+}
+
+.OpNode--findEmpahsis {
+  stroke: #fff3d7;
+}
+
+.OpNode--findEmpahsis.is-non-scaling {
+  stroke-width: 10;
+}
+
+.OpNode--findEmpahsis.is-scaling {
+  stroke-width: 24;
+}
+
+.OpNode--findEmpahsisContrast {
+  stroke: rgba(0, 0, 0, 0.07);
+}
+.OpNode--findEmpahsisContrast.is-non-scaling {
+  stroke-width: 12;
+}
+.OpNode--findEmpahsisContrast.is-scaling {
+  stroke-width: 26;
 }
 
 /* Tweak the popover aesthetics - unfortunate but necessary */

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.css
@@ -75,28 +75,6 @@ limitations under the License.
   justify-content: space-between;
 }
 
-.OpNode--findEmpahsis {
-  stroke: #fff3d7;
-}
-
-.OpNode--findEmpahsis.is-non-scaling {
-  stroke-width: 10;
-}
-
-.OpNode--findEmpahsis.is-scaling {
-  stroke-width: 24;
-}
-
-.OpNode--findEmpahsisContrast {
-  stroke: rgba(0, 0, 0, 0.07);
-}
-.OpNode--findEmpahsisContrast.is-non-scaling {
-  stroke-width: 12;
-}
-.OpNode--findEmpahsisContrast.is-scaling {
-  stroke-width: 26;
-}
-
 /* Tweak the popover aesthetics - unfortunate but necessary */
 
 .OpNode--popover .ant-popover-inner-content {

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.test.js
@@ -15,7 +15,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import OpNode, { getNodeDrawer, MODE_SERVICE, MODE_TIME, MODE_SELFTIME } from './OpNode';
+import OpNode, { getNodeRenderer, MODE_SERVICE, MODE_TIME, MODE_SELFTIME } from './OpNode';
 import CopyIcon from '../../common/CopyIcon';
 
 describe('<OpNode>', () => {
@@ -79,11 +79,6 @@ describe('<OpNode>', () => {
     expect(wrapper.find('.OpNode--mode-selftime').length).toBe(1);
   });
 
-  it('updates class when it matches search', () => {
-    wrapper.setProps({ isUiFindMatch: true });
-    expect(wrapper.find('.is-ui-find-match').length).toBe(1);
-  });
-
   it('renders a copy icon', () => {
     const copyIcon = wrapper.find(CopyIcon);
     expect(copyIcon.length).toBe(1);
@@ -91,7 +86,7 @@ describe('<OpNode>', () => {
     expect(copyIcon.prop('tooltipTitle')).toBe('Copy label');
   });
 
-  describe('getNodeDrawer()', () => {
+  describe('getNodeRenderer()', () => {
     const key = 'key test value';
     const vertex = {
       data: {
@@ -103,19 +98,10 @@ describe('<OpNode>', () => {
     };
 
     it('creates OpNode', () => {
-      const drawNode = getNodeDrawer(MODE_SERVICE, new Set());
+      const drawNode = getNodeRenderer(MODE_SERVICE);
       const opNode = drawNode(vertex);
       expect(opNode.type === 'OpNode');
-      expect(opNode.props.isUiFindMatch).toBe(false);
       expect(opNode.props.mode).toBe(MODE_SERVICE);
-    });
-
-    it('creates OpNode that matches uiFind', () => {
-      const drawNode = getNodeDrawer(MODE_TIME, new Set([key]));
-      const opNode = drawNode(vertex);
-      expect(opNode.type === 'OpNode');
-      expect(opNode.props.isUiFindMatch).toBe(true);
-      expect(opNode.props.mode).toBe(MODE_TIME);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
@@ -22,6 +22,7 @@ import TDagVertex from '../../../model/trace-dag/types/TDagVertex';
 import colorGenerator from '../../../utils/color-generator';
 
 import './OpNode.css';
+import EmphasizedNode from '../../common/EmphasizedNode';
 
 type Props = {
   count: number;
@@ -136,24 +137,7 @@ export function getNodeFindEmphasisRenderer(uiFindVertexKeys: Set<string> | null
     if (!uiFindVertexKeys || !uiFindVertexKeys.has(lv.vertex.key)) {
       return null;
     }
-    return (
-      <>
-        <rect
-          className="OpNode--findEmpahsisContrast is-non-scaling"
-          vectorEffect="non-scaling-stroke"
-          width={lv.width}
-          height={lv.height}
-        />
-        <rect className="OpNode--findEmpahsisContrast is-scaling" width={lv.width} height={lv.height} />
-        <rect
-          className="OpNode--findEmpahsis is-non-scaling"
-          vectorEffect="non-scaling-stroke"
-          width={lv.width}
-          height={lv.height}
-        />
-        <rect className="OpNode--findEmpahsis is-scaling" width={lv.width} height={lv.height} />
-      </>
-    );
+    return <EmphasizedNode height={lv.height} width={lv.width} />;
   };
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
@@ -22,6 +22,7 @@ limitations under the License.
 }
 
 .TraceGraph--graphWrapper {
+  background: #f0f0f0;
   bottom: 0;
   cursor: move;
   left: 0;
@@ -38,18 +39,21 @@ limitations under the License.
 }
 
 .TraceGraph--sidebar-container {
+  background: #f4f4f4;
   display: flex;
   z-index: 1;
 }
 
 .TraceGraph--menu {
+  border-left: 1px solid #e4e4e4;
+  border-right: 1px solid #e4e4e4;
   cursor: pointer;
   padding: 0.8rem;
 }
 
 .TraceGraph--menu > li {
   list-style-type: none;
-  text-align: right;
+  text-align: center;
   padding-bottom: 0.3rem;
 }
 
@@ -63,11 +67,7 @@ limitations under the License.
 }
 
 .TraceGraph--dag {
-  stroke-width: 1.2;
-}
-
-.TraceGraph--dag.is-small {
-  stroke-width: 0.7;
+  stroke-width: 0.8;
 }
 
 /* DAG minimap */

--- a/packages/jaeger-ui/src/components/common/EmphasizedNode.css
+++ b/packages/jaeger-ui/src/components/common/EmphasizedNode.css
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2018 The Jaeger Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.EmphasizedNode {
+  stroke: #fff3d7;
+}
+
+.EmphasizedNode.is-non-scaling {
+  stroke-width: 10;
+}
+
+.EmphasizedNode.is-scaling {
+  stroke-width: 34;
+}
+
+.EmphasizedNode--contrast {
+  stroke: rgba(0, 0, 0, 0.07);
+}
+
+.EmphasizedNode--contrast.is-non-scaling {
+  stroke-width: 12;
+}
+
+.EmphasizedNode--contrast.is-scaling {
+  stroke-width: 36;
+}

--- a/packages/jaeger-ui/src/components/common/EmphasizedNode.tsx
+++ b/packages/jaeger-ui/src/components/common/EmphasizedNode.tsx
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+
+import './EmphasizedNode.css';
+
+type Props = {
+  height: number;
+  width: number;
+};
+
+export default class EmphasizedNode extends React.PureComponent<Props> {
+  render() {
+    const { height, width } = this.props;
+    return (
+      <>
+        <rect
+          className="EmphasizedNode--contrast is-non-scaling"
+          vectorEffect="non-scaling-stroke"
+          width={width}
+          height={height}
+        />
+        <rect className="EmphasizedNode--contrast is-scaling" width={width} height={height} />
+        <rect
+          className="EmphasizedNode is-non-scaling"
+          vectorEffect="non-scaling-stroke"
+          width={width}
+          height={height}
+        />
+        <rect className="EmphasizedNode is-scaling" width={width} height={height} />
+      </>
+    );
+  }
+}

--- a/packages/plexus/src/cacheAs.tsx
+++ b/packages/plexus/src/cacheAs.tsx
@@ -24,4 +24,6 @@ export function makeCacheScope() {
   };
 }
 
-export default makeCacheScope();
+const defaultScope = Object.assign(makeCacheScope(), { makeScope: makeCacheScope });
+
+export default defaultScope;

--- a/packages/plexus/src/index.tsx
+++ b/packages/plexus/src/index.tsx
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { default as Digraph } from './Digraph';
-import { default as DirectedGraph } from './DirectedGraph';
-import { default as LayoutManager } from './LayoutManager';
+import cacheAs from './cacheAs';
+import Digraph from './Digraph';
+import DirectedGraph from './DirectedGraph';
+import LayoutManager from './LayoutManager';
 
-export default { Digraph, DirectedGraph, LayoutManager };
-export { Digraph, DirectedGraph, LayoutManager };
+export default { cacheAs, Digraph, DirectedGraph, LayoutManager };
+export { cacheAs, Digraph, DirectedGraph, LayoutManager };


### PR DESCRIPTION
## Which problem is this PR solving?

`TraceGraph` and `TraceDiffGraph` are still using the `DirectedGraph` component from plexus.

## Short description of the changes

Changed `TraceGraph` and `TraceDiffGraph` to use `Digraph`.

Also, tweaked the visuals for `TraceGraph` a bit.

| Before | After |
| --- | --- |
| <img width="916" alt="diff-mid-master" src="https://user-images.githubusercontent.com/2304337/62269125-15305700-b400-11e9-9307-d696bc49d9d8.png"> | <img width="916" alt="diff-mid-pr" src="https://user-images.githubusercontent.com/2304337/62269126-15305700-b400-11e9-85d2-9b036b5487e1.png"> |
| <img width="545" alt="diff-small-master" src="https://user-images.githubusercontent.com/2304337/62269127-15305700-b400-11e9-8d40-9f6c8d88bd3b.png"> | <img width="545" alt="diff-small-pr" src="https://user-images.githubusercontent.com/2304337/62269128-15305700-b400-11e9-9968-540045ae4508.png"> |
| <img width="686" alt="diff-small-sans-find-master" src="https://user-images.githubusercontent.com/2304337/62269129-15305700-b400-11e9-9579-a340ebdece01.png"> | <img width="686" alt="diff-small-sans-find-pr" src="https://user-images.githubusercontent.com/2304337/62269131-15305700-b400-11e9-856d-6ce9a900f29b.png"> |
| <img width="916" alt="tg-mid-master" src="https://user-images.githubusercontent.com/2304337/62269132-15305700-b400-11e9-8f69-06d4dc70fede.png"> | <img width="916" alt="tg-mid-pr" src="https://user-images.githubusercontent.com/2304337/62269133-15305700-b400-11e9-9f33-da5730e18425.png"> |
| <img width="916" alt="tr-mid-find-master" src="https://user-images.githubusercontent.com/2304337/62269134-15305700-b400-11e9-8ee3-6a38c3f831b9.png"> | <img width="916" alt="tr-mid-find-pr" src="https://user-images.githubusercontent.com/2304337/62269135-15c8ed80-b400-11e9-9684-7e527b0129fb.png"> |
