### PR TITLE
Make svc&op slugs instead of query params for GA

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/__snapshots__/DdgNodeContent.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/__snapshots__/DdgNodeContent.test.js.snap
@@ -27,7 +27,7 @@ exports[`<DdgNodeContent> DdgNodeContent.getNodeRenderer() returns a <DdgNodeCon
   >
     <a
       className="DdgNodeContent--actionsItem"
-      href="/deep-dependencies?operation=the-operation&service=the-service&showOp=0"
+      href="/deep-dependencies/the-service/the-operation?showOp=0"
     >
       <svg
         className="DdgNode--SetFocusIcon"

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
@@ -377,17 +377,17 @@ describe('DeepDependencyGraphPage', () => {
       },
     };
     const mockGraphModel = { getVisible: () => ({}) };
-    let getUrlParamsSpy;
+    let getUrlStateSpy;
     let makeGraphSpy;
 
     beforeAll(() => {
-      getUrlParamsSpy = jest.spyOn(url, 'getUrlParams');
+      getUrlStateSpy = jest.spyOn(url, 'getUrlState');
       makeGraphSpy = jest.spyOn(GraphModel, 'makeGraph');
     });
 
     beforeEach(() => {
-      getUrlParamsSpy.mockReset();
-      getUrlParamsSpy.mockReturnValue({ end, start });
+      getUrlStateSpy.mockReset();
+      getUrlStateSpy.mockReturnValue({ end, start });
       makeGraphSpy.mockReset();
       makeGraphSpy.mockReturnValue(mockGraphModel);
     });
@@ -395,7 +395,7 @@ describe('DeepDependencyGraphPage', () => {
     it('uses gets relevant params from location.search', () => {
       const result = mapStateToProps(state, ownProps);
       expect(result).toEqual(expect.objectContaining(expected));
-      expect(getUrlParamsSpy).toHaveBeenLastCalledWith(search);
+      expect(getUrlStateSpy).toHaveBeenLastCalledWith(search);
     });
 
     it('includes graphState iff location.search has service, start, end, and optionally operation', () => {

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -17,10 +17,11 @@ import { History as RouterHistory, Location } from 'history';
 import _get from 'lodash/get';
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
+import { match as Match } from 'react-router-dom';
 
 import Header from './Header';
 import Graph from './Graph';
-import { getUrl, getUrlState } from './url';
+import { getUrl, getUrlParams } from './url';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
 import { extractUiFindFromState, TExtractUiFindFromStateReturn } from '../common/UiFindInput';
@@ -63,6 +64,7 @@ type TReduxProps = TExtractUiFindFromStateReturn & {
 type TOwnProps = {
   history: RouterHistory;
   location: Location;
+  match: Match<{ operation?: string; service?: string }>;
 };
 
 type TProps = TDispatchProps & TReduxProps & TOwnProps;
@@ -244,8 +246,11 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
   const { services: stServices } = state;
   const { services, operationsForService } = stServices;
-  const urlState = getUrlState(ownProps.location.search);
-  const { density, operation, service, showOp } = urlState;
+  const urlState = getUrlParams(ownProps.location.search);
+  const { service: encodedService, operation: encodedOperation } = ownProps.match.params;
+  const service = encodedService && decodeURIComponent(encodedService);
+  const operation = encodedOperation && decodeURIComponent(encodedOperation);
+  const { density, showOp } = urlState;
   let graphState: TDdgStateEntry | undefined;
   // backend temporarily requires service and operation
   // if (service) {
@@ -261,7 +266,11 @@ export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxP
     graphState,
     services,
     operationsForService,
-    urlState,
+    urlState: {
+      ...urlState,
+      operation,
+      service,
+    },
     ...extractUiFindFromState(state),
   };
 }

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -21,7 +21,7 @@ import { match as Match } from 'react-router-dom';
 
 import Header from './Header';
 import Graph from './Graph';
-import { getUrl, getUrlParams } from './url';
+import { getUrl, getUrlState } from './url';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
 import { extractUiFindFromState, TExtractUiFindFromStateReturn } from '../common/UiFindInput';
@@ -246,7 +246,7 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
   const { services: stServices } = state;
   const { services, operationsForService } = stServices;
-  const urlState = getUrlParams(ownProps.location.search);
+  const urlState = getUrlState(ownProps.location.search);
   const { service: encodedService, operation: encodedOperation } = ownProps.match.params;
   const service = encodedService && decodeURIComponent(encodedService);
   const operation = encodedOperation && decodeURIComponent(encodedOperation);

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
@@ -15,7 +15,7 @@
 import queryString from 'query-string';
 import * as reactRouterDom from 'react-router-dom';
 
-import { ROUTE_PATH, matches, getUrl, getUrlParams } from './url';
+import { ROUTE_PATH, matches, getUrl, getUrlState } from './url';
 
 describe('DeepDependencyGraph/url', () => {
   describe('matches', () => {
@@ -58,6 +58,11 @@ describe('DeepDependencyGraph/url', () => {
       expect(getUrl({ paramA, paramB })).toBe(`/deep-dependencies?paramA=${paramA}&paramB=${paramB}`);
     });
 
+    it('converts truthiness of showOp into 0 or 1', () => {
+      expect(getUrl({ showOp: true })).toBe(`/deep-dependencies?showOp=1`);
+      expect(getUrl({ showOp: false })).toBe(`/deep-dependencies?showOp=0`);
+    });
+
     it('includes safe form of provided service', () => {
       const service = 'service/name';
       expect(getUrl({ service })).toBe(`/deep-dependencies/${encodeURIComponent(service)}?`);
@@ -70,23 +75,22 @@ describe('DeepDependencyGraph/url', () => {
         `/deep-dependencies/${encodeURIComponent(service)}/${encodeURIComponent(operation)}?`
       );
     });
-
-    it('converts truthiness of showOp into 0 or 1', () => {
-      expect(getUrl({ showOp: true })).toBe(`/deep-dependencies?showOp=1`);
-      expect(getUrl({ showOp: false })).toBe(`/deep-dependencies?showOp=0`);
-    });
   });
 
-  describe('getUrlParams', () => {
+  describe('getUrlState', () => {
     const search = 'test search';
     const density = 'test density';
     const end = '900';
+    const operation = 'operationName';
+    const service = 'serviceName';
     const showOp = '0';
     const start = '400';
     const visEncoding = 'vis encoding';
     const acceptableParams = {
       density,
       end,
+      operation,
+      service,
       showOp,
       start,
       visEncoding,
@@ -94,6 +98,8 @@ describe('DeepDependencyGraph/url', () => {
     const expectedParams = {
       density,
       end: Number.parseInt(end, 10),
+      operation,
+      service,
       showOp: Boolean(+showOp),
       start: Number.parseInt(start, 10),
       visEncoding,
@@ -117,16 +123,16 @@ describe('DeepDependencyGraph/url', () => {
 
     it('gets all values from queryString', () => {
       parseSpy.mockReturnValue(acceptableParams);
-      expect(getUrlParams(search)).toEqual(expectedParams);
+      expect(getUrlState(search)).toEqual(expectedParams);
       expect(parseSpy).toHaveBeenCalledWith(search);
     });
 
     it('handles absent values', () => {
-      ['end', 'start', 'visEncoding'].forEach(param => {
+      ['end', 'operation', 'service', 'start', 'visEncoding'].forEach(param => {
         const { [param]: unused, ...rest } = expectedParams;
         const { [param]: alsoUnused, ...rv } = acceptableParams;
         parseSpy.mockReturnValue(rv);
-        expect(getUrlParams(search)).toEqual(rest);
+        expect(getUrlState(search)).toEqual(rest);
         expect(parseSpy).toHaveBeenLastCalledWith(search);
       });
     });
@@ -135,7 +141,7 @@ describe('DeepDependencyGraph/url', () => {
       const { showOp: unused, ...rest } = expectedParams;
       const { showOp: alsoUnused, ...rv } = acceptableParams;
       parseSpy.mockReturnValue(rv);
-      expect(getUrlParams(search)).toEqual({ ...rest, showOp: true });
+      expect(getUrlState(search)).toEqual({ ...rest, showOp: true });
       expect(parseSpy).toHaveBeenLastCalledWith(search);
     });
 
@@ -143,7 +149,7 @@ describe('DeepDependencyGraph/url', () => {
       const { density: unused, ...rest } = expectedParams;
       const { density: alsoUnused, ...rv } = acceptableParams;
       parseSpy.mockReturnValue(rv);
-      expect(getUrlParams(search)).toEqual({ ...rest, density: 'ppe' });
+      expect(getUrlState(search)).toEqual({ ...rest, density: 'ppe' });
       expect(parseSpy).toHaveBeenLastCalledWith(search);
     });
 
@@ -155,28 +161,28 @@ describe('DeepDependencyGraph/url', () => {
         ...extraneous,
         ...acceptableParams,
       });
-      expect(getUrlParams(search)).toEqual(expect.not.objectContaining(extraneous));
+      expect(getUrlState(search)).toEqual(expect.not.objectContaining(extraneous));
       expect(parseSpy).toHaveBeenCalledWith(search);
     });
 
     it('omits falsy values', () => {
-      ['end', 'start', 'visEncoding'].forEach(param => {
+      ['end', 'operation', 'service', 'start', 'visEncoding'].forEach(param => {
         [null, undefined, ''].forEach(falsyPossibility => {
           parseSpy.mockReturnValue({ ...expectedParams, [param]: falsyPossibility });
-          expect(Reflect.has(getUrlParams(search), param)).toBe(false);
+          expect(Reflect.has(getUrlState(search), param)).toBe(false);
           expect(parseSpy).toHaveBeenLastCalledWith(search);
         });
       });
     });
 
     it('handles and warns on duplicate values', () => {
-      ['end', 'showOp', 'start', 'visEncoding'].forEach(param => {
+      ['end', 'operation', 'service', 'showOp', 'start', 'visEncoding'].forEach(param => {
         const secondParam = `second ${acceptableParams[param]}`;
         parseSpy.mockReturnValue({
           ...acceptableParams,
           [param]: [acceptableParams[param], secondParam],
         });
-        expect(getUrlParams(search)[param]).toBe(expectedParams[param]);
+        expect(getUrlState(search)[param]).toBe(expectedParams[param]);
         expect(warnSpy).toHaveBeenLastCalledWith(expect.stringContaining(secondParam));
         expect(parseSpy).toHaveBeenLastCalledWith(search);
       });

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
@@ -58,10 +58,12 @@ function firstParam(arg: string | string[]): string {
   return arg;
 }
 
-export function getUrlParams(search: string): TDdgSparseUrlState {
+export function getUrlState(search: string): TDdgSparseUrlState {
   const {
     density = EDdgDensity.PreventPathEntanglement,
     end,
+    operation,
+    service,
     showOp = '1',
     start,
     visEncoding,
@@ -72,6 +74,12 @@ export function getUrlParams(search: string): TDdgSparseUrlState {
   };
   if (end) {
     rv.end = Number.parseInt(firstParam(end), 10);
+  }
+  if (operation) {
+    rv.operation = firstParam(operation);
+  }
+  if (service) {
+    rv.service = firstParam(service);
   }
   if (start) {
     rv.start = Number.parseInt(firstParam(start), 10);


### PR DESCRIPTION
## Which problem is this PR solving?
- Analyzing query parameters in Google Analytics is not supported, while it is easy to track segments of the url path.

## Short description of the changes
- change `/deep-dependencies?service=myServiceName&operation=myOperationName` to `/deep-dependencies/myServiceName/myOperationName`
- service and operation remain optional
