### PR TITLE
Fix uiFind matches for spans with leading 0s

### DIFF
--- a/packages/jaeger-ui/src/utils/filter-spans.test.js
+++ b/packages/jaeger-ui/src/utils/filter-spans.test.js
@@ -114,6 +114,28 @@ describe('filterSpans', () => {
     expect(filterSpans(spanID2, spans)).toEqual(new Set([spanID2]));
   });
 
+  it('should return spans whose spanID matches a filter except for leading 0s', () => {
+    const spanID0WithLeading0s = `00${spanID0}`;
+    const spanID2WithLeading0s = `00${spanID2}`;
+
+    expect(filterSpans('spanID', spans)).toEqual(new Set([]));
+    expect(filterSpans(spanID0WithLeading0s, spans)).toEqual(new Set([spanID0]));
+    expect(filterSpans(spanID2WithLeading0s, spans)).toEqual(new Set([spanID2]));
+
+    const spansWithLeading0s = [
+      {
+        ...span0,
+        spanID: spanID0WithLeading0s,
+      },
+      {
+        ...span2,
+        spanID: spanID2WithLeading0s,
+      },
+    ];
+    expect(filterSpans(spanID0, spansWithLeading0s)).toEqual(new Set([spanID0WithLeading0s]));
+    expect(filterSpans(spanID2, spansWithLeading0s)).toEqual(new Set([spanID2WithLeading0s]));
+  });
+
   it('should return spans whose operationName match a filter', () => {
     expect(filterSpans('operationName', spans)).toEqual(new Set([spanID0, spanID2]));
     expect(filterSpans('operationName0', spans)).toEqual(new Set([spanID0]));

--- a/packages/jaeger-ui/src/utils/filter-spans.tsx
+++ b/packages/jaeger-ui/src/utils/filter-spans.tsx
@@ -59,7 +59,7 @@ export default function filterSpans(textFilter: string, spans: Span[] | TNil) {
     isTextInKeyValues(span.tags) ||
     span.logs.some(log => isTextInKeyValues(log.fields)) ||
     isTextInKeyValues(span.process.tags) ||
-    includeFilters.some(filter => filter === span.spanID);
+    includeFilters.some(filter => filter.replace(/^0*/, '') === span.spanID.replace(/^0*/, ''));
 
   // declare as const because need to disambiguate the type
   const rv: Set<string> = new Set(spans.filter(isSpanAMatch).map((span: Span) => span.spanID));


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #560 

## Short description of the changes
- Strip leading 0s out of filter string and spanID before comparing.
