### PR TITLE
Add ddg menu item, fetch server ops, expand GA cov

### DIFF
--- a/packages/jaeger-ui/src/actions/jaeger-api.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.js
@@ -47,6 +47,12 @@ export const fetchServiceOperations = createAction(
   serviceName => ({ serviceName })
 );
 
+export const fetchServiceServerOps = createAction(
+  '@JAEGER_API/FETCH_SERVICE_SERVER_OP',
+  serviceName => JaegerAPI.fetchServiceServerOps(serviceName),
+  serviceName => ({ serviceName })
+);
+
 export const fetchDeepDependencyGraph = createAction(
   '@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH',
   query => JaegerAPI.fetchDeepDependencyGraph(query),

--- a/packages/jaeger-ui/src/actions/jaeger-api.test.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.test.js
@@ -119,8 +119,16 @@ describe('actions/jaeger-api', () => {
     expect(called.verify()).toBeTruthy();
   });
 
-  // Temporary mock used until backend is available, TODO revert & re-enable test
-  xit('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should fetch the graph by params', () => {
+  it('@JAEGER_API/FETCH_SERVICE_SERVER_OP should call the JaegerAPI', () => {
+    const called = mock
+      .expects('fetchServiceServerOps')
+      .once()
+      .withExactArgs('service');
+    jaegerApiActions.fetchServiceServerOps('service');
+    expect(called.verify()).toBeTruthy();
+  });
+
+  it('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should fetch the graph by params', () => {
     mock.expects('fetchDeepDependencyGraph').withExactArgs(query);
     jaegerApiActions.fetchDeepDependencyGraph(query);
     expect(() => mock.verify()).not.toThrow();

--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -89,6 +89,14 @@ const JaegerAPI = {
   fetchServiceOperations(serviceName) {
     return getJSON(`${this.apiRoot}services/${encodeURIComponent(serviceName)}/operations`);
   },
+  fetchServiceServerOps(service) {
+    return getJSON(`${this.apiRoot}operations`, {
+      query: {
+        service,
+        spanKind: 'server',
+      },
+    });
+  },
   fetchServices() {
     return getJSON(`${this.apiRoot}services`);
   },

--- a/packages/jaeger-ui/src/api/jaeger.test.js
+++ b/packages/jaeger-ui/src/api/jaeger.test.js
@@ -81,6 +81,18 @@ describe('fetchDependencies', () => {
   });
 });
 
+describe('fetchServiceServerOps', () => {
+  it('GETs the specified query', () => {
+    const service = 'serviceName';
+    const query = { service, spanKind: 'server' };
+    JaegerAPI.fetchServiceServerOps(service);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      `${DEFAULT_API_ROOT}operations?${queryString.stringify(query)}`,
+      defaultOptions
+    );
+  });
+});
+
 describe('fetchTrace', () => {
   const generatedTraces = traceGenerator.traces({ numberOfTraces: 5 });
 

--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -16,7 +16,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
 
-import { TopNavImpl as TopNav } from './TopNav';
+import { mapStateToProps, TopNavImpl as TopNav } from './TopNav';
 
 describe('<TopNav>', () => {
   const labelGitHub = 'GitHub';
@@ -124,5 +124,12 @@ describe('<TopNav>', () => {
         });
       });
     });
+  });
+});
+
+describe('mapStateToProps', () => {
+  it('returns entire state', () => {
+    const testState = {};
+    expect(mapStateToProps(testState)).toBe(testState);
   });
 });

--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -78,8 +78,8 @@ describe('<TopNav>', () => {
       expect(items.length).toBe(1);
     });
 
-    it('renders the "Dependencies" button', () => {
-      const items = wrapper.find(Link).findWhere(link => /Dependencies/.test(link.text()));
+    it('renders the "System Architecture" button', () => {
+      const items = wrapper.find(Link).findWhere(link => /System Architecture/.test(link.text()));
       expect(items.length).toBe(1);
     });
   });

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -19,7 +19,8 @@ import { connect } from 'react-redux';
 import { RouteComponentProps, Link, withRouter } from 'react-router-dom';
 
 import TraceIDSearchInput from './TraceIDSearchInput';
-import * as dependencies from '../DependencyGraph/url';
+import * as dependencyGraph from '../DependencyGraph/url';
+import * as deepDependencies from '../DeepDependencies/url';
 import * as searchUrl from '../SearchTracePage/url';
 import * as diffUrl from '../TraceDiff/url';
 import { ReduxState } from '../../types';
