### PR TITLE
DDG: Remove kind.server filter and validate the case of service calling itself

### DIFF
--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
@@ -145,11 +145,6 @@ describe('transform traces to ddg paths', () => {
     );
   });
 
-  it('errors if span has ancestor id not in trace data', () => {
-    const traces = makeTraces(makeTrace([rootSpan, followsFocalSpan], missTraceID));
-    expect(() => transformTracesToPaths(traces, focalSvc)).toThrowError(/Ancestor spanID.*not found/);
-  });
-
   it('skips trace without data', () => {
     const traces = {
       ...makeTraces(shortTrace),

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
@@ -205,6 +205,20 @@ describe('transform traces to ddg paths', () => {
     );
   });
 
+  it('support client span root', () => {
+    const spanServiceAClient = makeSpan('SpanA2', undefined, 'client', 'opA', 'serviceA');
+    const spanServiceAServer = makeSpan('SpanA1', spanServiceAClient, 'server', 'opA', 'serviceA');
+    const clientServerTrace = makeTrace([spanServiceAClient, spanServiceAServer], 'clientServerTraceID');
+    spanServiceAServer.hasChildren = false;
+    const { dependencies: result } = transformTracesToPaths(
+      makeTraces(clientServerTrace),
+      clientServerTrace.data.processes[spanServiceAClient.processID].serviceName
+    );
+    expect(new Set(result)).toEqual(
+      new Set([makeExpectedPath([spanServiceAClient, spanServiceAServer], clientServerTrace)])
+    );
+  });
+
   it('dedupled paths', () => {
     const otherSpan = makeSpan('other-span', focalSpan);
     otherSpan.hasChildren = false;

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
@@ -22,10 +22,10 @@ describe('transform traces to ddg paths', () => {
     })),
     attributes: [{ key: 'exemplar_trace_id', value: trace.data.traceID }],
   });
-  const makeSpan = (spanName, parent, kind) => ({
+  const makeSpan = (spanName, parent, kind, operationName, processID) => ({
     hasChildren: true,
-    operationName: `${spanName} operation`,
-    processID: `${spanName} processID`,
+    operationName: operationName || `${spanName} operation`,
+    processID: processID || `${spanName} processID`,
     references: parent
       ? [
           {
@@ -52,7 +52,7 @@ describe('transform traces to ddg paths', () => {
         (result, span) => ({
           ...result,
           [span.processID]: {
-            serviceName: `${span.spanID.split(' ')[0]} service`,
+            serviceName: span.processID,
           },
         }),
         {}
@@ -152,23 +152,50 @@ describe('transform traces to ddg paths', () => {
     expect(result.length).toBe(1);
   });
 
-  it("omits span if tags does not have span.kind === 'server'", () => {
-    const badSpanName = 'test bad span name';
+  it("omits span if tags does not have span.kind === 'server' and is followed by the same service", () => {
+    const spanServiceAServer = makeSpan('SpanA1', focalSpan, 'server', 'opA', 'serviceA');
+    const otherSpanServiceAServer = makeSpan('SpanA2', spanServiceAServer, 'server', 'opB', 'serviceA');
+    otherSpanServiceAServer.hasChildren = false;
+    const spanServiceAClient = makeSpan('SpanA3', spanServiceAServer, 'client', 'opA', 'serviceA');
+    spanServiceAClient.hasChildren = false;
+    const spanServiceAKindless = makeSpan('SpanA4', spanServiceAServer, false, 'opA', 'serviceA');
+    spanServiceAKindless.hasChildren = false;
 
-    const clientSpan = makeSpan(badSpanName, focalSpan, 'client');
-    clientSpan.hasChildren = false;
-    const clientTrace = makeTrace([rootSpan, focalSpan, clientSpan], 'clientTraceID');
+    const spanServiceBClient = makeSpan('SpanB1', focalSpan, 'client', 'opA', 'serviceB');
+    const spanServiceBServer = makeSpan('SpanB2', spanServiceBClient, 'server', 'opB', 'serviceB');
+    spanServiceBServer.hasChildren = false;
 
-    const kindlessSpan = makeSpan(badSpanName, focalSpan, false);
-    kindlessSpan.hasChildren = false;
-    const kindlessTrace = makeTrace([rootSpan, focalSpan, kindlessSpan], 'kindlessTraceID');
+    const serverClientTrace = makeTrace(
+      [rootSpan, focalSpan, spanServiceAServer, spanServiceAClient],
+      'serverClientTraceID'
+    );
+    const clientServerTrace = makeTrace(
+      [rootSpan, focalSpan, spanServiceBClient, spanServiceBServer],
+      'clientServerTraceID'
+    );
+    const kindlessTrace = makeTrace(
+      [rootSpan, focalSpan, spanServiceAServer, spanServiceAKindless],
+      'kindlessTraceID'
+    );
+    const twoServersTrace = makeTrace(
+      [rootSpan, focalSpan, spanServiceAServer, otherSpanServiceAServer],
+      'twoServersTraceID'
+    );
+    const { dependencies: result } = transformTracesToPaths(
+      makeTraces(serverClientTrace, kindlessTrace, twoServersTrace, clientServerTrace),
+      focalSvc
+    );
 
-    const { dependencies: result } = transformTracesToPaths(makeTraces(clientTrace, kindlessTrace), focalSvc);
-
-    const path = makeExpectedPath([rootSpan, focalSpan], clientTrace);
+    const path = makeExpectedPath([rootSpan, focalSpan, spanServiceAServer], serverClientTrace);
     path.attributes.push({ key: 'exemplar_trace_id', value: kindlessTrace.data.traceID });
 
-    expect(new Set(result)).toEqual(new Set([path]));
+    expect(new Set(result)).toEqual(
+      new Set([
+        path,
+        makeExpectedPath([rootSpan, focalSpan, spanServiceAServer, otherSpanServiceAServer], twoServersTrace),
+        makeExpectedPath([rootSpan, focalSpan, spanServiceBServer], clientServerTrace),
+      ])
+    );
   });
 
   it('dedupled paths', () => {

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
@@ -200,7 +200,7 @@ describe('transform traces to ddg paths', () => {
           kindlessTrace,
         ]),
         makeExpectedPath([rootSpan, focalSpan, spanServiceAServer, otherSpanServiceAServer], twoServersTrace),
-        makeExpectedPath([rootSpan, focalSpan, spanServiceBServer], clientServerTrace),
+        makeExpectedPath([rootSpan, focalSpan, spanServiceBClient, spanServiceBServer], clientServerTrace),
       ])
     );
   });

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.test.js
@@ -60,7 +60,7 @@ describe('transform traces to ddg paths', () => {
         (result, span) => ({
           ...result,
           [span.processID]: {
-            serviceName: span.processID,
+            serviceName: `${span.processID}-name`,
           },
         }),
         {}

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import memoizeOne from 'memoize-one';
-import { getTraceSpanIdsAsTree } from '../../selectors/trace';
+import { getTraceSpanIdsAsTree, TREE_ROOT_ID } from '../../selectors/trace';
 
 import { TDdgPayloadEntry, TDdgPayloadPath, TDdgPayload } from './types';
 import { FetchedTrace } from '../../types';
@@ -36,7 +36,7 @@ function transformTracesToPaths(
       const tree = getTraceSpanIdsAsTree(data);
       tree.paths((pathIds: string[]) => {
         const paths = pathIds.reduce((reducedSpans: Span[], id: string): Span[] => {
-          if (id === '__root__') {
+          if (id === TREE_ROOT_ID) {
             return reducedSpans;
           }
           const span = spanMap.get(id);

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
@@ -45,20 +45,14 @@ function transformTracesToPaths(
           const spans = ancestors.reduce((reducedSpans: Span[], id: string): Span[] => {
             const span = spanMap.get(id);
             if (!span) throw new Error(`Ancestor spanID ${id} not found in trace ${traceID}`);
-            if (reducedSpans.length > 0) {
-              const headSpan = reducedSpans[reducedSpans.length - 1];
-              // Transition inside the same service ServiceA -> ServiceA
-              if (headSpan.processID === span.processID) {
-                if (isKindServer(span) && !isKindServer(headSpan)) {
-                  reducedSpans.pop();
-                  reducedSpans.push(span);
-                } else if (isKindServer(span) && isKindServer(headSpan)) {
-                  reducedSpans.push(span);
-                }
-                return reducedSpans;
-              }
+            if (reducedSpans.length === 0) {
+              reducedSpans.push(span);
+            } else if (
+              reducedSpans[reducedSpans.length - 1].processID !== span.processID ||
+              isKindServer(span)
+            ) {
+              reducedSpans.push(span);
             }
-            reducedSpans.push(span);
             return reducedSpans;
           }, []);
           const path: TDdgPayloadEntry[] = spans.map(({ processID, operationName: operation }) => ({

--- a/packages/jaeger-ui/src/utils/TreeNode.js
+++ b/packages/jaeger-ui/src/utils/TreeNode.js
@@ -97,4 +97,24 @@ export default class TreeNode {
       }
     }
   }
+
+  paths(fn) {
+    const stack = [];
+    stack.push({ node: this, childIndex: 0 });
+    const paths = [];
+    while (stack.length) {
+      const { node, childIndex } = stack[stack.length - 1];
+      if (node.children.length >= childIndex + 1) {
+        stack[stack.length - 1].childIndex++;
+        stack.push({ node: node.children[childIndex], childIndex: 0 });
+      } else {
+        if (node.children.length === 0) {
+          const path = stack.map(item => item.node.value);
+          fn(path);
+        }
+        stack.pop();
+      }
+    }
+    return paths;
+  }
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #554 

## Short description of the changes
- I removed the span.kind == server filter, instead validate when the service calls itself multiple times and remove all of those recursive calls and only preserve one of them.

Attached an image.

![Screenshot from 2020-04-04 09-35-55](https://user-images.githubusercontent.com/3799716/78454818-b50d4700-7657-11ea-8f0d-3d60e898dc70.png)

