### PR TITLE
Fix trace name resolution for spans with remote parents

### DIFF
--- a/packages/jaeger-ui/src/model/trace-viewer.js
+++ b/packages/jaeger-ui/src/model/trace-viewer.js
@@ -14,6 +14,6 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export function getTraceName(spans) {
-  const span = spans.filter(sp => !sp.references || !sp.references.length)[0];
+  const span = spans.find(sp => !sp.references || !sp.references.some(ref => ref.traceID === sp.traceID));
   return span ? `${span.process.serviceName}: ${span.operationName}` : '';
 }


### PR DESCRIPTION
When encountering a trace whose root span contains a reference to a remote parent span in a different trace, the UI would fail to determine the root span and instead display the fallback `<trace-without-root-span>` trace name.

This change makes it so that the first span that has no parents in the current trace is correctly considered the root span. Previously only a span with no references/parents was considered
the root span.

To simplify the logic and ensure consistency, `transformTraceData` was changed to use the fixed `getTraceName`.

Traces with remote parents are commonly used when handling HTTP or RPC requests from untrusted clients. See the [opencensus-specs util/HandleUntrustedRequests.md](https://github.com/census-instrumentation/opencensus-specs/blob/8600b7497457a277e681552005556407e9666997/utils/HandleUntrustedRequests.md) for an example of this approach.

I understand that I should add a test for this, but I'm unsure where would be appropriate. If someone can point me to an appropriate file, I'll add that to this PR.

<details>
<summary>An example of a trace that contains a remote parent.</summary>
<pre>
{
    "data": [
        {
            "traceID": "46412397683b6cee4f02fa1ac7e4d0db",
            "spans": [
                {
                    "traceID": "46412397683b6cee4f02fa1ac7e4d0db",
                    "spanID": "7ef1d2e931ada231",
                    "operationName": "operation",
                    "references": [
                        {
                            "refType": "CHILD_OF",
                            "traceID": "79b24a4a9fb5d4e46895ab64f55dfc90",
                            "spanID": "9111732227172a77"
                        }
                    ],
                    "startTime": 1257894000000000,
                    "duration": 1000,
                    "tags": [],
                    "logs": [],
                    "processID": "p1",
                    "warnings": null
                }
            ],
            "processes": {
                "p1": {
                    "serviceName": "service",
                    "tags": []
                }
            },
            "warnings": null
        }
    ],
    "total": 0,
    "limit": 0,
    "offset": 0,
    "errors": null
}
</pre>
</details>

Updates #117
Updates #134