### PR TITLE
Add memoizaion for getConfig

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
@@ -34,6 +34,7 @@ import {
   validateDurationFields,
 } from './SearchForm';
 import * as markers from './SearchForm.markers';
+import getConfig from '../../utils/config/get-config';
 
 function makeDateParams(dateOffset = 0) {
   const date = new Date();
@@ -402,6 +403,7 @@ describe('<SearchForm>', () => {
 
   it('uses config.search.maxLimit', () => {
     const maxLimit = 6789;
+    getConfig.apply({}, []);
     const config = {
       search: {
         maxLimit,

--- a/packages/jaeger-ui/src/utils/config/get-config.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-config.test.js
@@ -59,6 +59,7 @@ describe('getConfig()', () => {
     let getJaegerUiConfig;
 
     beforeEach(() => {
+      getConfig.apply({}, []);
       embedded = {};
       getJaegerUiConfig = jest.fn(() => embedded);
       window.getJaegerUiConfig = getJaegerUiConfig;
@@ -110,12 +111,12 @@ describe('getConfig()', () => {
       });
     });
 
-    it('processes deprecations every time `getConfig` is invoked', () => {
+    it('processes deprecations in `getConfig` is invoked only once', () => {
       processDeprecation.mockClear();
       getConfig();
       expect(processDeprecation.mock.calls.length).toBe(deprecations.length);
       getConfig();
-      expect(processDeprecation.mock.calls.length).toBe(2 * deprecations.length);
+      expect(processDeprecation.mock.calls.length).toBe(deprecations.length);
     });
   });
 });

--- a/packages/jaeger-ui/src/utils/config/get-config.tsx
+++ b/packages/jaeger-ui/src/utils/config/get-config.tsx
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import _get from 'lodash/get';
+import memoizeOne from 'memoize-one';
 
 import processDeprecation from './process-deprecation';
 import defaultConfig, { deprecations } from '../../constants/default-config';
@@ -24,7 +25,7 @@ let haveWarnedDeprecations = false;
  * Merge the embedded config from the query service (if present) with the
  * default config from `../../constants/default-config`.
  */
-export default function getConfig() {
+const getConfig = memoizeOne(function getConfig() {
   const getJaegerUiConfig = window.getJaegerUiConfig;
   if (typeof getJaegerUiConfig !== 'function') {
     if (!haveWarnedFactoryFn) {
@@ -53,7 +54,9 @@ export default function getConfig() {
     }
   }
   return rv;
-}
+});
+
+export default getConfig;
 
 export function getConfigValue(path: string) {
   return _get(getConfig(), path);


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- invoke JS config each time when `getConfig()` run
- resolve discussion from https://github.com/jaegertracing/jaeger-ui/pull/677 
## Short description of the changes
- Add memoization for `getConfig()`
