### PR TITLE
Ddg show hidden find matches

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
@@ -51,7 +51,7 @@ exports[`<Header> renders the hops selector if distanceToPathElems is provided 1
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>
@@ -120,7 +120,7 @@ exports[`<Header> renders the operation selector if a service is selected 1`] = 
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>
@@ -193,7 +193,7 @@ exports[`<Header> renders the operation selector if a service is selected 2`] = 
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>
@@ -250,7 +250,7 @@ exports[`<Header> renders with minimal props 1`] = `
           }
         />
         <span
-          className="DdgHeader--uiFindCount"
+          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
@@ -50,9 +50,6 @@ exports[`<Header> renders the hops selector if distanceToPathElems is provided 1
             }
           }
         />
-        <span
-          className="DdgHeader--uiFindInfo"
-        />
       </div>
     </div>
   </div>
@@ -118,9 +115,6 @@ exports[`<Header> renders the operation selector if a service is selected 1`] = 
               "className": "DdgHeader--uiFindInput",
             }
           }
-        />
-        <span
-          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>
@@ -192,9 +186,6 @@ exports[`<Header> renders the operation selector if a service is selected 2`] = 
             }
           }
         />
-        <span
-          className="DdgHeader--uiFindInfo"
-        />
       </div>
     </div>
   </div>
@@ -248,9 +239,6 @@ exports[`<Header> renders with minimal props 1`] = `
               "className": "DdgHeader--uiFindInput",
             }
           }
-        />
-        <span
-          className="DdgHeader--uiFindInfo"
         />
       </div>
     </div>

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.css
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.css
@@ -97,6 +97,6 @@ limitations under the License.
   white-space: nowrap;
 }
 
-.DdgHeader--uiFindInfo:empty {
-  display: none;
+.DdgHeader--uiFindInfo--tooltip {
+  white-space: nowrap;
 }

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.css
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.css
@@ -82,20 +82,21 @@ limitations under the License.
   border-radius: 0px;
 }
 
