### PR TITLE
Correct trace name resolution

### DIFF
--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -57,7 +57,7 @@ describe('getTraceName', () => {
       ],
     },
   ];
-  const spansWithMultipleRoots = [
+  const spansWithMultipleRootsDifferentByStartTime = [
     {
       spanID: firstSpanId,
       startTime: t + 200,
@@ -69,16 +69,52 @@ describe('getTraceName', () => {
       ],
     },
     {
-      spanID: secondSpanId, // root span
+      spanID: secondSpanId, // may be a root span
       startTime: t + 100,
+      references: [
+        {
+          spanID: missingSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
     },
     {
-      spanID: thirdSpanId, // root span
+      spanID: thirdSpanId, // root span (as the earliest)
       startTime: t,
       operationName,
       process: {
         serviceName,
       },
+      references: [
+        {
+          spanID: missingSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+  ];
+  const spansWithMultipleRootsWithOneWithoutRefs = [
+    {
+      spanID: firstSpanId,
+      startTime: t + 200,
+      references: [
+        {
+          spanID: thirdSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+    {
+      spanID: secondSpanId, // root span (as a span without any refs)
+      startTime: t + 100,
+      operationName,
+      process: {
+        serviceName,
+      },
+    },
+    {
+      spanID: thirdSpanId, // may be a root span
+      startTime: t,
       references: [
         {
           spanID: missingSpanId,
@@ -161,7 +197,11 @@ describe('getTraceName', () => {
   });
 
   it('returns an id of root span with the earliest startTime', () => {
-    expect(getTraceName(spansWithMultipleRoots)).toEqual(fullTraceName);
+    expect(getTraceName(spansWithMultipleRootsDifferentByStartTime)).toEqual(fullTraceName);
+  });
+
+  it('returns an id of root span without any refs', () => {
+    expect(getTraceName(spansWithMultipleRootsWithOneWithoutRefs)).toEqual(fullTraceName);
   });
 
   it('returns an id of root span with remote ref', () => {

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -18,7 +18,7 @@ describe('getTraceName', () => {
   const firstSpanId = 'firstSpanId';
   const secondSpanId = 'secondSpanId';
   const thirdSpanId = 'thirdSpanId';
-  const remoteSpanId = 'remoteSpanId';
+  const missingSpanId = 'missingSpanId';
 
   const serviceName = 'serviceName';
   const operationName = 'operationName';
@@ -79,7 +79,7 @@ describe('getTraceName', () => {
       },
       references: [
         {
-          spanID: remoteSpanId,
+          spanID: missingSpanId,
           refType: 'CHILD_OF',
         },
       ],
@@ -115,7 +115,7 @@ describe('getTraceName', () => {
       },
       references: [
         {
-          spanID: remoteSpanId,
+          spanID: missingSpanId,
           refType: 'CHILD_OF',
         },
       ],

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -21,7 +21,6 @@ describe('getTraceName', () => {
   const missingSpanId = 'missingSpanId';
 
   const currentTraceId = 'currentTraceId';
-  const anotherTraceId = 'anotherTraceId';
 
   const serviceName = 'serviceName';
   const operationName = 'operationName';
@@ -89,7 +88,7 @@ describe('getTraceName', () => {
       references: [
         {
           spanID: missingSpanId,
-          traceID: anotherTraceId,
+          traceID: currentTraceId,
         },
       ],
     },
@@ -104,7 +103,7 @@ describe('getTraceName', () => {
       references: [
         {
           spanID: missingSpanId,
-          traceID: anotherTraceId,
+          traceID: currentTraceId,
         },
       ],
     },
@@ -139,7 +138,7 @@ describe('getTraceName', () => {
       references: [
         {
           spanID: missingSpanId,
-          traceID: anotherTraceId,
+          traceID: currentTraceId,
         },
       ],
     },
@@ -180,7 +179,7 @@ describe('getTraceName', () => {
       references: [
         {
           spanID: missingSpanId,
-          traceID: anotherTraceId,
+          traceID: currentTraceId,
         },
       ],
     },

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Uber Technologies, Inc.
+// Copyright (c) 2020 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -20,6 +20,9 @@ describe('getTraceName', () => {
   const thirdSpanId = 'thirdSpanId';
   const missingSpanId = 'missingSpanId';
 
+  const currentTraceId = 'currentTraceId';
+  const anotherTraceId = 'anotherTraceId';
+
   const serviceName = 'serviceName';
   const operationName = 'operationName';
 
@@ -30,34 +33,37 @@ describe('getTraceName', () => {
   const spansWithNoRoots = [
     {
       spanID: firstSpanId,
+      traceID: currentTraceId,
       startTime: t + 200,
       process: {},
       references: [
         {
           spanID: secondSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
     {
       spanID: secondSpanId,
+      traceID: currentTraceId,
       startTime: t + 100,
       process: {},
       references: [
         {
           spanID: thirdSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
     {
       spanID: thirdSpanId,
+      traceID: currentTraceId,
       startTime: t,
       process: {},
       references: [
         {
           spanID: firstSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
@@ -65,28 +71,31 @@ describe('getTraceName', () => {
   const spansWithMultipleRootsDifferentByStartTime = [
     {
       spanID: firstSpanId,
+      traceID: currentTraceId,
       startTime: t + 200,
       process: {},
       references: [
         {
           spanID: thirdSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
     {
       spanID: secondSpanId, // may be a root span
+      traceID: currentTraceId,
       startTime: t + 100,
       process: {},
       references: [
         {
           spanID: missingSpanId,
-          refType: 'CHILD_OF',
+          traceID: anotherTraceId,
         },
       ],
     },
     {
       spanID: thirdSpanId, // root span (as the earliest)
+      traceID: currentTraceId,
       startTime: t,
       operationName,
       process: {
@@ -95,7 +104,7 @@ describe('getTraceName', () => {
       references: [
         {
           spanID: missingSpanId,
-          refType: 'CHILD_OF',
+          traceID: anotherTraceId,
         },
       ],
     },
@@ -103,17 +112,19 @@ describe('getTraceName', () => {
   const spansWithMultipleRootsWithOneWithoutRefs = [
     {
       spanID: firstSpanId,
+      traceID: currentTraceId,
       startTime: t + 200,
       process: {},
       references: [
         {
           spanID: thirdSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
     {
       spanID: secondSpanId, // root span (as a span without any refs)
+      traceID: currentTraceId,
       startTime: t + 100,
       operationName,
       process: {
@@ -122,12 +133,13 @@ describe('getTraceName', () => {
     },
     {
       spanID: thirdSpanId, // may be a root span
+      traceID: currentTraceId,
       startTime: t,
       process: {},
       references: [
         {
           spanID: missingSpanId,
-          refType: 'CHILD_OF',
+          traceID: anotherTraceId,
         },
       ],
     },
@@ -135,28 +147,31 @@ describe('getTraceName', () => {
   const spansWithOneRootWithRemoteRef = [
     {
       spanID: firstSpanId,
+      traceID: currentTraceId,
       startTime: t + 200,
       process: {},
       references: [
         {
           spanID: secondSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
     {
       spanID: secondSpanId,
+      traceID: currentTraceId,
       startTime: t + 100,
       process: {},
       references: [
         {
           spanID: thirdSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
     {
       spanID: thirdSpanId, // effective root span, since its parent is missing
+      traceID: currentTraceId,
       startTime: t,
       operationName,
       process: {
@@ -165,7 +180,7 @@ describe('getTraceName', () => {
       references: [
         {
           spanID: missingSpanId,
-          refType: 'CHILD_OF',
+          traceID: anotherTraceId,
         },
       ],
     },
@@ -173,17 +188,19 @@ describe('getTraceName', () => {
   const spansWithOneRootWithNoRefs = [
     {
       spanID: firstSpanId,
+      traceID: currentTraceId,
       startTime: t + 200,
       process: {},
       references: [
         {
           spanID: thirdSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },
     {
       spanID: secondSpanId, // root span
+      traceID: currentTraceId,
       startTime: t + 100,
       operationName,
       process: {
@@ -192,12 +209,13 @@ describe('getTraceName', () => {
     },
     {
       spanID: thirdSpanId,
+      traceID: currentTraceId,
       startTime: t,
       process: {},
       references: [
         {
           spanID: secondSpanId,
-          refType: 'CHILD_OF',
+          traceID: currentTraceId,
         },
       ],
     },

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -29,6 +29,7 @@ describe('getTraceName', () => {
     {
       spanID: firstSpanId,
       startTime: t + 200,
+      process: {},
       references: [
         {
           spanID: secondSpanId,
@@ -39,6 +40,7 @@ describe('getTraceName', () => {
     {
       spanID: secondSpanId,
       startTime: t + 100,
+      process: {},
       references: [
         {
           spanID: thirdSpanId,
@@ -49,6 +51,7 @@ describe('getTraceName', () => {
     {
       spanID: thirdSpanId,
       startTime: t,
+      process: {},
       references: [
         {
           spanID: firstSpanId,
@@ -61,6 +64,7 @@ describe('getTraceName', () => {
     {
       spanID: firstSpanId,
       startTime: t + 200,
+      process: {},
       references: [
         {
           spanID: thirdSpanId,
@@ -71,6 +75,7 @@ describe('getTraceName', () => {
     {
       spanID: secondSpanId, // may be a root span
       startTime: t + 100,
+      process: {},
       references: [
         {
           spanID: missingSpanId,
@@ -97,6 +102,7 @@ describe('getTraceName', () => {
     {
       spanID: firstSpanId,
       startTime: t + 200,
+      process: {},
       references: [
         {
           spanID: thirdSpanId,
@@ -115,6 +121,7 @@ describe('getTraceName', () => {
     {
       spanID: thirdSpanId, // may be a root span
       startTime: t,
+      process: {},
       references: [
         {
           spanID: missingSpanId,
@@ -127,6 +134,7 @@ describe('getTraceName', () => {
     {
       spanID: firstSpanId,
       startTime: t + 200,
+      process: {},
       references: [
         {
           spanID: secondSpanId,
@@ -137,6 +145,7 @@ describe('getTraceName', () => {
     {
       spanID: secondSpanId,
       startTime: t + 100,
+      process: {},
       references: [
         {
           spanID: thirdSpanId,
@@ -163,6 +172,7 @@ describe('getTraceName', () => {
     {
       spanID: firstSpanId,
       startTime: t + 200,
+      process: {},
       references: [
         {
           spanID: thirdSpanId,
@@ -181,6 +191,7 @@ describe('getTraceName', () => {
     {
       spanID: thirdSpanId,
       startTime: t,
+      process: {},
       references: [
         {
           spanID: secondSpanId,

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -154,7 +154,7 @@ describe('getTraceName', () => {
       ],
     },
     {
-      spanID: thirdSpanId, // root span
+      spanID: thirdSpanId, // effective root span, since its parent is missing
       startTime: t,
       operationName,
       process: {

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -1,0 +1,172 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getTraceName } from './trace-viewer';
+
+describe('getTraceName', () => {
+  const firstSpanId = 'firstSpanId';
+  const secondSpanId = 'secondSpanId';
+  const thirdSpanId = 'thirdSpanId';
+  const remoteSpanId = 'remoteSpanId';
+
+  const serviceName = 'serviceName';
+  const operationName = 'operationName';
+
+  const spansWithNoRoots = [
+    {
+      spanID: firstSpanId,
+      startTime: 1583758690000,
+      references: [
+        {
+          spanID: secondSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+    {
+      spanID: secondSpanId,
+      startTime: 1583758680000,
+      references: [
+        {
+          spanID: thirdSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+    {
+      spanID: thirdSpanId,
+      startTime: 1583758670000,
+      references: [
+        {
+          spanID: firstSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+  ];
+  const spansWithMultipleRoots = [
+    {
+      spanID: firstSpanId,
+      startTime: 1583758690000,
+      references: [
+        {
+          spanID: thirdSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+    {
+      spanID: secondSpanId, // root span
+      startTime: 1583758680000,
+    },
+    {
+      spanID: thirdSpanId, // root span
+      startTime: 1583758670000,
+      operationName,
+      process: {
+        serviceName,
+      },
+      references: [
+        {
+          spanID: remoteSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+  ];
+  const spansWithOneRootWithRemoteRef = [
+    {
+      spanID: firstSpanId,
+      startTime: 1583758690000,
+      references: [
+        {
+          spanID: secondSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+    {
+      spanID: secondSpanId,
+      startTime: 1583758680000,
+      references: [
+        {
+          spanID: thirdSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+    {
+      spanID: thirdSpanId, // root span
+      startTime: 1583758670000,
+      operationName,
+      process: {
+        serviceName,
+      },
+      references: [
+        {
+          spanID: remoteSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+  ];
+  const spansWithOneRootWithNoRefs = [
+    {
+      spanID: firstSpanId,
+      startTime: 1583758690000,
+      references: [
+        {
+          spanID: thirdSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+    {
+      spanID: secondSpanId, // root span
+      startTime: 1583758680000,
+      operationName,
+      process: {
+        serviceName,
+      },
+    },
+    {
+      spanID: thirdSpanId,
+      startTime: 1583758670000,
+      references: [
+        {
+          spanID: secondSpanId,
+          refType: 'CHILD_OF',
+        },
+      ],
+    },
+  ];
+
+  const fullTraceName = `${serviceName}: ${operationName}`;
+
+  it('returns an empty string if given spans with no root among them', () => {
+    expect(getTraceName(spansWithNoRoots)).toEqual('');
+  });
+
+  it('returns an id of root span with the earliest startTime', () => {
+    expect(getTraceName(spansWithMultipleRoots)).toEqual(fullTraceName);
+  });
+
+  it('returns an id of root span with remote ref', () => {
+    expect(getTraceName(spansWithOneRootWithRemoteRef)).toEqual(fullTraceName);
+  });
+
+  it('returns an id of root span with no refs', () => {
+    expect(getTraceName(spansWithOneRootWithNoRefs)).toEqual(fullTraceName);
+  });
+});

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -23,10 +23,12 @@ describe('getTraceName', () => {
   const serviceName = 'serviceName';
   const operationName = 'operationName';
 
+  const t = 1583758670000;
+
   const spansWithNoRoots = [
     {
       spanID: firstSpanId,
-      startTime: 1583758690000,
+      startTime: t + 200,
       references: [
         {
           spanID: secondSpanId,
@@ -36,7 +38,7 @@ describe('getTraceName', () => {
     },
     {
       spanID: secondSpanId,
-      startTime: 1583758680000,
+      startTime: t + 100,
       references: [
         {
           spanID: thirdSpanId,
@@ -46,7 +48,7 @@ describe('getTraceName', () => {
     },
     {
       spanID: thirdSpanId,
-      startTime: 1583758670000,
+      startTime: t,
       references: [
         {
           spanID: firstSpanId,
@@ -58,7 +60,7 @@ describe('getTraceName', () => {
   const spansWithMultipleRoots = [
     {
       spanID: firstSpanId,
-      startTime: 1583758690000,
+      startTime: t + 200,
       references: [
         {
           spanID: thirdSpanId,
@@ -68,11 +70,11 @@ describe('getTraceName', () => {
     },
     {
       spanID: secondSpanId, // root span
-      startTime: 1583758680000,
+      startTime: t + 100,
     },
     {
       spanID: thirdSpanId, // root span
-      startTime: 1583758670000,
+      startTime: t,
       operationName,
       process: {
         serviceName,
@@ -88,7 +90,7 @@ describe('getTraceName', () => {
   const spansWithOneRootWithRemoteRef = [
     {
       spanID: firstSpanId,
-      startTime: 1583758690000,
+      startTime: t + 200,
       references: [
         {
           spanID: secondSpanId,
@@ -98,7 +100,7 @@ describe('getTraceName', () => {
     },
     {
       spanID: secondSpanId,
-      startTime: 1583758680000,
+      startTime: t + 100,
       references: [
         {
           spanID: thirdSpanId,
@@ -108,7 +110,7 @@ describe('getTraceName', () => {
     },
     {
       spanID: thirdSpanId, // root span
-      startTime: 1583758670000,
+      startTime: t,
       operationName,
       process: {
         serviceName,
@@ -124,7 +126,7 @@ describe('getTraceName', () => {
   const spansWithOneRootWithNoRefs = [
     {
       spanID: firstSpanId,
-      startTime: 1583758690000,
+      startTime: t + 200,
       references: [
         {
           spanID: thirdSpanId,
@@ -134,7 +136,7 @@ describe('getTraceName', () => {
     },
     {
       spanID: secondSpanId, // root span
-      startTime: 1583758680000,
+      startTime: t + 100,
       operationName,
       process: {
         serviceName,
@@ -142,7 +144,7 @@ describe('getTraceName', () => {
     },
     {
       spanID: thirdSpanId,
-      startTime: 1583758670000,
+      startTime: t,
       references: [
         {
           spanID: secondSpanId,

--- a/packages/jaeger-ui/src/model/find-trace-name.test.js
+++ b/packages/jaeger-ui/src/model/find-trace-name.test.js
@@ -25,6 +25,8 @@ describe('getTraceName', () => {
 
   const t = 1583758670000;
 
+  // Note: this trace has a loop S1 <- S2 <- S3 <- S1, which is the only way
+  // to make the algorithm return an empty string as trace name.
   const spansWithNoRoots = [
     {
       spanID: firstSpanId,

--- a/packages/jaeger-ui/src/model/trace-viewer.tsx
+++ b/packages/jaeger-ui/src/model/trace-viewer.tsx
@@ -14,15 +14,20 @@
 
 import { Span } from '../types/trace';
 
+type spansDict = { [index: string]: Span };
+
 // eslint-disable-next-line import/prefer-default-export
 export function getTraceName(spans: Span[]) {
+  const allTraceSpans: spansDict = spans.reduce((dict, span) => ({ ...dict, [span.spanID]: span }), {});
   const rootSpan = spans
     .filter(sp => {
       if (!sp.references || !sp.references.length) {
         return true;
       }
+      const parentIDs = sp.references.filter(r => r.traceID === sp.traceID).map(r => r.spanID);
+
       // returns true if no parent from this trace found
-      return !sp.references.some(r => r.traceID === sp.traceID);
+      return !parentIDs.some(pID => Boolean(allTraceSpans[pID]));
     })
     .sort((sp1, sp2) => {
       const sp1ParentsNum = sp1.references ? sp1.references.length : 0;

--- a/packages/jaeger-ui/src/model/trace-viewer.tsx
+++ b/packages/jaeger-ui/src/model/trace-viewer.tsx
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Span } from '../types/trace';
+
 // eslint-disable-next-line import/prefer-default-export
-export function getTraceName(spans) {
+export function getTraceName(spans: Span[]) {
   const allSpanIDs = spans.map(sp => sp.spanID);
   const rootSpan = spans
     .filter(sp => {

--- a/packages/jaeger-ui/src/model/trace-viewer.tsx
+++ b/packages/jaeger-ui/src/model/trace-viewer.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2020 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/model/trace-viewer.tsx
+++ b/packages/jaeger-ui/src/model/trace-viewer.tsx
@@ -14,9 +14,11 @@
 
 import { Span } from '../types/trace';
 
+type spansDict = { [index: string]: Span };
+
 // eslint-disable-next-line import/prefer-default-export
 export function getTraceName(spans: Span[]) {
-  const allSpanIDs = spans.map(sp => sp.spanID);
+  const allTraceSpans: spansDict = spans.reduce((dict, span) => ({ ...dict, [span.spanID]: span }), {});
   const rootSpan = spans
     .filter(sp => {
       if (!sp.references || !sp.references.length) {
@@ -25,7 +27,7 @@ export function getTraceName(spans: Span[]) {
       const parentIDs = sp.references.filter(r => r.refType === 'CHILD_OF').map(r => r.spanID);
 
       // no parent from trace
-      return !parentIDs.some(pID => allSpanIDs.includes(pID));
+      return !parentIDs.some(pID => Boolean(allTraceSpans[pID]));
     })
     .sort((sp1, sp2) => sp1.startTime - sp2.startTime)[0];
 

--- a/packages/jaeger-ui/src/model/trace-viewer.tsx
+++ b/packages/jaeger-ui/src/model/trace-viewer.tsx
@@ -29,7 +29,12 @@ export function getTraceName(spans: Span[]) {
       // no parent from trace
       return !parentIDs.some(pID => Boolean(allTraceSpans[pID]));
     })
-    .sort((sp1, sp2) => sp1.startTime - sp2.startTime)[0];
+    .sort((sp1, sp2) => {
+      const sp1ParentsNum = sp1.references ? sp1.references.filter(r => r.refType === 'CHILD_OF').length : 0;
+      const sp2ParentsNum = sp2.references ? sp2.references.filter(r => r.refType === 'CHILD_OF').length : 0;
+
+      return sp1ParentsNum - sp2ParentsNum || sp1.startTime - sp2.startTime;
+    })[0];
 
   return rootSpan ? `${rootSpan.process.serviceName}: ${rootSpan.operationName}` : '';
 }

--- a/packages/jaeger-ui/tsconfig.lint.json
+++ b/packages/jaeger-ui/tsconfig.lint.json
@@ -30,7 +30,6 @@
     "src/api/jaeger.js",
     "src/components/SearchTracePage/SearchResults/ResultItem.markers.js",
     "src/model/order-by.js",
-    "src/model/trace-viewer.js",
     "src/selectors/process.js",
     "src/selectors/span.js",
     "src/selectors/trace.js",


### PR DESCRIPTION
Related to [#461](https://github.com/jaegertracing/jaeger-ui/pull/461).

There is a problem with resolution of a trace name for traces without spans with empty refs (when a "root span" is a span with remote parent).

This PR fixes this problem as suggested in a [discussion](https://github.com/jaegertracing/jaeger-ui/pull/461#discussion_r333851003). To detect a "root span" we:

1. Find all spans that either have no parent reference, or a parent reference that is not found among all trace's spans. 
2. Sort found spans by start time.
3. Take a first ("the earliest") span and make a trace name from this span's data.

Additionally, there are some unit tests for a different cases. 
