### PR TITLE
Migrate ArchiveNotifier from UNSAFE_componentWillReceiveProps

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/ArchiveNotifier/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/ArchiveNotifier/index.tsx
@@ -111,12 +111,9 @@ export default class ArchiveNotifier extends React.PureComponent<Props, State> {
     this.state = { notifiedState };
   }
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    const notifiedState = processProps(this.state.notifiedState, nextProps);
-    if (this.state.notifiedState !== notifiedState) {
-      this.setState({ notifiedState });
-    }
+  static getDerivedStateFromProps(props: Props, state: State) {
+    const notifiedState = processProps(state.notifiedState, props);
+    return { notifiedState };
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## Which problem is this PR solving?
- This work is part of what needs to be done to close Issue #374 and a child of PR: #610

## Short description of the changes
- migrate ArchiveNotifier from legacy lifecycle method UNSAFE_componentWillReceiveProps to getDerivedStateFromProps
