### PR TITLE
Fix #523 - Arrows are huge on Chrome Canary (Time sensitive)

### DIFF
--- a/packages/plexus/src/Digraph/SvgDefEntry.tsx
+++ b/packages/plexus/src/Digraph/SvgDefEntry.tsx
@@ -46,7 +46,7 @@ function renderDefaultMarker(
     <marker
       id={id}
       markerHeight={scale * 8}
-      markerUnits="strokeWidth"
+      markerUnits="userSpaceOnUse"
       markerWidth={scale * 8}
       orient="auto"
       refX={scale * 8}


### PR DESCRIPTION
## It may be worth releasing this fix as a patch.

#523 affects Chrome Canary which is version `Version 81.0.4023.0 (Official Build) canary (64-bit)` (on my machine).

Chrome is scheduled to update to version 81 on March 17th (see [Chrome Platform Status](https://www.chromestatus.com/features/schedule)).

When that happens, probably the current and all prior releases of Jaeger UI will have huge arrows on trace diffs, trace graph and ddg graphs. 

## Which problem is this PR solving?

Fixes #523 Plexus arrows are huge on Chrome Canary

**Before**

<img width="358" alt="Screen Shot 2020-02-18 at 5 25 41 am" src="https://user-images.githubusercontent.com/2304337/74728880-86572080-5211-11ea-8728-ab9230f65139.png">


**After**

<img width="362" alt="Screen Shot 2020-02-18 at 5 40 06 am" src="https://user-images.githubusercontent.com/2304337/74728883-88b97a80-5211-11ea-8d83-7c788473bc18.png">


## Short description of the changes

Change `markerUnits` in arrow definitions.
