### PR TITLE
[DDG stacked - 4] Perf improvement when creating DDG GraphModel

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent.tsx
@@ -21,7 +21,7 @@ import { focalNodeIcon, setFocusIcon } from './node-icons';
 import { getUrl } from '../url';
 import NewWindowIcon from '../../common/NewWindowIcon';
 import { getUrl as getSearchUrl } from '../../SearchTracePage/url';
-import { EViewModifier, TDdgVertex, PathElem } from '../../../model/ddg/types';
+import { EDdgDensity, EViewModifier, TDdgVertex, PathElem } from '../../../model/ddg/types';
 
 import './DdgNodeContent.css';
 
@@ -53,13 +53,15 @@ export default class DdgNodeContent extends React.PureComponent<TProps> {
 
   static getNodeRenderer(
     getVisiblePathElems: (vertexKey: string) => PathElem[] | undefined,
-    setViewModifier: (vertexKey: string, viewModifier: EViewModifier, enable: boolean) => void
+    setViewModifier: (vertexKey: string, viewModifier: EViewModifier, enable: boolean) => void,
+    density: EDdgDensity,
+    showOp: boolean
   ) {
     return function renderNode(vertex: TDdgVertex, utils: TRendererUtils, lv: TLayoutVertex<any> | null) {
       const { isFocalNode, key, operation, service } = vertex;
       return (
         <DdgNodeContent
-          focalNodeUrl={isFocalNode ? null : getUrl({ operation, service })}
+          focalNodeUrl={isFocalNode ? null : getUrl({ density, operation, service, showOp })}
           getVisiblePathElems={getVisiblePathElems}
           isFocalNode={isFocalNode}
           isPositioned={Boolean(lv)}

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/__snapshots__/DdgNodeContent.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/__snapshots__/DdgNodeContent.test.js.snap
@@ -27,7 +27,7 @@ exports[`<DdgNodeContent> DdgNodeContent.getNodeRenderer() returns a <DdgNodeCon
   >
     <a
       className="DdgNodeContent--actionsItem"
-      href="/deep-dependencies?operation=the-operation&service=the-service"
+      href="/deep-dependencies?operation=the-operation&service=the-service&showOp=0"
     >
       <svg
         className="DdgNode--SetFocusIcon"

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/index.tsx
@@ -22,15 +22,17 @@ import TNonEmptyArray from '@jaegertracing/plexus/lib/types/TNonEmptyArray';
 import DdgNodeContent from './DdgNodeContent';
 import getNodeRenderers from './getNodeRenderers';
 import getSetOnEdge from './getSetOnEdge';
-import { PathElem, TDdgVertex, EViewModifier } from '../../../model/ddg/types';
+import { PathElem, TDdgVertex, EDdgDensity, EViewModifier } from '../../../model/ddg/types';
 
 import './index.css';
 
 type TProps = {
+  density: EDdgDensity;
   edges: TEdge[];
   edgesViewModifiers: Map<string, number>;
   getVisiblePathElems: (vertexKey: string) => PathElem[] | undefined;
   setViewModifier: (vertexKey: string, viewModifier: EViewModifier, enable: boolean) => void;
+  showOp: boolean;
   uiFindMatches: Set<TDdgVertex> | undefined;
   vertices: TDdgVertex[];
   verticesViewModifiers: Map<string, number>;
@@ -67,10 +69,12 @@ export default class Graph extends PureComponent<TProps> {
 
   render() {
     const {
+      density,
       edges,
       edgesViewModifiers,
       getVisiblePathElems,
       setViewModifier,
+      showOp,
       uiFindMatches,
       vertices,
       verticesViewModifiers,
@@ -121,7 +125,7 @@ export default class Graph extends PureComponent<TProps> {
             layerType: 'html',
             measurable: true,
             measureNode: DdgNodeContent.measureNode,
-            renderNode: this.getNodeContentRenderer(getVisiblePathElems, setViewModifier),
+            renderNode: this.getNodeContentRenderer(getVisiblePathElems, setViewModifier, density, showOp),
           },
         ]}
       />

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
@@ -86,46 +86,6 @@ describe('DeepDependencyGraphPage', () => {
       });
     });
 
-    describe('shouldComponentUpdate', () => {
-      it('returns false if props are unchanged', () => {
-        expect(ddgPageImpl.shouldComponentUpdate({ ...props })).toBe(false);
-      });
-
-      it('returns false if irrelevant prop is changed', () => {
-        expect(ddgPageImpl.shouldComponentUpdate({ ...props, irrelevantProp: 'ignored' })).toBe(false);
-      });
-
-      it('returns false if graphState uxState prop is changed', () => {
-        const graphState = {
-          ...props.graphState,
-          uxState: new Map([[3, 4]]),
-        };
-        expect(ddgPageImpl.shouldComponentUpdate({ ...props, graphState })).toBe(false);
-      });
-
-      it('returns true if certain props change', () => {
-        [
-          'operationsForService',
-          'services',
-          'urlState.service',
-          'urlState.operation',
-          'urlState.start',
-          'urlState.end',
-          'urlState.visEncoding',
-          'graphState.state',
-        ].forEach(prop => {
-          const newProps = {
-            ...props,
-            urlState: { ...props.urlState },
-            graphState: { ...props.graphState },
-          };
-          expect(ddgPageImpl.shouldComponentUpdate(newProps)).toBe(false);
-          _set(newProps, prop, 'new value');
-          expect(ddgPageImpl.shouldComponentUpdate(newProps)).toBe(true);
-        });
-      });
-    });
-
     describe('updateUrlState', () => {
       let getUrlSpy;
 
@@ -275,6 +235,7 @@ describe('DeepDependencyGraphPage', () => {
           ],
           vertices,
         }),
+        getDerivedViewModifiers: () => ({ edges: new Map(), vertices: new Map() }),
         getVisibleUiFindMatches: () => new Set(vertices.slice(1)),
         getVisibleIndices: () => new Set(),
       };

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -191,10 +191,12 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
       content = (
         <Graph
           key={JSON.stringify(urlState)}
+          density={density}
           edges={edges}
           edgesViewModifiers={edgesViewModifiers}
           getVisiblePathElems={this.getVisiblePathElems}
           setViewModifier={this.setViewModifier}
+          showOp={showOp}
           uiFindMatches={uiFindMatches}
           vertices={vertices}
           verticesViewModifiers={verticesViewModifiers}

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
@@ -132,11 +132,11 @@ describe('DeepDependencyGraph/url', () => {
       expect(parseSpy).toHaveBeenLastCalledWith(search);
     });
 
-    it("defaults `density` to 'PPE'", () => {
+    it("defaults `density` to 'ppe'", () => {
       const { density: unused, ...rest } = expectedParams;
       const { density: alsoUnused, ...rv } = acceptableParams;
       parseSpy.mockReturnValue(rv);
-      expect(getUrlState(search)).toEqual({ ...rest, density: 'PPE' });
+      expect(getUrlState(search)).toEqual({ ...rest, density: 'ppe' });
       expect(parseSpy).toHaveBeenLastCalledWith(search);
     });
 

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getDerivedViewModifiers.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getDerivedViewModifiers.tsx
@@ -29,14 +29,14 @@ function getKeyFromVisIdx(graph: GraphModel, visIdx: number) {
 }
 
 export default function getDerivedViewModifiers(
-  graph: GraphModel,
+  this: GraphModel,
   visEncoding: string | undefined,
   viewModifiers: Map<number, number>
 ) {
   const vertices = new Map<string, number>();
   const edges = new Map<string, number>();
 
-  const visibleIndices = graph.getVisibleIndices(visEncoding);
+  const visibleIndices = this.getVisibleIndices(visEncoding);
 
   const pushVertexVm = (vm: number, key: string) => {
     // eslint-disable-next-line no-bitwise
@@ -53,11 +53,11 @@ export default function getDerivedViewModifiers(
     if (!visibleIndices.has(visIdx)) {
       return;
     }
-    pushVertexVm(vm, getKeyFromVisIdx(graph, visIdx));
+    pushVertexVm(vm, getKeyFromVisIdx(this, visIdx));
     if (vm !== EViewModifier.Hovered) {
       return;
     }
-    const hoveredPe = graph.visIdxToPathElem[visIdx];
+    const hoveredPe = this.visIdxToPathElem[visIdx];
     if (!hoveredPe) {
       throw new Error(`Invalid vis index: ${visIdx}`);
     }
@@ -69,7 +69,7 @@ export default function getDerivedViewModifiers(
         lastKey = null;
         continue;
       }
-      const key = getKeyFromVisIdx(graph, members[i].visibilityIdx);
+      const key = getKeyFromVisIdx(this, members[i].visibilityIdx);
       pushVertexVm(EViewModifier.PathHovered, key);
       if (lastKey) {
         pushEdgeVm(EViewModifier.PathHovered, lastKey, key);

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GraphModel from './index';
+import transformDdgData from '../transformDdgData';
+import { EDdgDensity } from '../types';
+
+function makePayloadEntry(pairStr) {
+  const [service, operation] = pairStr.split(':');
+  return { service, operation };
+}
+
+const payload = `
+  a:0   b:0   focal:focal   c:0   d:0
+        b:0   focal:focal   c:0
+        c:0   focal:focal   b:0
+  a:0   c:0   focal:focal   b:0   d:0
+  a:1   b:0   focal:focal   c:0   d:1
+`
+  .trim()
+  .split('\n')
+  .map(line => ({
+    path: line
+      .trim()
+      .split(/\s+/g)
+      .map(makePayloadEntry),
+  }));
+
+const testTable = [
+  // showOp, density, number of expected vertices
+  [false, EDdgDensity.MostConcise, 5],
+  [true, EDdgDensity.MostConcise, 7],
+  [false, EDdgDensity.UpstreamVsDownstream, 7],
+  [true, EDdgDensity.UpstreamVsDownstream, 9],
+  [false, EDdgDensity.PreventPathEntanglement, 9],
+  [true, EDdgDensity.PreventPathEntanglement, 11],
+  [false, EDdgDensity.ExternalVsInternal, 13],
+  [true, EDdgDensity.ExternalVsInternal, 15],
+];
+
+describe('getPathElemHasher()', () => {
+  const ddgModel = transformDdgData(payload, makePayloadEntry('focal:focal'));
+
+  describe('creates vertices based on density and showOp', () => {
+    it.each(testTable)('showOp: %p \t density: %p', (showOp, density, verticesCount) => {
+      const gm = new GraphModel({ ddgModel, density, showOp });
+      expect(gm.vertices.size).toBe(verticesCount);
+    });
+  });
+
+  it('throws error when not given supported density', () => {
+    const invalidDensity = () =>
+      new GraphModel({
+        ddgModel,
+        density: `${EDdgDensity.MostConcise} ${EDdgDensity.MostConcise}`,
+        showOp: true,
+      });
+    expect(invalidDensity).toThrowError();
+
+    const missingDensity = () => new GraphModel({ ddgModel, density: undefined, showOp: true });
+    expect(missingDensity).toThrowError();
+  });
+});

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
@@ -41,18 +41,11 @@ function getPpeHasher(elemToStr: TPathElemToStr) {
 }
 
 function getExtVsIntHasher(elemToStr: TPathElemToStr) {
-  return (pe: PathElem) =>
-    `${getElemsToFocal(pe)
-      .map(elemToStr)
-      .join('\n')}${pe.isExternal ? '; is-external' : ''}`;
+  return (pe: PathElem) => `${getPpeHasher(elemToStr)(pe)}${pe.isExternal ? '; is-external' : ''}`;
 }
 
-// It might make sense for this function live on PathElem so that pathElems can
-// be compared when checking how many inbound/outbound edges are visible for a
-// vertex, but maybe not as vertices could be densitiy-aware and provide that to
-// this fn. could also be property on pathElem that gets set by showElems
-// tl;dr may move in late-alpha.
-export default function getPathElemHasher(this: GraphModel) {
+// This function is bound to a GraphModel and returns a different hasher based on the model's layout settings
+export default function getPathElemHasher(this: GraphModel): TPathElemToStr {
   const elemToStr = this.showOp ? fmtElemShowOp : fmtElemSvcOnly;
 
   switch (this.density) {

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
@@ -47,13 +47,11 @@ function getExtVsIntHasher(elemToStr: TPathElemToStr) {
       .join('\n')}${pe.isExternal ? '; is-external' : ''}`;
 }
 
-// This function assumes the density is set to PPE with distinct operations
-// It is a class property so that it can be aware of density in late-alpha
-//
-// It might make sense to live on PathElem so that pathElems can be compared when checking how many
-// inbound/outbound edges are visible for a vertex, but maybe not as vertices could be densitiy-aware and
-// provide that to this fn. could also be property on pathElem that gets set by showElems
-// tl;dr may move in late-alpha
+// It might make sense for this function live on PathElem so that pathElems can
+// be compared when checking how many inbound/outbound edges are visible for a
+// vertex, but maybe not as vertices could be densitiy-aware and provide that to
+// this fn. could also be property on pathElem that gets set by showElems
+// tl;dr may move in late-alpha.
 export default function getPathElemHasher(this: GraphModel) {
   const elemToStr = this.showOp ? fmtElemShowOp : fmtElemSvcOnly;
 

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GraphModel from '.';
+import { PathElem, EDdgDensity } from '../types';
+
+type TPathElemToStr = (pe: PathElem) => string;
+
+function fmtElemShowOp(pe: PathElem) {
+  return `${pe.operation.service.name}\t${pe.operation.name}`;
+}
+
+function fmtElemSvcOnly(pe: PathElem) {
+  return pe.distance === 0 ? fmtElemShowOp(pe) : pe.operation.service.name;
+}
+
+function getElemsToFocal(pe: PathElem) {
+  const {
+    memberIdx,
+    memberOf: { focalIdx, members },
+  } = pe;
+  return members.slice(Math.min(focalIdx, memberIdx), Math.max(focalIdx, memberIdx) + 1);
+}
+
+function getPpeHasher(elemToStr: TPathElemToStr) {
+  return (pe: PathElem) =>
+    getElemsToFocal(pe)
+      .map(elemToStr)
+      .join('\n');
+}
+
+function getExtVsIntHasher(elemToStr: TPathElemToStr) {
+  return (pe: PathElem) =>
+    `${getElemsToFocal(pe)
+      .map(elemToStr)
+      .join('\n')}${pe.isExternal ? '; is-external' : ''}`;
+}
+
+// This function assumes the density is set to PPE with distinct operations
+// It is a class property so that it can be aware of density in late-alpha
+//
+// It might make sense to live on PathElem so that pathElems can be compared when checking how many
+// inbound/outbound edges are visible for a vertex, but maybe not as vertices could be densitiy-aware and
+// provide that to this fn. could also be property on pathElem that gets set by showElems
+// tl;dr may move in late-alpha
+export default function getPathElemHasher(this: GraphModel) {
+  const elemToStr = this.showOp ? fmtElemShowOp : fmtElemSvcOnly;
+
+  switch (this.density) {
+    case EDdgDensity.MostConcise: {
+      return elemToStr;
+    }
+    case EDdgDensity.UpstreamVsDownstream: {
+      return (pe: PathElem) => `${elemToStr(pe)}; direction=${Math.sign(pe.distance)}`;
+    }
+    case EDdgDensity.PreventPathEntanglement: {
+      return getPpeHasher(elemToStr);
+    }
+    case EDdgDensity.ExternalVsInternal: {
+      return getExtVsIntHasher(elemToStr);
+    }
+    default: {
+      throw new Error(
+        `Density: ${this.density} has not been implemented, try one of these: ${JSON.stringify(
+          EDdgDensity,
+          null,
+          2
+        )}`
+      );
+    }
+  }
+}

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
@@ -15,13 +15,17 @@
 import memoize from 'lru-memoize';
 import { TEdge } from '@jaegertracing/plexus/lib/types';
 
+import getDerivedViewModifiers from './getDerivedViewModifiers';
+import getEdgeId from './getEdgeId';
+import getPathElemHasher from './getPathElemHasher';
 import { PathElem, EDdgDensity, TDdgDistanceToPathElems, TDdgModel, TDdgVertex } from '../types';
 import { decode } from '../visibility-codec';
 
-export { default as getDerivedViewModifiers } from './getDerivedViewModifiers';
 export { default as getEdgeId } from './getEdgeId';
 
 export default class GraphModel {
+  readonly getDerivedViewModifiers = memoize(3)(getDerivedViewModifiers.bind(this));
+  private readonly getPathElemHasher = getPathElemHasher;
   readonly density: EDdgDensity;
   readonly distanceToPathElems: TDdgDistanceToPathElems;
   readonly pathElemToEdge: Map<PathElem, TEdge>;
@@ -41,9 +45,12 @@ export default class GraphModel {
     this.vertices = new Map();
     this.visIdxToPathElem = ddgModel.visIdxToPathElem.slice();
 
+    const hasher = this.getPathElemHasher();
+    const edgesById = new Map<string, TEdge>();
+
     ddgModel.visIdxToPathElem.forEach(pathElem => {
       // If there is a compatible vertex for this pathElem, use it, else, make a new vertex
-      const key = this.getVertexKey(pathElem);
+      const key = hasher(pathElem);
       let vertex: TDdgVertex | undefined = this.vertices.get(key);
       if (!vertex) {
         const isFocalNode = !pathElem.distance;
@@ -54,18 +61,18 @@ export default class GraphModel {
           operation: this.showOp || isFocalNode ? pathElem.operation.name : null,
         };
         this.vertices.set(key, vertex);
-        this.vertexToPathElems.set(vertex, new Set());
+        this.vertexToPathElems.set(vertex, new Set([pathElem]));
+      } else {
+        const pathElemsForVertex = this.vertexToPathElems.get(vertex);
+        /* istanbul ignore next */
+        if (!pathElemsForVertex) {
+          throw new Error(`Vertex exists without pathElems, vertex: ${vertex}`);
+        }
+        // Link vertex back to this pathElem
+        pathElemsForVertex.add(pathElem);
       }
-
       // Link pathElem to its vertex
       this.pathElemToVertex.set(pathElem, vertex);
-
-      const pathElemsForVertex = this.vertexToPathElems.get(vertex);
-
-      /* istanbul ignore next */
-      if (!pathElemsForVertex) {
-        throw new Error(`Vertex exists without pathElems, vertex: ${vertex}`);
-      }
 
       // If the newly-visible PathElem is not the focalNode, it needs to be connected to the rest of the graph
       const connectedElem = pathElem.focalSideNeighbor;
@@ -78,37 +85,18 @@ export default class GraphModel {
         }
 
         // Create edge connecting current vertex to connectedVertex
-        const newEdge =
-          pathElem.distance > 0
-            ? {
-                from: connectedVertex.key,
-                to: vertex.key,
-              }
-            : {
-                from: vertex.key,
-                to: connectedVertex.key,
-              };
-
-        // Check if equivalent edge already exists
-        let existingEdge: TEdge | undefined;
-        const elemArr = Array.from(pathElemsForVertex);
-        for (let i = 0; i < elemArr.length; i += 1) {
-          const edge = this.pathElemToEdge.get(elemArr[i]);
-          // With PPE as the only supported heuristic, the following two lines cannot be fully tested
-          if (edge) {
-            if (edge.to === newEdge.to && edge.from === newEdge.from) {
-              existingEdge = edge;
-              break;
-            }
-          }
+        const from = pathElem.distance > 0 ? connectedVertex.key : vertex.key;
+        const to = pathElem.distance > 0 ? vertex.key : connectedVertex.key;
+        const edgeId = getEdgeId(from, to);
+        const existingEdge = edgesById.get(edgeId);
+        if (!existingEdge) {
+          const edge = { from, to };
+          edgesById.set(edgeId, edge);
+          this.pathElemToEdge.set(pathElem, edge);
+        } else {
+          this.pathElemToEdge.set(pathElem, existingEdge);
         }
-
-        // Prefer existing edge, else use new edge
-        this.pathElemToEdge.set(pathElem, existingEdge || newEdge);
       }
-
-      // Link vertex back to this pathElem
-      pathElemsForVertex.add(pathElem);
     });
 
     Object.freeze(this.distanceToPathElems);
@@ -119,54 +107,54 @@ export default class GraphModel {
     Object.freeze(this.visIdxToPathElem);
   }
 
-  // This function assumes the density is set to PPE with distinct operations
-  // It is a class property so that it can be aware of density in late-alpha
-  //
-  // It might make sense to live on PathElem so that pathElems can be compared when checking how many
-  // inbound/outbound edges are visible for a vertex, but maybe not as vertices could be densitiy-aware and
-  // provide that to this fn. could also be property on pathElem that gets set by showElems
-  // tl;dr may move in late-alpha
-  private getVertexKey = (pathElem: PathElem): string => {
-    const elemToStr = this.showOp
-      ? ({ operation }: PathElem) => `${operation.service.name}----${operation.name}`
-      : // Always show the operation for the focal node, i.e. when distance === 0
-        ({ distance, operation }: PathElem) =>
-          distance === 0 ? `${operation.service.name}----${operation.name}` : operation.service.name;
+  // // This function assumes the density is set to PPE with distinct operations
+  // // It is a class property so that it can be aware of density in late-alpha
+  // //
+  // // It might make sense to live on PathElem so that pathElems can be compared when checking how many
+  // // inbound/outbound edges are visible for a vertex, but maybe not as vertices could be densitiy-aware and
+  // // provide that to this fn. could also be property on pathElem that gets set by showElems
+  // // tl;dr may move in late-alpha
+  // private getVertexKey = (pathElem: PathElem): string => {
+  //   const elemToStr = this.showOp
+  //     ? ({ operation }: PathElem) => `${operation.service.name}----${operation.name}`
+  //     : // Always show the operation for the focal node, i.e. when distance === 0
+  //       ({ distance, operation }: PathElem) =>
+  //         distance === 0 ? `${operation.service.name}----${operation.name}` : operation.service.name;
 
-    switch (this.density) {
-      case EDdgDensity.MostConcise: {
-        return elemToStr(pathElem);
-      }
-      case EDdgDensity.UpstreamVsDownstream: {
-        return `${elemToStr(pathElem)}=${Math.sign(pathElem.distance)}`;
-      }
-      case EDdgDensity.PreventPathEntanglement:
-      case EDdgDensity.ExternalVsInternal: {
-        const decorate =
-          this.density === EDdgDensity.ExternalVsInternal
-            ? (str: string) => `${str}${pathElem.isExternal ? '----external' : ''}`
-            : (str: string) => str;
-        const { memberIdx, memberOf } = pathElem;
-        const { focalIdx, members } = memberOf;
+  //   switch (this.density) {
+  //     case EDdgDensity.MostConcise: {
+  //       return elemToStr(pathElem);
+  //     }
+  //     case EDdgDensity.UpstreamVsDownstream: {
+  //       return `${elemToStr(pathElem)}=${Math.sign(pathElem.distance)}`;
+  //     }
+  //     case EDdgDensity.PreventPathEntanglement:
+  //     case EDdgDensity.ExternalVsInternal: {
+  //       const decorate =
+  //         this.density === EDdgDensity.ExternalVsInternal
+  //           ? (str: string) => `${str}${pathElem.isExternal ? '----external' : ''}`
+  //           : (str: string) => str;
+  //       const { memberIdx, memberOf } = pathElem;
+  //       const { focalIdx, members } = memberOf;
 
-        return decorate(
-          members
-            .slice(Math.min(focalIdx, memberIdx), Math.max(focalIdx, memberIdx) + 1)
-            .map(elemToStr)
-            .join('____')
-        );
-      }
-      default: {
-        throw new Error(
-          `Density: ${this.density} has not been implemented, try one of these: ${JSON.stringify(
-            EDdgDensity,
-            null,
-            2
-          )}`
-        );
-      }
-    }
-  };
+  //       return decorate(
+  //         members
+  //           .slice(Math.min(focalIdx, memberIdx), Math.max(focalIdx, memberIdx) + 1)
+  //           .map(elemToStr)
+  //           .join('____')
+  //       );
+  //     }
+  //     default: {
+  //       throw new Error(
+  //         `Density: ${this.density} has not been implemented, try one of these: ${JSON.stringify(
+  //           EDdgDensity,
+  //           null,
+  //           2
+  //         )}`
+  //       );
+  //     }
+  //   }
+  // };
 
   private getDefaultVisiblePathElems() {
     return ([] as PathElem[]).concat(

--- a/packages/jaeger-ui/src/model/ddg/types.tsx
+++ b/packages/jaeger-ui/src/model/ddg/types.tsx
@@ -27,10 +27,10 @@ export enum EViewModifier {
 }
 
 export enum EDdgDensity {
-  MostConcise = 'MC',
-  UpstreamVsDownstream = 'UvD',
-  PreventPathEntanglement = 'PPE',
-  ExternalVsInternal = 'EvI',
+  ExternalVsInternal = 'ext-vs-int',
+  MostConcise = 'mc',
+  PreventPathEntanglement = 'ppe',
+  UpstreamVsDownstream = 'up-vs-down',
 }
 
 export enum ECheckedStatus {


### PR DESCRIPTION
## Which problem is this PR solving?

There was (and still is, but less so) a noticeable pause when changing graph density settings.

## Short description of the changes

The changes in this PR: [5cd94bd ... b5e9a76](https://github.com/jaegertracing/jaeger-ui/pull/440/files/5cd94bd2c9d1abd3e4e2e75ff571eeb194beef82..b5e9a76bd0c7e03fe4b048b2ac03f6c0a710f494)

### Performance improvement

The aggregate time spent creating the `GraphModel` when changing the density from `EvI` to `PPE`, then `UvD` and then `MC`:

- Before: **4.24 seconds**
- After: **0.125 seconds**

#### Data set

- 4,289 paths
- 25,658 path elements
- 69 graph vertices (on MC density)
- 162 graph edges (on MC density)
