### PR TITLE
Ddg hidden ui matches count

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
@@ -51,7 +51,7 @@ exports[`<Header> renders the hops selector if distanceToPathElems is provided 1
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>
@@ -120,7 +120,7 @@ exports[`<Header> renders the operation selector if a service is selected 1`] = 
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>
@@ -193,7 +193,7 @@ exports[`<Header> renders the operation selector if a service is selected 2`] = 
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>
@@ -250,7 +250,7 @@ exports[`<Header> renders with minimal props 1`] = `
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.css
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.css
@@ -82,20 +82,21 @@ limitations under the License.
   border-radius: 0px;
 }
 
-.DdgHeader--uiFindCount {
+.DdgHeader--uiFindInfo {
   background: #ffffb8;
   border: 1px dashed #fadb14;
   border-radius: 4px;
   color: #ad8b00;
   margin-left: 0.25em;
   margin-right: 0.5em;
-  transition: width 0.5s;
   padding: 0.27em 0.4em;
   stroke: #666;
   stroke-width: 1.2px;
   text-align: center;
+  transition: width 0.5s;
+  white-space: nowrap;
 }
 
-.DdgHeader--uiFindCount:empty {
+.DdgHeader--uiFindInfo:empty {
   display: none;
 }

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
@@ -66,6 +66,22 @@ describe('<Header>', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders the expected uiFind matches information', () => {
+    const getMatchesInfo = () => wrapper.find('.DdgHeader--uiFindInfo').text();
+    expect(getMatchesInfo()).toBe('');
+
+    const uiFindCount = 20;
+    wrapper.setProps({ uiFindCount });
+    expect(getMatchesInfo()).toBe(`${uiFindCount}`);
+
+    wrapper.setProps({ hiddenUiFindMatches: new Set() });
+    expect(getMatchesInfo()).toBe(`${uiFindCount}`);
+
+    const hiddenUiFindMatches = new Set(['hidden', 'match', 'vertices']);
+    wrapper.setProps({ hiddenUiFindMatches });
+    expect(getMatchesInfo()).toBe(`${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`);
+  });
+
   it('focuses uiFindInput IFF rendered when clicking on wrapping div', () => {
     const click = () => wrapper.find('.DdgHeader--uiFind').simulate('click');
     const focus = jest.fn();

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -19,13 +19,14 @@ import HopsSelector from './HopsSelector';
 import NameSelector from './NameSelector';
 import LayoutSettings from './LayoutSettings';
 import UiFindInput from '../../common/UiFindInput';
-import { EDirection, TDdgDistanceToPathElems, EDdgDensity } from '../../../model/ddg/types';
+import { EDirection, TDdgDistanceToPathElems, TDdgVertex, EDdgDensity } from '../../../model/ddg/types';
 
 import './index.css';
 
 type TProps = {
   density: EDdgDensity;
   distanceToPathElems?: TDdgDistanceToPathElems;
+  hiddenUiFindMatches?: Set<TDdgVertex>;
   operation?: string;
   operations: string[] | undefined;
   service?: string;
@@ -52,6 +53,7 @@ export default class Header extends React.PureComponent<TProps> {
     const {
       density,
       distanceToPathElems,
+      hiddenUiFindMatches,
       operation,
       operations,
       service,
@@ -65,6 +67,9 @@ export default class Header extends React.PureComponent<TProps> {
       uiFindCount,
       visEncoding,
     } = this.props;
+    const uiFindResult = uiFindCount != null && hiddenUiFindMatches ? 
+      `${uiFindCount || 0} / ${uiFindCount || 0 + hiddenUiFindMatches.size}`
+      : uiFindCount;
 
     return (
       <header className="DdgHeader">
@@ -108,7 +113,7 @@ export default class Header extends React.PureComponent<TProps> {
                 forwardedRef={this._uiFindInput}
                 inputProps={{ className: 'DdgHeader--uiFindInput' }}
               />
-              <span className="DdgHeader--uiFindCount">{uiFindCount}</span>
+                  <span className="DdgHeader--uiFindCount">{uiFindResult}</span>
             </div>
           </div>
         </div>

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -49,11 +49,19 @@ export default class Header extends React.PureComponent<TProps> {
     }
   };
 
+  getUiFindInfo = () => {
+    const { hiddenUiFindMatches, uiFindCount } = this.props;
+
+    if (uiFindCount === undefined) return '';
+    if (!hiddenUiFindMatches || !hiddenUiFindMatches.size) return uiFindCount;
+
+    return `${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`;
+  };
+
   render() {
     const {
       density,
       distanceToPathElems,
-      hiddenUiFindMatches,
       operation,
       operations,
       service,
@@ -64,12 +72,8 @@ export default class Header extends React.PureComponent<TProps> {
       setService,
       showOperations,
       toggleShowOperations,
-      uiFindCount,
       visEncoding,
     } = this.props;
-    const uiFindResult = uiFindCount != null && hiddenUiFindMatches ? 
-      `${uiFindCount || 0} / ${uiFindCount || 0 + hiddenUiFindMatches.size}`
-      : uiFindCount;
 
     return (
       <header className="DdgHeader">
@@ -113,7 +117,7 @@ export default class Header extends React.PureComponent<TProps> {
                 forwardedRef={this._uiFindInput}
                 inputProps={{ className: 'DdgHeader--uiFindInput' }}
               />
-                  <span className="DdgHeader--uiFindCount">{uiFindResult}</span>
+              <span className="DdgHeader--uiFindInfo">{this.getUiFindInfo()}</span>
             </div>
           </div>
         </div>

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
@@ -38,6 +38,7 @@ describe('DeepDependencyGraphPage', () => {
           edges: [],
           vertices: [],
         }),
+        getHiddenUiFindMatches: () => new Set(),
         getVisibleUiFindMatches: () => new Set(),
       },
       fetchServices: jest.fn(),
@@ -236,7 +237,8 @@ describe('DeepDependencyGraphPage', () => {
           vertices,
         }),
         getDerivedViewModifiers: () => ({ edges: new Map(), vertices: new Map() }),
-        getVisibleUiFindMatches: () => new Set(vertices.slice(1)),
+        getHiddenUiFindMatches: () => new Set(vertices.slice(1)),
+        getVisibleUiFindMatches: () => new Set(vertices.slice(0, 1)),
         getVisibleIndices: () => new Set(),
       };
 
@@ -291,15 +293,16 @@ describe('DeepDependencyGraphPage', () => {
         expect(unknownIndication).toMatch(/Unknown graphState/);
       });
 
-      it('calculates uiFindCount', () => {
-        const wrapper = shallow(<DeepDependencyGraphPageImpl {...props} graph={graph} />);
+      it('calculates uiFindCount and hiddenUiFindMatches', () => {
+        const wrapper = shallow(
+          <DeepDependencyGraphPageImpl {...props} graph={undefined} uiFind="truthy uiFind" />
+        );
         expect(wrapper.find(Header).prop('uiFindCount')).toBe(undefined);
+        expect(wrapper.find(Header).prop('hiddenUiFindMatches')).toBe(undefined);
 
-        wrapper.setProps({ uiFind: '' });
-        expect(wrapper.find(Header).prop('uiFindCount')).toBe(undefined);
-
-        wrapper.setProps({ uiFind: 'truthy uiFind' });
-        expect(wrapper.find(Header).prop('uiFindCount')).toBe(vertices.length - 1);
+        wrapper.setProps({ graph });
+        expect(wrapper.find(Header).prop('uiFindCount')).toBe(1);
+        expect(wrapper.find(Header).prop('hiddenUiFindMatches').size).toBe(vertices.length - 1);
       });
     });
   });

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -175,6 +175,7 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
     const distanceToPathElems =
       graphState && graphState.state === fetchedState.DONE ? graphState.model.distanceToPathElems : undefined;
     const uiFindMatches = graph && graph.getVisibleUiFindMatches(uiFind, visEncoding);
+    const hiddenUiFindMatches = graph && graph.getHiddenUiFindMatches(uiFind, visEncoding);
 
     let content: React.ReactElement | null = null;
     if (!graphState) {
@@ -220,6 +221,7 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
           <Header
             density={density}
             distanceToPathElems={distanceToPathElems}
+            hiddenUiFindMatches={hiddenUiFindMatches}
             operation={operation}
             operations={operationsForService[service || '']}
             service={service}

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
@@ -179,18 +179,18 @@ export default class GraphModel {
     return vertexSet;
   }
 
-  public getVisibleUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
-    (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
-      const { vertices } = this.getVisible(visEncoding);
-      return GraphModel.getUiFindMatches(vertices, uiFind);
-    }
-  );
-
   public getHiddenUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
     (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
       const visible = new Set(this.getVisible(visEncoding).vertices);
       const hidden: TDdgVertex[] = Array.from(this.vertices.values()).filter(vertex => !visible.has(vertex));
       return GraphModel.getUiFindMatches(hidden, uiFind);
+    }
+  );
+
+  public getVisibleUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
+    (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
+      const { vertices } = this.getVisible(visEncoding);
+      return GraphModel.getUiFindMatches(vertices, uiFind);
     }
   );
 

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
@@ -156,29 +156,41 @@ export default class GraphModel {
     }
   );
 
-  public getVisibleUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
-    (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
-      const vertexSet: Set<TDdgVertex> = new Set();
-      if (!uiFind) return vertexSet;
+  private static getUiFindMatches(vertices: TDdgVertex[], uiFind?: string) {
+    const vertexSet: Set<TDdgVertex> = new Set();
+    if (!uiFind) return vertexSet;
 
-      const uiFindArr = uiFind
-        .trim()
-        .toLowerCase()
-        .split(' ');
-      const { vertices } = this.getVisible(visEncoding);
-      for (let i = 0; i < vertices.length; i++) {
-        const { service, operation } = vertices[i];
-        const svc = service.toLowerCase();
-        const op = operation && operation.toLowerCase();
-        for (let j = 0; j < uiFindArr.length; j++) {
-          if (svc.includes(uiFindArr[j]) || (op && op.includes(uiFindArr[j]))) {
-            vertexSet.add(vertices[i]);
-            break;
-          }
+    const uiFindArr = uiFind
+      .trim()
+      .toLowerCase()
+      .split(' ');
+    for (let i = 0; i < vertices.length; i++) {
+      const { service, operation } = vertices[i];
+      const svc = service.toLowerCase();
+      const op = operation && operation.toLowerCase();
+      for (let j = 0; j < uiFindArr.length; j++) {
+        if (svc.includes(uiFindArr[j]) || (op && op.includes(uiFindArr[j]))) {
+          vertexSet.add(vertices[i]);
+          break;
         }
       }
+    }
 
-      return vertexSet;
+    return vertexSet;
+  }
+
+  public getVisibleUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
+    (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
+      const { vertices } = this.getVisible(visEncoding);
+      return GraphModel.getUiFindMatches(vertices, uiFind);
+    }
+  );
+
+  public getHiddenUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
+    (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
+      const visible = new Set(this.getVisible(visEncoding).vertices);
+      const hidden: TDdgVertex[] = Array.from(this.vertices.values()).filter(vertex => !visible.has(vertex));
+      return GraphModel.getUiFindMatches(hidden, uiFind);
     }
   );
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Currently, the DDG UI will report 0 matches if all matches are hidden, or under represent the number of matches. This would be counter productive to certain use cases.

## Short description of the changes
- Show `visible / total` uiFind matches:
![image](https://user-images.githubusercontent.com/3471184/65169406-7514a880-da14-11e9-977b-67ce61035914.png)

## Future Work
- Change the indicator into a button that will expand the graph to show the hidden matches.