### PR TITLE
Search results link spans

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -56,6 +56,7 @@ type SearchResultsProps = {
   queryOfResults?: SearchQuery,
   showStandaloneLink: boolean,
   skipMessage?: boolean,
+  spanLinks?: Record<string, string> | undefined | null,
   traces: TraceSummary[],
 };
 
@@ -91,7 +92,7 @@ export const sortFormSelector = formValueSelector('traceResultsSort');
 export class UnconnectedSearchResults extends React.PureComponent<SearchResultsProps> {
   props: SearchResultsProps;
 
-  static defaultProps = { skipMessage: false, queryOfResults: undefined };
+  static defaultProps = { skipMessage: false, spanLinks: undefined, queryOfResults: undefined };
 
   toggleComparison = (traceID: string, remove: boolean) => {
     const { cohortAddTrace, cohortRemoveTrace } = this.props;
@@ -123,6 +124,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
       queryOfResults,
       showStandaloneLink,
       skipMessage,
+      spanLinks,
       traces,
     } = this.props;
 
@@ -203,7 +205,11 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
                 <ResultItem
                   durationPercent={getPercentageOfDuration(trace.duration, maxTraceDuration)}
                   isInDiffCohort={cohortIds.has(trace.traceID)}
-                  linkTo={getLocation(trace.traceID, { fromSearch: searchUrl })}
+                  linkTo={getLocation(
+                    trace.traceID,
+                    { fromSearch: searchUrl },
+                    spanLinks && spanLinks[trace.traceID]
+                  )}
                   toggleComparison={this.toggleComparison}
                   trace={trace}
                   disableComparision={disableComparisons}

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -17,7 +17,6 @@
 import React, { Component } from 'react';
 import { Col, Row, Tabs } from 'antd';
 import PropTypes from 'prop-types';
-import queryString from 'query-string';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import store from 'store';
@@ -25,7 +24,7 @@ import memoizeOne from 'memoize-one';
 
 import SearchForm from './SearchForm';
 import SearchResults, { sortFormSelector } from './SearchResults';
-import { isSameQuery, getUrl } from './url';
+import { isSameQuery, getUrl, getUrlState } from './url';
 import * as jaegerApiActions from '../../actions/jaeger-api';
 import * as fileReaderActions from '../../actions/file-reader-api';
 import ErrorMessage from '../common/ErrorMessage';
@@ -90,6 +89,7 @@ export class SearchTracePageImpl extends Component {
       traceResults,
       queryOfResults,
       loadJsonTraces,
+      urlQueryParams,
     } = this.props;
     const hasTraceResults = traceResults && traceResults.length > 0;
     const showErrors = errors && !loadingTraces;
@@ -132,6 +132,7 @@ export class SearchTracePageImpl extends Component {
               queryOfResults={queryOfResults}
               showStandaloneLink={Boolean(embedded)}
               skipMessage={isHomepage}
+              spanLinks={urlQueryParams && urlQueryParams.spanLinks}
               traces={traceResults}
             />
           )}
@@ -232,7 +233,7 @@ const stateServicesXformer = memoizeOne(stateServices => {
 // export to test
 export function mapStateToProps(state) {
   const { embedded, router, services: stServices, traceDiff } = state;
-  const query = queryString.parse(router.location.search);
+  const query = getUrlState(router.location.search);
   const isHomepage = !Object.keys(query).length;
   const { query: queryOfResults, traces, maxDuration, traceError, loadingTraces } = stateTraceXformer(
     state.trace

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
@@ -105,6 +105,7 @@ describe('<SearchTracePage>', () => {
     expect(historyPush.mock.calls.length).toBe(1);
     expect(historyPush.mock.calls[0][0]).toEqual({
       pathname: `/trace/${traceID}`,
+      search: undefined,
       state: { fromSearch: '/search?' },
     });
   });

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
@@ -94,7 +94,7 @@ describe('SearchTracePage/url', () => {
             [trace1]: span2,
           },
         })
-      ).toBe(`/search?span=${span0}%2C${span1}%40${trace0}&span=${span2}%40${trace1}&traceID=${trace2}`);
+      ).toBe(`/search?span=${span0}%20${span1}%40${trace0}&span=${span2}%40${trace1}&traceID=${trace2}`);
     });
   });
 
