### PR TITLE
Fixes Jeager UI broken when accessing via IPv6 address (#491)

### DIFF
--- a/packages/jaeger-ui/src/utils/prefix-url.test.js
+++ b/packages/jaeger-ui/src/utils/prefix-url.test.js
@@ -16,7 +16,7 @@
 
 jest.mock('../site-prefix', () => `${global.location.origin}/a/site/prefix/`);
 
-import prefixUrl from './prefix-url';
+import prefixUrl, { getPathPrefix } from './prefix-url';
 
 const PATH_PREFIX = '/a/site/prefix';
 
@@ -34,6 +34,28 @@ describe('prefixUrl()', () => {
   tests.forEach(({ source, target }) => {
     it(`prefixes "${source}" correctly`, () => {
       expect(prefixUrl(source)).toBe(target);
+    });
+  });
+});
+
+describe('getPathPrefix()', () => {
+  const tests = [
+    { address: '2a00:8a00:4000:751e::1c:8443' },
+    { address: '[2a00:8a00:4000:751e::1c]:8443' },
+    { address: '[2a00:8a00:4000:751e:0000:0000:0000:001c]:8443' },
+    { address: '[::]:443' },
+    { address: '127.0.0.1' },
+    { address: '127.0.0.1:8443' },
+    { address: 'jaeger.mydomain.com:8443' },
+    { address: 'jaeger.mydomain.com' },
+  ];
+
+  tests.forEach(({ address }) => {
+    it(`handles "${address}" correctly`, () => {
+      const origin = `https://${address}`;
+      const sitePrefix = `https://${address}/jaeger`;
+      const target = '/jaeger';
+      expect(getPathPrefix(origin, sitePrefix)).toBe(target);
     });
   });
 });

--- a/packages/jaeger-ui/src/utils/prefix-url.tsx
+++ b/packages/jaeger-ui/src/utils/prefix-url.tsx
@@ -15,6 +15,7 @@
 import sitePrefix from '../site-prefix';
 
 const origin = process.env.NODE_ENV === 'test' ? global.location.origin : window.location.origin;
+
 /**
  * Generate the URL prefix from `sitePrefix` and use it for all subsequent calls
  * to `prefixUrl()`. `sitePrefix` should be an absolute URL, e.g. with an origin.
@@ -24,8 +25,15 @@ const origin = process.env.NODE_ENV === 'test' ? global.location.origin : window
  * - `"http://localhost:3000/abc/"` to `"/abc"`
  * - `"http://localhost:3000/abc/def/"` to `"/abc/def"`
  */
-const rx = new RegExp(`^${origin}|/$`, 'ig');
-const pathPrefix = sitePrefix.replace(rx, '');
+// exported for tests
+export function getPathPrefix(orig?: string, sitePref?: string) {
+  const o = orig == null ? '' : orig.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const s = sitePref == null ? '' : sitePref;
+  const rx = new RegExp(`^${o}|/$`, 'ig');
+  return s.replace(rx, '');
+}
+
+const pathPrefix = getPathPrefix(origin, sitePrefix);
 
 /**
  * Add the path prefix to the  URL. See [site-prefix.js](../site-prefix.js) and


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Jeager UI broken when accessing via IPv6 address (#491)

## Short description of the changes
Corrected the logic to determine pathPrefix by escaping RegEx characters
