### PR TITLE
Fixes handling of numeric strings in span tag values

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -45,7 +45,12 @@ describe('LinkValue', () => {
 describe('<KeyValuesTable>', () => {
   let wrapper;
 
-  const data = [{ key: 'span.kind', value: 'client' }, { key: 'omg', value: 'mos-def' }];
+  const data = [
+    { key: 'span.kind', value: 'client' },
+    { key: 'omg', value: 'mos-def' },
+    { key: 'numericString', value: '12345678901234567890' },
+    { key: 'jsonkey', value: JSON.stringify({ hello: 'world' }) },
+  ];
 
   beforeEach(() => {
     wrapper = shallow(<KeyValuesTable data={data} />);
@@ -125,6 +130,16 @@ describe('<KeyValuesTable>', () => {
     copyIcons.forEach((copyIcon, i) => {
       expect(copyIcon.prop('copyText')).toBe(JSON.stringify(data[i], null, 2));
       expect(copyIcon.prop('tooltipTitle')).toBe('Copy JSON');
+    });
+  });
+
+  it('renders a span value containing numeric string correctly', () => {
+    const el = wrapper.find('.ub-inline-block');
+    expect(el.length).toBe(data.length);
+    el.forEach((valueDiv, i) => {
+      if (data[i].key !== 'jsonkey') {
+        expect(valueDiv.html()).toMatch(`"${data[i].value}"`);
+      }
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -23,13 +23,14 @@ import { KeyValuePair, Link } from '../../../../types/trace';
 
 import './KeyValuesTable.css';
 
-const jsonObjectOrArrayStartRegex = '/^({|[)/';
+const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 
 function parseIfComplexJson(value: any) {
   // if the value is a string representing actual json object or array, then use json-markup
-  if (typeof value === 'string' && jsonObjectOrArrayStartRegex.match(value)) {
+  if (typeof value === 'string' && value.match(jsonObjectOrArrayStartRegex)) {
     // otherwise just return as is
     try {
+      console.log('parsing JSON');
       return JSON.parse(value);
       // eslint-disable-next-line no-empty
     } catch (_) {}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -27,10 +27,9 @@ const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 
 function parseIfComplexJson(value: any) {
   // if the value is a string representing actual json object or array, then use json-markup
-  if (typeof value === 'string' && value.match(jsonObjectOrArrayStartRegex)) {
+  if (typeof value === 'string' && jsonObjectOrArrayStartRegex.test(value)) {
     // otherwise just return as is
     try {
-      console.log('parsing JSON');
       return JSON.parse(value);
       // eslint-disable-next-line no-empty
     } catch (_) {}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -23,11 +23,17 @@ import { KeyValuePair, Link } from '../../../../types/trace';
 
 import './KeyValuesTable.css';
 
-function parseIfJson(value: any) {
-  try {
-    return JSON.parse(value);
-    // eslint-disable-next-line no-empty
-  } catch (_) {}
+const jsonObjectOrArrayStartRegex = '/^({|[)/';
+
+function parseIfComplexJson(value: any) {
+  // if the value is a string representing actual json object or array, then use json-markup
+  if (typeof value === 'string' && jsonObjectOrArrayStartRegex.match(value)) {
+    // otherwise just return as is
+    try {
+      return JSON.parse(value);
+      // eslint-disable-next-line no-empty
+    } catch (_) {}
+  }
   return value;
 }
 
@@ -66,7 +72,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
         <tbody className="KeyValueTable--body">
           {data.map((row, i) => {
             const markup = {
-              __html: jsonMarkup(parseIfJson(row.value)),
+              __html: jsonMarkup(parseIfComplexJson(row.value)),
             };
             // eslint-disable-next-line react/no-danger
             const jsonTable = <div className="ub-inline-block" dangerouslySetInnerHTML={markup} />;


### PR DESCRIPTION
Signed-off-by: Matus Majchrak <matus.majchrak@gmail.com>
Fixes the rendering of span tag values that contain numeric strings

Hi this is my first PR to this project so bear with me :) 

Resolves #396 

## Which problem is this PR solving?

As stated in bug #396, span tags containing numeric strings will be converted to actual numbers and rendered in scientific notation if they are large enough. 

## Short description of the changes

As hinted by @tiffon, this commit limits the json conversion of tag values only to cases, when the value is an actual string and is not a primitive type(i.e. only if it is object or array) 

The one open point from my side, is what would be a meaningful test for the rendering of tag value containing real json object(if it is required) as I had some trouble creating an elegant test case that would verify the `dangerouslySetInnerHTML` contents(right now I verify it by call to `html()` and then string matching...) and what role should tag `type` attribute play in the rendering: 
e.g.
given span tag payload:
```
{
  "key": "numberTag",
 "type": "int",
  "value": 123
},
{
  "key": "numberAsString",
 "type": "string",
  "value": "123"
}
```
Not sure if this is a valid case. 
In any case, looking forward to your feedback.