@@ -116,7 +116,7 @@ describe('SearchTracePage/url', () => {
 
     it('converts multiple spans to traceID and spanLinks', () => {
       expect(
-        getUrlState(`span=${span0}%2C${span1}%40${trace0}&span=${span2}%40${trace1}&traceID=${trace2}`)
+        getUrlState(`span=${span0}%20${span1}%40${trace0}&span=${span2}%40${trace1}&traceID=${trace2}`)
       ).toEqual({
         traceID: expect.arrayContaining([trace0, trace1, trace2]),
         spanLinks: {

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
@@ -126,6 +126,17 @@ describe('SearchTracePage/url', () => {
       });
     });
 
+    it('converts span param without spanIDs to just traceID', () => {
+      expect(getUrlState(`span=${span0}%20${span1}%40${trace0}&span=%40${trace1}&traceID=${trace2}`)).toEqual(
+        {
+          traceID: expect.arrayContaining([trace0, trace1, trace2]),
+          spanLinks: {
+            [trace0]: `${span0} ${span1}`,
+          },
+        }
+      );
+    });
+
     it('handles duplicate traceIDs', () => {
       expect(
         getUrlState(

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
@@ -1,0 +1,133 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getUrl, getUrlState, isSameQuery } from './url';
+
+describe('SearchTracePage/url', () => {
+  const span0 = 'span-0';
+  const span1 = 'span-1';
+  const span2 = 'span-2';
+  const trace0 = 'trace-0';
+  const trace1 = 'trace-1';
+  const trace2 = 'trace-2';
+
+  describe('getUrl', () => {
+    it('handles no args given', () => {
+      expect(getUrl()).toBe('/search');
+    });
+
+    it('handles empty args', () => {
+      expect(getUrl({})).toBe('/search?');
+    });
+
+    it('includes provided args', () => {
+      const paramA = 'aParam';
+      const paramB = 'bParam';
+      expect(getUrl({ paramA, paramB })).toBe(`/search?paramA=${paramA}&paramB=${paramB}`);
+    });
+
+    it('converts spanLink and traceID to traceID and span', () => {
+      expect(
+        getUrl({
+          traceID: [trace0],
+          spanLinks: {
+            [trace0]: span0,
+          },
+        })
+      ).toBe(`/search?span=${span0}%40${trace0}`);
+    });
+
+    it('handles missing traceID for spanLinks', () => {
+      expect(
+        getUrl({
+          spanLinks: {
+            [trace0]: span0,
+          },
+        })
+      ).toBe(`/search?span=${span0}%40${trace0}`);
+    });
+
+    it('converts spanLink and other traceID to traceID and span', () => {
+      expect(
+        getUrl({
+          traceID: [trace0, trace2],
+          spanLinks: {
+            [trace0]: span0,
+          },
+        })
+      ).toBe(`/search?span=${span0}%40${trace0}&traceID=${trace2}`);
+    });
+
+    it('converts spanLinks to traceID and span', () => {
+      expect(
+        getUrl({
+          traceID: [trace0, trace1, trace2],
+          spanLinks: {
+            [trace0]: `${span0} ${span1}`,
+            [trace1]: span2,
+          },
+        })
+      ).toBe(`/search?span=${span0}%2C${span1}%40${trace0}&span=${span2}%40${trace1}&traceID=${trace2}`);
+    });
+  });
+
+  describe('getUrlState', () => {
+    it('gets search params', () => {
+      const service = 'svc-0';
+      const operation = 'op-0';
+      expect(getUrlState(`service=${service}&operation=${operation}`)).toEqual({ service, operation });
+    });
+
+    it('converts span to traceID and spanLinks', () => {
+      expect(getUrlState(`span=${span0}%40${trace0}`)).toEqual({
+        traceID: [trace0],
+        spanLinks: {
+          [trace0]: span0,
+        },
+      });
+    });
+
+    it('converts multiple spans to traceID and spanLinks', () => {
+      expect(
+        getUrlState(`span=${span0}%2C${span1}%40${trace0}&span=${span2}%40${trace1}&traceID=${trace2}`)
+      ).toEqual({
+        traceID: expect.arrayContaining([trace0, trace1, trace2]),
+        spanLinks: {
+          [trace0]: `${span0} ${span1}`,
+          [trace1]: span2,
+        },
+      });
+    });
+
+    it('handles duplicate traceIDs', () => {
+      expect(
+        getUrlState(
+          `span=${span0}%40${trace0}&span=${span1}%40${trace0}&span=${span2}%40${trace1}&traceID=${trace1}&traceID=${trace2}`
+        )
+      ).toEqual({
+        traceID: expect.arrayContaining([trace0, trace1, trace2]),
+        spanLinks: {
+          [trace0]: `${span0} ${span1}`,
+          [trace1]: span2,
+        },
+      });
+    });
+  });
+
+  describe('isSameQuery', () => {
+    it('returns `false` if only one argument is falsy', () => {
+      expect(isSameQuery({})).toBe(false);
+    });
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
@@ -42,9 +42,10 @@ export function getUrl(query?: TUrlState) {
   if (!query) return searchUrl;
 
   const { traceID, spanLinks, ...rest } = query;
-  const ids = traceID
-    ? (Array.isArray(traceID) ? traceID : [traceID]).filter((id: string) => !spanLinks || !spanLinks[id])
-    : [];
+  let ids = traceID;
+  if (spanLinks && traceID) {
+    ids = (Array.isArray(traceID) ? traceID : [traceID]).filter((id: string) => !spanLinks[id]);
+  }
   const stringifyArg = {
     ...rest,
     span:
@@ -52,7 +53,7 @@ export function getUrl(query?: TUrlState) {
       Object.keys(spanLinks).reduce((res: string[], trace: string) => {
         return [...res, `${spanLinks[trace].replace(/ /g, ',')}@${trace}`];
       }, []),
-    traceID: ids.length ? ids : undefined,
+    traceID: ids && ids.length ? ids : undefined,
   };
   return `${searchUrl}?${queryString.stringify(stringifyArg)}`;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
@@ -69,8 +69,10 @@ export const getUrlState: (search: string) => TUrlState = memoizeOne(function ge
     (Array.isArray(span) ? span : [span]).forEach(s => {
       const [spansStr, trace] = s.split('@');
       traceIDs.add(trace);
-      if (spanLinks[trace]) spanLinks[trace] = spanLinks[trace].concat(' ', spansStr);
-      else spanLinks[trace] = spansStr;
+      if (spansStr) {
+        if (spanLinks[trace]) spanLinks[trace] = spanLinks[trace].concat(' ', spansStr);
+        else spanLinks[trace] = spansStr;
+      }
     });
     rv.spanLinks = spanLinks;
   }

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
@@ -51,7 +51,7 @@ export function getUrl(query?: TUrlState) {
     span:
       spanLinks &&
       Object.keys(spanLinks).reduce((res: string[], trace: string) => {
-        return [...res, `${spanLinks[trace].replace(/ /g, ',')}@${trace}`];
+        return [...res, `${spanLinks[trace]}@${trace}`];
       }, []),
     traceID: ids && ids.length ? ids : undefined,
   };
@@ -68,10 +68,9 @@ export const getUrlState: (search: string) => TUrlState = memoizeOne(function ge
   if (span && span.length) {
     (Array.isArray(span) ? span : [span]).forEach(s => {
       const [spansStr, trace] = s.split('@');
-      const uiFind = spansStr.replace(/,/g, ' ');
       traceIDs.add(trace);
-      if (spanLinks[trace]) spanLinks[trace] = spanLinks[trace].concat(' ', uiFind);
-      else spanLinks[trace] = uiFind;
+      if (spanLinks[trace]) spanLinks[trace] = spanLinks[trace].concat(' ', spansStr);
+      else spanLinks[trace] = spansStr;
     });
     rv.spanLinks = spanLinks;
   }

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import memoizeOne from 'memoize-one';
 import queryString from 'query-string';
 import { matchPath } from 'react-router-dom';
 
@@ -31,10 +32,51 @@ export function matches(path: string) {
   return Boolean(matchPath(path, ROUTE_MATCHER));
 }
 
-export function getUrl(query?: Record<string, unknown> | null | undefined) {
-  const search = query ? `?${queryString.stringify(query)}` : '';
-  return prefixUrl(`/search${search}`);
+type TUrlState = Record<string, string | string[] | undefined | Record<string, string>> & {
+  traceID?: string | string[];
+  spanLinks?: Record<string, string>;
+};
+
+export function getUrl(query?: TUrlState) {
+  const searchUrl = prefixUrl(`/search`);
+  if (!query) return searchUrl;
+
+  const { traceID, spanLinks, ...rest } = query;
+  const ids = traceID
+    ? (Array.isArray(traceID) ? traceID : [traceID]).filter((id: string) => !spanLinks || !spanLinks[id])
+    : [];
+  const stringifyArg = {
+    ...rest,
+    span:
+      spanLinks &&
+      Object.keys(spanLinks).reduce((res: string[], trace: string) => {
+        return [...res, `${spanLinks[trace].replace(/ /g, ',')}@${trace}`];
+      }, []),
+    traceID: ids.length ? ids : undefined,
+  };
+  return `${searchUrl}?${queryString.stringify(stringifyArg)}`;
 }
+
+export const getUrlState: (search: string) => TUrlState = memoizeOne(function getUrlState(
+  search: string
+): TUrlState {
+  const { traceID, span, ...rest } = queryString.parse(search);
+  const rv: TUrlState = { ...rest };
+  const traceIDs = new Set(!traceID || Array.isArray(traceID) ? traceID : [traceID]);
+  const spanLinks: Record<string, string> = {};
+  if (span && span.length) {
+    (Array.isArray(span) ? span : [span]).forEach(s => {
+      const [spansStr, trace] = s.split('@');
+      const uiFind = spansStr.replace(/,/g, ' ');
+      traceIDs.add(trace);
+      if (spanLinks[trace]) spanLinks[trace] = spanLinks[trace].concat(' ', uiFind);
+      else spanLinks[trace] = uiFind;
+    });
+    rv.spanLinks = spanLinks;
+  }
+  if (traceIDs.size) rv.traceID = [...traceIDs];
+  return rv;
+});
 
 export function isSameQuery(a: SearchQuery, b: SearchQuery) {
   if (Boolean(a) !== Boolean(b)) {

--- a/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.test.js
@@ -45,7 +45,7 @@ describe(ReferenceLink, () => {
 
     it('render for external trace', () => {
       const component = shallow(<ReferenceLink reference={externalRef} focusSpan={focusMock} />);
-      const link = component.find('a[href="/trace/trace2/uiFind?=span2"]');
+      const link = component.find('a[href="/trace/trace2?uiFind=span2"]');
       expect(link.length).toBe(1);
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.tsx
@@ -24,8 +24,6 @@ type ReferenceLinkProps = {
   onClick?: () => void;
 };
 
-const linkToExternalSpan = (traceID: string, spanID: string) => `${getUrl(traceID)}/uiFind?=${spanID}`;
-
 export default function ReferenceLink(props: ReferenceLinkProps) {
   const { reference, children, className, focusSpan, ...otherProps } = props;
   delete otherProps.onClick;
@@ -38,7 +36,7 @@ export default function ReferenceLink(props: ReferenceLinkProps) {
   }
   return (
     <a
-      href={linkToExternalSpan(reference.traceID, reference.spanID)}
+      href={getUrl(reference.traceID, reference.spanID)}
       target="_blank"
       rel="noopener noreferrer"
       className={className}

--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getLocation, getUrl } from '.';
+
+describe('TracePage/url', () => {
+  const traceID = 'trace-id';
+  const uiFind = 'ui-find';
+
+  describe('getUrl', () => {
+    it('includes traceID without uiFind', () => {
+      expect(getUrl(traceID)).toBe(`/trace/${traceID}`);
+    });
+
+    it('includes traceID and uiFind', () => {
+      expect(getUrl(traceID, uiFind)).toBe(`/trace/${traceID}?uiFind=${uiFind}`);
+    });
+  });
+
+  describe('getLocation', () => {
+    const state = {
+      from: 'some-url',
+    };
+
+    it('passes provided state with correct pathname, without uiFind', () => {
+      expect(getLocation(traceID, state)).toEqual({
+        state,
+        pathname: getUrl(traceID),
+      });
+    });
+
+    it('passes provided state with correct pathname with uiFind', () => {
+      expect(getLocation(traceID, state, uiFind)).toEqual({
+        state,
+        pathname: getUrl(traceID),
+        search: `uiFind=${uiFind}`,
+      });
+    });
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/url/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.tsx
@@ -12,19 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import queryString from 'query-string';
+
 import prefixUrl from '../../../utils/prefix-url';
 
 import { TNil } from '../../../types';
 
 export const ROUTE_PATH = prefixUrl('/trace/:id');
 
-export function getUrl(id: string) {
-  return prefixUrl(`/trace/${id}`);
+export function getUrl(id: string, uiFind?: string): string {
+  const traceUrl = prefixUrl(`/trace/${id}`);
+  if (!uiFind) return traceUrl;
+
+  return `${traceUrl}?${queryString.stringify({ uiFind })}`;
 }
 
-export function getLocation(id: string, state: Record<string, any> | TNil) {
+export function getLocation(id: string, state: Record<string, any> | TNil, uiFind?: string) {
   return {
     state,
-    pathname: prefixUrl(`/trace/${id}`),
+    pathname: getUrl(id),
+    search: uiFind && queryString.stringify({ uiFind }),
   };
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- closes #526 
- Fixes `getExternalLink` for `ReferenceLink` used when a span has external references

## Short description of the changes
- `SearchTracePage/url` parses `span` into `spanLinks` and `traceID` (unchanged: `traceID` is used to fetch traces instead of searching)
- `spanLinks` are given to `SearchResults` to pass a `uiFind` value to the `TracePage` (unchanged: this is how deep linking into `TracePage` already behaves)