### PR TITLE
Fixes TraceTimelineViewer span details render issue

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
@@ -305,7 +305,7 @@ describe('<VirtualizedTraceViewImpl>', () => {
       expect(
         rowWrapper.containsMatchingElement(
           <SpanBarRow
-            className={instance.clippingCssClasses}
+            className={instance.getClippingCssClasses()}
             columnDivision={props.spanNameColumnWidth}
             isChildrenExpanded
             isDetailExpanded={false}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -17,6 +17,7 @@ import cx from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
+import _isEqual from 'lodash/isEqual';
 
 // import { History as RouterHistory, Location } from 'history';
 
@@ -148,8 +149,8 @@ function getCssClasses(currentViewRange: [number, number]) {
 }
 
 const memoizedGenerateRowStates = memoizeOne(generateRowStatesFromTrace);
-const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc);
-const memoizedGetCssClasses = memoizeOne(getCssClasses);
+const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc, _isEqual);
+const memoizedGetCssClasses = memoizeOne(getCssClasses, _isEqual);
 
 // export from tests
 export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceViewProps> {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -20,6 +20,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 // import { History as RouterHistory, Location } from 'history';
 
+import memoizeOne from 'memoize-one';
 import { actions } from './duck';
 import ListView from './ListView';
 import SpanBarRow from './SpanBarRow';
@@ -130,6 +131,14 @@ function generateRowStates(
   return rowStates;
 }
 
+function generateRowStatesFromTrace(
+  trace: Trace | TNil,
+  childrenHiddenIDs: Set<string>,
+  detailStates: Map<string, DetailState | TNil>
+): RowState[] {
+  return trace ? generateRowStates(trace.spans, childrenHiddenIDs, detailStates) : [];
+}
+
 function getCssClasses(currentViewRange: [number, number]) {
   const [zoomStart, zoomEnd] = currentViewRange;
   return cx({
@@ -138,28 +147,16 @@ function getCssClasses(currentViewRange: [number, number]) {
   });
 }
 
+const memoizedGenerateRowStates = memoizeOne(generateRowStatesFromTrace);
+const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc);
+const memoizedGetCssClasses = memoizeOne(getCssClasses);
+
 // export from tests
 export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceViewProps> {
-  clippingCssClasses: string;
   listView: ListView | TNil;
-  rowStates: RowState[];
-  getViewedBounds: ViewedBoundsFunctionType;
-
   constructor(props: VirtualizedTraceViewProps) {
     super(props);
-    // keep "prop derivations" on the instance instead of calculating in
-    // `.render()` to avoid recalculating in every invocation of `.renderRow()`
-    const { currentViewRangeTime, childrenHiddenIDs, detailStates, setTrace, trace, uiFind } = props;
-    this.clippingCssClasses = getCssClasses(currentViewRangeTime);
-    const [zoomStart, zoomEnd] = currentViewRangeTime;
-    this.getViewedBounds = createViewedBoundsFunc({
-      min: trace.startTime,
-      max: trace.endTime,
-      viewStart: zoomStart,
-      viewEnd: zoomEnd,
-    });
-    this.rowStates = generateRowStates(trace.spans, childrenHiddenIDs, detailStates);
-
+    const { setTrace, trace, uiFind } = props;
     setTrace(trace, uiFind);
   }
 
@@ -180,14 +177,11 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
   }
 
   componentDidUpdate(prevProps: Readonly<VirtualizedTraceViewProps>) {
-    const { childrenHiddenIDs, detailStates, registerAccessors, trace, currentViewRangeTime } = prevProps;
+    const { registerAccessors, trace } = prevProps;
     const {
       shouldScrollToFirstUiFindMatch,
       clearShouldScrollToFirstUiFindMatch,
       scrollToFirstVisibleSpan,
-      currentViewRangeTime: nextViewRangeTime,
-      childrenHiddenIDs: nextHiddenIDs,
-      detailStates: nextDetailStates,
       registerAccessors: nextRegisterAccessors,
       setTrace,
       trace: nextTrace,
@@ -198,21 +192,6 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       setTrace(nextTrace, uiFind);
     }
 
-    if (trace !== nextTrace || childrenHiddenIDs !== nextHiddenIDs || detailStates !== nextDetailStates) {
-      this.rowStates = nextTrace ? generateRowStates(nextTrace.spans, nextHiddenIDs, nextDetailStates) : [];
-    }
-
-    if (currentViewRangeTime !== nextViewRangeTime) {
-      this.clippingCssClasses = getCssClasses(nextViewRangeTime);
-      const [zoomStart, zoomEnd] = nextViewRangeTime;
-      this.getViewedBounds = createViewedBoundsFunc({
-        min: trace.startTime,
-        max: trace.endTime,
-        viewStart: zoomStart,
-        viewEnd: zoomEnd,
-      });
-    }
-
     if (this.listView && registerAccessors !== nextRegisterAccessors) {
       nextRegisterAccessors(this.getAccessors());
     }
@@ -221,6 +200,28 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       scrollToFirstVisibleSpan();
       clearShouldScrollToFirstUiFindMatch();
     }
+  }
+
+  getRowStates(): RowState[] {
+    const { childrenHiddenIDs, detailStates, trace } = this.props;
+    return memoizedGenerateRowStates(trace, childrenHiddenIDs, detailStates);
+  }
+
+  getClippingCssClasses(): string {
+    const { currentViewRangeTime } = this.props;
+    return memoizedGetCssClasses(currentViewRangeTime);
+  }
+
+  getViewedBounds(): ViewedBoundsFunctionType {
+    const { currentViewRangeTime, trace } = this.props;
+    const [zoomStart, zoomEnd] = currentViewRangeTime;
+
+    return memoizedViewBoundsFunc({
+      min: trace.startTime,
+      max: trace.endTime,
+      viewStart: zoomStart,
+      viewEnd: zoomEnd,
+    });
   }
 
   focusSpan = (uiFind: string) => {
@@ -259,12 +260,12 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
 
   getCollapsedChildren = () => this.props.childrenHiddenIDs;
 
-  mapRowIndexToSpanIndex = (index: number) => this.rowStates[index].spanIndex;
+  mapRowIndexToSpanIndex = (index: number) => this.getRowStates()[index].spanIndex;
 
   mapSpanIndexToRowIndex = (index: number) => {
-    const max = this.rowStates.length;
+    const max = this.getRowStates().length;
     for (let i = 0; i < max; i++) {
-      const { spanIndex } = this.rowStates[i];
+      const { spanIndex } = this.getRowStates()[i];
       if (spanIndex === index) {
         return i;
       }
@@ -283,7 +284,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
   // use long form syntax to avert flow error
   // https://github.com/facebook/flow/issues/3076#issuecomment-290944051
   getKeyFromIndex = (index: number) => {
-    const { isDetail, span } = this.rowStates[index];
+    const { isDetail, span } = this.getRowStates()[index];
     return `${span.spanID}--${isDetail ? 'detail' : 'bar'}`;
   };
 
@@ -291,9 +292,9 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     const parts = key.split('--');
     const _spanID = parts[0];
     const _isDetail = parts[1] === 'detail';
-    const max = this.rowStates.length;
+    const max = this.getRowStates().length;
     for (let i = 0; i < max; i++) {
-      const { span, isDetail } = this.rowStates[i];
+      const { span, isDetail } = this.getRowStates()[i];
       if (span.spanID === _spanID && isDetail === _isDetail) {
         return i;
       }
@@ -302,7 +303,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
   };
 
   getRowHeight = (index: number) => {
-    const { span, isDetail } = this.rowStates[index];
+    const { span, isDetail } = this.getRowStates()[index];
     if (!isDetail) {
       return DEFAULT_HEIGHTS.bar;
     }
@@ -315,7 +316,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
   linksGetter = (span: Span, items: KeyValuePair[], itemIndex: number) => getLinks(span, items, itemIndex);
 
   renderRow = (key: string, style: React.CSSProperties, index: number, attrs: {}) => {
-    const { isDetail, span, spanIndex } = this.rowStates[index];
+    const { isDetail, span, spanIndex } = this.getRowStates()[index];
     return isDetail
       ? this.renderSpanDetailRow(span, key, style, attrs)
       : this.renderSpanBarRow(span, spanIndex, key, style, attrs);
@@ -348,7 +349,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     if (isCollapsed) {
       const rpcSpan = findServerChildSpan(trace.spans.slice(spanIndex));
       if (rpcSpan) {
-        const rpcViewBounds = this.getViewedBounds(rpcSpan.startTime, rpcSpan.startTime + rpcSpan.duration);
+        const rpcViewBounds = this.getViewedBounds()(rpcSpan.startTime, rpcSpan.startTime + rpcSpan.duration);
         rpc = {
           color: colorGenerator.getColorByKey(rpcSpan.process.serviceName),
           operationName: rpcSpan.operationName,
@@ -361,7 +362,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     return (
       <div className="VirtualizedTraceView--row" key={key} style={style} {...attrs}>
         <SpanBarRow
-          className={this.clippingCssClasses}
+          className={this.getClippingCssClasses()}
           color={color}
           columnDivision={spanNameColumnWidth}
           isChildrenExpanded={!isCollapsed}
@@ -372,7 +373,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           onChildrenToggled={childrenToggle}
           rpc={rpc}
           showErrorIcon={showErrorIcon}
-          getViewedBounds={this.getViewedBounds}
+          getViewedBounds={this.getViewedBounds()}
           traceStartTime={trace.startTime}
           span={span}
           focusSpan={this.focusSpan}
@@ -428,7 +429,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       <div className="VirtualizedTraceView--spans">
         <ListView
           ref={this.setListView}
-          dataLength={this.rowStates.length}
+          dataLength={this.getRowStates().length}
           itemHeightGetter={this.getRowHeight}
           itemRenderer={this.renderRow}
           viewBuffer={300}


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- This fixes Issue #628 , a  regression when  refactored `VirtualizedTraceView` to remove deprecated method `componentWillReceiveProps` and use the `componentDidUpdate` instead. 

## Short description of the changes
- The component was using `componentWillReceiveProps` to derive data from properties and store in the instance attributes to avoid recompute it in each render call, With the migration, that process was changed to `componentDidUpdate`, but this is not correct, `RowState` computation on that method doesn't trigger a new render process, so we ended up seeing something not in sync with the `RowState`.  This change uses memoization for `rowState` to avoid recompute it each time. 
