### PR TITLE
Fixed missing 'types/node' dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,6 +1539,11 @@
   dependencies:
     moment "*"
 
+"@types/node@*":
+  version "14.0.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.24.tgz#b0f86f58564fa02a28b68f8b55d4cdec42e3b9d6"
+  integrity sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==
+
 "@types/object-hash@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types%2fobject-hash/-/object-hash-1.3.0.tgz#b20db2074129f71829d61ff404e618c4ac3d73cf"


### PR DESCRIPTION
Fixes #601 

Not sure how this didn't get generated in `yarn.lock` as part of #598?