### PR TITLE
clear console errors (proptype violations) from CLI output

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
@@ -56,6 +56,7 @@ const DATE_FORMAT = 'YYYY-MM-DD';
 const TIME_FORMAT = 'HH:mm';
 const defaultProps = {
   dataCenters: ['dc1'],
+  handleSubmit: () => {},
   searchMaxLookback: {
     label: '2 Days',
     value: '2d',

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
@@ -24,7 +24,7 @@ import transformTraceData from '../../../model/transform-trace-data';
 const trace = transformTraceData(traceGenerator.trace({}));
 
 it('<ResultItem /> should render base case correctly', () => {
-  const wrapper = shallow(<ResultItem trace={trace} durationPercent={50} />);
+  const wrapper = shallow(<ResultItem trace={trace} durationPercent={50} linkTo="" />);
   const numberOfSpanText = wrapper
     .find(`[data-test="${markers.NUM_SPANS}"]`)
     .first()
@@ -36,7 +36,7 @@ it('<ResultItem /> should render base case correctly', () => {
 });
 
 it('<ResultItem /> should not render any ServiceTags when there are no services', () => {
-  const wrapper = shallow(<ResultItem trace={{ ...trace, services: [] }} durationPercent={50} />);
+  const wrapper = shallow(<ResultItem trace={{ ...trace, services: [] }} durationPercent={50} linkTo="" />);
   const serviceTags = wrapper.find(`[data-test="${markers.SERVICE_TAGS}"]`).find(Tag);
   expect(serviceTags).toHaveLength(0);
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Tidying up, Developer Ergonomics, Papercuts, etc.

## Short description of the changes
- These tests, due to missing required props, were leaving console.error messages in the test run CLI output. It doesn't effect the tests, it doesn't cause any false positives or negatives, but it could be seen as a distraction seeing red output fly across the screen in an otherwise passing test.
