### PR TITLE
Avoid the horizontal scrollbar (KeyValueTable)

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -23,6 +23,7 @@ limitations under the License.
   font-size: 13px;
   font-family: monospace;
   white-space: pre-wrap;
+  word-break: break-all;
 }
 .json-markup-key {
   font-weight: bold;


### PR DESCRIPTION
## Which problem is this PR solving?
![scroll-before](https://user-images.githubusercontent.com/6965111/82820356-acdcc580-9eaa-11ea-8747-5835382f152b.gif)

The "copy" icon should not cause a horizontal scroll to appear on the expanded KeyValue table.
There is also no need to treat the values as linguistic composites of non-breakable words - they can just as likely be just strings of symbols, for which break-word would actually degrade, rather than improve visual perception.
After the change:
![scroll-after](https://user-images.githubusercontent.com/6965111/82820925-c7fc0500-9eab-11ea-83bc-990246a3c430.gif)
