### PR TITLE
Remove UNSAFE_componentWillMount lifecycle methods

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DependencyForceGraph.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DependencyForceGraph.js
@@ -37,8 +37,7 @@ export default class DependencyForceGraph extends Component {
     };
   }
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this.onResize();
     this.debouncedResize = debounce((...args) => this.onResize(...args), 50);
     window.addEventListener('resize', this.debouncedResize);

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.js
@@ -66,8 +66,7 @@ export class DependencyGraphPageImpl extends Component {
     };
   }
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this.props.fetchDependencies();
   }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/DetailTableData.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/DetailTableData.tsx
@@ -37,17 +37,12 @@ type State = {
  * Used to render the detail column.
  */
 export default class DetailTableData extends Component<Props, State> {
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
+  constructor(props: Readonly<Props>) {
+    super(props);
     const element = this.props.values.map(item => {
       return { uid: _.uniqueId('id'), value: item };
     });
-    this.setState(prevState => {
-      return {
-        ...prevState,
-        element,
-      };
-    });
+    this.state = { element };
   }
 
   render() {

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/MainTableData.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/MainTableData.tsx
@@ -39,18 +39,13 @@ type State = {
  * Used to render the main column.
  */
 export default class MainTableData extends Component<Props, State> {
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
+  constructor(props: Readonly<Props>) {
+    super(props);
     const element = this.props.values.map(item => {
       return { uid: _.uniqueId('id'), value: item };
     });
 
-    this.setState(prevState => {
-      return {
-        ...prevState,
-        element,
-      };
-    });
+    this.state = { element };
   }
 
   render() {


### PR DESCRIPTION
Refactor components to no longer use UNSAFE_componentWillMount methods adhering to current React best practices.

Guides Used:
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#adding-event-listeners-or-subscriptions

## Which problem is this PR solving?
- This work is part of what needs to be done to close Issue #374 and a child of PR: #610 

## Short description of the changes
- Refactored some of the easier deprecated lifecycle methods.
