### PR TITLE
Additional Test Coverage around TimelineViewingLayer

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.js
@@ -50,7 +50,7 @@ describe('<TimelineViewingLayer>', () => {
 
   it('sets _root to the root DOM node', () => {
     expect(instance._root).toBeDefined();
-    expect(wrapper.find('.TimelineViewingLayer').getDOMNode()).toBe(instance._root);
+    expect(wrapper.find('.TimelineViewingLayer').getDOMNode()).toBe(instance._root.current);
   });
 
   describe('uses DraggableManager', () => {
@@ -75,8 +75,15 @@ describe('<TimelineViewingLayer>', () => {
     it('returns the dragging bounds from _getDraggingBounds()', () => {
       const left = 10;
       const width = 100;
-      instance._root.getBoundingClientRect = () => ({ left, width });
+      instance._root.current.getBoundingClientRect = () => ({ left, width });
       expect(instance._getDraggingBounds()).toEqual({ width, clientXLeft: left });
+    });
+
+    it('throws error on call to _getDraggingBounds() on unmounted component', () => {
+      wrapper.unmount();
+      expect(instance._getDraggingBounds).toThrow(
+        'Component must be mounted in order to determine DraggableBounds'
+      );
     });
 
     it('updates viewRange.time.cursor via _draggerReframe._onMouseMove', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.js
@@ -101,7 +101,7 @@ describe('<TimelineViewingLayer>', () => {
 
     it('handles drag move via _draggerReframe._onDragMove', () => {
       const anchor = 0.25;
-      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: Math.random() } };
+      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
       const value = 0.5;
       const shift = mapFromSubRange(viewStart, viewEnd, value);
       // make sure `anchor` is already present on the props
@@ -118,11 +118,28 @@ describe('<TimelineViewingLayer>', () => {
       const value = 0.5;
       const shift = mapFromSubRange(viewStart, viewEnd, value);
       const anchor = 0.25;
-      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: Math.random() } };
+      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift } };
       wrapper.setProps({ viewRangeTime });
       instance._draggerReframe._onDragEnd({ manager, value });
       expect(manager.resetBounds.mock.calls).toEqual([[]]);
       expect(props.updateViewRangeTime.mock.calls).toEqual([[anchor, shift, 'timeline-header']]);
+    });
+
+    it('_draggerReframe._onDragEnd sorts anchor and shift', () => {
+      const manager = { resetBounds: jest.fn() };
+      const value = 0.5;
+      const shift = mapFromSubRange(viewStart, viewEnd, value);
+      const anchor = 0.75;
+      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift } };
+      wrapper.setProps({ viewRangeTime });
+      instance._draggerReframe._onDragEnd({ manager, value });
+      expect(props.updateViewRangeTime.mock.calls).toEqual([[shift, anchor, 'timeline-header']]);
+    });
+
+    it('resets draggable bounds on boundsInvalidator update', () => {
+      const spy = jest.spyOn(instance._draggerReframe, 'resetBounds');
+      wrapper.setProps({ boundsInvalidator: 'SOMETHING-NEW' });
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -153,6 +170,24 @@ describe('<TimelineViewingLayer>', () => {
       const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor: viewStart, shift: viewEnd } };
       wrapper.setProps({ viewRangeTime });
       expect(wrapper.find('.isDraggingRight.isReframeDrag').length).toBe(1);
+    });
+
+    it('renders the reframe dragging normalized left', () => {
+      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor: -0.25, shift: viewEnd } };
+      wrapper.setProps({ viewRangeTime });
+      expect(wrapper.find('.isDraggingRight.isReframeDrag').length).toBe(1);
+    });
+
+    it('renders the reframe dragging normalized right', () => {
+      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor: viewStart, shift: 1.25 } };
+      wrapper.setProps({ viewRangeTime });
+      expect(wrapper.find('.isDraggingRight.isReframeDrag').length).toBe(1);
+    });
+
+    it('does not render the reframe on out of bounds', () => {
+      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor: 1.5, shift: 1.75 } };
+      wrapper.setProps({ viewRangeTime });
+      expect(wrapper.find('.isReframeDrag').length).toBe(0);
     });
 
     it('renders the shiftStart dragging', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -122,7 +122,7 @@ function getMarkers(
  */
 export default class TimelineViewingLayer extends React.PureComponent<TimelineViewingLayerProps> {
   _draggerReframe: DraggableManager;
-  _root: Element | TNil;
+  _root: React.RefObject<HTMLDivElement>;
 
   constructor(props: TimelineViewingLayerProps) {
     super(props);
@@ -134,7 +134,7 @@ export default class TimelineViewingLayer extends React.PureComponent<TimelineVi
       onMouseLeave: this._handleReframeMouseLeave,
       onMouseMove: this._handleReframeMouseMove,
     });
-    this._root = undefined;
+    this._root = React.createRef();
   }
 
   // eslint-disable-next-line camelcase
@@ -149,15 +149,12 @@ export default class TimelineViewingLayer extends React.PureComponent<TimelineVi
     this._draggerReframe.dispose();
   }
 