-.DdgHeader--uiFindCount {
+.DdgHeader--uiFindInfo {
   background: #ffffb8;
   border: 1px dashed #fadb14;
   border-radius: 4px;
   color: #ad8b00;
   margin-left: 0.25em;
   margin-right: 0.5em;
-  transition: width 0.5s;
   padding: 0.27em 0.4em;
   stroke: #666;
   stroke-width: 1.2px;
   text-align: center;
+  transition: width 0.5s;
+  white-space: nowrap;
 }
 
-.DdgHeader--uiFindCount:empty {
+.DdgHeader--uiFindInfo:empty {
   display: none;
 }

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
@@ -66,6 +66,22 @@ describe('<Header>', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders the expected uiFind matches information', () => {
+    const getMatchesInfo = () => wrapper.find('.DdgHeader--uiFindInfo').text();
+    expect(getMatchesInfo()).toBe('');
+
+    const uiFindCount = 20;
+    wrapper.setProps({ uiFindCount });
+    expect(getMatchesInfo()).toBe(`${uiFindCount}`);
+
+    wrapper.setProps({ hiddenUiFindMatches: new Set() });
+    expect(getMatchesInfo()).toBe(`${uiFindCount}`);
+
+    const hiddenUiFindMatches = new Set(['hidden', 'match', 'vertices']);
+    wrapper.setProps({ hiddenUiFindMatches });
+    expect(getMatchesInfo()).toBe(`${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`);
+  });
+
   it('focuses uiFindInput IFF rendered when clicking on wrapping div', () => {
     const click = () => wrapper.find('.DdgHeader--uiFind').simulate('click');
     const focus = jest.fn();

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
@@ -14,6 +14,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Tooltip } from 'antd';
 
 import Header from './index';
 import HopsSelector from './HopsSelector';
@@ -66,22 +67,6 @@ describe('<Header>', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders the expected uiFind matches information', () => {
-    const getMatchesInfo = () => wrapper.find('.DdgHeader--uiFindInfo').text();
-    expect(getMatchesInfo()).toBe('');
-
-    const uiFindCount = 20;
-    wrapper.setProps({ uiFindCount });
-    expect(getMatchesInfo()).toBe(`${uiFindCount}`);
-
-    wrapper.setProps({ hiddenUiFindMatches: new Set() });
-    expect(getMatchesInfo()).toBe(`${uiFindCount}`);
-
-    const hiddenUiFindMatches = new Set(['hidden', 'match', 'vertices']);
-    wrapper.setProps({ hiddenUiFindMatches });
-    expect(getMatchesInfo()).toBe(`${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`);
-  });
-
   it('focuses uiFindInput IFF rendered when clicking on wrapping div', () => {
     const click = () => wrapper.find('.DdgHeader--uiFind').simulate('click');
     const focus = jest.fn();
@@ -90,5 +75,55 @@ describe('<Header>', () => {
     wrapper.instance()._uiFindInput = { current: { focus } };
     click();
     expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  describe('uiFind match information', () => {
+    const getBtn = () => wrapper.find('button');
+    const getMatchesInfo = () => wrapper.find('.DdgHeader--uiFindInfo');
+    const getTooltip = () => wrapper.find(Tooltip);
+    const hiddenUiFindMatches = new Set(['hidden', 'match', 'vertices']);
+    const uiFindCount = 20;
+
+    it('renders no info if count is `undefined`', () => {
+      expect(getMatchesInfo()).toHaveLength(0);
+      expect(getTooltip()).toHaveLength(0);
+    });
+
+    it('renders count if `hiddenUiFindMatches` is `undefined` or empty', () => {
+      const expectedText = `${uiFindCount}`;
+      const expectedTitle = 'All matches are visible';
+
+      wrapper.setProps({ uiFindCount });
+      expect(getMatchesInfo().text()).toBe(expectedText);
+      expect(getTooltip().prop('title')).toBe(expectedTitle);
+      expect(getBtn().prop('disabled')).toBe(true);
+
+      wrapper.setProps({ hiddenUiFindMatches: new Set() });
+      expect(getMatchesInfo().text()).toBe(expectedText);
+      expect(getTooltip().prop('title')).toBe(expectedTitle);
+      expect(getBtn().prop('disabled')).toBe(true);
+    });
+
+    it('renders count out of total if both are provided', () => {
+      const expectedText = `${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`;
+      const expectedTitle = 'Click to view hidden matches';
+
+      wrapper.setProps({ hiddenUiFindMatches, uiFindCount });
+      expect(getMatchesInfo().text()).toBe(expectedText);
+      expect(getTooltip().prop('title')).toBe(expectedTitle);
+      expect(getBtn().prop('disabled')).toBe(false);
+    });
+
+    it('calls props.showVertices with vertices in props.hiddenUiFindMatches when clicked with hiddenUiFindMatches', () => {
+      const showVertices = jest.fn();
+      wrapper.setProps({ showVertices, uiFindCount });
+      getBtn().simulate('click');
+      expect(showVertices).toHaveBeenCalledTimes(0);
+
+      wrapper.setProps({ hiddenUiFindMatches });
+      getBtn().simulate('click');
+      expect(showVertices).toHaveBeenCalledTimes(1);
+      expect(showVertices).toHaveBeenCalledWith(Array.from(hiddenUiFindMatches));
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -66,9 +66,8 @@ export default class Header extends React.PureComponent<TProps> {
 
     return (
       <Tooltip overlayClassName="DdgHeader--uiFindInfo--tooltip" placement="topRight" title={tipText}>
+        {/* arbitrary span is necessary as Tooltip alters child's styling */}
         <span>
-          {' '}
-          {/* arbitrary span is necessary as Tooltip alters child's styling */}
           <button
             className="DdgHeader--uiFindInfo"
             disabled={noMore}

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Icon, Input } from 'antd';
+import { Icon, Input, Tooltip } from 'antd';
 
 import HopsSelector from './HopsSelector';
 import NameSelector from './NameSelector';
@@ -36,6 +36,7 @@ type TProps = {
   setOperation: (operation: string) => void;
   setService: (service: string) => void;
   showOperations: boolean;
+  showVertices: (vertices: TDdgVertex[]) => void;
   toggleShowOperations: (enable: boolean) => void;
   uiFindCount: number | undefined;
   visEncoding?: string;
@@ -52,10 +53,38 @@ export default class Header extends React.PureComponent<TProps> {
   getUiFindInfo = () => {
     const { hiddenUiFindMatches, uiFindCount } = this.props;
 
-    if (uiFindCount === undefined) return '';
-    if (!hiddenUiFindMatches || !hiddenUiFindMatches.size) return uiFindCount;
+    if (uiFindCount === undefined) return null;
 
-    return `${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`;
+    let btnText = `${uiFindCount}`;
+    let noMore = true;
+    let tipText = 'All matches are visible';
+    if (hiddenUiFindMatches && hiddenUiFindMatches.size) {
+      noMore = false;
+      btnText = `${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`;
+      tipText = 'Click to view hidden matches';
+    }
+
+    return (
+      <Tooltip overlayClassName="DdgHeader--uiFindInfo--tooltip" placement="topRight" title={tipText}>
+        <span>
+          {' '}
+          {/* arbitrary span is necessary as Tooltip alters child's styling */}
+          <button
+            className="DdgHeader--uiFindInfo"
+            disabled={noMore}
+            onClick={this.handleInfoClick}
+            type="button"
+          >
+            {btnText}
+          </button>
+        </span>
+      </Tooltip>
+    );
+  };
+
+  handleInfoClick = () => {
+    const { hiddenUiFindMatches, showVertices } = this.props;
+    if (hiddenUiFindMatches) showVertices(Array.from(hiddenUiFindMatches));
   };
 
   render() {
@@ -117,7 +146,7 @@ export default class Header extends React.PureComponent<TProps> {
                 forwardedRef={this._uiFindInput}
                 inputProps={{ className: 'DdgHeader--uiFindInput' }}
               />
-              <span className="DdgHeader--uiFindInfo">{this.getUiFindInfo()}</span>
+              {this.getUiFindInfo()}
             </div>
           </div>
         </div>

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -49,11 +49,19 @@ export default class Header extends React.PureComponent<TProps> {
     }
   };
 
+  getUiFindInfo = () => {
+    const { hiddenUiFindMatches, uiFindCount } = this.props;
+
+    if (uiFindCount === undefined) return '';
+    if (!hiddenUiFindMatches || !hiddenUiFindMatches.size) return uiFindCount;
+
+    return `${uiFindCount} / ${uiFindCount + hiddenUiFindMatches.size}`;
+  };
+
   render() {
     const {
       density,
       distanceToPathElems,
-      hiddenUiFindMatches,
       operation,
       operations,
       service,
@@ -64,12 +72,8 @@ export default class Header extends React.PureComponent<TProps> {
       setService,
       showOperations,
       toggleShowOperations,
-      uiFindCount,
       visEncoding,
     } = this.props;
-    const uiFindResult = uiFindCount != null && hiddenUiFindMatches ? 
-      `${uiFindCount || 0} / ${uiFindCount || 0 + hiddenUiFindMatches.size}`
-      : uiFindCount;
 
     return (
       <header className="DdgHeader">
@@ -113,7 +117,7 @@ export default class Header extends React.PureComponent<TProps> {
                 forwardedRef={this._uiFindInput}
                 inputProps={{ className: 'DdgHeader--uiFindInput' }}
               />
-                  <span className="DdgHeader--uiFindCount">{uiFindResult}</span>
+              <span className="DdgHeader--uiFindInfo">{this.getUiFindInfo()}</span>
             </div>
           </div>
         </div>

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
@@ -38,6 +38,7 @@ describe('DeepDependencyGraphPage', () => {
           edges: [],
           vertices: [],
         }),
+        getHiddenUiFindMatches: () => new Set(),
         getVisibleUiFindMatches: () => new Set(),
       },
       fetchServices: jest.fn(),
@@ -236,7 +237,8 @@ describe('DeepDependencyGraphPage', () => {
           vertices,
         }),
         getDerivedViewModifiers: () => ({ edges: new Map(), vertices: new Map() }),
-        getVisibleUiFindMatches: () => new Set(vertices.slice(1)),
+        getHiddenUiFindMatches: () => new Set(vertices.slice(1)),
+        getVisibleUiFindMatches: () => new Set(vertices.slice(0, 1)),
         getVisibleIndices: () => new Set(),
       };
 
@@ -291,15 +293,16 @@ describe('DeepDependencyGraphPage', () => {
         expect(unknownIndication).toMatch(/Unknown graphState/);
       });
 
-      it('calculates uiFindCount', () => {
-        const wrapper = shallow(<DeepDependencyGraphPageImpl {...props} graph={graph} />);
+      it('calculates uiFindCount and hiddenUiFindMatches', () => {
+        const wrapper = shallow(
+          <DeepDependencyGraphPageImpl {...props} graph={undefined} uiFind="truthy uiFind" />
+        );
         expect(wrapper.find(Header).prop('uiFindCount')).toBe(undefined);
+        expect(wrapper.find(Header).prop('hiddenUiFindMatches')).toBe(undefined);
 
-        wrapper.setProps({ uiFind: '' });
-        expect(wrapper.find(Header).prop('uiFindCount')).toBe(undefined);
-
-        wrapper.setProps({ uiFind: 'truthy uiFind' });
-        expect(wrapper.find(Header).prop('uiFindCount')).toBe(vertices.length - 1);
+        wrapper.setProps({ graph });
+        expect(wrapper.find(Header).prop('uiFindCount')).toBe(1);
+        expect(wrapper.find(Header).prop('hiddenUiFindMatches').size).toBe(vertices.length - 1);
       });
     });
   });

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -33,6 +33,7 @@ import {
   EDirection,
   TDdgModelParams,
   TDdgSparseUrlState,
+  TDdgVertex,
   EDdgDensity,
   EViewModifier,
 } from '../../model/ddg/types';
@@ -162,6 +163,13 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
     });
   };
 
+  showVertices = (vertices: TDdgVertex[]) => {
+    const { graph, urlState } = this.props;
+    const { visEncoding } = urlState;
+    if (!graph) return;
+    this.updateUrlState({ visEncoding: graph.getVisWithVertices(vertices, visEncoding) });
+  };
+
   toggleShowOperations = (enable: boolean) => this.updateUrlState({ showOp: enable });
 
   updateUrlState = (newValues: Partial<TDdgSparseUrlState>) => {
@@ -231,6 +239,7 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
             setOperation={this.setOperation}
             setService={this.setService}
             showOperations={showOp}
+            showVertices={this.showVertices}
             toggleShowOperations={this.toggleShowOperations}
             uiFindCount={uiFind ? uiFindMatches && uiFindMatches.size : undefined}
             visEncoding={visEncoding}

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getDerivedViewModifiers.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getDerivedViewModifiers.tsx
@@ -37,9 +37,11 @@ export default function getDerivedViewModifiers(
   const vertices = new Map<string, number>();
   const edges = new Map<string, number>();
 
-  const visibleIndices = new Set(visEncoding == null
-    ? this.getDefaultVisiblePathElems().map(pe => pe.visibilityIdx)
-    : new Set(decode(visEncoding)));
+  const visibleIndices = new Set(
+    visEncoding == null
+      ? this.getDefaultVisiblePathElems().map(pe => pe.visibilityIdx)
+      : new Set(decode(visEncoding))
+  );
 
   const pushVertexVm = (vm: number, key: string) => {
     // eslint-disable-next-line no-bitwise

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.tsx
@@ -25,19 +25,8 @@ function fmtElemSvcOnly(pe: PathElem) {
   return pe.distance === 0 ? fmtElemShowOp(pe) : pe.operation.service.name;
 }
 
-function getElemsToFocal(pe: PathElem) {
-  const {
-    memberIdx,
-    memberOf: { focalIdx, members },
-  } = pe;
-  return members.slice(Math.min(focalIdx, memberIdx), Math.max(focalIdx, memberIdx) + 1);
-}
-
 function getPpeHasher(elemToStr: TPathElemToStr) {
-  return (pe: PathElem) =>
-    getElemsToFocal(pe)
-      .map(elemToStr)
-      .join('\n');
+  return (pe: PathElem) => pe.focalPath.map(elemToStr).join('\n');
 }
 
 function getExtVsIntHasher(elemToStr: TPathElemToStr) {

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.test.js
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.test.js
@@ -251,6 +251,19 @@ describe('GraphModel', () => {
     });
   });
 
+  describe('getVisWithVertices', () => {
+    const convergentGraph = new GraphModel({
+      ddgModel: convergentModel,
+      density: EDdgDensity.PreventPathEntanglement,
+      showOp: true,
+    });
+
+    it('handles absent visEncoding', () => {
+      const alreadyVisible = convergentGraph.getDefaultVisiblePathElems();
+      console.log(convergentGraph.distanceToPathElems(4));
+    });
+  });
+
   describe('getVisibleUiFindMatches', () => {
     const convergentGraph = new GraphModel({
       ddgModel: convergentModel,

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
@@ -19,7 +19,7 @@ import { TEdge } from '@jaegertracing/plexus/lib/types';
 import getDerivedViewModifiers from './getDerivedViewModifiers';
 import getEdgeId from './getEdgeId';
 import getPathElemHasher from './getPathElemHasher';
-import { decode } from '../visibility-codec';
+import { decode, encode } from '../visibility-codec';
 
 import { PathElem, EDdgDensity, TDdgDistanceToPathElems, TDdgModel, TDdgVertex } from '../types';
 
@@ -193,6 +193,21 @@ export default class GraphModel {
       return GraphModel.getUiFindMatches(vertices, uiFind);
     }
   );
+
+  public getVisWithVertices = (vertices: TDdgVertex[], visEncoding?: string) => {
+    const indices: Set<number> = this.getVisibleIndices(visEncoding);
+
+    vertices.forEach(vertex => {
+      const elems = this.vertexToPathElems.get(vertex);
+      if (!elems) throw new Error(`${vertex} does not exist in graph`);
+
+      elems.forEach(elem => {
+        elem.focalPath.forEach(({ visibilityIdx }) => indices.add(visibilityIdx));
+      });
+    });
+
+    return encode(Array.from(indices));
+  };
 
   public getVertexVisiblePathElems = (
     vertexKey: string,

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
@@ -179,18 +179,18 @@ export default class GraphModel {
     return vertexSet;
   }
 
-  public getVisibleUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
-    (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
-      const { vertices } = this.getVisible(visEncoding);
-      return GraphModel.getUiFindMatches(vertices, uiFind);
-    }
-  );
-
   public getHiddenUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
     (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
       const visible = new Set(this.getVisible(visEncoding).vertices);
       const hidden: TDdgVertex[] = Array.from(this.vertices.values()).filter(vertex => !visible.has(vertex));
       return GraphModel.getUiFindMatches(hidden, uiFind);
+    }
+  );
+
+  public getVisibleUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<TDdgVertex> = memoize(10)(
+    (uiFind?: string, visEncoding?: string): Set<TDdgVertex> => {
+      const { vertices } = this.getVisible(visEncoding);
+      return GraphModel.getUiFindMatches(vertices, uiFind);
     }
   );
 

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
@@ -137,7 +137,6 @@ export default class GraphModel {
         if (edge) edges.add(edge);
         const vertex = this.pathElemToVertex.get(pathElem);
         if (vertex) vertices.add(vertex);
-        else throw new Error(`PathElem wasn't present in initial model: ${pathElem}`);
       });
 
       return {
@@ -186,7 +185,7 @@ export default class GraphModel {
   );
 
   public getVisWithVertices = (vertices: TDdgVertex[], visEncoding?: string) => {
-    const indices: Set<number> = this.getVisibleIndices(visEncoding);
+    const indices: Set<number> = new Set(this.getVisiblePathElems(visEncoding).map(pe => pe.visibilityIdx));
 
     vertices.forEach(vertex => {
       const elems = this.vertexToPathElems.get(vertex);

--- a/packages/jaeger-ui/src/model/ddg/PathElem.test.js
+++ b/packages/jaeger-ui/src/model/ddg/PathElem.test.js
@@ -16,6 +16,31 @@ import PathElem from './PathElem';
 import { simplePath } from './sample-paths.test.resources';
 
 describe('PathElem', () => {
+  const getPath = () => {
+    const path = {
+      focalIdx: 2,
+    };
+    const members = simplePath.map(
+      ({ operation, service }, i) =>
+        new PathElem({
+          memberIdx: i,
+          operation: {
+            name: operation,
+            service: {
+              name: service,
+            },
+          },
+          path,
+        })
+    );
+    members[2].visibilityIdx = 0;
+    members[3].visibilityIdx = 1;
+    members[1].visibilityIdx = 2;
+    members[4].visibilityIdx = 3;
+    members[0].visibilityIdx = 4;
+    path.members = members;
+    return path;
+  };
   const testMemberIdx = 3;
   const testOperation = {};
   const testPath = {
@@ -85,29 +110,28 @@ describe('PathElem', () => {
     expect(focalElem.isExternal).toBe(false);
   });
 
+  describe('focalPath', () => {
+    const path = getPath();
+
+    it('returns array of itself if it is focal elem', () => {
+      const targetPathElem = path.members[path.focalIdx];
+      expect(targetPathElem.focalPath).toEqual([targetPathElem]);
+    });
+
+    it('returns path to focal elem in correct order for upstream elem', () => {
+      const targetPathElem = path.members[0];
+      expect(targetPathElem.focalPath).toEqual(path.members.slice(0, path.focalIdx + 1));
+    });
+
+    it('returns path to focal elem in correct order for downstream elem', () => {
+      const idx = path.members.length - 1;
+      const targetPathElem = path.members[idx];
+      expect(targetPathElem.focalPath).toEqual(path.members.slice(path.focalIdx, idx + 1));
+    });
+  });
+
   describe('legibility', () => {
-    const path = {
-      focalIdx: 2,
-    };
-    const members = simplePath.map(
-      ({ operation, service }, i) =>
-        new PathElem({
-          memberIdx: i,
-          operation: {
-            name: operation,
-            service: {
-              name: service,
-            },
-          },
-          path,
-        })
-    );
-    members[2].visibilityIdx = 0;
-    members[3].visibilityIdx = 1;
-    members[1].visibilityIdx = 2;
-    members[4].visibilityIdx = 3;
-    members[0].visibilityIdx = 4;
-    path.members = members;
+    const path = getPath();
     const targetPathElem = path.members[1];
 
     it('creates consumable JSON', () => {

--- a/packages/jaeger-ui/src/model/ddg/PathElem.tsx
+++ b/packages/jaeger-ui/src/model/ddg/PathElem.tsx
@@ -38,6 +38,17 @@ export default class PathElem {
     return this.memberIdx - this.memberOf.focalIdx;
   }
 
+  get focalPath(): PathElem[] {
+    const result: PathElem[] = [];
+    let current: PathElem | null = this;
+    while (current) {
+      result.push(current);
+      current = current.focalSideNeighbor;
+    }
+    if (this.distance > 0) result.reverse();
+    return result;
+  }
+
   get focalSideNeighbor(): PathElem | null {
     if (!this.distance) return null;
     return this.memberOf.members[this.memberIdx - Math.sign(this.distance)];


### PR DESCRIPTION
## Which problem is this PR solving?
- If there are hidden uiFind matches, they can be difficult to locate in large graphs.

## Short description of the changes
- Makes indication of hidden uiFind matches a button that reveals hidden matches.

Branched off of [this PR](https://github.com/jaegertracing/jaeger-ui/pull/452), diff is captured in [these three commits](https://github.com/jaegertracing/jaeger-ui/pull/453/files/44a3f7a4f4dabddc2070aaa23707182c78b2a4b2..1607e0b99781ffe3aeaecef0d25a1bb1671eb16c).