### PR TITLE
WIP: Support for customizing the display of operation names

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -104,6 +104,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
       duration,
       hasChildren: isParent,
       operationName,
+      operationLabel,
       process: { serviceName },
     } = span;
     const label = formatDuration(duration);
@@ -169,7 +170,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                   </span>
                 )}
               </span>
-              <small className="endpoint-name">{rpc ? rpc.operationName : operationName}</small>
+              <small className="endpoint-name">{rpc ? rpc.operationName : operationName}{operationLabel ? (' ' + operationLabel) : ''}</small>
             </a>
             {span.references && span.references.length > 1 && (
               <ReferencesButton

--- a/packages/jaeger-ui/src/model/transform-trace-data.tsx
+++ b/packages/jaeger-ui/src/model/transform-trace-data.tsx
@@ -162,7 +162,7 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
   });
   const traceName = getTraceName(spans);
   const services = Object.keys(svcCounts).map(name => ({ name, numberOfSpans: svcCounts[name] }));
-  return {
+  const trace = {
     services,
     spans,
     traceID,
@@ -175,4 +175,11 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
     startTime: traceStartTime,
     endTime: traceEndTime,
   };
+
+  const traceProcessor = getConfigValue("traceProcessor");
+  if (typeof traceProcessor === 'function') {
+    traceProcessor(trace);
+  }
+
+  return trace;
 }

--- a/packages/jaeger-ui/src/types/trace.tsx
+++ b/packages/jaeger-ui/src/types/trace.tsx
@@ -67,6 +67,7 @@ export type Span = SpanData & {
   references: NonNullable<SpanData['references']>;
   warnings: NonNullable<SpanData['warnings']>;
   subsidiarilyReferencedBy: Array<SpanReference>;
+  operationLabel: string;
 };
 
 export type TraceData = {


### PR DESCRIPTION
See https://github.com/jaegertracing/jaeger-ui/issues/675 for backstory. Marking it as WIP as it's far from ready.

With the following config file:

```js
function UIConfig() {
    return {
        "traceProcessor": async function (trace) {
            for (const span of trace.spans) {
                const tags = {};

                for (const kv of span.tags) {
                    tags[kv.key] = kv.value;
                }

                if ("http.method" in tags) {
                    span.operationLabel = `${tags["http.method"]} → ${tags["http.status_code"]}`;
                }
            }
        },
    };
}
```

I can get the following view:

<img width="392" alt="image" src="https://user-images.githubusercontent.com/89186/104681034-334a4f80-56a6-11eb-80b0-efbb43bd5811.png">

This doesn't change the stats view, as expected:

<img width="511" alt="image" src="https://user-images.githubusercontent.com/89186/104681137-7d333580-56a6-11eb-8673-a5f9a85f831c.png">

This solves the immediate issue, but I'd like to be able to do `async` fetches in my `traceProcessor` to allow augmenting traces with data that is not immediately available. One use-case is having a customer specific SLO and adding a `warning` to spans if they breach the SLO. Given that the call chain leading to `traceProcessor` is not `async`, this currently doesn't work. I'm not a front-end expert to figure this out by myself and it would be nice to get some hints.

Let me know if this is the right approach.