### PR TITLE
Fix leading 0s breaking row interactions

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.tsx
@@ -68,11 +68,11 @@ function trackParent(store: Store<ReduxState>, { payload }: Action<TSpanIdValue>
   }
   const { spanID } = payload;
   const isHidden = st.traceTimeline.childrenHiddenIDs.has(spanID);
-  const trace = st.trace.traces[traceID].data;
-  if (!trace) {
+  const trace = st.trace.traces[traceID] || st.trace.traces[traceID.replace(/^0*/, '')];
+  if (!trace || !trace.data) {
     return;
   }
-  const span = trace.spans.find(sp => sp.spanID === spanID);
+  const span = trace.data.spans.find(sp => sp.spanID === spanID);
   if (span) {
     trackEvent(CATEGORY_PARENT, getToggleValue(!isHidden), span.depth);
   }


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #548 

## Short description of the changes
- Handle leading 0s in `trackParent` for expanding/collapsing a row
- Improve test coverage in `TraceTimelineViewer/duck.track.tsx`
