### PR TITLE
Fix span links for leading 0s trace ID

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
@@ -148,9 +148,13 @@ describe('lookback utils', () => {
 
     it('creates timestamp for days ago', () => {
       [1, 2, 4, 7].forEach(lookbackNum => {
-        expect(nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}d`, now)).toBe(
-          lookbackNum * 24 * hourInMicroseconds
-        );
+        const actual = nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}d`, now);
+        const expected = lookbackNum * 24 * hourInMicroseconds;
+        try {
+          expect(actual).toBe(expected);
+        } catch (_e) {
+          expect(Math.abs(actual - expected)).toBe(hourInMicroseconds);
+        }
       });
     });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -208,7 +208,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
                   linkTo={getLocation(
                     trace.traceID,
                     { fromSearch: searchUrl },
-                    spanLinks && spanLinks[trace.traceID]
+                    spanLinks && (spanLinks[trace.traceID] || spanLinks[trace.traceID.replace(/^0*/, '')])
                   )}
                   toggleComparison={this.toggleComparison}
                   trace={trace}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
@@ -74,6 +74,36 @@ describe('<SearchResults>', () => {
       expect(wrapper.find(ResultItem).length).toBe(traces.length);
     });
 
+    it('deep links traces', () => {
+      const uiFind = 'ui-find';
+      const spanLinks = {
+        [traces[0].traceID]: uiFind,
+      };
+      wrapper.setProps({ spanLinks });
+      const results = wrapper.find(ResultItem);
+      expect(results.at(0).prop('linkTo').search).toBe(`uiFind=${uiFind}`);
+      expect(results.at(1).prop('linkTo').search).toBeUndefined();
+    });
+
+    it('deep links traces with leading 0', () => {
+      const uiFind0 = 'ui-find-0';
+      const uiFind1 = 'ui-find-1';
+      const traceID0 = '00traceID0';
+      const traceID1 = 'traceID1';
+      const spanLinks = {
+        [traceID0]: uiFind0,
+        [traceID1]: uiFind1,
+      };
+      const zeroIDTraces = [
+        { traceID: traceID0, spans: [], processes: {} },
+        { traceID: `000${traceID1}`, spans: [], processes: {} },
+      ];
+      wrapper.setProps({ spanLinks, traces: zeroIDTraces });
+      const results = wrapper.find(ResultItem);
+      expect(results.at(0).prop('linkTo').search).toBe(`uiFind=${uiFind0}`);
+      expect(results.at(1).prop('linkTo').search).toBe(`uiFind=${uiFind1}`);
+    });
+
     describe('ddg', () => {
       const searchParam = 'view';
       const viewDdg = 'ddg';

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
@@ -45,7 +45,7 @@ describe('SearchTracePage/url', () => {
       ).toBe(`/search?traceID=${trace0}`);
     });
 
-    it('converts spanLink and traceID to traceID and span', () => {
+    it('converts spanLink and its traceID to just span', () => {
       expect(
         getUrl({
           traceID: trace0,


### PR DESCRIPTION
## Which problem is this PR solving?
- When `?span=${id}@${traceID}` fetches a trace such that:
```
trace.traceID = `0+${traceID}`
```
the deep linking would not be passed on.

## Short description of the changes
- Check span links for `trace.traceID` with leading 0s stripped out if `trace.traceID` is not present in `spanLinks`
