### PR TITLE
Identify uninstrumented services

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -48,6 +48,12 @@ type SpanBarRowProps = {
         serviceName: string;
       }
     | TNil;
+  noInstrumentedServer?:
+    | {
+        color: string;
+        serviceName: string;
+      }
+    | TNil;
   showErrorIcon: boolean;
   getViewedBounds: ViewedBoundsFunctionType;
   traceStartTime: number;
@@ -87,6 +93,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
       isMatchingFilter,
       numTicks,
       rpc,
+      noInstrumentedServer,
       showErrorIcon,
       getViewedBounds,
       traceStartTime,
@@ -149,6 +156,16 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                     <IoArrowRightA />{' '}
                     <i className="SpanBarRow--rpcColorMarker" style={{ background: rpc.color }} />
                     {rpc.serviceName}
+                  </span>
+                )}
+                {noInstrumentedServer && (
+                  <span>
+                    <IoArrowRightA />{' '}
+                    <i
+                      className="SpanBarRow--rpcColorMarker"
+                      style={{ background: noInstrumentedServer.color }}
+                    />
+                    {noInstrumentedServer.serviceName}
                   </span>
                 )}
               </span>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
@@ -355,6 +355,23 @@ describe('<VirtualizedTraceViewImpl>', () => {
         )
       ).toBe(true);
     });
+
+    it('renders a SpanBarRow with a client span and no instrumented server span', () => {
+      const externServiceName = 'externalServiceTest';
+      const leafSpan = trace.spans.find(span => !span.hasChildren);
+      const leafSpanIndex = trace.spans.indexOf(leafSpan);
+      const clientTags = [
+        { key: 'span.kind', value: 'client' },
+        { key: 'peer.service', value: externServiceName },
+        ...leafSpan.tags,
+      ];
+      const altTrace = updateSpan(trace, leafSpanIndex, { tags: clientTags });
+      wrapper.setProps({ trace: altTrace });
+      const rowWrapper = mount(instance.renderRow('some-key', {}, leafSpanIndex, {}));
+      const spanBarRow = rowWrapper.find(SpanBarRow);
+      expect(spanBarRow.length).toBe(1);
+      expect(spanBarRow.prop('noInstrumentedServer')).not.toBeNull();
+    });
   });
 
   describe('shouldScrollToFirstUiFindMatch', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
@@ -117,4 +117,7 @@ export function findServerChildSpan(spans: Span[]) {
   return null;
 }
 
+export const isKindClient = (span: Span): Boolean =>
+  span.tags.some(({ key, value }) => key === 'span.kind' && value === 'client');
+
 export { formatDuration } from '../../../utils/date';


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #594 

## Short description of the changes

 Implement proposed visualization of external/uninstrumented spans mentioned on #594, this is *work in progress* I'm not sure if the logic to detect such cases is right. This PR identifies an uninstrumented service checking spans that meets the following criteria:

* Leaf span
* span.kind == client
* peer.service tag present

Is this the correct way? or may be I'm missing something? Once we agreed on the logic I can add tests.
