### PR TITLE
Add script tags from config to body

### DIFF
--- a/packages/jaeger-ui/src/components/App/index.js
+++ b/packages/jaeger-ui/src/components/App/index.js
@@ -32,6 +32,7 @@ import TracePage from '../TracePage';
 import { ROUTE_PATH as tracePath } from '../TracePage/url';
 import JaegerAPI, { DEFAULT_API_ROOT } from '../../api/jaeger';
 import configureStore from '../../utils/configure-store';
+import processScripts from '../../utils/config/process-scripts';
 import prefixUrl from '../../utils/prefix-url';
 
 import '../common/vars.css';
@@ -45,6 +46,7 @@ export default class JaegerUIApp extends Component {
     super(props);
     this.store = configureStore(history);
     JaegerAPI.apiRoot = DEFAULT_API_ROOT;
+    processScripts();
   }
 
   render() {

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -25,11 +25,17 @@ export type ConfigMenuGroup = {
   items: ConfigMenuItem[];
 };
 
+export type TScript = {
+  text: string;
+  type: 'inline';
+};
+
 export type Config = {
   archiveEnabled?: boolean;
   dependencies?: { dagMaxServicesLen?: number; menuEnabled?: boolean };
   menu: (ConfigMenuGroup | ConfigMenuItem)[];
   search?: { maxLookback: { label: string; value: string } };
+  scripts?: TScript[];
   tracking?: {
     gaID: string | TNil;
     trackErrors: boolean | TNil;

--- a/packages/jaeger-ui/src/utils/config/process-scripts.test.js
+++ b/packages/jaeger-ui/src/utils/config/process-scripts.test.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as config from './get-config';
+import processScripts from './process-scripts';
+
+describe('processScripts', () => {
+  const getConfigValueSpy = jest.spyOn(config, 'getConfigValue');
+  const createTextNodeSpy = jest.spyOn(document, 'createTextNode');
+  const createElementSpy = jest.spyOn(document, 'createElement');
+  const appendScriptSpy = jest.spyOn(document.body, 'appendChild');
+  const appendTextSpy = jest.fn();
+  const mockValue = (text, number) => `${text} --- ${number}`;
+  const texts = ['text 0', 'text 1'];
+  const configScripts = texts.map(text => ({ text, type: 'inline' }));
+  let scriptElems;
+
+  beforeAll(() => {
+    createTextNodeSpy.mockImplementation(text => mockValue(text, createTextNodeSpy.mock.calls.length));
+    createElementSpy.mockImplementation(text => {
+      const script = {
+        append: appendTextSpy,
+        identifier: mockValue(text, createElementSpy.mock.calls.length),
+      };
+      scriptElems.push(script);
+      return script;
+    });
+    appendScriptSpy.mockImplementation();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scriptElems = [];
+  });
+
+  it('adds inline scripts', () => {
+    getConfigValueSpy.mockReturnValue(configScripts);
+
+    processScripts();
+    texts.forEach((text, i) => {
+      expect(createTextNodeSpy).toHaveBeenCalledWith(text);
+      expect(appendTextSpy).toHaveBeenCalledWith(mockValue(text, 1 + i));
+      expect(appendScriptSpy).toHaveBeenCalledWith(scriptElems[i]);
+    });
+    expect(createElementSpy).toHaveBeenCalledWith('script');
+    expect(createElementSpy).toHaveBeenCalledTimes(texts.length);
+  });
+
+  it('ignores other script types', () => {
+    getConfigValueSpy.mockReturnValue([...configScripts, { type: 'not-inline' }]);
+
+    processScripts();
+    expect(createElementSpy).toHaveBeenCalledTimes(texts.length);
+  });
+
+  it('handles no scripts', () => {
+    getConfigValueSpy.mockReturnValue(undefined);
+    expect(processScripts).not.toThrowError();
+  });
+});

--- a/packages/jaeger-ui/src/utils/config/process-scripts.tsx
+++ b/packages/jaeger-ui/src/utils/config/process-scripts.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getConfigValue } from './get-config';
+import { TScript } from '../../types/config';
+
+export default function() {
+  const scripts = getConfigValue('scripts');
+  if (scripts) {
+    scripts.forEach((script: TScript) => {
+      if (script.type === 'inline') {
+        const textElem = document.createTextNode(script.text);
+        const scriptElem = document.createElement('script');
+        scriptElem.append(textElem);
+        document.body.appendChild(scriptElem);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- We need the ability to run non-OSS code on the UI without treating Jaeger UI as a component library.

## Short description of the changes
- Adds scripts field to config, which are added to the document body.
- Initially only inline scripts are supported, as the config is a JSON and we need the ability to define an onLoad function if we were to use a `src`
