### PR TITLE
Push external link creation up to TracePage

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -26,6 +26,7 @@ import { TNil, ReduxState } from '../../../types';
 import { Span, Trace } from '../../../types/trace';
 
 import './index.css';
+import ExternalLinkContext from '../url/externalLinkContext';
 
 type TDispatchProps = {
   setSpanNameColumnWidth: (width: number) => void;
@@ -44,6 +45,7 @@ type TProps = TDispatchProps & {
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRange: IViewRange;
+  createLinkToExternalSpan: (traceID: string, spanID: string) => string;
 };
 
 const NUM_TICKS = 5;
@@ -86,27 +88,30 @@ export class TraceTimelineViewerImpl extends React.PureComponent<TProps> {
       updateNextViewRangeTime,
       updateViewRangeTime,
       viewRange,
+      createLinkToExternalSpan,
       ...rest
     } = this.props;
     const { spanNameColumnWidth, trace } = rest;
 
     return (
-      <div className="TraceTimelineViewer">
-        <TimelineHeaderRow
-          duration={trace.duration}
-          nameColumnWidth={spanNameColumnWidth}
-          numTicks={NUM_TICKS}
-          onCollapseAll={this.collapseAll}
-          onCollapseOne={this.collapseOne}
-          onColummWidthChange={setSpanNameColumnWidth}
-          onExpandAll={this.expandAll}
-          onExpandOne={this.expandOne}
-          viewRangeTime={viewRange.time}
-          updateNextViewRangeTime={updateNextViewRangeTime}
-          updateViewRangeTime={updateViewRangeTime}
-        />
-        <VirtualizedTraceView {...rest} currentViewRangeTime={viewRange.time.current} />
-      </div>
+      <ExternalLinkContext.Provider value={createLinkToExternalSpan}>
+        <div className="TraceTimelineViewer">
+          <TimelineHeaderRow
+            duration={trace.duration}
+            nameColumnWidth={spanNameColumnWidth}
+            numTicks={NUM_TICKS}
+            onCollapseAll={this.collapseAll}
+            onCollapseOne={this.collapseOne}
+            onColummWidthChange={setSpanNameColumnWidth}
+            onExpandAll={this.expandAll}
+            onExpandOne={this.expandOne}
+            viewRangeTime={viewRange.time}
+            updateNextViewRangeTime={updateNextViewRangeTime}
+            updateViewRangeTime={updateViewRangeTime}
+          />
+          <VirtualizedTraceView {...rest} currentViewRangeTime={viewRange.time.current} />
+        </div>
+      </ExternalLinkContext.Provider>
     );
   }
 }

--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -473,6 +473,17 @@ describe('<TracePage>', () => {
     });
   });
 
+  describe('TraceTimelineView props', () => {
+    it('gets correct createLinkToExternalSpan prop', () => {
+      wrapper.instance().setHeaderHeight({ clientHeight: 100 });
+      wrapper.update();
+      const timeline = wrapper.find(TraceTimelineViewer);
+      expect(timeline.props().createLinkToExternalSpan('trace1', 'span1')).toBe(
+        '/trace/trace1/uiFind?=span1'
+      );
+    });
+  });
+
   describe('_adjustViewRange()', () => {
     let instance;
     let time;

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -118,6 +118,8 @@ export function makeShortcutCallbacks(adjRange: (start: number, end: number) => 
   return _mapValues(shortcutConfig, getHandler);
 }
 
+const createLinkToExternalSpan = (traceID: string, spanID: string) => `${getUrl(traceID)}/uiFind?=${spanID}`;
+
 // export for tests
 export class TracePageImpl extends React.PureComponent<TProps, TState> {
   state: TState;
@@ -403,6 +405,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
                 updateNextViewRangeTime={this.updateNextViewRangeTime}
                 updateViewRangeTime={this.updateViewRangeTime}
                 viewRange={viewRange}
+                createLinkToExternalSpan={createLinkToExternalSpan}
               />
             </section>
           ))}

--- a/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.test.js
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import ReferenceLink from './ReferenceLink';
+import ExternalLinkContext from './externalLinkContext';
 
 describe(ReferenceLink, () => {
   const focusMock = jest.fn();
@@ -44,9 +45,19 @@ describe(ReferenceLink, () => {
     });
 
     it('render for external trace', () => {
-      const component = shallow(<ReferenceLink reference={externalRef} focusSpan={focusMock} />);
-      const link = component.find('a[href="/trace/trace2/uiFind?=span2"]');
+      const component = mount(
+        <ExternalLinkContext.Provider value={(trace, span) => `${trace}/${span}`}>
+          <ReferenceLink reference={externalRef} focusSpan={focusMock} />
+        </ExternalLinkContext.Provider>
+      );
+      const link = component.find('a[href="trace2/span2"]');
       expect(link.length).toBe(1);
+    });
+
+    it('throws if ExternalLinkContext is not set', () => {
+      expect(() => mount(<ReferenceLink reference={externalRef} focusSpan={focusMock} />)).toThrow(
+        'ExternalLinkContext'
+      );
     });
   });
   describe('focus span', () => {

--- a/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { SpanReference } from '../../../types/trace';
-import { getUrl } from '.';
+import ExternalLinkContext from './externalLinkContext';
 
 type ReferenceLinkProps = {
   reference: SpanReference;
@@ -23,8 +23,6 @@ type ReferenceLinkProps = {
   focusSpan: (spanID: string) => void;
   onClick?: () => void;
 };
-
-const linkToExternalSpan = (traceID: string, spanID: string) => `${getUrl(traceID)}/uiFind?=${spanID}`;
 
 export default function ReferenceLink(props: ReferenceLinkProps) {
   const { reference, children, className, focusSpan, ...otherProps } = props;
@@ -36,15 +34,27 @@ export default function ReferenceLink(props: ReferenceLinkProps) {
       </a>
     );
   }
+
   return (
-    <a
-      href={linkToExternalSpan(reference.traceID, reference.spanID)}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={className}
-      {...otherProps}
-    >
-      {children}
-    </a>
+    <ExternalLinkContext.Consumer>
+      {createLinkToExternalSpan => {
+        if (!createLinkToExternalSpan) {
+          throw new Error(
+            "ExternalLinkContext does not have a value, you probably forgot to setup it's provider"
+          );
+        }
+        return (
+          <a
+            href={createLinkToExternalSpan(reference.traceID, reference.spanID)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={className}
+            {...otherProps}
+          >
+            {children}
+          </a>
+        );
+      }}
+    </ExternalLinkContext.Consumer>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/url/externalLinkContext.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/url/externalLinkContext.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+
+/**
+ * There are several places where external links to spans are created. The url layout though is something
+ * that should be decided on the application level and not on the component level but at the same time
+ * propagating the factory function everywhere could be cumbersome so we use this context for that.
+ */
+const ExternalLinkContext = React.createContext<((traceID: string, spanID: string) => string) | undefined>(
+  undefined
+);
+ExternalLinkContext.displayName = 'ExternalLinkContext';
+export default ExternalLinkContext;


### PR DESCRIPTION
Signed-off-by: Andrej Ocenas <mr.ocenas@gmail.com>

## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/508

## Short description of the changes
- Extracts `linkToExternalSpan` and make it into external dependency. It also passes it on in a context so it does not have to be passed on through all the layers which seemed beneficial here but can be changed to standard props passing.
