### PR TITLE
[DDG stacked - 5] Add density setting: one resource per level

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.tsx
@@ -50,6 +50,12 @@ const densityOptions = [
       'This setting differentiates upstream nodes from downstream nodes. And, within the each section, a given resource is represented by only one node.',
   },
   {
+    option: EDdgDensity.OnePerLevel,
+    title: 'One resource per level',
+    description:
+      'Represents each resource at most one time for any given level, or number of hops, from the focal node.',
+  },
+  {
     option: EDdgDensity.PreventPathEntanglement,
     title: 'Show paths to the focal node',
     description:

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
@@ -43,6 +43,8 @@ const testTable = [
   [true, EDdgDensity.MostConcise, 7],
   [false, EDdgDensity.UpstreamVsDownstream, 7],
   [true, EDdgDensity.UpstreamVsDownstream, 9],
+  [false, EDdgDensity.OnePerLevel, 7],
+  [true, EDdgDensity.OnePerLevel, 9],
   [false, EDdgDensity.PreventPathEntanglement, 9],
   [true, EDdgDensity.PreventPathEntanglement, 11],
   [false, EDdgDensity.ExternalVsInternal, 13],

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
@@ -23,10 +23,10 @@ function makePayloadEntry(pairStr) {
 
 const payload = `
   a:0   b:0   focal:focal   c:0   d:0
-        b:0   focal:focal   c:0
+  a:0   c:0   focal:focal   d:0   c:0
+        c:1   focal:focal   b:0   d:0
         c:0   focal:focal   b:0
-  a:0   c:0   focal:focal   b:0   d:0
-  a:1   b:0   focal:focal   c:0   d:1
+  a:0   c:0   focal:focal   b:0
 `
   .trim()
   .split('\n')
@@ -40,15 +40,15 @@ const payload = `
 const testTable = [
   // showOp, density, number of expected vertices
   [false, EDdgDensity.MostConcise, 5],
-  [true, EDdgDensity.MostConcise, 7],
+  [true, EDdgDensity.MostConcise, 6],
   [false, EDdgDensity.UpstreamVsDownstream, 7],
-  [true, EDdgDensity.UpstreamVsDownstream, 9],
-  [false, EDdgDensity.OnePerLevel, 7],
-  [true, EDdgDensity.OnePerLevel, 9],
-  [false, EDdgDensity.PreventPathEntanglement, 9],
-  [true, EDdgDensity.PreventPathEntanglement, 11],
+  [true, EDdgDensity.UpstreamVsDownstream, 8],
+  [false, EDdgDensity.OnePerLevel, 9],
+  [true, EDdgDensity.OnePerLevel, 10],
+  [false, EDdgDensity.PreventPathEntanglement, 11],
+  [true, EDdgDensity.PreventPathEntanglement, 12],
   [false, EDdgDensity.ExternalVsInternal, 13],
-  [true, EDdgDensity.ExternalVsInternal, 15],
+  [true, EDdgDensity.ExternalVsInternal, 14],
 ];
 
 describe('getPathElemHasher()', () => {

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
@@ -62,6 +62,9 @@ export default function getPathElemHasher(this: GraphModel) {
     case EDdgDensity.UpstreamVsDownstream: {
       return (pe: PathElem) => `${elemToStr(pe)}; direction=${Math.sign(pe.distance)}`;
     }
+    case EDdgDensity.OnePerLevel: {
+      return (pe: PathElem) => `${elemToStr(pe)}; distance=${pe.distance}`;
+    }
     case EDdgDensity.PreventPathEntanglement: {
       return getPpeHasher(elemToStr);
     }

--- a/packages/jaeger-ui/src/model/ddg/types.tsx
+++ b/packages/jaeger-ui/src/model/ddg/types.tsx
@@ -29,6 +29,7 @@ export enum EViewModifier {
 export enum EDdgDensity {
   ExternalVsInternal = 'ext-vs-int',
   MostConcise = 'mc',
+  OnePerLevel = 'per-level',
   PreventPathEntanglement = 'ppe',
   UpstreamVsDownstream = 'up-vs-down',
 }


### PR DESCRIPTION
#### Naming

- Density setting "Show paths to the focal node"
  - AKA "PPE"
- Density setting "Separate upstream from downstream nodes"
  - AKA "Up-vs-Down"




## Which problem is this PR solving?

The Up-vs-Down density setting is drastically more dense than the next, less dense setting PPE.

The PPE setting can easily result in too much information being shown as a given resource (service or service:operation) can appear many times in the graph; for instance, the service in the PPE screenshot is represented by 21 different nodes in the graph.

On the other hand, the Up-vs-Down setting can reduce the granularity too much, resulting in interesting paths of nodes being aggregated together. For instance, the highlighted service is represented by one node in the graph, but the node is present in 21 unique paths.


## Short description of the changes

**Changes in this PR: [6d9430c](https://github.com/jaegertracing/jaeger-ui/pull/441/commits/6d9430cc7e6f8ca5d8c28de243df22564477592d)**

This PR adds a new density setting: "One resource per level" AKA "Per-Level".

The Per-Level density setting allows a node per level in the graph, which is to say one per hop. In the screenshot, the highlighted service is represented by four nodes. This is a vast reduction from 21, but the various paths the node is involved with are still discernible via the path-highlighting mouse-over effect.

## Screenshots

In the screenshots, operations are not shown and a single service is highlighted. If there are multiple highlighted nodes, then the service is shown multiple times.

**PPE**

<img width="1427" alt="00-ppe" src="https://user-images.githubusercontent.com/2304337/62842222-aa441300-bc7e-11e9-9f3a-3e91a13d7552.png">

**Up-vs-Down**

<img width="1427" alt="01-mc" src="https://user-images.githubusercontent.com/2304337/62842223-aa441300-bc7e-11e9-97d9-b500196f3f9b.png">

**Up-vs-Down with hover**

<img width="1427" alt="02-mc-em" src="https://user-images.githubusercontent.com/2304337/62842224-aa441300-bc7e-11e9-87e1-8a966efd747a.png">

**Per-Level**

<img width="1427" alt="03-per-lvl" src="https://user-images.githubusercontent.com/2304337/62842225-aadca980-bc7e-11e9-85e5-35d3248e667f.png">

**Per-Level with hover**

<img width="1427" alt="04-per-lvl-em-a" src="https://user-images.githubusercontent.com/2304337/62842226-aadca980-bc7e-11e9-9e18-ac3b87fc190e.png">

**Per-Level with hover**

<img width="1427" alt="05-per-lvl-em-b" src="https://user-images.githubusercontent.com/2304337/62842227-ab754000-bc7e-11e9-9460-f32894e4dd37.png">
