### PR TITLE
Fix search results DDG path ordering

### DIFF
--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
@@ -18,18 +18,12 @@ import spanAncestorIds from '../../utils/span-ancestor-ids';
 
 import { TDdgPayloadEntry, TDdgPayloadPath, TDdgPayload } from './types';
 import { FetchedTrace } from '../../types';
-import { Span, Trace } from '../../types/trace';
-
-function convertSpan(span: Span, trace: Trace): TDdgPayloadEntry {
-  const serviceName = trace.processes[span.processID].serviceName;
-  const operationName = span.operationName;
-  return { service: serviceName, operation: operationName };
-}
+import { Span } from '../../types/trace';
 
 function transformTracesToPaths(
   traces: Record<string, FetchedTrace>,
   focalService: string,
-  focalOperation: string | undefined
+  focalOperation?: string
 ): TDdgPayload {
   const dependencies: TDdgPayloadPath[] = [];
   Object.values(traces).forEach(({ data }) => {
@@ -52,7 +46,10 @@ function transformTracesToPaths(
 
           const path: TDdgPayloadEntry[] = spans
             .filter(span => span.tags.find(({ key, value }) => key === 'span.kind' && value === 'server'))
-            .map(span => convertSpan(span, data));
+            .map(({ processID, operationName: operation }) => ({
+              service: data.processes[processID].serviceName,
+              operation,
+            }));
 
           if (
             path.some(

--- a/packages/jaeger-ui/src/utils/span-ancestor-ids.tsx
+++ b/packages/jaeger-ui/src/utils/span-ancestor-ids.tsx
@@ -29,12 +29,12 @@ function getFirstAncestor(span: Span): Span | TNil {
 }
 
 export default function spanAncestorIds(span: Span | TNil): string[] {
-  if (!span) return [];
-  const ancestorIDs: Set<string> = new Set();
+  const ancestorIDs: string[] = [];
+  if (!span) return ancestorIDs;
   let ref = getFirstAncestor(span);
   while (ref) {
-    ancestorIDs.add(ref.spanID);
+    ancestorIDs.push(ref.spanID);
     ref = getFirstAncestor(ref);
   }
-  return Array.from(ancestorIDs);
+  return ancestorIDs;
 }


### PR DESCRIPTION
Signed-off-by: Everett Ross <reverett@uber.com>

## Which problem is this PR solving?
- Closes #485

## Short description of the changes
- Paths were reversed, except last element of path was still last (i.e.: 12345 was rendered as 43215)
- Paths were not filtered by kind, resulting in client span noise
