### PR TITLE
Move redux up from VirtualizedTraceView

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
@@ -18,10 +18,9 @@ import ListView from './ListView';
 import SpanBarRow from './SpanBarRow';
 import DetailState from './SpanDetail/DetailState';
 import SpanDetailRow from './SpanDetailRow';
-import { DEFAULT_HEIGHTS, VirtualizedTraceViewImpl } from './VirtualizedTraceView';
+import VirtualizedTraceView, { DEFAULT_HEIGHTS } from './VirtualizedTraceView';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
-import updateUiFindSpy from '../../../utils/update-ui-find';
 
 jest.mock('./SpanTreeOffset');
 jest.mock('../../../utils/update-ui-find');
@@ -29,7 +28,6 @@ jest.mock('../../../utils/update-ui-find');
 describe('<VirtualizedTraceViewImpl>', () => {
   let wrapper;
   let instance;
-  const focusUiFindMatchesMock = jest.fn();
 
   const trace = transformTraceData(traceGenerator.trace({ numberOfSpans: 10 }));
   const props = {
@@ -47,18 +45,11 @@ describe('<VirtualizedTraceViewImpl>', () => {
     registerAccessors: jest.fn(),
     scrollToFirstVisibleSpan: jest.fn(),
     setSpanNameColumnWidth: jest.fn(),
-    focusUiFindMatches: focusUiFindMatchesMock,
     setTrace: jest.fn(),
     shouldScrollToFirstUiFindMatch: false,
     spanNameColumnWidth: 0.5,
     trace,
     uiFind: 'uiFind',
-    history: {
-      replace: () => {},
-    },
-    location: {
-      search: null,
-    },
   };
 
   function expandRow(rowIndex) {
@@ -97,7 +88,7 @@ describe('<VirtualizedTraceViewImpl>', () => {
         props[key].mockReset();
       }
     });
-    wrapper = shallow(<VirtualizedTraceViewImpl {...props} />);
+    wrapper = shallow(<VirtualizedTraceView {...props} />);
     instance = wrapper.instance();
   });
 
@@ -398,19 +389,6 @@ describe('<VirtualizedTraceViewImpl>', () => {
       it('returns false if all props are unchanged', () => {
         expect(wrapper.instance().shouldComponentUpdate(props)).toBe(false);
       });
-    });
-  });
-
-  describe('focusSpan', () => {
-    it('calls updateUiFind and focusUiFindMatches', () => {
-      const spanName = 'span1';
-      instance.focusSpan(spanName);
-      expect(updateUiFindSpy).toHaveBeenLastCalledWith({
-        history: props.history,
-        location: props.location,
-        uiFind: spanName,
-      });
-      expect(focusUiFindMatchesMock).toHaveBeenLastCalledWith(trace, spanName, false);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -14,13 +14,7 @@
 
 import * as React from 'react';
 import cx from 'classnames';
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
-import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-// import { History as RouterHistory, Location } from 'history';
-
-import { actions } from './duck';
 import ListView from './ListView';
 import SpanBarRow from './SpanBarRow';
 import DetailState from './SpanDetail/DetailState';
@@ -33,15 +27,14 @@ import {
   ViewedBoundsFunctionType,
 } from './utils';
 import { Accessors } from '../ScrollManager';
-import { extractUiFindFromState, TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
+import { TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
 import getLinks from '../../../model/link-patterns';
 import colorGenerator from '../../../utils/color-generator';
-import { TNil, ReduxState } from '../../../types';
+import { TNil } from '../../../types';
 import { Log, Span, Trace, KeyValuePair } from '../../../types/trace';
 import TTraceTimeline from '../../../types/TTraceTimeline';
 
 import './VirtualizedTraceView.css';
-import updateUiFind from '../../../utils/update-ui-find';
 
 type RowState = {
   isDetail: boolean;
@@ -55,9 +48,9 @@ type TVirtualizedTraceViewOwnProps = {
   scrollToFirstVisibleSpan: () => void;
   registerAccessors: (accesors: Accessors) => void;
   trace: Trace;
-};
+  focusSpan: (uiFind: string) => void;
 
-type TDispatchProps = {
+  // was from redux
   childrenToggle: (spanID: string) => void;
   clearShouldScrollToFirstUiFindMatch: () => void;
   detailLogItemToggle: (spanID: string, log: Log) => void;
@@ -69,14 +62,11 @@ type TDispatchProps = {
   detailToggle: (spanID: string) => void;
   setSpanNameColumnWidth: (width: number) => void;
   setTrace: (trace: Trace | TNil, uiFind: string | TNil) => void;
-  focusUiFindMatches: (trace: Trace, uiFind: string | TNil, allowHide?: boolean) => void;
 };
 
 type VirtualizedTraceViewProps = TVirtualizedTraceViewOwnProps &
-  TDispatchProps &
   TExtractUiFindFromStateReturn &
-  TTraceTimeline &
-  RouteComponentProps;
+  TTraceTimeline;
 
 // export for tests
 export const DEFAULT_HEIGHTS = {
@@ -139,7 +129,7 @@ function getCssClasses(currentViewRange: [number, number]) {
 }
 
 // export from tests
-export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceViewProps> {
+export default class VirtualizedTraceView extends React.Component<VirtualizedTraceViewProps> {
   clippingCssClasses: string;
   listView: ListView | TNil;
   rowStates: RowState[];
@@ -222,18 +212,6 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       clearShouldScrollToFirstUiFindMatch();
     }
   }
-
-  focusSpan = (uiFind: string) => {
-    const { trace, focusUiFindMatches, location, history } = this.props;
-    if (trace) {
-      updateUiFind({
-        location,
-        history,
-        uiFind,
-      });
-      focusUiFindMatches(trace, uiFind, false);
-    }
-  };
 
   getAccessors() {
     const lv = this.listView;
@@ -332,6 +310,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       findMatchesIDs,
       spanNameColumnWidth,
       trace,
+      focusSpan,
     } = this.props;
     // to avert flow error
     if (!trace) {
@@ -375,7 +354,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           getViewedBounds={this.getViewedBounds}
           traceStartTime={trace.startTime}
           span={span}
-          focusSpan={this.focusSpan}
+          focusSpan={focusSpan}
         />
       </div>
     );
@@ -395,6 +374,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       detailToggle,
       spanNameColumnWidth,
       trace,
+      focusSpan,
     } = this.props;
     const detailState = detailStates.get(spanID);
     if (!trace || !detailState) {
@@ -417,7 +397,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           span={span}
           tagsToggle={detailTagsToggle}
           traceStartTime={trace.startTime}
-          focusSpan={this.focusSpan}
+          focusSpan={focusSpan}
         />
       </div>
     );
@@ -442,28 +422,3 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     );
   }
 }
-
-/* istanbul ignore next */
-function mapStateToProps(state: ReduxState): TTraceTimeline & TExtractUiFindFromStateReturn {
-  return {
-    ...extractUiFindFromState(state),
-    ...state.traceTimeline,
-  };
-}
-
-/* istanbul ignore next */
-function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
-  return (bindActionCreators(actions, dispatch) as any) as TDispatchProps;
-}
-
-export default withRouter(
-  connect<
-    TTraceTimeline & TExtractUiFindFromStateReturn,
-    TDispatchProps,
-    TVirtualizedTraceViewOwnProps,
-    ReduxState
-  >(
-    mapStateToProps,
-    mapDispatchToProps
-  )(VirtualizedTraceViewImpl)
-);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.js
@@ -15,7 +15,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import TraceTimelineViewer, { TraceTimelineViewerImpl } from './index';
+import TraceTimelineViewer from './index';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
 import TimelineHeaderRow from './TimelineHeaderRow';
@@ -30,11 +30,19 @@ describe('<TraceTimelineViewer>', () => {
         current: [0, 1],
       },
     },
-    spanNameColumnWidth: 0.5,
+    traceTimeline: {
+      spanNameColumnWidth: 0.5,
+    },
     expandAll: jest.fn(),
     collapseAll: jest.fn(),
     expandOne: jest.fn(),
     collapseOne: jest.fn(),
+    history: {
+      replace: () => {},
+    },
+    location: {
+      search: null,
+    },
   };
   const options = {
     context: {
@@ -49,16 +57,13 @@ describe('<TraceTimelineViewer>', () => {
   };
 
   let wrapper;
-  let connectedWrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<TraceTimelineViewerImpl {...props} />, options);
-    connectedWrapper = shallow(<TraceTimelineViewer {...props} />, options);
+    wrapper = shallow(<TraceTimelineViewer {...props} />, options);
   });
 
   it('it does not explode', () => {
     expect(wrapper).toBeDefined();
-    expect(connectedWrapper).toBeDefined();
   });
 
   it('it sets up actions', () => {

--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -80,13 +80,14 @@ describe('makeShortcutCallbacks()', () => {
 });
 
 describe('<TracePage>', () => {
-  TraceTimelineViewer.prototype.shouldComponentUpdate.mockReturnValue(false);
+  TraceTimelineViewer.mockReturnValue('');
 
   const trace = transformTraceData(traceGenerator.trace({}));
+  const focusUiFindMatchesMock = jest.fn();
   const defaultProps = {
     acknowledgeArchive: () => {},
     fetchTrace() {},
-    focusUiFindMatches: jest.fn(),
+    focusUiFindMatches: focusUiFindMatchesMock,
     id: trace.traceID,
     history: {
       replace: () => {},
@@ -699,15 +700,43 @@ describe('<TracePage>', () => {
       expect(track.trackRange.mock.calls).toEqual([[src, range, [0, 1]]]);
     });
   });
+
+  describe('focusSpan', () => {
+    it('calls updateUiFind and focusUiFindMatches', () => {
+      const spanName = 'span1';
+      wrapper.instance().focusSpan(spanName);
+      expect(updateUiFindSpy).toHaveBeenLastCalledWith({
+        history: defaultProps.history,
+        location: defaultProps.location,
+        uiFind: spanName,
+      });
+      expect(focusUiFindMatchesMock).toHaveBeenLastCalledWith(trace, spanName, false);
+    });
+  });
 });
 
 describe('mapDispatchToProps()', () => {
   it('creates the actions correctly', () => {
-    expect(mapDispatchToProps(() => {})).toEqual({
+    expect(mapDispatchToProps(() => {})).toMatchObject({
       acknowledgeArchive: expect.any(Function),
       archiveTrace: expect.any(Function),
       fetchTrace: expect.any(Function),
       focusUiFindMatches: expect.any(Function),
+      setSpanNameColumnWidth: expect.any(Function),
+      collapseAll: expect.any(Function),
+      collapseOne: expect.any(Function),
+      expandAll: expect.any(Function),
+      expandOne: expect.any(Function),
+      childrenToggle: expect.any(Function),
+      clearShouldScrollToFirstUiFindMatch: expect.any(Function),
+      detailLogItemToggle: expect.any(Function),
+      detailLogsToggle: expect.any(Function),
+      detailWarningsToggle: expect.any(Function),
+      detailReferencesToggle: expect.any(Function),
+      detailProcessToggle: expect.any(Function),
+      detailTagsToggle: expect.any(Function),
+      detailToggle: expect.any(Function),
+      setTrace: expect.any(Function),
     });
   });
 });


### PR DESCRIPTION
Signed-off-by: Andrej Ocenas <mr.ocenas@gmail.com>

## Which problem is this PR solving?
- Part of: https://github.com/jaegertracing/jaeger-ui/issues/508

## Short description of the changes
- Pushing redux and url creation (focusSpan) dependencies up from VirtualizedTraceView and TraceTimelineViewer to TracePage so it will be easier to move them to separate package.