@@ -44,9 +45,17 @@ const NAV_LINKS = [
 
 if (getConfigValue('dependencies.menuEnabled')) {
   NAV_LINKS.push({
-    to: dependencies.getUrl(),
-    matches: dependencies.matches,
-    text: 'Dependencies',
+    to: dependencyGraph.getUrl(),
+    matches: dependencyGraph.matches,
+    text: 'System Architecture',
+  });
+}
+
+if (getConfigValue('deepDependencies.menuEnabled')) {
+  NAV_LINKS.push({
+    to: deepDependencies.getUrl(),
+    matches: deepDependencies.matches,
+    text: 'Service Dependencies',
   });
 }
 

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -126,7 +126,8 @@ export function TopNavImpl(props: Props) {
 
 TopNavImpl.CustomNavDropdown = CustomNavDropdown;
 
-function mapStateToProps(state: ReduxState) {
+// export for tests
+export function mapStateToProps(state: ReduxState) {
   return state;
 }
 

--- a/packages/jaeger-ui/src/components/App/index.css
+++ b/packages/jaeger-ui/src/components/App/index.css
@@ -27,28 +27,3 @@ a {
 a:hover {
   color: #00474e;
 }
-
-/* TODO: Delete to end of file */
-a[href='/deep-dependencies'] {
-  overflow: hidden;
-  padding-right: 40px;
-  position: relative;
-}
-
-.ant-menu-horizontal > li:last-child {
-  padding-right: 0px;
-}
-
-a[href='/deep-dependencies']:after {
-  content: 'New!';
-  background-color: red;
-  height: 60px;
-  overflow: hidden;
-  padding-left: 30px;
-  padding-top: 25px;
-  position: absolute;
-  right: -50px;
-  top: -25px;
-  transform: rotateZ(45deg);
-  width: 100px;
-}

--- a/packages/jaeger-ui/src/components/App/index.css
+++ b/packages/jaeger-ui/src/components/App/index.css
@@ -27,3 +27,28 @@ a {
 a:hover {
   color: #00474e;
 }
+
+/* TODO: Delete to end of file */
+a[href='/deep-dependencies'] {
+  overflow: hidden;
+  padding-right: 40px;
+  position: relative;
+}
+
+.ant-menu-horizontal > li:last-child {
+  padding-right: 0px;
+}
+
+a[href='/deep-dependencies']:after {
+  content: 'New!';
+  background-color: red;
+  height: 60px;
+  overflow: hidden;
+  padding-left: 30px;
+  padding-top: 25px;
+  position: absolute;
+  right: -50px;
+  top: -25px;
+  transform: rotateZ(45deg);
+  width: 100px;
+}

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.tsx
@@ -104,7 +104,6 @@ export default class LayoutSettings extends React.PureComponent<TProps> {
                   <h4>Show operations</h4>
                   <p>
                     Controls whether or not the operations are considered when creating nodes for the graph.
-                    Note: The operation of the focal node is always shown.
                   </p>
                 </div>
               </Checkbox>

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.tsx
@@ -43,7 +43,7 @@ export const densityOptions = [
     title: 'One node per resource',
     note: 'Most conscise',
     description:
-      "This setting represents each resource one time in the graph, regardless of whether or not it's upstream or downstream of the focal node. This results in the most desnse graph layout, possible.",
+      "This setting represents each resource one time in the graph, regardless of whether or not it's upstream or downstream of the focal node. This results in the most dense graph layout, possible.",
   },
   {
     option: EDdgDensity.UpstreamVsDownstream,

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -120,7 +120,6 @@ export default class Header extends React.PureComponent<TProps> {
       services,
       setDensity,
       setDistance,
-      setOperation,
       setService,
       showOperations,
       showParameters,

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
@@ -724,7 +724,7 @@ describe('DeepDependencyGraphPage', () => {
       },
     };
     const services = [service];
-    const operationsForService = {
+    const serverOpsForService = {
       [service]: ['some operation'],
     };
     const state = {
@@ -735,7 +735,7 @@ describe('DeepDependencyGraphPage', () => {
         },
       },
       services: {
-        operationsForService,
+        serverOpsForService,
         otherState: 'otherState',
         services,
       },
@@ -821,9 +821,9 @@ describe('DeepDependencyGraphPage', () => {
       expect(doneResult.graph).toBe(mockGraph);
     });
 
-    it('includes services and operationsForService', () => {
+    it('includes services and serverOpsForService', () => {
       expect(mapStateToProps(state, ownProps)).toEqual(
-        expect.objectContaining({ operationsForService, services })
+        expect.objectContaining({ operationsForService: serverOpsForService, services })
       );
     });
 

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.js
@@ -37,7 +37,7 @@ describe('DeepDependencyGraphPage', () => {
       addViewModifier: jest.fn(),
       fetchDeepDependencyGraph: () => {},
       fetchServices: jest.fn(),
-      fetchServiceOperations: jest.fn(),
+      fetchServiceServerOps: jest.fn(),
       graphState: {
         model: {
           distanceToPathElems: new Map(),
@@ -48,7 +48,7 @@ describe('DeepDependencyGraphPage', () => {
       history: {
         push: jest.fn(),
       },
-      operationsForService: {},
+      serverOpsForService: {},
       removeViewModifierFromIndices: jest.fn(),
       urlState: {
         start: 'testStart',
@@ -81,7 +81,7 @@ describe('DeepDependencyGraphPage', () => {
     describe('constructor', () => {
       beforeEach(() => {
         props.fetchServices.mockReset();
-        props.fetchServiceOperations.mockReset();
+        props.fetchServiceServerOps.mockReset();
       });
 
       it('fetches services if services are not provided', () => {
@@ -94,12 +94,12 @@ describe('DeepDependencyGraphPage', () => {
       it('fetches operations if service is provided without operations', () => {
         const { service, ...urlState } = props.urlState;
         new DeepDependencyGraphPageImpl({ ...props, urlState }); // eslint-disable-line no-new
-        expect(props.fetchServiceOperations).not.toHaveBeenCalled();
-        new DeepDependencyGraphPageImpl({ ...props, operationsForService: { [service]: [] } }); // eslint-disable-line no-new
-        expect(props.fetchServiceOperations).not.toHaveBeenCalled();
+        expect(props.fetchServiceServerOps).not.toHaveBeenCalled();
+        new DeepDependencyGraphPageImpl({ ...props, serverOpsForService: { [service]: [] } }); // eslint-disable-line no-new
+        expect(props.fetchServiceServerOps).not.toHaveBeenCalled();
         new DeepDependencyGraphPageImpl(props); // eslint-disable-line no-new
-        expect(props.fetchServiceOperations).toHaveBeenLastCalledWith(service);
-        expect(props.fetchServiceOperations).toHaveBeenCalledTimes(1);
+        expect(props.fetchServiceServerOps).toHaveBeenLastCalledWith(service);
+        expect(props.fetchServiceServerOps).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -343,7 +343,7 @@ describe('DeepDependencyGraphPage', () => {
         });
 
         beforeEach(() => {
-          props.fetchServiceOperations.mockReset();
+          props.fetchServiceServerOps.mockReset();
           trackSetServiceSpy.mockClear();
         });
 
@@ -359,17 +359,17 @@ describe('DeepDependencyGraphPage', () => {
 
         it('fetches operations for service when not yet provided', () => {
           ddgPageImpl.setService(service);
-          expect(props.fetchServiceOperations).toHaveBeenLastCalledWith(service);
-          expect(props.fetchServiceOperations).toHaveBeenCalledTimes(1);
+          expect(props.fetchServiceServerOps).toHaveBeenLastCalledWith(service);
+          expect(props.fetchServiceServerOps).toHaveBeenCalledTimes(1);
           expect(trackSetServiceSpy).toHaveBeenCalledTimes(1);
 
           const pageWithOpForService = new DeepDependencyGraphPageImpl({
             ...props,
-            operationsForService: { [service]: [props.urlState.operation] },
+            serverOpsForService: { [service]: [props.urlState.operation] },
           });
-          const { length: callCount } = props.fetchServiceOperations.mock.calls;
+          const { length: callCount } = props.fetchServiceServerOps.mock.calls;
           pageWithOpForService.setService(service);
-          expect(props.fetchServiceOperations).toHaveBeenCalledTimes(callCount);
+          expect(props.fetchServiceServerOps).toHaveBeenCalledTimes(callCount);
           expect(trackSetServiceSpy).toHaveBeenCalledTimes(2);
         });
       });
@@ -680,15 +680,15 @@ describe('DeepDependencyGraphPage', () => {
 
       it('passes correct operations to Header', () => {
         const wrapper = shallow(
-          <DeepDependencyGraphPageImpl {...props} graph={graph} operationsForService={undefined} />
+          <DeepDependencyGraphPageImpl {...props} graph={graph} serverOpsForService={undefined} />
         );
         expect(wrapper.find(Header).prop('operations')).toBe(undefined);
 
-        const operationsForService = {
+        const serverOpsForService = {
           [props.urlState.service]: ['testOperation0', 'testOperation1'],
         };
-        wrapper.setProps({ operationsForService });
-        expect(wrapper.find(Header).prop('operations')).toBe(operationsForService[props.urlState.service]);
+        wrapper.setProps({ serverOpsForService });
+        expect(wrapper.find(Header).prop('operations')).toBe(serverOpsForService[props.urlState.service]);
 
         const { service: _, ...urlStateWithoutService } = props.urlState;
         wrapper.setProps({ urlState: urlStateWithoutService });
@@ -703,7 +703,7 @@ describe('DeepDependencyGraphPage', () => {
         addViewModifier: expect.any(Function),
         fetchDeepDependencyGraph: expect.any(Function),
         fetchServices: expect.any(Function),
-        fetchServiceOperations: expect.any(Function),
+        fetchServiceServerOps: expect.any(Function),
         removeViewModifierFromIndices: expect.any(Function),
       });
     });
@@ -823,7 +823,7 @@ describe('DeepDependencyGraphPage', () => {
 
     it('includes services and serverOpsForService', () => {
       expect(mapStateToProps(state, ownProps)).toEqual(
-        expect.objectContaining({ operationsForService: serverOpsForService, services })
+        expect.objectContaining({ serverOpsForService, services })
       );
     });
 

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -329,7 +329,7 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps> {
 // export for tests
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
   const { services: stServices } = state;
-  const { services, operationsForService } = stServices;
+  const { services, serverOpsForService: operationsForService } = stServices;
   const urlState = getUrlState(ownProps.location.search);
   const { density, operation, service, showOp: urlStateShowOp } = urlState;
   const showOp = urlStateShowOp !== undefined ? urlStateShowOp : operation !== undefined;
@@ -354,10 +354,11 @@ export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxP
 
 // export for tests
 export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
-  const { fetchDeepDependencyGraph, fetchServiceOperations, fetchServices } = bindActionCreators(
-    jaegerApiActions,
-    dispatch
-  );
+  const {
+    fetchDeepDependencyGraph,
+    fetchServiceServerOps: fetchServiceOperations,
+    fetchServices,
+  } = bindActionCreators(jaegerApiActions, dispatch);
   const { addViewModifier, removeViewModifierFromIndices } = bindActionCreators(ddgActions, dispatch);
 
   return {

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
@@ -30,12 +30,13 @@ export function matches(path: string) {
 
 export function getUrl(args?: { [key: string]: unknown; showOp?: boolean }, baseUrl: string = ROUTE_PATH) {
   if (args && !_isEmpty(args)) {
-    const stringifyArgs = Reflect.has(args, 'showOp')
-      ? {
-          ...args,
-          showOp: args.showOp ? 1 : 0,
-        }
-      : args;
+    const stringifyArgs =
+      Reflect.has(args, 'showOp') && args.showOp !== undefined
+        ? {
+            ...args,
+            showOp: args.showOp ? 1 : 0,
+          }
+        : args;
     return `${baseUrl}?${queryString.stringify(stringifyArgs)}`;
   }
   return baseUrl;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.test.js
@@ -17,28 +17,78 @@ import { shallow } from 'enzyme';
 import { Button } from 'antd';
 
 import AltViewOptions from './AltViewOptions';
+import * as url from '../../DeepDependencies/url';
+import * as getConfig from '../../../utils/config/get-config';
 
 describe('AltViewOptions', () => {
+  let getConfigValueSpy;
+  let getUrlSpy;
+  let getUrlStateSpy;
+  let openSpy;
+
+  let wrapper;
+  const getBtn = (btnIndex = 0) => wrapper.find(Button).at(btnIndex);
+  const getLabel = (btnIndex = 0) => getBtn(btnIndex).prop('children');
   const props = {
     traceResultsView: true,
     onTraceGraphViewClicked: jest.fn(),
   };
-  let wrapper;
+
+  beforeAll(() => {
+    getUrlSpy = jest.spyOn(url, 'getUrl');
+    getUrlStateSpy = jest.spyOn(url, 'getUrlState');
+    getConfigValueSpy = jest.spyOn(getConfig, 'getConfigValue');
+    openSpy = jest.spyOn(window, 'open').mockImplementation();
+  });
 
   beforeEach(() => {
-    props.onTraceGraphViewClicked.mockClear();
+    jest.clearAllMocks();
     wrapper = shallow(<AltViewOptions {...props} />);
   });
 
+  afterAll(() => {
+    openSpy.mockRestore();
+  });
+
   it('renders correct label', () => {
-    const getLabel = () =>
-      wrapper
-        .find(Button)
-        .first()
-        .prop('children');
     expect(getLabel()).toBe('Deep Dependency Graph');
 
     wrapper.setProps({ traceResultsView: false });
     expect(getLabel()).toBe('Trace Results');
+  });
+
+  it('renders button to view full ddg iff ddg is enabled and search results are viewed as ddg', () => {
+    expect(getLabel()).toBe('Deep Dependency Graph');
+    expect(wrapper.find(Button).length).toBe(1);
+
+    getConfigValueSpy.mockReturnValue(true);
+    wrapper.setProps({ traceResultsView: false });
+    expect(wrapper.find(Button).length).toBe(2);
+    expect(getLabel()).toBe('Trace Results');
+    expect(getLabel(1)).toBe('View All Dependencies');
+
+    wrapper.setProps({ traceResultsView: true });
+    expect(getLabel()).toBe('Deep Dependency Graph');
+    expect(wrapper.find(Button).length).toBe(1);
+  });
+
+  it('opens correct ddg url with correct target when view full ddg button is clicked', () => {
+    const mockUrl = 'test url';
+    const mockUrlState = { service: 'serviceName', showOp: true };
+    getConfigValueSpy.mockReturnValue(true);
+    getUrlSpy.mockReturnValue(mockUrl);
+    getUrlStateSpy.mockReturnValue(mockUrlState);
+
+    wrapper.setProps({ traceResultsView: false });
+    const viewDdgBtn = getBtn(1);
+    viewDdgBtn.simulate('click', {});
+    expect(getUrlSpy).toHaveBeenLastCalledWith(mockUrlState);
+    expect(openSpy).toHaveBeenLastCalledWith(mockUrl, '_self');
+
+    viewDdgBtn.simulate('click', { ctrlKey: true });
+    expect(openSpy).toHaveBeenLastCalledWith(mockUrl, '_blank');
+
+    viewDdgBtn.simulate('click', { metaKey: true });
+    expect(openSpy).toHaveBeenLastCalledWith(mockUrl, '_blank');
   });
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.test.js
@@ -31,7 +31,11 @@ describe('AltViewOptions', () => {
   });
 
   it('renders correct label', () => {
-    const getLabel = () => wrapper.find(Button).prop('children');
+    const getLabel = () =>
+      wrapper
+        .find(Button)
+        .first()
+        .prop('children');
     expect(getLabel()).toBe('Deep Dependency Graph');
 
     wrapper.setProps({ traceResultsView: false });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.tsx
@@ -15,16 +15,35 @@
 import * as React from 'react';
 import { Button } from 'antd';
 
+import { trackConversions, EAltViewActions } from './index.track';
+import { getUrl, getUrlState } from '../../DeepDependencies/url';
+import { getConfigValue } from '../../../utils/config/get-config';
+
 type Props = {
   onTraceGraphViewClicked: () => void;
   traceResultsView: boolean;
 };
 
+function viewAllDep({ ctrlKey, metaKey }: React.MouseEvent<HTMLButtonElement>) {
+  trackConversions(EAltViewActions.Ddg);
+  const { density, operation, service, showOp } = getUrlState(window.location.search);
+  window.open(getUrl({ density, operation, service, showOp }), ctrlKey || metaKey ? '_blank' : '_self');
+}
+
 export default function AltViewOptions(props: Props) {
   const { onTraceGraphViewClicked, traceResultsView } = props;
-  return (
+  const toggleBtn = (
     <Button className="ub-ml2" htmlType="button" onClick={onTraceGraphViewClicked}>
       {traceResultsView ? 'Deep Dependency Graph' : 'Trace Results'}
     </Button>
+  );
+  if (traceResultsView || !getConfigValue('deepDependencies.menuEnabled')) return toggleBtn;
+  return (
+    <>
+      {toggleBtn}
+      <Button className="ub-ml2" htmlType="button" onClick={viewAllDep}>
+        View All Dependencies
+      </Button>
+    </>
   );
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -58,7 +58,7 @@ export default class ResultItem extends React.PureComponent<Props> {
     const numSpans = spans.length;
     const numErredSpans = spans.filter(sp => sp.tags.some(isErrorTag)).length;
     return (
-      <div className="ResultItem" onClick={trackTraceConversions}>
+      <div className="ResultItem" onClick={trackTraceConversions} role="button">
         <ResultItemTitle
           duration={duration}
           durationPercent={durationPercent}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom';
 import { sortBy } from 'lodash';
 import moment from 'moment';
 
+import { trackConversions, EAltViewActions } from './index.track';
 import * as markers from './ResultItem.markers';
 import ResultItemTitle from './ResultItemTitle';
 import colorGenerator from '../../../utils/color-generator';
@@ -38,6 +39,7 @@ type Props = {
 };
 
 const isErrorTag = ({ key, value }: KeyValuePair) => key === 'error' && (value === true || value === 'true');
+const trackTraceConversions = () => trackConversions(EAltViewActions.Traces);
 
 export default class ResultItem extends React.PureComponent<Props> {
   render() {
@@ -56,7 +58,7 @@ export default class ResultItem extends React.PureComponent<Props> {
     const numSpans = spans.length;
     const numErredSpans = spans.filter(sp => sp.tags.some(isErrorTag)).length;
     return (
-      <div className="ResultItem">
+      <div className="ResultItem" onClick={trackTraceConversions}>
         <ResultItemTitle
           duration={duration}
           durationPercent={durationPercent}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
@@ -41,6 +41,8 @@ type Props = {
 
 const DEFAULT_DURATION_PERCENT = 0;
 
+const stopCheckboxPropagation = (evt: React.MouseEvent) => evt.stopPropagation();
+
 export default class ResultItemTitle extends React.PureComponent<Props> {
   static defaultProps: Partial<Props> = {
     disableComparision: false,
@@ -80,16 +82,18 @@ export default class ResultItemTitle extends React.PureComponent<Props> {
       }
     }
     const isErred = state === fetchedState.ERROR;
+    // Separate propagation management and toggle manegement due to ant-design#16400
+    const checkboxProps = {
+      className: 'ResultItemTitle--item ub-flex-none',
+      checked: !isErred && isInDiffCohort,
+      disabled: isErred,
+      onChange: this.toggleComparison,
+      onClick: stopCheckboxPropagation,
+    };
+
     return (
       <div className="ResultItemTitle">
-        {!disableComparision && (
-          <Checkbox
-            className="ResultItemTitle--item ub-flex-none"
-            checked={!isErred && isInDiffCohort}
-            disabled={isErred}
-            onChange={this.toggleComparison}
-          />
-        )}
+        {!disableComparision && <Checkbox {...checkboxProps} />}
         {/* TODO: Shouldn't need cast */}
         <WrapperComponent {...(wrapperProps as { [key: string]: any; to: string })}>
           <span

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/__snapshots__/ResultItemTitle.test.js.snap
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/__snapshots__/ResultItemTitle.test.js.snap
@@ -10,6 +10,7 @@ exports[`ResultItemTitle renders as expected 1`] = `
     disabled={false}
     indeterminate={false}
     onChange={[Function]}
+    onClick={[Function]}
     prefixCls="ant-checkbox"
   />
   <Link

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.track.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.track.tsx
@@ -16,6 +16,7 @@ import { trackEvent } from '../../../utils/tracking';
 
 // export for tests
 export const CATEGORY_ALT_VIEW = 'jaeger/ux/search-results/alt-view';
+export const CATEGORY_CONVERSIONS = 'jaeger/ux/search-results/conversions';
 
 export enum EAltViewActions {
   Ddg = 'ddg',
@@ -24,4 +25,8 @@ export enum EAltViewActions {
 
 export function trackAltView(view: EAltViewActions) {
   trackEvent(CATEGORY_ALT_VIEW, view);
+}
+
+export function trackConversions(view: EAltViewActions) {
+  trackEvent(CATEGORY_CONVERSIONS, view);
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.test.js
@@ -60,10 +60,34 @@ describe('middlewareHooks', () => {
       extraTrackArgs: [columnWidth.tracked],
     },
     {
+      action: track.ACTION_COLLAPSE_ALL,
+      category: track.CATEGORY_EXPAND_COLLAPSE,
+      msg: 'tracks a GA event for collapsing all',
+      type: types.COLLAPSE_ALL,
+    },
+    {
+      action: track.ACTION_COLLAPSE_ONE,
+      category: track.CATEGORY_EXPAND_COLLAPSE,
+      msg: 'tracks a GA event for collapsing a level',
+      type: types.COLLAPSE_ONE,
+    },
+    {
       msg: 'tracks a GA event for collapsing a parent',
       type: types.CHILDREN_TOGGLE,
       category: track.CATEGORY_PARENT,
       extraTrackArgs: [123],
+    },
+    {
+      action: track.ACTION_EXPAND_ALL,
+      category: track.CATEGORY_EXPAND_COLLAPSE,
+      msg: 'tracks a GA event for expanding all',
+      type: types.COLLAPSE_ALL,
+    },
+    {
+      action: track.ACTION_EXPAND_ONE,
+      category: track.CATEGORY_EXPAND_COLLAPSE,
+      msg: 'tracks a GA event for expanding a level',
+      type: types.COLLAPSE_ONE,
     },
     {
       msg: 'tracks a GA event for toggling a detail row',
@@ -93,15 +117,16 @@ describe('middlewareHooks', () => {
     },
   ];
 
-  cases.forEach(_case => {
-    const { msg, type, category, extraTrackArgs = [], payloadCustom = null } = _case;
-    it(msg, () => {
-      const action = { type, payload: payloadCustom || payload };
-      track.middlewareHooks[type](store, action);
-      expect(trackEvent.mock.calls.length).toBe(1);
-      expect(trackEvent.mock.calls[0]).toEqual([category, expect.any(String), ...extraTrackArgs]);
-    });
-  });
+  cases.forEach(
+    ({ action = expect.any(String), msg, type, category, extraTrackArgs = [], payloadCustom = null }) => {
+      it(msg, () => {
+        const reduxAction = { type, payload: payloadCustom || payload };
+        track.middlewareHooks[type](store, reduxAction);
+        expect(trackEvent.mock.calls.length).toBe(1);
+        expect(trackEvent.mock.calls[0]).toEqual([category, action, ...extraTrackArgs]);
+      });
+    }
+  );
 
   it('has the correct keys and they refer to functions', () => {
     expect(Object.keys(track.middlewareHooks).sort()).toEqual(

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.test.js
@@ -107,11 +107,15 @@ describe('middlewareHooks', () => {
     expect(Object.keys(track.middlewareHooks).sort()).toEqual(
       [
         types.CHILDREN_TOGGLE,
+        types.COLLAPSE_ALL,
+        types.COLLAPSE_ONE,
         types.DETAIL_TOGGLE,
         types.DETAIL_TAGS_TOGGLE,
         types.DETAIL_PROCESS_TOGGLE,
         types.DETAIL_LOGS_TOGGLE,
         types.DETAIL_LOG_ITEM_TOGGLE,
+        types.EXPAND_ALL,
+        types.EXPAND_ONE,
         types.SET_SPAN_NAME_COLUMN_WIDTH,
       ].sort()
     );

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -20,10 +20,6 @@ export default deepFreeze(
   Object.defineProperty(
     {
       archiveEnabled: false,
-      // TODO: remove default
-      deepDependencies: {
-        menuEnabled: true,
-      },
       dependencies: {
         dagMaxNumServices: FALLBACK_DAG_MAX_NUM_SERVICES,
         menuEnabled: true,

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -20,6 +20,10 @@ export default deepFreeze(
   Object.defineProperty(
     {
       archiveEnabled: false,
+      // TODO: remove default
+      deepDependencies: {
+        menuEnabled: true,
+      },
       dependencies: {
         dagMaxNumServices: FALLBACK_DAG_MAX_NUM_SERVICES,
         menuEnabled: true,

--- a/packages/jaeger-ui/src/reducers/services.js
+++ b/packages/jaeger-ui/src/reducers/services.js
@@ -45,15 +45,14 @@ function fetchServicesErred(state, { payload: error }) {
 }
 
 function fetchServerOpsStarted(state, { meta: { serviceName } }) {
-  const serverOpForService = {
+  const serverOpsForService = {
     ...state.operationsForService,
     [serviceName]: [],
   };
-  return { ...state, serverOpForService };
+  return { ...state, serverOpsForService };
 }
 
-function fetchServerOpsDone(state, { meta: { serviceName }, payload }) {
-  const { data: serverOpStructs } = payload;
+function fetchServerOpsDone(state, { meta: { serviceName }, payload: { data: serverOpStructs } }) {
   if (!Array.isArray(serverOpStructs)) return state;
 
   const serverOpsForService = {

--- a/packages/jaeger-ui/src/reducers/services.js
+++ b/packages/jaeger-ui/src/reducers/services.js
@@ -16,8 +16,8 @@ import { handleActions } from 'redux-actions';
 
 import {
   fetchServices,
-  fetchServiceServerOps as fetchServerOps,
   fetchServiceOperations as fetchOps,
+  fetchServiceServerOps as fetchServerOps,
 } from '../actions/jaeger-api';
 import { localeStringComparator } from '../utils/sort';
 

--- a/packages/jaeger-ui/src/reducers/services.test.js
+++ b/packages/jaeger-ui/src/reducers/services.test.js
@@ -19,10 +19,11 @@ const initialState = serviceReducer(undefined, {});
 
 function verifyInitialState() {
   expect(initialState).toEqual({
-    services: null,
-    loading: false,
     error: null,
+    loading: false,
     operationsForService: {},
+    serverOpsForService: {},
+    services: null,
   });
 }
 
@@ -35,19 +36,21 @@ it('#92 - ensures services is at least an empty array', () => {
     type: `${fetchServices}_FULFILLED`,
     payload: { data: services },
   });
-  expect(state).toEqual({
+  const expected = {
+    ...initialState,
     services: [],
-    operationsForService: {},
-    loading: false,
-    error: null,
-  });
+  };
+  expect(state).toEqual(expected);
 });
 
 it('should handle a fetch services with loading state', () => {
   const state = serviceReducer(initialState, {
     type: `${fetchServices}_PENDING`,
   });
-  const expected = { ...initialState, loading: true };
+  const expected = {
+    ...initialState,
+    loading: true,
+  };
   expect(state).toEqual(expected);
 });
 
@@ -57,12 +60,11 @@ it('should handle successful services fetch', () => {
     type: `${fetchServices}_FULFILLED`,
     payload: { data: services.slice() },
   });
-  expect(state).toEqual({
+  const expected = {
+    ...initialState,
     services,
-    operationsForService: {},
-    loading: false,
-    error: null,
-  });
+  };
+  expect(state).toEqual(expected);
 });
 
 it('should handle a failed services fetch', () => {
@@ -71,12 +73,12 @@ it('should handle a failed services fetch', () => {
     type: `${fetchServices}_REJECTED`,
     payload: error,
   });
-  expect(state).toEqual({
+  const expected = {
+    ...initialState,
     error,
     services: [],
-    operationsForService: {},
-    loading: false,
-  });
+  };
+  expect(state).toEqual(expected);
 });
 
 it('should handle a successful fetching operations for a service ', () => {

--- a/packages/jaeger-ui/src/reducers/services.test.js
+++ b/packages/jaeger-ui/src/reducers/services.test.js
@@ -12,87 +12,174 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { fetchServices, fetchServiceOperations } from '../actions/jaeger-api';
+import { fetchServices, fetchServiceOperations, fetchServiceServerOps } from '../actions/jaeger-api';
 import serviceReducer from './services';
 
 const initialState = serviceReducer(undefined, {});
 
-function verifyInitialState() {
-  expect(initialState).toEqual({
-    error: null,
-    loading: false,
-    operationsForService: {},
-    serverOpsForService: {},
-    services: null,
-  });
-}
+describe('reducers/services', () => {
+  function verifyInitialState() {
+    expect(initialState).toEqual({
+      error: null,
+      loading: false,
+      operationsForService: {},
+      serverOpsForService: {},
+      services: null,
+    });
+  }
 
-beforeEach(verifyInitialState);
-afterEach(verifyInitialState);
+  beforeEach(verifyInitialState);
+  afterEach(verifyInitialState);
 
-it('#92 - ensures services is at least an empty array', () => {
-  const services = null;
-  const state = serviceReducer(initialState, {
-    type: `${fetchServices}_FULFILLED`,
-    payload: { data: services },
-  });
-  const expected = {
-    ...initialState,
-    services: [],
-  };
-  expect(state).toEqual(expected);
-});
-
-it('should handle a fetch services with loading state', () => {
-  const state = serviceReducer(initialState, {
-    type: `${fetchServices}_PENDING`,
-  });
-  const expected = {
-    ...initialState,
-    loading: true,
-  };
-  expect(state).toEqual(expected);
-});
-
-it('should handle successful services fetch', () => {
-  const services = ['a', 'b', 'c'];
-  const state = serviceReducer(initialState, {
-    type: `${fetchServices}_FULFILLED`,
-    payload: { data: services.slice() },
-  });
-  const expected = {
-    ...initialState,
-    services,
-  };
-  expect(state).toEqual(expected);
-});
-
-it('should handle a failed services fetch', () => {
-  const error = new Error('some-message');
-  const state = serviceReducer(initialState, {
-    type: `${fetchServices}_REJECTED`,
-    payload: error,
-  });
-  const expected = {
-    ...initialState,
-    error,
-    services: [],
-  };
-  expect(state).toEqual(expected);
-});
-
-it('should handle a successful fetching operations for a service ', () => {
   const ops = ['a', 'b'];
-  const state = serviceReducer(initialState, {
-    type: `${fetchServiceOperations}_FULFILLED`,
-    meta: { serviceName: 'serviceA' },
-    payload: { data: ops.slice() },
+  const serviceName = 'test service';
+
+  it('#92 - ensures services is at least an empty array', () => {
+    const services = null;
+    const state = serviceReducer(initialState, {
+      type: `${fetchServices}_FULFILLED`,
+      payload: { data: services },
+    });
+    const expected = {
+      ...initialState,
+      services: [],
+    };
+    expect(state).toEqual(expected);
   });
-  const expected = {
-    ...initialState,
-    operationsForService: {
-      serviceA: ops,
-    },
-  };
-  expect(state).toEqual(expected);
+
+  it('should handle a fetch services with loading state', () => {
+    const state = serviceReducer(initialState, {
+      type: `${fetchServices}_PENDING`,
+    });
+    const expected = {
+      ...initialState,
+      loading: true,
+    };
+    expect(state).toEqual(expected);
+  });
+
+  it('should handle successful services fetch', () => {
+    const services = ['a', 'b', 'c'];
+    const state = serviceReducer(initialState, {
+      type: `${fetchServices}_FULFILLED`,
+      payload: { data: services.slice() },
+    });
+    const expected = {
+      ...initialState,
+      services,
+    };
+    expect(state).toEqual(expected);
+  });
+
+  it('should handle a failed services fetch', () => {
+    const error = new Error('some-message');
+    const state = serviceReducer(initialState, {
+      type: `${fetchServices}_REJECTED`,
+      payload: error,
+    });
+    const expected = {
+      ...initialState,
+      error,
+      services: [],
+    };
+    expect(state).toEqual(expected);
+  });
+
+  it('should handle a successful operations for a service fetch', () => {
+    const state = serviceReducer(initialState, {
+      type: `${fetchServiceOperations}_FULFILLED`,
+      meta: { serviceName },
+      payload: { data: ops.slice() },
+    });
+    const expected = {
+      ...initialState,
+      operationsForService: {
+        [serviceName]: ops,
+      },
+    };
+    expect(state).toEqual(expected);
+  });
+
+  it('should handle if successful operations for a service fetch returns non-array', () => {
+    const state = serviceReducer(initialState, {
+      type: `${fetchServiceOperations}_FULFILLED`,
+      meta: { serviceName },
+      payload: { data: null },
+    });
+    const expected = {
+      ...initialState,
+      operationsForService: {
+        [serviceName]: [],
+      },
+    };
+    expect(state).toEqual(expected);
+  });
+
+  it('should handle a pending operations for a service fetch', () => {
+    const state = serviceReducer(
+      {
+        ...initialState,
+        operationsForService: {
+          [serviceName]: ops,
+        },
+      },
+      {
+        type: `${fetchServiceOperations}_PENDING`,
+        meta: { serviceName },
+      }
+    );
+    const expected = {
+      ...initialState,
+      operationsForService: {
+        [serviceName]: [],
+      },
+    };
+    expect(state).toEqual(expected);
+  });
+
+  it('should handle a successful server operations for a service fetch', () => {
+    const state = serviceReducer(initialState, {
+      type: `${fetchServiceServerOps}_FULFILLED`,
+      meta: { serviceName },
+      payload: { data: ops.map(name => ({ name })) },
+    });
+    const expected = {
+      ...initialState,
+      serverOpsForService: {
+        [serviceName]: ops,
+      },
+    };
+    expect(state).toEqual(expected);
+  });
+
+  it('should no-op if successful server operations for a service fetch returns non-array', () => {
+    const state = serviceReducer(initialState, {
+      type: `${fetchServiceServerOps}_FULFILLED`,
+      meta: { serviceName },
+      payload: { data: 'invalid data' },
+    });
+    expect(state).toBe(initialState);
+  });
+
+  it('should handle a pending server operations for a service fetch', () => {
+    const state = serviceReducer(
+      {
+        ...initialState,
+        serverOpsForService: {
+          [serviceName]: ops,
+        },
+      },
+      {
+        type: `${fetchServiceServerOps}_PENDING`,
+        meta: { serviceName },
+      }
+    );
+    const expected = {
+      ...initialState,
+      serverOpsForService: {
+        [serviceName]: [],
+      },
+    };
+    expect(state).toEqual(expected);
+  });
 });

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -32,6 +32,7 @@ export type TScript = {
 
 export type Config = {
   archiveEnabled?: boolean;
+  deepDependencies?: { menuEnabled?: boolean };
   dependencies?: { dagMaxServicesLen?: number; menuEnabled?: boolean };
   menu: (ConfigMenuGroup | ConfigMenuItem)[];
   search?: { maxLookback: { label: string; value: string } };

--- a/packages/jaeger-ui/src/types/index.tsx
+++ b/packages/jaeger-ui/src/types/index.tsx
@@ -52,6 +52,7 @@ export type ReduxState = {
   };
   services: {
     services: (string[]) | TNil;
+    serverOpsForService: Record<string, string[]>;
     operationsForService: Record<string, string[]>;
     loading: boolean;
     error: ApiError | TNil;


### PR DESCRIPTION
## Short description of the changes
- Read `deepDependencies.menuEnabled` from `config.json` and add Menu link if it is
- Add link to `/deep-dependencies` to search results DDG if `deepDependencies.menuEnabled` is `true`
- Only fetch server ops for DDG operations dropdown
- Add GA tracking for show/expand one/all and for search results to DDG / gantt chart conversions