-  _setRoot = (elm: Element | TNil) => {
-    this._root = elm;
-  };
-
   _getDraggingBounds = (): DraggableBounds => {
-    if (!this._root) {
-      throw new Error('invalid state');
+    const current = this._root.current;
+    if (!current) {
+      throw new Error('Component must be mounted in order to determine DraggableBounds');
     }
-    const { left: clientXLeft, width } = this._root.getBoundingClientRect();
+    const { left: clientXLeft, width } = current.getBoundingClientRect();
     return { clientXLeft, width };
   };
 
@@ -205,7 +202,7 @@ export default class TimelineViewingLayer extends React.PureComponent<TimelineVi
       <div
         aria-hidden
         className="TimelineViewingLayer"
-        ref={this._setRoot}
+        ref={this._root}
         onMouseDown={this._draggerReframe.handleMouseDown}
         onMouseLeave={this._draggerReframe.handleMouseLeave}
         onMouseMove={this._draggerReframe.handleMouseMove}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -171,20 +171,22 @@ export default class TimelineViewingLayer extends React.PureComponent<TimelineVi
     this.props.updateNextViewRangeTime({ cursor: undefined });
   };
 
-  _handleReframeDragUpdate = ({ value }: DraggingUpdate) => {
+  _getAnchorAndShift = (value: number) => {
     const { current, reframe } = this.props.viewRangeTime;
     const [viewStart, viewEnd] = current;
     const shift = mapFromViewSubRange(viewStart, viewEnd, value);
     const anchor = reframe ? reframe.anchor : shift;
+    return { anchor, shift };
+  };
+
+  _handleReframeDragUpdate = ({ value }: DraggingUpdate) => {
+    const { anchor, shift } = this._getAnchorAndShift(value);
     const update = { reframe: { anchor, shift } };
     this.props.updateNextViewRangeTime(update);
   };
 
   _handleReframeDragEnd = ({ manager, value }: DraggingUpdate) => {
-    const { current, reframe } = this.props.viewRangeTime;
-    const [viewStart, viewEnd] = current;
-    const shift = mapFromViewSubRange(viewStart, viewEnd, value);
-    const anchor = reframe ? reframe.anchor : shift;
+    const { anchor, shift } = this._getAnchorAndShift(value);
     const [start, end] = shift < anchor ? [shift, anchor] : [anchor, shift];
     manager.resetBounds();
     this.props.updateViewRangeTime(start, end, 'timeline-header');


### PR DESCRIPTION
## Which problem is this PR solving?
- Adding additional test coverage around TimelineViewingLayer
- Removing some "randomness" from the test suite that caused some coverage jitter (see: TimelineViewingLayer showing up in many Codecov reports in PR's that don't touch this component)
- Some minor refactors inside TimelineViewingLayer

## Short description of the changes
- Added tests for more unit coverage
- Added a new function to DRY out the component a little (_getAnchorAndShift)
- Refactored the ref to use CreateRef API introduced in React 16.3 over callback ref
- Removed randomness from test suite causing code coverage fluxuations based on random chance (executing out of bounds paths)
