### PR TITLE
span bar row size fix

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.css
@@ -28,7 +28,7 @@ limitations under the License.
   /* The size of the indentGuide is based off of the iconWrapper */
   padding-right: calc(0.5rem + 12px);
   height: 100%;
-  border-left: 1px solid transparent;
+  border-left: 3px solid transparent;
   display: inline-flex;
 }
 
@@ -39,15 +39,11 @@ limitations under the License.
 }
 
 .SpanTreeOffset--indentGuide.is-active {
-  /* The size of the indentGuide is based off of the iconWrapper */
-  padding-right: calc(0.5rem + 11px);
-  border-left: 0px;
+  border-left: 3px solid darkgrey;
 }
 
 .SpanTreeOffset--indentGuide.is-active:before {
-  content: '';
-  padding-left: 3px;
-  background-color: darkgrey;
+  background-color: transparent;
 }
 
 .SpanTreeOffset--iconWrapper {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
resolves #589 

## Short description of the changes

bug 👇 (black inner bar is custom critical path info, it does not affect a bug)
![ezgif com-optimize (1)](https://user-images.githubusercontent.com/10380560/87802369-c7ec0600-c859-11ea-88b3-304aa7a329db.gif)

Steps to reproduce:
- use chrome 84
- hover on SpanTreeOffset element, move cursor

What happens:
Not sure why but pseudo element `:before` increases parent's height on `:hover`, so [here](https://github.com/ozonru/jaeger-ui/blob/master/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ListView/index.tsx#L357) after rendering jaeger thinks that element height changed and fall into [recomputing y positions](https://github.com/jaegertracing/jaeger-ui/blob/master/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ListView/index.tsx#L372), this happens on each span hover so span height is growing infinitely 

I fixed size of `indentGuide`, this actually improves perf a little bit (no [layout](https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/#Layout) happens)