### PR TITLE
Allow to use non-root span as trace name

### DIFF
--- a/packages/jaeger-ui/src/model/trace-viewer.js
+++ b/packages/jaeger-ui/src/model/trace-viewer.js
@@ -14,6 +14,13 @@
 
 // eslint-disable-next-line import/prefer-default-export
 export function getTraceName(spans) {
-  const span = spans.filter(sp => !sp.references || !sp.references.length)[0];
+  // find span with "trace_name" tag
+  let span = spans.filter(
+    sp => sp.tags.filter(tg => tg.key === 'trace_name' && tg.value === true).length > 0
+  )[0];
+  if (span == null) {
+    // find span without references
+    span = spans.filter(sp => !sp.references || !sp.references.length)[0];
+  }
   return span ? `${span.process.serviceName}: ${span.operationName}` : '';
 }

--- a/packages/jaeger-ui/src/utils/tracking/index.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/index.tsx
@@ -170,7 +170,7 @@ if (isGaEnabled) {
         dom: true,
         location: true,
       },
-      environment: process.env.NODE_ENV || 'unkonwn',
+      environment: process.env.NODE_ENV || 'unknown',
       transport: trackRavenError,
     };
     if (versionShort && versionShort !== 'unknown') {


### PR DESCRIPTION
##  Which problem is this PR solving?
Allow to use name of span with tag trace_name == true as name of trace.
It is very useful when using with traefik to get clear trace names instead of "traefik: EntryPoint example.com"
It is not a significant change. Should I have been to open issue before?

## Short description of the changes
- Change getTraceName to find spans with tag trace_name == true first in /jaeger-ui/packages/jaeger-ui/src/model/trace-viewer.js
- Use trace-viewer's  getTraceName in /packages/jaeger-ui/src/model/transform-trace-data.tsx
- Fix typo in /packages/jaeger-ui/src/utils/tracking/index.tsx
