### PR TITLE
Add ga dimension for config cookie

### DIFF
--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -49,7 +49,7 @@ export type Config = {
     cookieToDimension?: {
       cookie: string;
       dimension: string;
-    };
+    }[];
     gaID: string | TNil;
     trackErrors: boolean | TNil;
   };

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -46,6 +46,10 @@ export type Config = {
   scripts?: TScript[];
   topTagPrefixes?: string[];
   tracking?: {
+    cookieToDimension?: {
+      cookie: string;
+      dimension: string;
+    };
     gaID: string | TNil;
     trackErrors: boolean | TNil;
   };

--- a/packages/jaeger-ui/src/utils/tracking/index.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/index.test.js
@@ -29,7 +29,7 @@ import ReactGA from 'react-ga';
 import * as tracking from './index';
 
 let longStr = '---';
-function getStr(len: number) {
+function getStr(len) {
   while (longStr.length < len) {
     longStr += longStr.slice(0, len - longStr.length);
   }

--- a/packages/jaeger-ui/src/utils/tracking/index.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/index.tsx
@@ -45,15 +45,6 @@ const gaID = _get(config, 'tracking.gaID');
 export const isGaEnabled = isTest || isDebugMode || (isProd && Boolean(gaID));
 const isErrorsEnabled = isDebugMode || (isGaEnabled && Boolean(_get(config, 'tracking.trackErrors')));
 
-const cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');
-if (cookiesToDimensions) {
-  cookiesToDimensions.forEach(({ cookie, dimension }: { cookie: string; dimension: string }) => {
-    const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookie}=([^\\s;]*)`));
-    if (match) ReactGA.set({ [dimension]: match[1] });
-    else console.warn(`${cookie} not present in cookies, could not set dimension: ${dimension}`);
-  });
-}
-
 /* istanbul ignore next */
 function logTrackingCalls() {
   const calls = ReactGA.testModeAPI.calls;
@@ -162,6 +153,15 @@ if (isGaEnabled) {
     appName: 'Jaeger UI',
     appVersion: versionLong,
   });
+  const cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');
+  if (cookiesToDimensions) {
+    cookiesToDimensions.forEach(({ cookie, dimension }: { cookie: string; dimension: string }) => {
+      const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookie}=([^\\s;]*)`));
+      if (match) ReactGA.set({ [dimension]: match[1] });
+      // eslint-disable-next-line no-console
+      else console.warn(`${cookie} not present in cookies, could not set dimension: ${dimension}`);
+    });
+  }
   if (isErrorsEnabled) {
     const ravenConfig: RavenOptions = {
       autoBreadcrumbs: {

--- a/packages/jaeger-ui/src/utils/tracking/index.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/index.tsx
@@ -45,11 +45,13 @@ const gaID = _get(config, 'tracking.gaID');
 export const isGaEnabled = isTest || isDebugMode || (isProd && Boolean(gaID));
 const isErrorsEnabled = isDebugMode || (isGaEnabled && Boolean(_get(config, 'tracking.trackErrors')));
 
-const cookieToDimension = _get(config, 'tracking.cookieToDimension');
-if (cookieToDimension) {
-  const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookieToDimension.cookie}=([^\\s;]*)`));
-  if (match) ReactGA.set({ [cookieToDimension.dimension]: match[1] });
-  else console.warn(`${cookieToDimension} not present in cookies`);
+const cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');
+if (cookiesToDimensions) {
+  cookiesToDimensions.forEach(({ cookie, dimension }: { cookie: string; dimension: string }) => {
+    const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookie}=([^\\s;]*)`));
+    if (match) ReactGA.set({ [dimension]: match[1] });
+    else console.warn(`${cookie} not present in cookies, could not set dimension: ${dimension}`);
+  });
 }
 
 /* istanbul ignore next */

--- a/packages/jaeger-ui/src/utils/tracking/index.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/index.tsx
@@ -45,6 +45,13 @@ const gaID = _get(config, 'tracking.gaID');
 export const isGaEnabled = isTest || isDebugMode || (isProd && Boolean(gaID));
 const isErrorsEnabled = isDebugMode || (isGaEnabled && Boolean(_get(config, 'tracking.trackErrors')));
 
+const cookieToDimension = _get(config, 'tracking.cookieToDimension');
+if (cookieToDimension) {
+  const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookieToDimension.cookie}=([^\\s;]*)`));
+  if (match) ReactGA.set({ [cookieToDimension.dimension]: match[1] });
+  else console.warn(`${cookieToDimension} not present in cookies`);
+}
+
 /* istanbul ignore next */
 function logTrackingCalls() {
   const calls = ReactGA.testModeAPI.calls;


### PR DESCRIPTION
## Which problem is this PR solving?
- Ability to specify custom dimensions.

## Short description of the changes
- Read cookie and dimension names from config, if cookie is present, set dimension to cookie value.
