### PR TITLE
Change QualityMetrics lookback param to hours

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -89,8 +89,8 @@ const JaegerAPI = {
   fetchDependencies(endTs = new Date().getTime(), lookback = DEFAULT_DEPENDENCY_LOOKBACK) {
     return getJSON(`${this.apiRoot}dependencies`, { query: { endTs, lookback } });
   },
-  fetchQualityMetrics(service, lookback) {
-    return getJSON(`/qualitymetrics-v2`, { query: { service, lookback } });
+  fetchQualityMetrics(service, hours) {
+    return getJSON(`/qualitymetrics-v2`, { query: { hours, service } });
   },
   fetchServiceOperations(serviceName) {
     return getJSON(`${this.apiRoot}services/${encodeURIComponent(serviceName)}/operations`);

--- a/packages/jaeger-ui/src/api/jaeger.test.js
+++ b/packages/jaeger-ui/src/api/jaeger.test.js
@@ -91,11 +91,11 @@ describe('fetchDependencies', () => {
 
 describe('fetchQualityMetrics', () => {
   it('GETs the specified service and lookback', () => {
-    const lookback = '3h';
+    const hours = '108';
     const service = 'test-service';
-    JaegerAPI.fetchQualityMetrics(service, lookback);
+    JaegerAPI.fetchQualityMetrics(service, hours);
     expect(fetchMock).toHaveBeenLastCalledWith(
-      `/qualitymetrics-v2?${queryString.stringify({ service, lookback })}`,
+      `/qualitymetrics-v2?${queryString.stringify({ service, hours })}`,
       defaultOptions
     );
   });

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.test.js
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.test.js
@@ -72,6 +72,7 @@ describe('QualityMetrics', () => {
       it('fetches quality metrics', () => {
         shallow(<UnconnectedQualityMetrics {...props} />);
         expect(fetchQualityMetricsSpy).toHaveBeenCalledTimes(1);
+        expect(fetchQualityMetricsSpy).toHaveBeenCalledWith(props.service, props.lookback);
       });
     });
 
@@ -98,20 +99,27 @@ describe('QualityMetrics', () => {
 
       it('clears state and fetches quality metrics if service changed', () => {
         expect(fetchQualityMetricsSpy).toHaveBeenCalledTimes(1);
-        wrapper.setProps({ service: `not-${props.service}` });
+
+        const service = `not-${props.service}`;
+        wrapper.setProps({ service });
         expect(fetchQualityMetricsSpy).toHaveBeenCalledTimes(2);
+        expect(fetchQualityMetricsSpy).toHaveBeenLastCalledWith(service, props.lookback);
         expect(wrapper.state()).toEqual(expectedState);
       });
 
       it('clears state and fetches quality metrics if lookback changed', () => {
         expect(fetchQualityMetricsSpy).toHaveBeenCalledTimes(1);
-        wrapper.setProps({ lookback: `not-${props.lookback}` });
+
+        const lookback = `not-${props.lookback}`;
+        wrapper.setProps({ lookback });
         expect(fetchQualityMetricsSpy).toHaveBeenCalledTimes(2);
+        expect(fetchQualityMetricsSpy).toHaveBeenLastCalledWith(props.service, lookback);
         expect(wrapper.state()).toEqual(expectedState);
       });
 
       it('no-ops if neither service or lookback changed', () => {
         expect(fetchQualityMetricsSpy).toHaveBeenCalledTimes(1);
+
         wrapper.setProps({ services: [] });
         expect(fetchQualityMetricsSpy).toHaveBeenCalledTimes(1);
       });

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.tsx
@@ -90,7 +90,7 @@ export class UnconnectedQualityMetrics extends React.PureComponent<TProps, TStat
 
     this.setState({ loading: true });
 
-    JaegerAPI.fetchQualityMetrics(service, `${lookback}h`)
+    JaegerAPI.fetchQualityMetrics(service, lookback)
       .then((qualityMetrics: TQualityMetrics) => {
         this.setState({ qualityMetrics, loading: false });
       })


### PR DESCRIPTION
## Which problem is this PR solving?
- BE uses `hours` as a `uint` not `lookback` as a duration

## Short description of the changes
- Change API request from `/qualitymetrics-v2?service=${service}&lookback=${hours}h` to `/qualitymetrics-v2?service=${service}&hours=${hours}`
