### PR TITLE
Usage of a helper for trace name when preparing trace data

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -76,23 +76,7 @@ describe('transformTraceData()', () => {
       ],
       startTime,
       duration,
-      tags: [
-        {
-          key: 'http.url',
-          type: 'string',
-          value: 'https://example.com/getSome',
-        },
-        {
-          key: 'http.method',
-          type: 'string',
-          value: 'get',
-        },
-        {
-          key: 'http.status_code',
-          type: 'float64',
-          value: 200,
-        },
-      ],
+      tags: [],
       processID: 'p1',
     },
     {
@@ -108,28 +92,7 @@ describe('transformTraceData()', () => {
       ],
       startTime: startTime + 100,
       duration,
-      tags: [
-        {
-          key: 'http.url',
-          type: 'string',
-          value: 'https://example.com/getSomeAnother',
-        },
-        {
-          key: 'http.method',
-          type: 'string',
-          value: 'get',
-        },
-        {
-          key: 'error',
-          type: 'bool',
-          value: true,
-        },
-        {
-          key: 'http.status_code',
-          type: 'float64',
-          value: 404,
-        },
-      ],
+      tags: [],
       processID: 'p1',
     },
   ];
@@ -147,23 +110,7 @@ describe('transformTraceData()', () => {
     ],
     startTime: startTime + 50,
     duration,
-    tags: [
-      {
-        key: 'http.url',
-        type: 'string',
-        value: 'https://example.com/getRoot',
-      },
-      {
-        key: 'http.method',
-        type: 'string',
-        value: 'get',
-      },
-      {
-        key: 'http.status_code',
-        type: 'float64',
-        value: 200,
-      },
-    ],
+    tags: [],
     processID: 'p1',
   };
 
@@ -173,41 +120,14 @@ describe('transformTraceData()', () => {
     operationName: rootOperationName,
     startTime: startTime + 50,
     duration,
-    tags: [
-      {
-        key: 'http.url',
-        type: 'string',
-        value: 'https://example.com/getRoot',
-      },
-      {
-        key: 'http.method',
-        type: 'string',
-        value: 'get',
-      },
-      {
-        key: 'http.status_code',
-        type: 'float64',
-        value: 200,
-      },
-    ],
+    tags: [],
     processID: 'p1',
   };
 
   const processes = {
     p1: {
       serviceName,
-      tags: [
-        {
-          key: 'ip',
-          type: 'string',
-          value: '0.0.0.0',
-        },
-        {
-          key: 'hostname',
-          type: 'string',
-          value: 'localhost',
-        },
-      ],
+      tags: [],
     },
   };
 

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { orderTags, deduplicateTags } from './transform-trace-data';
+import transformTraceData, { orderTags, deduplicateTags } from './transform-trace-data';
 
 describe('orderTags()', () => {
   it('correctly orders tags', () => {
@@ -51,5 +51,193 @@ describe('deduplicateTags()', () => {
       { key: 'a.ip', value: '8.8.8.8' },
     ]);
     expect(tagsInfo.warnings).toEqual(['Duplicate tag "b.ip:8.8.4.4"']);
+  });
+});
+
+describe('transformTraceData()', () => {
+  const startTime = 1586160015434000;
+  const duration = 34000;
+  const traceID = 'f77950feed55c1ce91dd8e87896623a6';
+  const rootSpanID = 'd4dcb46e95b781f5';
+  const rootOperationName = 'rootOperation';
+  const serviceName = 'serviceName';
+
+  const spans = [
+    {
+      traceID,
+      spanID: '41f71485ed2593e4',
+      operationName: 'someOperationName',
+      references: [
+        {
+          refType: 'CHILD_OF',
+          traceID,
+          spanID: rootSpanID,
+        },
+      ],
+      startTime,
+      duration,
+      tags: [
+        {
+          key: 'http.url',
+          type: 'string',
+          value: 'https://example.com/getSome',
+        },
+        {
+          key: 'http.method',
+          type: 'string',
+          value: 'get',
+        },
+        {
+          key: 'http.status_code',
+          type: 'float64',
+          value: 200,
+        },
+      ],
+      processID: 'p1',
+    },
+    {
+      traceID,
+      spanID: '4f623fd33c213cba',
+      operationName: 'anotherOperationName',
+      references: [
+        {
+          refType: 'CHILD_OF',
+          traceID,
+          spanID: rootSpanID,
+        },
+      ],
+      startTime: startTime + 100,
+      duration,
+      tags: [
+        {
+          key: 'http.url',
+          type: 'string',
+          value: 'https://example.com/getSomeAnother',
+        },
+        {
+          key: 'http.method',
+          type: 'string',
+          value: 'get',
+        },
+        {
+          key: 'error',
+          type: 'bool',
+          value: true,
+        },
+        {
+          key: 'http.status_code',
+          type: 'float64',
+          value: 404,
+        },
+      ],
+      processID: 'p1',
+    },
+  ];
+
+  const rootSpanWithMissingRef = {
+    traceID,
+    spanID: rootSpanID,
+    operationName: rootOperationName,
+    references: [
+      {
+        refType: 'CHILD_OF',
+        traceID,
+        spanID: 'missingSpanId',
+      },
+    ],
+    startTime: startTime + 50,
+    duration,
+    tags: [
+      {
+        key: 'http.url',
+        type: 'string',
+        value: 'https://example.com/getRoot',
+      },
+      {
+        key: 'http.method',
+        type: 'string',
+        value: 'get',
+      },
+      {
+        key: 'http.status_code',
+        type: 'float64',
+        value: 200,
+      },
+    ],
+    processID: 'p1',
+  };
+
+  const rootSpanWithoutRefs = {
+    traceID,
+    spanID: rootSpanID,
+    operationName: rootOperationName,
+    startTime: startTime + 50,
+    duration,
+    tags: [
+      {
+        key: 'http.url',
+        type: 'string',
+        value: 'https://example.com/getRoot',
+      },
+      {
+        key: 'http.method',
+        type: 'string',
+        value: 'get',
+      },
+      {
+        key: 'http.status_code',
+        type: 'float64',
+        value: 200,
+      },
+    ],
+    processID: 'p1',
+  };
+
+  const processes = {
+    p1: {
+      serviceName,
+      tags: [
+        {
+          key: 'ip',
+          type: 'string',
+          value: '0.0.0.0',
+        },
+        {
+          key: 'hostname',
+          type: 'string',
+          value: 'localhost',
+        },
+      ],
+    },
+  };
+
+  it('should return null for trace without traceID', () => {
+    const traceData = {
+      traceID: undefined,
+      processes,
+      spans,
+    };
+
+    expect(transformTraceData(traceData)).toEqual(null);
+  });
+
+  it('should return trace data with correct traceName based on root span with missing ref', () => {
+    const traceData = {
+      traceID,
+      processes,
+      spans: [...spans, rootSpanWithMissingRef],
+    };
+
+    expect(transformTraceData(traceData).traceName).toEqual(`${serviceName}: ${rootOperationName}`);
+  });
+
+  it('should return trace data with correct traceName based on root span without any refs', () => {
+    const traceData = {
+      traceID,
+      processes,
+      spans: [...spans, rootSpanWithoutRefs],
+    };
+
+    expect(transformTraceData(traceData).traceName).toEqual(`${serviceName}: ${rootOperationName}`);
   });
 });


### PR DESCRIPTION
In continue of #541.

Now there is a `getTraceName()` method that can deal with a "root spans" with missing references. But it doesn't use when traces data transforms for a "Search" and "Compare" pages.
Seems like it should be using here.