### PR TITLE
Add more GA events, fix clear uiFind & kbd modal

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -24,6 +24,7 @@ import queryString from 'query-string';
 import AltViewOptions from './AltViewOptions';
 import DiffSelection from './DiffSelection';
 import * as markers from './index.markers';
+import { trackAltView } from './index.track';
 import ResultItem from './ResultItem';
 import ScatterPlot from './ScatterPlot';
 import { getUrl } from '../url';
@@ -105,6 +106,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
     const { location, history } = this.props;
     const urlState = queryString.parse(location.search);
     const view = urlState.view && urlState.view === 'ddg' ? 'traces' : 'ddg';
+    trackAltView(view);
     history.push(getUrl({ ...urlState, view }));
   };
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
@@ -17,6 +17,7 @@ import { shallow } from 'enzyme';
 
 import { UnconnectedSearchResults as SearchResults } from '.';
 import * as markers from './index.markers';
+import * as track from './index.track';
 import AltViewOptions from './AltViewOptions';
 import DiffSelection from './DiffSelection';
 import ResultItem from './ResultItem';
@@ -78,8 +79,13 @@ describe('<SearchResults>', () => {
       const viewDdg = 'ddg';
       const viewTraces = 'traces';
       const search = `${searchParam}=${viewDdg}`;
+      let trackAltViewSpy;
 
-      it('updates url to view ddg and back and back again', () => {
+      beforeAll(() => {
+        trackAltViewSpy = jest.spyOn(track, 'trackAltView');
+      });
+
+      it('updates url to view ddg and back and back again - and tracks changes', () => {
         const otherParam = 'param';
         const otherValue = 'value';
         const otherSearch = `?${otherParam}=${otherValue}`;
@@ -89,16 +95,19 @@ describe('<SearchResults>', () => {
         const toggle = wrapper.find(AltViewOptions).prop('onTraceGraphViewClicked');
         toggle();
         expect(push).toHaveBeenLastCalledWith(getUrl({ [otherParam]: otherValue, [searchParam]: viewDdg }));
+        expect(trackAltViewSpy).toHaveBeenLastCalledWith(viewDdg);
 
         wrapper.setProps({ location: { search: `${otherSearch}&${search}` } });
         toggle();
         expect(push).toHaveBeenLastCalledWith(
           getUrl({ [otherParam]: otherValue, [searchParam]: viewTraces })
         );
+        expect(trackAltViewSpy).toHaveBeenLastCalledWith(viewTraces);
 
         wrapper.setProps({ location: { search: `${otherSearch}&${searchParam}=${viewTraces}` } });
         toggle();
         expect(push).toHaveBeenLastCalledWith(getUrl({ [otherParam]: otherValue, [searchParam]: viewDdg }));
+        expect(trackAltViewSpy).toHaveBeenLastCalledWith(viewDdg);
       });
 
       it('shows ddg instead of scatterplot and results', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.track.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.track.test.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { trackAltView, CATEGORY_ALT_VIEW, EAltViewActions } from './index.track';
+import * as trackingUtils from '../../../utils/tracking';
+
+describe('SearchResults tracking', () => {
+  let trackEvent;
+
+  beforeAll(() => {
+    trackEvent = jest.spyOn(trackingUtils, 'trackEvent').mockImplementation();
+  });
+
+  beforeEach(() => {
+    trackEvent.mockClear();
+  });
+
+  it('tracks changes to view', () => {
+    const actions = Object.values(EAltViewActions);
+    // sanity check
+    expect(actions.length).toBeGreaterThan(0);
+
+    actions.forEach(action => {
+      trackAltView(action);
+      expect(trackEvent).toHaveBeenLastCalledWith(CATEGORY_ALT_VIEW, action);
+    });
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.track.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.track.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { trackEvent } from '../../../utils/tracking';
+
+// export for tests
+export const CATEGORY_ALT_VIEW = 'jaeger/ux/search-results/alt-view';
+
+export enum EAltViewActions {
+  Ddg = 'ddg',
+  Traces = 'traces',
+}
+
+export function trackAltView(view: EAltViewActions) {
+  trackEvent(CATEGORY_ALT_VIEW, view);
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/KeyboardShortcutsHelp.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/KeyboardShortcutsHelp.test.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { Button, Modal } from 'antd';
+import { shallow } from 'enzyme';
+
+import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
+import * as track from './KeyboardShortcutsHelp.track';
+
+describe('KeyboardShortcutsHelp', () => {
+  const testClassName = 'test--ClassName';
+  const wrapper = shallow(<KeyboardShortcutsHelp className={testClassName} />);
+  let trackSpy;
+
+  beforeAll(() => {
+    trackSpy = jest.spyOn(track, 'default');
+  });
+
+  beforeEach(() => {
+    trackSpy.mockReset();
+  });
+
+  it('renders as expected', () => {
+    expect(wrapper.find(Button).hasClass(testClassName)).toBe(true);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('opens modal and tracks its opening', () => {
+    expect(wrapper.setState({ visible: false }));
+
+    wrapper.find(Button).simulate('click', {});
+    expect(wrapper.state('visible')).toBe(true);
+    expect(trackSpy).toHaveBeenCalled();
+  });
+
+  it('closes modal', () => {
+    wrapper.setState({ visible: true });
+    wrapper.find(Modal).prop('onOk')();
+    expect(wrapper.state('visible')).toBe(false);
+
+    wrapper.setState({ visible: true });
+    wrapper.find(Modal).prop('onCancel')();
+    expect(wrapper.state('visible')).toBe(false);
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/KeyboardShortcutsHelp.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/KeyboardShortcutsHelp.tsx
@@ -52,7 +52,6 @@ const getRowClass = (_: any, index: number) => (index % 2 > 0 ? ODD_ROW_CLASS : 
 let kbdTable: React.ReactNode | null = null;
 
 function getHelpModal() {
-  track();
   if (kbdTable) {
     return kbdTable;
   }
@@ -90,7 +89,10 @@ export default class KeyboardShortcutsHelp extends React.PureComponent<Props, St
     visible: false,
   };
 
-  onCtaClicked = () => this.setState({ visible: true });
+  onCtaClicked = () => {
+    track();
+    this.setState({ visible: true });
+  };
 
   onCloserClicked = () => this.setState({ visible: false });
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/KeyboardShortcutsHelp.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/KeyboardShortcutsHelp.test.js.snap
@@ -1,0 +1,234 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KeyboardShortcutsHelp renders as expected 1`] = `
+<Fragment>
+  <Button
+    block={false}
+    className="test--ClassName"
+    ghost={false}
+    htmlType="button"
+    loading={false}
+    onClick={[Function]}
+    prefixCls="ant-btn"
+  >
+    <span
+      className="KeyboardShortcutsHelp--cta"
+    >
+      ⌘
+    </span>
+  </Button>
+  <Modal
+    bodyStyle={
+      Object {
+        "padding": 0,
+      }
+    }
+    cancelButtonDisabled={false}
+    cancelButtonProps={
+      Object {
+        "style": Object {
+          "display": "none",
+        },
+      }
+    }
+    confirmLoading={false}
+    maskTransitionName="fade"
+    okButtonDisabled={false}
+    okType="primary"
+    onCancel={[Function]}
+    onOk={[Function]}
+    prefixCls="ant-modal"
+    title="Keyboard Shortcuts"
+    transitionName="zoom"
+    visible={false}
+    width={520}
+  >
+    <Table
+      bordered={false}
+      className="KeyboardShortcutsHelp--table u-simple-scrollbars"
+      dataSource={
+        Array [
+          Object {
+            "description": "Scroll down",
+            "kbds": <kbd>
+              S
+            </kbd>,
+            "key": "S",
+          },
+          Object {
+            "description": "Scroll up",
+            "kbds": <kbd>
+              W
+            </kbd>,
+            "key": "W",
+          },
+          Object {
+            "description": "Scroll to the next visible span",
+            "kbds": <kbd>
+              F
+            </kbd>,
+            "key": "F",
+          },
+          Object {
+            "description": "Scroll to the previous visible span",
+            "kbds": <kbd>
+              B
+            </kbd>,
+            "key": "B",
+          },
+          Object {
+            "description": "Pan left",
+            "kbds": <kbd>
+              A
+            </kbd>,
+            "key": "A",
+          },
+          Object {
+            "description": "Pan left",
+            "kbds": <kbd>
+              ←
+            </kbd>,
+            "key": "←",
+          },
+          Object {
+            "description": "Pan left — Large",
+            "kbds": <kbd>
+              ⇧ A
+            </kbd>,
+            "key": "⇧,A",
+          },
+          Object {
+            "description": "Pan left — Large",
+            "kbds": <kbd>
+              ⇧ ←
+            </kbd>,
+            "key": "⇧,←",
+          },
+          Object {
+            "description": "Pan right",
+            "kbds": <kbd>
+              D
+            </kbd>,
+            "key": "D",
+          },
+          Object {
+            "description": "Pan right",
+            "kbds": <kbd>
+              →
+            </kbd>,
+            "key": "→",
+          },
+          Object {
+            "description": "Pan right — Large",
+            "kbds": <kbd>
+              ⇧ D
+            </kbd>,
+            "key": "⇧,D",
+          },
+          Object {
+            "description": "Pan right — Large",
+            "kbds": <kbd>
+              ⇧ →
+            </kbd>,
+            "key": "⇧,→",
+          },
+          Object {
+            "description": "Zoom in",
+            "kbds": <kbd>
+              ↑
+            </kbd>,
+            "key": "↑",
+          },
+          Object {
+            "description": "Zoom in — Large",
+            "kbds": <kbd>
+              ⇧ ↑
+            </kbd>,
+            "key": "⇧,↑",
+          },
+          Object {
+            "description": "Zoom out",
+            "kbds": <kbd>
+              ↓
+            </kbd>,
+            "key": "↓",
+          },
+          Object {
+            "description": "Zoom out — Large",
+            "kbds": <kbd>
+              ⇧ ↓
+            </kbd>,
+            "key": "⇧,↓",
+          },
+          Object {
+            "description": "Collapse All",
+            "kbds": <kbd>
+              ]
+            </kbd>,
+            "key": "]",
+          },
+          Object {
+            "description": "Expand All",
+            "kbds": <kbd>
+              [
+            </kbd>,
+            "key": "[",
+          },
+          Object {
+            "description": "Collapse One Level",
+            "kbds": <kbd>
+              P
+            </kbd>,
+            "key": "P",
+          },
+          Object {
+            "description": "Expand One Level",
+            "kbds": <kbd>
+              O
+            </kbd>,
+            "key": "O",
+          },
+          Object {
+            "description": "Search Spans",
+            "kbds": <kbd>
+              CTRL B
+            </kbd>,
+            "key": "CTRL,B",
+          },
+          Object {
+            "description": "Clear Search",
+            "kbds": <kbd>
+              ESCAPE
+            </kbd>,
+            "key": "ESCAPE",
+          },
+        ]
+      }
+      indentSize={20}
+      loading={false}
+      locale={Object {}}
+      pagination={false}
+      prefixCls="ant-table"
+      rowClassName={[Function]}
+      rowKey="key"
+      showHeader={false}
+      size="middle"
+      useFixedHeader={false}
+    >
+      <Column
+        dataIndex="description"
+        key="description"
+        render={[Function]}
+        title="Description"
+      />
+      <Column
+        align="right"
+        dataIndex="kbds"
+        key="kbds"
+        render={[Function]}
+        title="Key(s)"
+      />
+    </Table>
+  </Modal>
+</Fragment>
+`;

--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -117,6 +117,7 @@ describe('<TracePage>', () => {
       expect(updateUiFindSpy).toHaveBeenCalledWith({
         history: defaultProps.history,
         location: defaultProps.location,
+        trackFindFunction: track.trackFilter,
       });
     });
 
@@ -135,23 +136,76 @@ describe('<TracePage>', () => {
     });
   });
 
-  describe('focusUiFindMatches', () => {
-    beforeEach(() => {
-      defaultProps.focusUiFindMatches.mockReset();
+  describe('viewing uiFind matches', () => {
+    describe('focusUiFindMatches', () => {
+      let trackFocusSpy;
+
+      beforeAll(() => {
+        trackFocusSpy = jest.spyOn(track, 'trackFocusMatches');
+      });
+
+      beforeEach(() => {
+        defaultProps.focusUiFindMatches.mockReset();
+        trackFocusSpy.mockReset();
+      });
+
+      it('calls props.focusUiFindMatches with props.trace.data and uiFind when props.trace.data is present', () => {
+        const uiFind = 'test ui find';
+        wrapper.setProps({ uiFind });
+        wrapper.find(TracePageHeader).prop('focusUiFindMatches')();
+        expect(defaultProps.focusUiFindMatches).toHaveBeenCalledWith(defaultProps.trace.data, uiFind);
+        expect(trackFocusSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('handles when props.trace.data is absent', () => {
+        const propFn = wrapper.find(TracePageHeader).prop('focusUiFindMatches');
+        wrapper.setProps({ trace: {} });
+        propFn();
+        expect(defaultProps.focusUiFindMatches).not.toHaveBeenCalled();
+        expect(trackFocusSpy).not.toHaveBeenCalled();
+      });
     });
 
-    it('calls props.focusUiFindMatches with props.trace.data and uiFind when props.trace.data is present', () => {
-      const uiFind = 'test ui find';
-      wrapper.setProps({ uiFind });
-      wrapper.find(TracePageHeader).prop('focusUiFindMatches')();
-      expect(defaultProps.focusUiFindMatches).toHaveBeenCalledWith(defaultProps.trace.data, uiFind);
+    describe('nextResult', () => {
+      let trackNextSpy;
+
+      beforeAll(() => {
+        trackNextSpy = jest.spyOn(track, 'trackNextMatch');
+      });
+
+      beforeEach(() => {
+        trackNextSpy.mockReset();
+      });
+
+      it('calls scrollToNextVisibleSpan and tracks it', () => {
+        const scrollNextSpy = jest
+          .spyOn(wrapper.instance()._scrollManager, 'scrollToNextVisibleSpan')
+          .mockImplementation();
+        wrapper.find(TracePageHeader).prop('nextResult')();
+        expect(trackNextSpy).toHaveBeenCalledTimes(1);
+        expect(scrollNextSpy).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it('handles when props.trace.data is absent', () => {
-      const propFn = wrapper.find(TracePageHeader).prop('focusUiFindMatches');
-      wrapper.setProps({ trace: {} });
-      propFn();
-      expect(defaultProps.focusUiFindMatches).not.toHaveBeenCalled();
+    describe('prevResult', () => {
+      let trackPrevSpy;
+
+      beforeAll(() => {
+        trackPrevSpy = jest.spyOn(track, 'trackPrevMatch');
+      });
+
+      beforeEach(() => {
+        trackPrevSpy.mockReset();
+      });
+
+      it('calls scrollToPrevVisibleSpan and tracks it', () => {
+        const scrollPrevSpy = jest
+          .spyOn(wrapper.instance()._scrollManager, 'scrollToPrevVisibleSpan')
+          .mockImplementation();
+        wrapper.find(TracePageHeader).prop('prevResult')();
+        expect(trackPrevSpy).toHaveBeenCalledTimes(1);
+        expect(scrollPrevSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/index.track.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.track.test.js
@@ -16,7 +16,19 @@
 
 jest.mock('../../utils/tracking');
 
-import { ACTION_RANGE_REFRAME, ACTION_RANGE_SHIFT, CATEGORY_RANGE, trackRange } from './index.track';
+import {
+  ACTION_FOCUS,
+  ACTION_NEXT,
+  ACTION_PREV,
+  ACTION_RANGE_REFRAME,
+  ACTION_RANGE_SHIFT,
+  CATEGORY_MATCH_INTERACTIONS,
+  CATEGORY_RANGE,
+  trackFocusMatches,
+  trackNextMatch,
+  trackPrevMatch,
+  trackRange,
+} from './index.track';
 import { trackEvent } from '../../utils/tracking';
 
 describe('trackRange', () => {
@@ -92,5 +104,18 @@ describe('trackRange', () => {
       expect(trackEvent.mock.calls.length).toBe(1);
       expect(trackEvent.mock.calls[0]).toEqual([CATEGORY_RANGE, rangeType, source]);
     });
+  });
+});
+
+describe('track match interactions', () => {
+  const cases = [
+    ['focusing matches', ACTION_FOCUS, trackFocusMatches],
+    ['viewing next match', ACTION_NEXT, trackNextMatch],
+    ['viewing previous match', ACTION_PREV, trackPrevMatch],
+  ];
+
+  it.each(cases)('tracks %s', (_msg, action, trackFn) => {
+    trackFn();
+    expect(trackEvent).toHaveBeenLastCalledWith(CATEGORY_MATCH_INTERACTIONS, action);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/index.track.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.track.tsx
@@ -16,14 +16,30 @@ import { trackEvent } from '../../utils/tracking';
 import getTrackFilter from '../../utils/tracking/getTrackFilter';
 
 // export for tests
-export const CATEGORY_RANGE = 'jaeger/ux/trace/range';
 export const CATEGORY_FILTER = 'jaeger/ux/trace/filter';
+export const CATEGORY_MATCH_INTERACTIONS = 'jaeger/ux/trace/match-interactions';
+export const CATEGORY_RANGE = 'jaeger/ux/trace/range';
 
 // export for tests
+export const ACTION_FOCUS = 'focus';
+export const ACTION_NEXT = 'next';
+export const ACTION_PREV = 'previous';
 export const ACTION_RANGE_REFRAME = 'reframe';
 export const ACTION_RANGE_SHIFT = 'shift';
 
 export const trackFilter = getTrackFilter(CATEGORY_FILTER);
+
+export function trackFocusMatches() {
+  trackEvent(CATEGORY_MATCH_INTERACTIONS, ACTION_FOCUS);
+}
+
+export function trackNextMatch() {
+  trackEvent(CATEGORY_MATCH_INTERACTIONS, ACTION_NEXT);
+}
+
+export function trackPrevMatch() {
+  trackEvent(CATEGORY_MATCH_INTERACTIONS, ACTION_PREV);
+}
 
 function getRangeAction(current: [number, number], next: [number, number]) {
   const [curStart, curEnd] = current;

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -25,7 +25,7 @@ import { bindActionCreators } from 'redux';
 
 import ArchiveNotifier from './ArchiveNotifier';
 import { actions as archiveActions } from './ArchiveNotifier/duck';
-import { trackRange } from './index.track';
+import { trackFilter, trackFocusMatches, trackNextMatch, trackPrevMatch, trackRange } from './index.track';
 import {
   CombokeysHandler,
   merge as mergeShortcuts,
@@ -240,12 +240,11 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
 
   clearSearch = () => {
     const { history, location } = this.props;
-    // flow does not allow omitting optional kwargs when using an object literal.
-    const arg = {
+    updateUiFind({
       history,
       location,
-    };
-    updateUiFind(arg);
+      trackFindFunction: trackFilter,
+    });
     if (this._searchBar.current) this._searchBar.current.blur();
   };
 
@@ -308,8 +307,19 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
   focusUiFindMatches = () => {
     const { trace, focusUiFindMatches, uiFind } = this.props;
     if (trace && trace.data) {
+      trackFocusMatches();
       focusUiFindMatches(trace.data, uiFind);
     }
+  };
+
+  nextResult = () => {
+    trackNextMatch();
+    this._scrollManager.scrollToNextVisibleSpan();
+  };
+
+  prevResult = () => {
+    trackPrevMatch();
+    this._scrollManager.scrollToPrevVisibleSpan();
   };
 
   render() {
@@ -348,11 +358,11 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
       hideMap: Boolean(traceGraphView || (embedded && embedded.timeline.hideMinimap)),
       hideSummary: Boolean(embedded && embedded.timeline.hideSummary),
       linkToStandalone: getUrl(id),
-      nextResult: this._scrollManager.scrollToNextVisibleSpan,
+      nextResult: this.nextResult,
       onArchiveClicked: this.archiveTrace,
       onSlimViewClicked: this.toggleSlimView,
       onTraceGraphViewClicked: this.toggleTraceGraphView,
-      prevResult: this._scrollManager.scrollToPrevVisibleSpan,
+      prevResult: this.prevResult,
       ref: this._searchBar,
       resultCount: findCount,
       showArchiveButton: !isEmbedded && archiveEnabled,

--- a/packages/jaeger-ui/src/utils/update-ui-find.test.js
+++ b/packages/jaeger-ui/src/utils/update-ui-find.test.js
@@ -43,11 +43,9 @@ describe('updateUiFind', () => {
     ...location,
     search: `?${queryStringStringifySpyMockReturnValue}`,
   };
-  const trackFindFunction = jest.fn();
 
   beforeEach(() => {
     replaceMock.mockReset();
-    trackFindFunction.mockClear();
     queryStringParseSpy.mockClear();
     queryStringStringifySpy.mockClear();
   });
@@ -91,7 +89,24 @@ describe('updateUiFind', () => {
     expect(replaceMock).toHaveBeenCalledWith(expectedReplaceMockArgument);
   });
 
+  it('no-ops when given existing value', () => {
+    updateUiFind({
+      history,
+      location,
+      uiFind: existingUiFind,
+    });
+    expect(queryStringParseSpy).toHaveBeenCalledWith(location.search);
+    expect(queryStringStringifySpy).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
   describe('trackFindFunction provided', () => {
+    const trackFindFunction = jest.fn();
+
+    beforeEach(() => {
+      trackFindFunction.mockClear();
+    });
+
     it('tracks undefined when uiFind value is omitted', () => {
       updateUiFind({
         history,
@@ -109,6 +124,26 @@ describe('updateUiFind', () => {
         uiFind: newUiFind,
       });
       expect(trackFindFunction).toHaveBeenCalledWith(newUiFind);
+    });
+
+    it('does not track unchanged value', () => {
+      updateUiFind({
+        history,
+        location,
+        trackFindFunction,
+        uiFind: existingUiFind,
+      });
+      expect(trackFindFunction).not.toHaveBeenCalled();
+
+      queryStringParseSpy.mockReturnValueOnce({
+        uiFind: undefined,
+      });
+      updateUiFind({
+        history,
+        location,
+        trackFindFunction,
+      });
+      expect(trackFindFunction).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/jaeger-ui/src/utils/update-ui-find.tsx
+++ b/packages/jaeger-ui/src/utils/update-ui-find.tsx
@@ -29,8 +29,8 @@ export default function updateUiFind({
   trackFindFunction?: (uiFind: string | TNil) => void;
   uiFind?: string | TNil;
 }) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { uiFind: omittedOldValue, ...queryParams } = queryString.parse(location.search);
+  const { uiFind: oldUiFind, ...queryParams } = queryString.parse(location.search);
+  if (oldUiFind === uiFind) return;
   if (trackFindFunction) {
     trackFindFunction(uiFind);
   }


### PR DESCRIPTION
## Which problem is this PR solving?
- Some user actions of interest were not being tracked, two user actions weren't being tracked correctly. 

## Short description of the changes
- Track keyboard shortcut modal open event on modal open, not on render.
- Track uiFind clear events caused by clicking clear button or hitting escape, not just when deleting all characters in input.
- - Do not track uiFind events when value is unchanged (e.g. spamming esc, or clicking blurring input without typing)
- Track trace timeline uiFind interactions (focus, next, prev)
- Track use of new Search Results Ddg
