### PR TITLE
Prevent DAG crashes because of empty service name string

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.js
@@ -35,6 +35,11 @@ export default class DAG extends React.Component {
     serviceCalls: [],
   };
 
+  constructor(props) {
+    super(props);
+    this.cytoscapeRef = React.createRef();
+  }
+
   componentDidMount() {
     const { serviceCalls } = this.props;
     const nodeMap = {};
@@ -55,8 +60,9 @@ export default class DAG extends React.Component {
         });
       }
     });
+
     cytoscape({
-      container: document.getElementById('cy'),
+      container: this.cytoscapeRef.current,
       boxSelectionEnabled: false,
       autounselectify: true,
       layout: {
@@ -104,6 +110,7 @@ export default class DAG extends React.Component {
           left: 0,
           top: 0,
         }}
+        ref={this.cytoscapeRef}
       />
     );
   }

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.js
@@ -41,17 +41,19 @@ export default class DAG extends React.Component {
     const nodes = [];
     const edges = [];
     serviceCalls.forEach(d => {
-      if (!nodeMap[d.parent]) {
-        nodes.push({ data: { id: d.parent } });
-        nodeMap[d.parent] = true;
+      if (d.parent.trim().length !== 0 && d.child.trim().length !== 0) {
+        if (!nodeMap[d.parent]) {
+          nodes.push({ data: { id: d.parent } });
+          nodeMap[d.parent] = true;
+        }
+        if (!nodeMap[d.child]) {
+          nodes.push({ data: { id: d.child } });
+          nodeMap[d.child] = true;
+        }
+        edges.push({
+          data: { source: d.parent, target: d.child, label: `${d.callCount}` },
+        });
       }
-      if (!nodeMap[d.child]) {
-        nodes.push({ data: { id: d.child } });
-        nodeMap[d.child] = true;
-      }
-      edges.push({
-        data: { source: d.parent, target: d.child, label: `${d.callCount}` },
-      });
     });
     cytoscape({
       container: document.getElementById('cy'),

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -12,14 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* eslint-disable import/first */
-jest.mock('cytoscape');
-
 import React from 'react';
 import { mount } from 'enzyme';
-
 import DAG from './DAG';
 
+// mock canvas API (we don't care about canvas results)
+
+window.HTMLCanvasElement.prototype.getContext = function() {
+  return {
+    fillRect() {},
+    clearRect() {},
+    getImageData(x, y, w, h) {
+      return {
+        data: new Array(w * h * 4),
+      };
+    },
+    putImageData() {},
+    createImageData() {
+      return [];
+    },
+    setTransform() {},
+    drawImage() {},
+    save() {},
+    fillText() {},
+    restore() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    closePath() {},
+    stroke() {},
+    translate() {},
+    scale() {},
+    rotate() {},
+    arc() {},
+    fill() {},
+    measureText() {
+      return { width: 0 };
+    },
+    transform() {},
+    rect() {},
+    clip() {},
+  };
+};
 describe('<DAG>', () => {
   it('does not explode', () => {
     const serviceCalls = [
@@ -27,6 +61,17 @@ describe('<DAG>', () => {
         callCount: 1,
         child: 'child-id',
         parent: 'parent-id',
+      },
+    ];
+    expect(mount(<DAG serviceCalls={serviceCalls} />)).toBeDefined();
+  });
+
+  it('does not explode with empty strings or string with only spaces', () => {
+    const serviceCalls = [
+      {
+        callCount: 1,
+        child: '',
+        parent: ' ',
       },
     ];
     expect(mount(<DAG serviceCalls={serviceCalls} />)).toBeDefined();


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #634 

## Short description of the changes
- With this change the DAG won't show a node with an empty service, this prevents DAG view crashes because Cytoscape doesn't allow an empty string as an ID.
