### PR TITLE
Allow UI elements to be injected and remove Antd dependency

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
-import { Popover } from 'antd';
+import UIElementsContext, { UIPopover } from '../uiElementsContext';
 
 import SpanBar from './SpanBar';
 
@@ -67,7 +67,11 @@ describe('<SpanBar>', () => {
   };
 
   it('renders without exploding', () => {
-    const wrapper = mount(<SpanBar {...props} />);
+    const wrapper = mount(
+      <UIElementsContext.Provider value={{ Popover: () => '' }}>
+        <SpanBar {...props} />
+      </UIElementsContext.Provider>
+    );
     expect(wrapper).toBeDefined();
     const { onMouseOver, onMouseOut } = wrapper.find('.SpanBar--wrapper').props();
     const labelElm = wrapper.find('.SpanBar--label');
@@ -80,7 +84,11 @@ describe('<SpanBar>', () => {
 
   it('log markers count', () => {
     // 3 log entries, two grouped together with the same timestamp
-    const wrapper = mount(<SpanBar {...props} />);
-    expect(wrapper.find(Popover).length).toEqual(2);
+    const wrapper = mount(
+      <UIElementsContext.Provider value={{ Popover: () => '' }}>
+        <SpanBar {...props} />
+      </UIElementsContext.Provider>
+    );
+    expect(wrapper.find(UIPopover).length).toEqual(2);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import React from 'react';
-import { Popover } from 'antd';
 import _groupBy from 'lodash/groupBy';
 import { onlyUpdateForKeys, compose, withState, withProps } from 'recompose';
 
@@ -22,6 +21,7 @@ import AccordianLogs from './SpanDetail/AccordianLogs';
 import { ViewedBoundsFunctionType } from './utils';
 import { TNil } from '../../../types';
 import { Span } from '../../../types/trace';
+import { UIPopover } from '../uiElementsContext';
 
 import './SpanBar.css';
 
@@ -102,7 +102,7 @@ function SpanBar(props: TInnerProps) {
       </div>
       <div>
         {Object.keys(logGroups).map(positionKey => (
-          <Popover
+          <UIPopover
             key={positionKey}
             arrowPointAtCenter
             overlayClassName="SpanBar--logHint"
@@ -117,7 +117,7 @@ function SpanBar(props: TInnerProps) {
             }
           >
             <div className="SpanBar--logMarker" style={{ left: positionKey }} />
-          </Popover>
+          </UIPopover>
         ))}
       </div>
       {rpc && (

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Input } from 'antd';
+import { Input, Popover } from 'antd';
 import { Location, History as RouterHistory } from 'history';
 import _clamp from 'lodash/clamp';
 import _get from 'lodash/get';
@@ -55,6 +55,7 @@ import { TraceArchive } from '../../types/archive';
 import { EmbeddedState } from '../../types/embedded';
 import filterSpans from '../../utils/filter-spans';
 import updateUiFind from '../../utils/update-ui-find';
+import UIElementsContext from './uiElementsContext';
 
 import './index.css';
 
@@ -395,15 +396,17 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
             </section>
           ) : (
             <section style={{ paddingTop: headerHeight }}>
-              <TraceTimelineViewer
-                registerAccessors={this._scrollManager.setAccessors}
-                scrollToFirstVisibleSpan={this._scrollManager.scrollToFirstVisibleSpan}
-                findMatchesIDs={spanFindMatches}
-                trace={data}
-                updateNextViewRangeTime={this.updateNextViewRangeTime}
-                updateViewRangeTime={this.updateViewRangeTime}
-                viewRange={viewRange}
-              />
+              <UIElementsContext.Provider value={{ Popover }}>
+                <TraceTimelineViewer
+                  registerAccessors={this._scrollManager.setAccessors}
+                  scrollToFirstVisibleSpan={this._scrollManager.scrollToFirstVisibleSpan}
+                  findMatchesIDs={spanFindMatches}
+                  trace={data}
+                  updateNextViewRangeTime={this.updateNextViewRangeTime}
+                  updateViewRangeTime={this.updateViewRangeTime}
+                  viewRange={viewRange}
+                />
+              </UIElementsContext.Provider>
             </section>
           ))}
       </div>

--- a/packages/jaeger-ui/src/components/TracePage/uiElementsContext.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/uiElementsContext.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+
+type TooltipPlacement =
+  | 'top'
+  | 'left'
+  | 'right'
+  | 'bottom'
+  | 'topLeft'
+  | 'topRight'
+  | 'bottomLeft'
+  | 'bottomRight'
+  | 'leftTop'
+  | 'leftBottom'
+  | 'rightTop'
+  | 'rightBottom';
+type PopoverInterface = React.ComponentClass<
+  {
+    content?: React.ReactNode;
+    arrowPointAtCenter?: boolean;
+    overlayClassName?: string;
+    placement?: TooltipPlacement;
+    children?: React.ReactNode;
+  },
+  {}
+>;
+type Elements = {
+  Popover: PopoverInterface;
+};
+
+/**
+ * Allows for injecting custom UI elements that will be used. Mainly for styling and removing dependency on
+ * any specific UI library but can also inject specific behaviour.
+ */
+const UIElementsContext = React.createContext<Elements | undefined>(undefined);
+UIElementsContext.displayName = 'UIElementsContext';
+export default UIElementsContext;
+
+type GetElementsContextProps = {
+  children: (elements: Elements) => React.ReactNode;
+};
+
+/**
+ * Convenience render prop style component to handle error state when elements are not defined.
+ */
+export function GetElementsContext(props: GetElementsContextProps) {
+  return (
+    <UIElementsContext.Consumer>
+      {(value: Elements | undefined) => {
+        if (!value) {
+          throw new Error(
+            'Elements context is required. You probably forget to use UIElementsContext.Provider'
+          );
+        }
+        return props.children(value);
+      }}
+    </UIElementsContext.Consumer>
+  );
+}
+
+export function UIPopover(props: React.ComponentProps<PopoverInterface>) {
+  return (
+    <GetElementsContext>
+      {(elements: Elements) => {
+        return <elements.Popover {...props} />;
+      }}
+    </GetElementsContext>
+  );
+}


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Part of both https://github.com/jaegertracing/jaeger-ui/issues/509 and https://github.com/jaegertracing/jaeger-ui/issues/508

## Short description of the changes
This tries to remove dependency on Antd. Issue with Antd is first the size of the overall dependency, global styles and problematic theming that would have theme both the trace UI and the Antd elements separately.

This provides a react context that needs to be used for injecting required UI components. This would  allow injecting custom UI element to make theming better. For example in Grafana we use custom component library to share styling and behaviour.

Caveats:
- It is hard to provide any defaults as that would mean a default UI library needs to be included. Antd could be defined as a peer dependency, that though would mean a warning if you do not install it which is probably not ideal. That UI components are required will make this a bit harder to use. Long term defaults can be implemented directly in the jeager ui though.
- This is designed so that the context provider is public and users implementing this as a library would use it directly ala Redux provider. Seems better than having long list of props but that is subjective.