### PR TITLE
Don't rely on json-markup for non-json strings

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -46,9 +46,10 @@ describe('<KeyValuesTable>', () => {
   let wrapper;
 
   const data = [
-    { key: 'span.kind', value: 'client' },
-    { key: 'omg', value: '{not-a-json' },
-    { key: 'numeric', value: 123456789 },
+    { key: 'span.kind', value: 'client', expected: 'client' },
+    { key: 'omg', value: 'mos-def', expected: 'mos-def' },
+    { key: 'numericString', value: '12345678901234567890', expected: '12345678901234567890' },
+    { key: 'numeric', value: 123456789, expected: '123456789' },
     { key: 'jsonkey', value: JSON.stringify({ hello: 'world' }) },
   ];
 
@@ -138,7 +139,7 @@ describe('<KeyValuesTable>', () => {
     expect(el.length).toBe(data.length);
     el.forEach((valueDiv, i) => {
       if (data[i].key !== 'jsonkey') {
-        expect(valueDiv.html()).toMatch(data[i].value.toString());
+        expect(valueDiv.html()).toMatch(data[i].expected);
       }
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -138,7 +138,7 @@ describe('<KeyValuesTable>', () => {
     expect(el.length).toBe(data.length);
     el.forEach((valueDiv, i) => {
       if (data[i].key !== 'jsonkey') {
-        expect(valueDiv.html()).toMatch(`"${data[i].value}"`);
+        expect(valueDiv.text()).toBe(data[i].value);
       }
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -47,8 +47,8 @@ describe('<KeyValuesTable>', () => {
 
   const data = [
     { key: 'span.kind', value: 'client' },
-    { key: 'omg', value: 'mos-def' },
-    { key: 'numericString', value: '12345678901234567890' },
+    { key: 'omg', value: '{not-a-json' },
+    { key: 'numeric', value: 123456789 },
     { key: 'jsonkey', value: JSON.stringify({ hello: 'world' }) },
   ];
 
@@ -138,7 +138,7 @@ describe('<KeyValuesTable>', () => {
     expect(el.length).toBe(data.length);
     el.forEach((valueDiv, i) => {
       if (data[i].key !== 'jsonkey') {
-        expect(valueDiv.text()).toBe(data[i].value);
+        expect(valueDiv.html()).toMatch(data[i].value.toString());
       }
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -25,16 +25,47 @@ import './KeyValuesTable.css';
 
 const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 
-function parseIfComplexJson(value: any) {
-  // if the value is a string representing actual json object or array, then use json-markup
-  if (typeof value === 'string' && jsonObjectOrArrayStartRegex.test(value)) {
-    // otherwise just return as is
-    try {
-      return JSON.parse(value);
-      // eslint-disable-next-line no-empty
-    } catch (_) {}
+function tryParseJson(value: string) {
+  try {
+    return JSON.parse(value)
+  } catch (_) {
+    return value;
   }
-  return value;
+}
+
+const stringMarkup = (value: string) => (
+  <div className="json-markup">
+    <span className="json-markup-string">{value}</span>
+  </div>
+)
+
+function _jsonMarkup(value: any) {
+  const markup = { __html: jsonMarkup(value) };
+
+  return (
+    // eslint-disable-next-line react/no-danger
+    <div dangerouslySetInnerHTML={markup} />
+  );
+}
+
+function formatValue(value: any) {
+  let content;
+
+  // if the value is a string representing actual json object or array, then use json-markup
+  if (typeof value === 'string') {
+    // otherwise just return as is
+    content = jsonObjectOrArrayStartRegex.test(value)
+      ? _jsonMarkup(tryParseJson(value))
+      : stringMarkup(value);
+  } else {
+    content = _jsonMarkup(value)
+  }
+
+  return (
+    <div className="ub-inline-block">
+      {content}
+    </div>
+  )
 }
 
 export const LinkValue = (props: { href: string; title?: string; children: React.ReactNode }) => (
@@ -71,11 +102,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
       <table className="u-width-100">
         <tbody className="KeyValueTable--body">
           {data.map((row, i) => {
-            const markup = {
-              __html: jsonMarkup(parseIfComplexJson(row.value)),
-            };
-            // eslint-disable-next-line react/no-danger
-            const jsonTable = <div className="ub-inline-block" dangerouslySetInnerHTML={markup} />;
+            const jsonTable = formatValue(row.value);
             const links = linksGetter ? linksGetter(data, i) : null;
             let valueMarkup;
             if (links && links.length === 1) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -29,9 +29,7 @@ function tryParseJson(value: string) {
   // if the value is a string representing actual json object or array, then use json-markup
   // otherwise just return as is
   try {
-    return jsonObjectOrArrayStartRegex.test(value)
-      ? JSON.parse(value)
-      : value
+    return jsonObjectOrArrayStartRegex.test(value) ? JSON.parse(value) : value;
   } catch (_) {
     return value;
   }
@@ -57,9 +55,7 @@ function formatValue(value: any) {
 
   if (typeof value === 'string') {
     const parsed = tryParseJson(value);
-    content = (typeof parsed === 'string')
-      ? stringMarkup(parsed)
-      : _jsonMarkup(parsed);
+    content = typeof parsed === 'string' ? stringMarkup(parsed) : _jsonMarkup(parsed);
   } else {
     content = _jsonMarkup(value);
   }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -27,7 +27,7 @@ const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 
 function tryParseJson(value: string) {
   try {
-    return JSON.parse(value)
+    return JSON.parse(value);
   } catch (_) {
     return value;
   }
@@ -37,7 +37,7 @@ const stringMarkup = (value: string) => (
   <div className="json-markup">
     <span className="json-markup-string">{value}</span>
   </div>
-)
+);
 
 function _jsonMarkup(value: any) {
   const markup = { __html: jsonMarkup(value) };
@@ -58,14 +58,10 @@ function formatValue(value: any) {
       ? _jsonMarkup(tryParseJson(value))
       : stringMarkup(value);
   } else {
-    content = _jsonMarkup(value)
+    content = _jsonMarkup(value);
   }
 
-  return (
-    <div className="ub-inline-block">
-      {content}
-    </div>
-  )
+  return <div className="ub-inline-block">{content}</div>;
 }
 
 export const LinkValue = (props: { href: string; title?: string; children: React.ReactNode }) => (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -56,7 +56,7 @@ function formatValue(value: any) {
   let content;
 
   if (typeof value === 'string') {
-    let parsed = tryParseJson(value);
+    const parsed = tryParseJson(value);
     content = (typeof parsed === 'string')
       ? stringMarkup(parsed)
       : _jsonMarkup(parsed);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -26,8 +26,12 @@ import './KeyValuesTable.css';
 const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 
 function tryParseJson(value: string) {
+  // if the value is a string representing actual json object or array, then use json-markup
+  // otherwise just return as is
   try {
-    return JSON.parse(value);
+    return jsonObjectOrArrayStartRegex.test(value)
+      ? JSON.parse(value)
+      : value
   } catch (_) {
     return value;
   }
@@ -51,12 +55,11 @@ function _jsonMarkup(value: any) {
 function formatValue(value: any) {
   let content;
 
-  // if the value is a string representing actual json object or array, then use json-markup
   if (typeof value === 'string') {
-    // otherwise just return as is
-    content = jsonObjectOrArrayStartRegex.test(value)
-      ? _jsonMarkup(tryParseJson(value))
-      : stringMarkup(value);
+    let parsed = tryParseJson(value);
+    content = (typeof parsed === 'string')
+      ? stringMarkup(parsed)
+      : _jsonMarkup(parsed);
   } else {
     content = _jsonMarkup(value);
   }


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #571 

The presence of those quotes around strings is not only unnecessary (the value type is inferred from the text [color](https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css#L30-L41)), but also confusing (when the value itself contains quotes)

## Short description of the changes

Added a separate function in case the value is a non-json string.

Before:
<img width="612" alt="Screenshot 2020-05-25 at 22 00 15" src="https://user-images.githubusercontent.com/6965111/82837889-2ab4c700-9ed3-11ea-9567-699cce27eb17.png">

After:
<img width="592" alt="Screenshot 2020-05-25 at 21 56 38" src="https://user-images.githubusercontent.com/6965111/82837848-fe994600-9ed2-11ea-8ea6-fe720ed6910c.png">

