### PR TITLE
Fix trace scoped links not supporting numeric fields

### DIFF
--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -310,31 +310,42 @@ describe('computeTraceLink()', () => {
   const linkPatterns = [
     {
       type: 'traces',
-      url: 'http://example.com/?myKey=#{traceID}',
+      url: 'http://example.com/?traceID=#{traceID}',
       text: 'first link (#{traceID})',
     },
     {
       type: 'traces',
-      url: 'http://example.com/?myKey=#{traceID}&myKey=#{myKey}',
-      text: 'second link (#{myKey})',
+      url: 'http://example.com/?traceID#{traceID}&myKey=#{myKey}',
+      text: 'second link will not render because myKey is not in the trace',
+    },
+    {
+      type: 'traces',
+      url:
+        'http://example.com/?traceID=#{traceID}&traceName=#{traceName}&startTime=#{startTime}&endTime=#{endTime}&duration=#{duration}',
+      text: 'third link (#{traceID}, #{traceName}, #{startTime}, #{endTime}, #{duration})',
     },
   ].map(processLinkPattern);
 
   const trace = {
     processes: [],
+    traceName: 'theTrace',
     traceID: 'trc1',
     spans: [],
     startTime: 1000,
-    endTime: 2000,
-    duration: 1000,
+    endTime: 3000,
+    duration: 2000,
     services: [],
   };
 
-  it('correctly computes links', () => {
+  it('correctly computes trace scoped links', () => {
     expect(computeTraceLink(linkPatterns, trace)).toEqual([
       {
-        url: 'http://example.com/?myKey=trc1',
+        url: 'http://example.com/?traceID=trc1',
         text: 'first link (trc1)',
+      },
+      {
+        url: 'http://example.com/?traceID=trc1&traceName=theTrace&startTime=1000&endTime=3000&duration=2000',
+        text: 'third link (trc1, theTrace, 1000, 3000, 2000)',
       },
     ]);
   });

--- a/packages/jaeger-ui/src/model/link-patterns.tsx
+++ b/packages/jaeger-ui/src/model/link-patterns.tsx
@@ -145,7 +145,7 @@ function callTemplate(template: ProcessedTemplate, data: any) {
 export function computeTraceLink(linkPatterns: ProcessedLinkPattern[], trace: Trace) {
   const result: TLinksRV = [];
   const validKeys = (Object.keys(trace) as (keyof Trace)[]).filter(
-    key => typeof trace[key] === 'string' || trace[key] === 'number'
+    key => typeof trace[key] === 'string' || typeof trace[key] === 'number'
   );
 
   linkPatterns


### PR DESCRIPTION
From https://www.jaegertracing.io/docs/1.17/frontend-ui/#link-patterns

"For traces, the supported template fields are: duration, endTime,
startTime, traceName and traceID."

Fixes #465

Signed-off-by: Will Tran <will@autonomic.ai>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- using duration, endTime, and startTime in trace scoped links caused the link to not display, counter to documentation.

## Short description of the changes
- Added missing `typeof`
- Improved test to cover all documented keys
