### PR TITLE
Consume new API format

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/index.test.js
@@ -27,8 +27,8 @@ import * as codec from '../../../../model/ddg/visibility-codec';
 import HopsSelector from '.';
 
 describe('HopsSelector', () => {
-  const { distanceToPathElems } = transformDdgData([longSimplePath, simplePath].map(wrap), focalPayloadElem);
-  const { distanceToPathElems: shortPathElems } = transformDdgData([shortPath].map(wrap), focalPayloadElem);
+  const { distanceToPathElems } = transformDdgData(wrap([longSimplePath, simplePath]), focalPayloadElem);
+  const { distanceToPathElems: shortPathElems } = transformDdgData(wrap([shortPath]), focalPayloadElem);
 
   describe('without distanceToPathElems', () => {
     it('renders empty div', () => {

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/getPathElemHasher.test.js
@@ -14,6 +14,7 @@
 
 import GraphModel from './index';
 import transformDdgData from '../transformDdgData';
+import { wrap } from '../sample-paths.test.resources';
 import { EDdgDensity } from '../types';
 
 function makePayloadEntry(pairStr) {
@@ -30,12 +31,12 @@ const payload = `
 `
   .trim()
   .split('\n')
-  .map(line => ({
-    path: line
+  .map(line =>
+    line
       .trim()
       .split(/\s+/g)
-      .map(makePayloadEntry),
-  }));
+      .map(makePayloadEntry)
+  );
 
 const testTable = [
   // showOp, density, number of expected vertices
@@ -52,7 +53,7 @@ const testTable = [
 ];
 
 describe('getPathElemHasher()', () => {
-  const ddgModel = transformDdgData(payload, makePayloadEntry('focal:focal'));
+  const ddgModel = transformDdgData(wrap(payload), makePayloadEntry('focal:focal'));
 
   describe('creates vertices based on density and showOp', () => {
     it.each(testTable)('showOp: %p \t density: %p', (showOp, density, verticesCount) => {

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.test.js
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.test.js
@@ -25,9 +25,9 @@ import { EDdgDensity } from '../types';
 import { encode } from '../visibility-codec';
 
 describe('GraphModel', () => {
-  const convergentModel = transformDdgData(convergentPaths.map(wrap), focalPayloadElem);
-  const doubleFocalModel = transformDdgData([doubleFocalPath, simplePath].map(wrap), focalPayloadElem);
-  const simpleModel = transformDdgData([simplePath].map(wrap), focalPayloadElem);
+  const convergentModel = transformDdgData(wrap(convergentPaths), focalPayloadElem);
+  const doubleFocalModel = transformDdgData(wrap([doubleFocalPath, simplePath]), focalPayloadElem);
+  const simpleModel = transformDdgData(wrap([simplePath]), focalPayloadElem);
 
   /**
    * This function takes in a Graph and validates the structure based on the expected vertices.

--- a/packages/jaeger-ui/src/model/ddg/sample-paths.test.resources.js
+++ b/packages/jaeger-ui/src/model/ddg/sample-paths.test.resources.js
@@ -89,4 +89,6 @@ export const convergentPaths = [
   [firstPayloadElem, focalPayloadElem, divergentPayloadElem, afterPayloadElem, lastPayloadElem],
 ];
 
-export const wrap = path => ({ path });
+export const wrap = paths => ({
+  dependencies: paths.map(path => ({ path, attributes: [] })),
+});

--- a/packages/jaeger-ui/src/model/ddg/transformDdgData.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformDdgData.test.js
@@ -26,7 +26,7 @@ describe('transform ddg data', () => {
       ? { service: focalPayloadElem.service }
       : focalPayloadElem;
     const { paths, services, visIdxToPathElem } = transformDdgData(
-      payload.map(testResources.wrap),
+      testResources.wrap(payload),
       focalPayloadElemArgument
     );
 
@@ -124,11 +124,11 @@ describe('transform ddg data', () => {
       almostDoubleFocalPath,
     } = testResources;
     const { visIdxToPathElem: presortedPathsVisIdxToPathElem } = transformDdgData(
-      [simplePath, doubleFocalPath, almostDoubleFocalPath, longSimplePath].map(testResources.wrap),
+      testResources.wrap([simplePath, doubleFocalPath, almostDoubleFocalPath, longSimplePath]),
       focalPayloadElem
     );
     const { visIdxToPathElem: unsortedPathsVisIdxToPathElem } = transformDdgData(
-      [longSimplePath, almostDoubleFocalPath, simplePath, doubleFocalPath].map(testResources.wrap),
+      testResources.wrap([longSimplePath, almostDoubleFocalPath, simplePath, doubleFocalPath]),
       focalPayloadElem
     );
 
@@ -166,21 +166,43 @@ describe('transform ddg data', () => {
   it('throws an error if a path lacks the focalPayloadElem', () => {
     const { simplePath, noFocalPath, doubleFocalPath, focalPayloadElem } = testResources;
     expect(() =>
-      transformDdgData([simplePath, noFocalPath, doubleFocalPath].map(testResources.wrap), focalPayloadElem)
+      testResources.wrap(transformDdgData([simplePath, noFocalPath, doubleFocalPath]), focalPayloadElem)
     ).toThrowError();
   });
 
   it('creates equal hashes iff paths are equivalent', () => {
     const { focalPayloadElem, doubleFocalPath, longSimplePath, simplePath, wrap } = testResources;
-    const simpleModel = transformDdgData([simplePath, longSimplePath].map(wrap), focalPayloadElem);
-    const reverseModel = transformDdgData([longSimplePath, simplePath].map(wrap), focalPayloadElem);
+    const simpleModel = transformDdgData(wrap([simplePath, longSimplePath]), focalPayloadElem);
+    const reverseModel = transformDdgData(wrap([longSimplePath, simplePath]), focalPayloadElem);
 
     expect(reverseModel).not.toEqual(simpleModel);
     expect(reverseModel).not.toBe(simpleModel);
     expect(reverseModel.hash).toBe(simpleModel.hash);
 
-    const diffModel = transformDdgData([doubleFocalPath].map(wrap), focalPayloadElem);
+    const diffModel = transformDdgData(wrap([doubleFocalPath]), focalPayloadElem);
 
     expect(diffModel.hash).not.toBe(simpleModel.hash);
+  });
+
+  it('adds traceIDs to paths from attributes', () => {
+    const { focalPayloadElem, doubleFocalPath, simplePath, wrap } = testResources;
+    const payload = wrap([simplePath, doubleFocalPath]);
+    payload.dependencies.forEach((dependency, i) => {
+      // eslint-disable-next-line no-param-reassign
+      dependency.attributes = [
+        {
+          key: 'exemplar_trace_id',
+          value: `trace ${i} a`,
+        },
+        {
+          key: 'exemplar_trace_id',
+          value: `trace ${i} b`,
+        },
+      ];
+    });
+    const model = transformDdgData(payload, focalPayloadElem);
+    model.paths.forEach((path, i) => {
+      expect(path.traceIDs).toEqual([`trace ${i} a`, `trace ${i} b`]);
+    });
   });
 });

--- a/packages/jaeger-ui/src/model/ddg/transformDdgData.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformDdgData.test.js
@@ -166,8 +166,8 @@ describe('transform ddg data', () => {
   it('throws an error if a path lacks the focalPayloadElem', () => {
     const { simplePath, noFocalPath, doubleFocalPath, focalPayloadElem } = testResources;
     expect(() =>
-      testResources.wrap(transformDdgData([simplePath, noFocalPath, doubleFocalPath]), focalPayloadElem)
-    ).toThrowError();
+      transformDdgData(testResources.wrap([simplePath, noFocalPath, doubleFocalPath]), focalPayloadElem)
+    ).toThrowError(/focalNode/);
   });
 
   it('creates equal hashes iff paths are equivalent', () => {

--- a/packages/jaeger-ui/src/model/ddg/types.tsx
+++ b/packages/jaeger-ui/src/model/ddg/types.tsx
@@ -51,9 +51,15 @@ export type TDdgPayloadEntry = {
 };
 
 export type TDdgPayload = {
-  path: TDdgPayloadEntry[];
-  trace_id: string; // eslint-disable-line camelcase
-}[];
+  dependencies: {
+    path: TDdgPayloadEntry[];
+    // TODO: Everett Tech Debt: Fix KeyValuePair types
+    attributes: {
+      key: 'exemplar_trace_id'; // eslint-disable-line camelcase
+      value: string;
+    }[];
+  }[];
+};
 
 export type TDdgService = {
   name: string;
@@ -71,7 +77,7 @@ export type TDdgServiceMap = Map<string, TDdgService>;
 export type TDdgPath = {
   focalIdx: number;
   members: PathElem[];
-  traceID: string;
+  traceIDs: string[];
 };
 
 export type TDdgDistanceToPathElems = Map<number, PathElem[]>;

--- a/packages/jaeger-ui/src/model/ddg/visibility-codec.test.js
+++ b/packages/jaeger-ui/src/model/ddg/visibility-codec.test.js
@@ -67,8 +67,8 @@ describe('visibility-codec', () => {
   });
 
   describe('encodeDistance', () => {
-    const ddgModel = transformDdgData([longSimplePath, simplePath].map(wrap), focalPayloadElem);
-    const shortModel = transformDdgData([shortPath].map(wrap), focalPayloadElem);
+    const ddgModel = transformDdgData(wrap([longSimplePath, simplePath]), focalPayloadElem);
+    const shortModel = transformDdgData(wrap([shortPath]), focalPayloadElem);
 
     /**
      * Creates a visibility encoding containing all indices between two specified hops, inclusive, except

--- a/packages/jaeger-ui/src/types/trace.tsx
+++ b/packages/jaeger-ui/src/types/trace.tsx
@@ -16,6 +16,7 @@
  * All timestamps are in microseconds
  */
 
+// TODO: Everett Tech Debt: Fix KeyValuePair types
 export type KeyValuePair = {
   key: string;
   value: any;


### PR DESCRIPTION
The payload format has changed slightly, update `transformDdgData` to handle this change, and update view traces to consume multiple traceIDs per path elem.