### PR TITLE
Show combined trace

### DIFF
--- a/packages/jaeger-ui/src/actions/jaeger-api.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.js
@@ -15,11 +15,48 @@
 import { createAction } from 'redux-actions';
 import JaegerAPI from '../api/jaeger';
 
-export const fetchTrace = createAction(
-  '@JAEGER_API/FETCH_TRACE',
-  id => JaegerAPI.fetchTrace(id),
-  id => ({ id })
-);
+export function mergeAll(id) {
+  return traces => {
+    if (traces.data.length < 2) {
+      return traces;
+    }
+    const ot = { traceID: id, spans: [], processes: {}, warnings: [] };
+
+    const processMap = {};
+
+    traces.data.forEach(trace => {
+      const tracePidMap = {};
+      Object.entries(trace.processes).forEach(([pid, process]) => {
+        const pJson = JSON.stringify(process);
+        let targetPid = processMap[pJson];
+        if (!targetPid) {
+          targetPid = `p${Object.keys(processMap).length + 1}`;
+          processMap[pJson] = targetPid;
+          ot.processes[targetPid] = process;
+        }
+        tracePidMap[pid] = targetPid;
+      });
+      trace.spans.forEach(span => {
+        const ns = span;
+        ns.processID = tracePidMap[ns.processID];
+        ot.spans.push(ns);
+      });
+      if (trace.warnings) {
+        trace.warnings.forEach(j => ot.warnings.push(j));
+      }
+    });
+
+    return { data: [ot] };
+  };
+}
+
+function reduceFetch(id) {
+  const ids = id.split('|');
+  const promise = ids.length < 2 ? JaegerAPI.fetchTrace(id) : JaegerAPI.searchTraces({ traceID: ids });
+  return promise && promise.then(mergeAll(id));
+}
+
+export const fetchTrace = createAction('@JAEGER_API/FETCH_TRACE', id => reduceFetch(id), id => ({ id }));
 
 export const fetchMultipleTraces = createAction(
   '@JAEGER_API/FETCH_MULTIPLE_TRACES',

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/DiffSelection.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/DiffSelection.css
@@ -32,3 +32,7 @@ limitations under the License.
   border: 1px solid #ccc;
   border-bottom: none;
 }
+
+.DiffSelection--message button {
+  margin-left: 7px;
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/DiffSelection.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/DiffSelection.tsx
@@ -18,7 +18,7 @@ import { Link } from 'react-router-dom';
 
 import ResultItemTitle from './ResultItemTitle';
 import { getUrl } from '../../TraceDiff/url';
-import { getUrl as getTracePageUrl } from '../../TracePage/url';
+import { getUrl as getTracePageUrl, getCombineUrl } from '../../TracePage/url';
 import { fetchedState } from '../../../constants';
 
 import { FetchedTrace } from '../../../types';
@@ -41,6 +41,12 @@ export default class DiffSelection extends React.PureComponent<Props> {
     const compareBtn = (
       <Button className="ub-right" disabled={cohort.length < 2} htmlType="button" type="primary">
         Compare Traces
+      </Button>
+    );
+    const combineHref = cohort.length > 1 ? getCombineUrl(cohort) : null;
+    const combineBtn = (
+      <Button className="ub-right" disabled={cohort.length < 2} htmlType="button" type="primary">
+        Show Combined
       </Button>
     );
     return (
@@ -70,6 +76,7 @@ export default class DiffSelection extends React.PureComponent<Props> {
           {traces.length > 0 ? (
             <React.Fragment>
               {compareHref ? <Link to={compareHref}>{compareBtn}</Link> : compareBtn}
+              {combineHref ? <Link to={combineHref}>{combineBtn}</Link> : combineBtn}
               <h2 className="ub-m0">{cohort.length} Selected for comparison</h2>
             </React.Fragment>
           ) : (

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/__snapshots__/DiffSelection.test.js.snap
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/__snapshots__/DiffSelection.test.js.snap
@@ -37,6 +37,18 @@ exports[`DiffSelection renders a trace as expected 1`] = `
     >
       Compare Traces
     </Button>
+    <Button
+      block={false}
+      className="ub-right"
+      disabled={true}
+      ghost={false}
+      htmlType="button"
+      loading={false}
+      prefixCls="ant-btn"
+      type="primary"
+    >
+      Show Combined
+    </Button>
     <h2
       className="ub-m0"
     >
@@ -111,6 +123,23 @@ exports[`DiffSelection renders multiple traces as expected 1`] = `
         type="primary"
       >
         Compare Traces
+      </Button>
+    </Link>
+    <Link
+      replace={false}
+      to="/trace/trace-id-0|trace-id-1"
+    >
+      <Button
+        block={false}
+        className="ub-right"
+        disabled={false}
+        ghost={false}
+        htmlType="button"
+        loading={false}
+        prefixCls="ant-btn"
+        type="primary"
+      >
+        Show Combined
       </Button>
     </Link>
     <h2

--- a/packages/jaeger-ui/src/components/TracePage/url.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/url.tsx
@@ -22,6 +22,10 @@ export function getUrl(id: string) {
   return prefixUrl(`/trace/${id}`);
 }
 
+export function getCombineUrl(id: string[]) {
+  return prefixUrl(`/trace/${id.join('|')}`);
+}
+
 export function getLocation(id: string, state: Record<string, any> | TNil) {
   return {
     state,


### PR DESCRIPTION
## Which problem is this PR solving?
- Adds the ability to combine and show many traces in a single trace view. This is useful in many cases, including when searching for a specific tag (e.g. for a session ID) and then showing all those traces in a single view. It also reveals concurrent interactions e.g. between transactions and disk flushes, in the case of a database.

![jaeger-feature-preview](https://user-images.githubusercontent.com/789359/69921670-2185f880-1462-11ea-8dc2-34eb9b14743c.gif)

Here's for example a case of 3 traces combined in a single screen:

<img width="991" alt="three-traces" src="https://user-images.githubusercontent.com/789359/69922014-2fd61380-1466-11ea-9f6d-ec2804b1a32e.png">

## Short description of the changes
- It informally extends the definition of trace id to a set of `|` separated ids in the form `traceid1|traceid2...`. For example the url `/trace/traceid1|traceid2` will use a trace with id `traceid1|traceid2`. Composite ids are handled as usual everywhere, but at the very low level (`jaeger-api`) where instead of fetching a single trace, we now delegate to `JaegerAPI.searchTraces({ traceID: ids }` and then merge the results to a single composite trace with `mergeAll()`. A button is added that allows a user to select many traces by reusing the diff selection mechanism.

Many things can be improved but this is a starting point for discussion.