### PR TITLE
Sort span tags in alphabetical order

### DIFF
--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -66,7 +66,6 @@ export default deepFreeze(
         gaID: null,
         trackErrors: true,
       },
-      topTagPrefixes: ['http.'],
     },
     // fields that should be individually merged vs wholesale replaced
     '__mergeFields',

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -66,6 +66,7 @@ export default deepFreeze(
         gaID: null,
         trackErrors: true,
       },
+      topTagPrefixes: ['http.'],
     },
     // fields that should be individually merged vs wholesale replaced
     '__mergeFields',

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { orderTags } from './transform-trace-data';
+import { orderTags, deduplicateTags } from './transform-trace-data';
 
 describe('orderTags()', () => {
   it('correctly orders tags', () => {
@@ -29,5 +29,23 @@ describe('orderTags()', () => {
       { key: 'a.ip', value: '8.8.8.8' },
       { key: 'b.ip', value: '8.8.4.4' },
     ]);
+  });
+});
+
+describe('deduplicateTags()', () => {
+  it('deduplicates tags', () => {
+    const tagsInfo = deduplicateTags([
+      { key: 'b.ip', value: '8.8.4.4' },
+      { key: 'b.ip', value: '8.8.8.8' },
+      { key: 'b.ip', value: '8.8.4.4' },
+      { key: 'a.ip', value: '8.8.8.8' },
+    ]);
+
+    expect(tagsInfo.tags).toEqual([
+      { key: 'b.ip', value: '8.8.4.4' },
+      { key: 'b.ip', value: '8.8.8.8' },
+      { key: 'a.ip', value: '8.8.8.8' },
+    ]);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag "b.ip:8.8.4.4"']);
   });
 });

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { orderTags } from './transform-trace-data';
+
+describe('orderTags()', () => {
+  it('correctly orders tags', () => {
+    const orderedTags = orderTags(
+      [
+        { key: 'b.ip', value: '8.8.4.4' },
+        { key: 'http.status_code', value: '200' },
+        { key: 'a.ip', value: '8.8.8.8' },
+      ],
+      ['http.']
+    );
+    expect(orderedTags).toEqual([
+      { key: 'http.status_code', value: '200' },
+      { key: 'a.ip', value: '8.8.8.8' },
+      { key: 'b.ip', value: '8.8.4.4' },
+    ]);
+  });
+});

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -19,14 +19,18 @@ describe('orderTags()', () => {
     const orderedTags = orderTags(
       [
         { key: 'b.ip', value: '8.8.4.4' },
-        { key: 'http.status_code', value: '200' },
+        { key: 'http.Status_code', value: '200' },
+        { key: 'z.ip', value: '8.8.8.16' },
         { key: 'a.ip', value: '8.8.8.8' },
+        { key: 'http.message', value: 'ok' },
       ],
-      ['http.']
+      ['z.', 'a.', 'HTTP.']
     );
     expect(orderedTags).toEqual([
-      { key: 'http.status_code', value: '200' },
+      { key: 'z.ip', value: '8.8.8.16' },
       { key: 'a.ip', value: '8.8.8.8' },
+      { key: 'http.message', value: 'ok' },
+      { key: 'http.Status_code', value: '200' },
       { key: 'b.ip', value: '8.8.4.4' },
     ]);
   });

--- a/packages/jaeger-ui/src/model/transform-trace-data.tsx
+++ b/packages/jaeger-ui/src/model/transform-trace-data.tsx
@@ -19,7 +19,7 @@ import { getConfigValue } from '../utils/config/get-config';
 import { KeyValuePair, Span, SpanData, Trace, TraceData } from '../types/trace';
 import TreeNode from '../utils/TreeNode';
 
-function deduplicateTags(spanTags: Array<KeyValuePair>) {
+export function deduplicateTags(spanTags: Array<KeyValuePair>) {
   const warningsHash: Map<string, string> = new Map<string, string>();
   const tags: Array<KeyValuePair> = spanTags.reduce<Array<KeyValuePair>>((uniqueTags, tag) => {
     if (!uniqueTags.some(t => t.key === tag.key && t.value === tag.value)) {

--- a/packages/jaeger-ui/src/model/transform-trace-data.tsx
+++ b/packages/jaeger-ui/src/model/transform-trace-data.tsx
@@ -109,6 +109,9 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
     span.tags = span.tags || [];
     span.references = span.references || [];
     const tagsInfo = deduplicateTags(span.tags);
+    tagsInfo.tags.sort((a, b) => {
+      return a.key.localeCompare(b.key);
+    });
     span.tags = tagsInfo.tags;
     span.warnings = span.warnings.concat(tagsInfo.warnings);
     span.references.forEach(ref => {

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -36,6 +36,7 @@ export type Config = {
   menu: (ConfigMenuGroup | ConfigMenuItem)[];
   search?: { maxLookback: { label: string; value: string } };
   scripts?: TScript[];
+  topTagPrefixes?: string[];
   tracking?: {
     gaID: string | TNil;
     trackErrors: boolean | TNil;


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #218 
Expanding a span on the UI shows collapsed list of tags which can be expanded again. When there are many tags it's hard to find the one a person is looking for

## Short description of the changes
- Trace span tags are getting sorted after deduplication in reducer
- New option `topTagPrefixes?: string[]` introduced in UI configuration file. Tags with keys matching this prefixes will be displayed at the top preserving order of prefixes. 