### PR TITLE
Pass a function that doesn't return anything to FileUpload component

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -104,7 +104,11 @@ export class SearchTracePageImpl extends Component {
                   {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
                 </TabPane>
                 <TabPane tab="JSON File" key="fileLoader">
-                  <FileLoader loadJsonTraces={loadJsonTraces} />
+                  <FileLoader
+                    loadJsonTraces={(fileList: FileList) => {
+                      loadJsonTraces(fileList);
+                    }}
+                  />
                 </TabPane>
               </Tabs>
             </div>


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes https://github.com/jaegertracing/jaeger-ui/issues/657

## Short description of the changes

- In this PR: https://github.com/jaegertracing/jaeger-ui/pull/622/files a Redux middleware was updated to return the value of `next(..)` in order to preserve the Promises chain, which I think is correct.

- The problem is that ` Upload.Dragger ` and our component `FileUploader` expect a function that returns nothing `(...)=>void`  and the `Upload` component which is used by `Upload.Dragger` expect a function that returns nothing or a custom request, not a Promise, returning a Promise breaks the underling `Upload` component.  `Upload.Dragger`  (and our component `FileUploader`) has type definition for their parameters and Typescript is suppose to do some type checks here , but the search page was not migrated to TS.


Wondering if may be we should do the migration and enforce the types more to prevent future errors like this one. May be in a subsequent PR.
