### PR TITLE
Avoid resize on mouse hover (KeyValueTable)

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -45,7 +45,7 @@ limitations under the License.
 }
 
 .KeyValueTable--row:not(:hover) > .KeyValueTable--copyColumn > .KeyValueTable--copyIcon {
-  display: none;
+  visibility: hidden;
 }
 
 .KeyValueTable--row > td {


### PR DESCRIPTION
## Which problem is this PR solving?
![before](https://user-images.githubusercontent.com/6965111/82814657-3b981500-9ea0-11ea-94a9-628bc0bc744c.gif)
The table cell should not resize on hover.
This is quite annoying, esp. with longer messages, where word-wrap gets all messed up.
After the change:
![after](https://user-images.githubusercontent.com/6965111/82814667-3e930580-9ea0-11ea-9301-be1fc36f21c1.gif)
