### PR TITLE
Improve duration formatting

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/__snapshots__/ResultItemTitle.test.js.snap
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/__snapshots__/ResultItemTitle.test.js.snap
@@ -29,7 +29,7 @@ exports[`ResultItemTitle renders as expected 1`] = `
     <span
       className="ub-right ub-relative"
     >
-      0.15ms
+      150μs
     </span>
     <h3
       className="ResultItemTitle--title"

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceHeader.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceHeader.test.js.snap
@@ -24,7 +24,7 @@ exports[`TraceHeader Attrs Attrs renders as expected when missing props 1`] = `
       Duration: 
     </span>
     <strong>
-      0ms
+      0μs
     </strong>
   </li>
   <li
@@ -67,7 +67,7 @@ exports[`TraceHeader Attrs renders as expected when provided props 1`] = `
       Duration: 
     </span>
     <strong>
-      0.7ms
+      700μs
     </strong>
   </li>
   <li

--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { formatDuration, ONE_MILLISECOND, ONE_SECOND, ONE_MINUTE, ONE_DAY } from './date.tsx';
+
+describe('formatDuration', () => {
+  it('keeps microseconds the same', () => {
+    expect(formatDuration(1)).toBe('1μs');
+  });
+
+  it('formats values in different durations', () => {
+    const input = 13 * ONE_SECOND + 256 * ONE_MILLISECOND + 777;
+    expect(formatDuration(input)).toBe('13s 256ms 777μs');
+  });
+
+  it('rounds the number of microseconds', () => {
+    const input = 256 * ONE_MILLISECOND + 0.7;
+    expect(formatDuration(input)).toBe('256ms 1μs');
+  });
+
+  it('displays a maximum of 3 units and rounds the last one', () => {
+    const input = 10 * ONE_MINUTE + 13 * ONE_SECOND + 256 * ONE_MILLISECOND + 777;
+    expect(formatDuration(input)).toBe('10m 13s 257ms');
+  });
+
+  it('skips units that are empty', () => {
+    const input = 2 * ONE_DAY + 5 * ONE_MINUTE;
+    expect(formatDuration(input)).toBe('2d 5m');
+  });
+
+  it('displays times less than a μs', () => {
+    const input = 0.1;
+    expect(formatDuration(input)).toBe('0.1μs');
+  });
+
+  it('displays times of 0', () => {
+    const input = 0;
+    expect(formatDuration(input)).toBe('0μs');
+  });
+});

--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2020 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -21,7 +21,7 @@ describe('formatDuration', () => {
 
   it('formats values in different durations', () => {
     const input = 13 * ONE_SECOND + 256 * ONE_MILLISECOND + 777;
-    expect(formatDuration(input)).toBe('13s 256ms 777μs');
+    expect(formatDuration(input)).toBe('13s 257ms');
   });
 
   it('rounds the number of microseconds', () => {
@@ -29,14 +29,14 @@ describe('formatDuration', () => {
     expect(formatDuration(input)).toBe('256ms 1μs');
   });
 
-  it('displays a maximum of 3 units and rounds the last one', () => {
-    const input = 10 * ONE_MINUTE + 13 * ONE_SECOND + 256 * ONE_MILLISECOND + 777;
-    expect(formatDuration(input)).toBe('10m 13s 257ms');
+  it('displays a maximum of 2 units and rounds the last one', () => {
+    const input = 10 * ONE_MINUTE + 13 * ONE_SECOND + 777 * ONE_MILLISECOND;
+    expect(formatDuration(input)).toBe('10m 14s');
   });
 
   it('skips units that are empty', () => {
     const input = 2 * ONE_DAY + 5 * ONE_MINUTE;
-    expect(formatDuration(input)).toBe('2d 5m');
+    expect(formatDuration(input)).toBe('2d');
   });
 
   it('displays times less than a μs', () => {

--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -12,31 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { formatDuration, ONE_MILLISECOND, ONE_SECOND, ONE_MINUTE, ONE_DAY } from './date.tsx';
+import { formatDuration, ONE_MILLISECOND, ONE_SECOND, ONE_MINUTE, ONE_HOUR, ONE_DAY } from './date.tsx';
 
 describe('formatDuration', () => {
   it('keeps microseconds the same', () => {
     expect(formatDuration(1)).toBe('1μs');
   });
 
-  it('formats values in different durations', () => {
-    const input = 13 * ONE_SECOND + 256 * ONE_MILLISECOND + 777;
-    expect(formatDuration(input)).toBe('13s 257ms');
-  });
-
-  it('rounds the number of microseconds', () => {
-    const input = 256 * ONE_MILLISECOND + 0.7;
-    expect(formatDuration(input)).toBe('256ms 1μs');
-  });
-
   it('displays a maximum of 2 units and rounds the last one', () => {
-    const input = 10 * ONE_MINUTE + 13 * ONE_SECOND + 777 * ONE_MILLISECOND;
-    expect(formatDuration(input)).toBe('10m 14s');
+    const input = 10 * ONE_DAY + 13 * ONE_HOUR + 30 * ONE_MINUTE;
+    expect(formatDuration(input)).toBe('10d 14h');
   });
 
   it('skips units that are empty', () => {
     const input = 2 * ONE_DAY + 5 * ONE_MINUTE;
     expect(formatDuration(input)).toBe('2d');
+  });
+
+  it('displays milliseconds in decimals', () => {
+    const input = 2 * ONE_MILLISECOND + 357;
+    expect(formatDuration(input)).toBe('2.36ms');
+  });
+
+  it('displays seconds in decimals', () => {
+    const input = 2 * ONE_SECOND + 357 * ONE_MILLISECOND;
+    expect(formatDuration(input)).toBe('2.36s');
+  });
+
+  it('displays minutes in split units', () => {
+    const input = 2 * ONE_MINUTE + 30 * ONE_SECOND + 555 * ONE_MILLISECOND;
+    expect(formatDuration(input)).toBe('2m 31s');
+  });
+
+  it('displays hours in split units', () => {
+    const input = 2 * ONE_HOUR + 30 * ONE_MINUTE + 30 * ONE_SECOND;
+    expect(formatDuration(input)).toBe('2h 31m');
   });
 
   it('displays times less than a μs', () => {

--- a/packages/jaeger-ui/src/utils/date.tsx
+++ b/packages/jaeger-ui/src/utils/date.tsx
@@ -96,13 +96,17 @@ export function formatSecondTime(duration: number) {
 }
 
 /**
- * Humanizes the duration based on the inputUnit
+ * Humanizes the duration for display.
  *
  * Example:
  * 5000ms => 5s
  * 1000μs => 1ms
+ * 183840s => 2d 3h 4m
+ *
+ * @param {number} duration (in microseconds)
+ * @return {string} formatted duration
  */
-export function formatDuration(duration: number, inputUnit: string = 'microseconds'): string {
+export function formatDuration(duration: number): string {
   if (duration < 1) {
     return `${_round(duration, 2)}μs`;
   }

--- a/packages/jaeger-ui/src/utils/date.tsx
+++ b/packages/jaeger-ui/src/utils/date.tsx
@@ -20,6 +20,7 @@ import { toFloatPrecision } from './number';
 
 const TODAY = 'Today';
 const YESTERDAY = 'Yesterday';
+const DATE_FORMAT_DISPLAYED_UNITS = 2;
 
 export const STANDARD_DATE_FORMAT = 'YYYY-MM-DD';
 export const STANDARD_TIME_FORMAT = 'HH:mm';
@@ -121,7 +122,7 @@ export function formatDuration(duration: number): string {
   return (
     _dropWhile(unitValues, ([value]) => value < 1)
       // Display a maximum of three units
-      .slice(0, 3)
+      .slice(0, DATE_FORMAT_DISPLAYED_UNITS)
       // Round the final value and floor the rest
       .map<[number, string]>(([value, unit], index, all) => [
         index === all.length - 1 ? Math.round(value) : Math.floor(value),


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #319

## Short description of the changes
Improves the duration formatting in the UI so that larger durations are easier to read. I've listed some examples below comparing the old and new formatting:

Old | New | Comment
----- | ----- | ----
0ms | 0μs | Smallest displayed unit used to be ms, now it is μs
1.5s | 1.5s | Durations less than 1 minute are displayed in decimals
1.5m | 1m 30s | Units are split instead of using decimal points
183840s | 2d 3h 4m | No more then 3 units are displayed as going all the way to ms on a day long duration seemed overkill
173040 | 2d 4m | Units that are 0 are hidden

Each of these behaviours are open for discussion, I just tried to pick something that looked sensible.


In addition, this PR also removes the `inputUnit` parameter of the `formatDuration` function. I did this because the parameter would significantly complicate the implementation of the function and it isn't used anywhere I could find in the code base. The duration is always assumed to be given in microseconds which is consistent with the behaviour of other functions in the file. If a duration of a different unit is ever used, then it is probably best to create a function that will convert it to microseconds before passing it to the `formatDuration` function.
