### PR TITLE
Show seconds in trace start time on the trace page

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
@@ -96,6 +96,14 @@ limitations under the License.
   padding: 0.25rem 0.5rem;
 }
 
+.TracePageHeader--overviewItem--valueDetail {
+  color: #aaa;
+}
+
+.TracePageHeader--overviewItem--value:hover > .TracePageHeader--overviewItem--valueDetail {
+  color: unset;
+}
+
 .TracePageHeader--archiveIcon {
   font-size: 1.78em;
   margin-right: 0.15em;

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -68,7 +68,18 @@ export const HEADER_ITEMS = [
   {
     key: 'timestamp',
     label: 'Trace Start',
-    renderer: (trace: Trace) => formatDatetime(trace.startTime),
+    renderer: (trace: Trace) => {
+      const dateStr = formatDatetime(trace.startTime);
+      const match = dateStr.match(/^(.+)(:\d\d\.\d+)$/);
+      return match ? (
+        <span className="TracePageHeader--overviewItem--value">
+          {match[1]}
+          <span className="TracePageHeader--overviewItem--valueDetail">{match[2]}</span>
+        </span>
+      ) : (
+        dateStr
+      );
+    },
   },
   {
     key: 'duration',

--- a/packages/jaeger-ui/src/utils/date.tsx
+++ b/packages/jaeger-ui/src/utils/date.tsx
@@ -22,7 +22,7 @@ const YESTERDAY = 'Yesterday';
 
 export const STANDARD_DATE_FORMAT = 'YYYY-MM-DD';
 export const STANDARD_TIME_FORMAT = 'HH:mm';
-export const STANDARD_DATETIME_FORMAT = 'LLL';
+export const STANDARD_DATETIME_FORMAT = 'MMMM D YYYY, HH:mm:ss.SSS';
 export const ONE_MILLISECOND = 1000;
 export const ONE_SECOND = 1000 * ONE_MILLISECOND;
 export const DEFAULT_MS_PRECISION = Math.log10(ONE_MILLISECOND);


### PR DESCRIPTION
## Which problem is this PR solving?

Trace start time, on the trace page, is not granularity enough.

## Short description of the changes

Show the seconds and sub-seconds of the trace start time in the trace page header.

The seconds and sub-seconds are presented with reduced contrast:

<img width="269" alt="Screen Shot 2019-08-03 at 11 02 48 PM" src="https://user-images.githubusercontent.com/2304337/62418913-ddfdb800-b642-11e9-89ac-fe6e312b9ff5.png">

The seconds and sub-seconds are shown at full contrast when the datetime value is hovered:


<img width="267" alt="Screen Shot 2019-08-03 at 11 02 55 PM" src="https://user-images.githubusercontent.com/2304337/62418914-ddfdb800-b642-11e9-9c55-6d55ec7785eb.png">