### PR TITLE
Fix search.maxLimit configuration 

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -34,7 +34,7 @@ import * as jaegerApiActions from '../../actions/jaeger-api';
 import { formatDate, formatTime } from '../../utils/date';
 import reduxFormFieldAdapter from '../../utils/redux-form-field-adapter';
 import { DEFAULT_OPERATION, DEFAULT_LIMIT, DEFAULT_LOOKBACK } from '../../constants/search-form';
-import getConfigValue from '../../utils/config/get-config';
+import { getConfigValue } from '../../utils/config/get-config';
 import './SearchForm.css';
 
 const FormItem = Form.Item;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
@@ -392,6 +392,19 @@ describe('<SearchForm>', () => {
     btn = wrapper.find(`[data-test="${markers.SUBMIT_BTN}"]`);
     expect(btn.prop('disabled')).toBeTruthy();
   });
+
+  it('uses config.search.maxLimit', () => {
+    const maxLimit = 6789;
+    const config = {
+      search: {
+        maxLimit,
+      },
+    };
+    window.getJaegerUiConfig = jest.fn(() => config);
+    wrapper = shallow(<SearchForm {...defaultProps} selectedService="svcA" />);
+    const field = wrapper.find(`Field[name="resultsLimit"]`);
+    expect(field.prop('props').max).toEqual(maxLimit);
+  });
 });
 
 describe('validation', () => {


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #532 

## Short description of the changes
- now the `getConfigValue` is used instead of the default exported `getConfig`
