### PR TITLE
Render seconds in dark color, millis in light

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -72,7 +72,7 @@ export const HEADER_ITEMS = [
     label: 'Trace Start',
     renderer: (trace: Trace) => {
       const dateStr = formatDatetime(trace.startTime);
-      const match = dateStr.match(/^(.+)(:\d\d\.\d+)$/);
+      const match = dateStr.match(/^(.+)(\.\d+)$/);
       return match ? (
         <span className="TracePageHeader--overviewItem--value">
           {match[1]}


### PR DESCRIPTION
Use light color only for the decimals, not the main hh:mm:ss timestamp

![image](https://user-images.githubusercontent.com/3523016/88470829-77b31a80-cecf-11ea-9aee-ea6c09eb7e81.png)
