### PR TITLE
Upgrade build to Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8'
+  - '10'
 cache: yarn
 env:
   global:


### PR DESCRIPTION
Code coverage breaks with Node 8
```
$ yarn global add codecov
yarn global v1.22.5
[1/4] Resolving packages...
a@^4.0.0ap@0.0.1[2/4] Fetching packages...
error teeny-request@7.0.1: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.17.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
after_success.2
0.10s$ codecov
codecov: command not found
```