### PR TITLE
Tweak css definition for span tree offset color

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.css
@@ -39,11 +39,11 @@ limitations under the License.
 }
 
 .SpanTreeOffset--indentGuide.is-active {
-  border-left: 3px solid darkgrey;
+  border-left-color: darkgrey;
 }
 
 .SpanTreeOffset--indentGuide.is-active:before {
-  background-color: transparent;
+  background-color: darkgrey;
 }
 
 .SpanTreeOffset--iconWrapper {


### PR DESCRIPTION
## Short description of the changes
- Remove redundant width and style border definition
- Make bold indent guide line up with inactive indent guide
