### PR TITLE
Generic web analytics tracking implementation

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -119,7 +119,8 @@
       "!src/setup*.js",
       "!src/utils/DraggableManager/demo/*.tsx",
       "!src/utils/test/**/*.js",
-      "!src/demo/**/*.js"
+      "!src/demo/**/*.js",
+      "!src/types/*"
     ]
   },
   "browserslist": [

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -85,6 +85,7 @@ export default deepFreeze(
       tracking: {
         gaID: null,
         trackErrors: true,
+        customWebAnalytics: null,
       },
     },
     // fields that should be individually merged vs wholesale replaced

--- a/packages/jaeger-ui/src/middlewares/track.tsx
+++ b/packages/jaeger-ui/src/middlewares/track.tsx
@@ -17,7 +17,7 @@ import { Dispatch, Store } from 'react-redux';
 
 import { middlewareHooks as searchHooks } from '../components/SearchTracePage/SearchForm.track';
 import { middlewareHooks as timelineHooks } from '../components/TracePage/TraceTimelineViewer/duck.track';
-import { isGaEnabled } from '../utils/tracking';
+import { isWaEnabled } from '../utils/tracking';
 import { ReduxState } from '../types';
 
 type TMiddlewareFn = (store: Store<ReduxState>, action: Action<any>) => void;
@@ -36,4 +36,4 @@ function trackingMiddleware(store: Store<ReduxState>) {
   };
 }
 
-export default isGaEnabled ? trackingMiddleware : undefined;
+export default isWaEnabled ? trackingMiddleware : undefined;

--- a/packages/jaeger-ui/src/types/index.tsx
+++ b/packages/jaeger-ui/src/types/index.tsx
@@ -22,11 +22,13 @@ import { EmbeddedState } from './embedded';
 import { SearchQuery } from './search';
 import TDdgState from './TDdgState';
 import TNil from './TNil';
+import IWebAnalytics from './tracking';
 import { Trace } from './trace';
 import TTraceDiffState from './TTraceDiffState';
 import TTraceTimeline from './TTraceTimeline';
 
 export type TNil = TNil;
+export type IWebAnalytics = IWebAnalytics;
 
 export type FetchedState = 'FETCH_DONE' | 'FETCH_ERROR' | 'FETCH_LOADING';
 

--- a/packages/jaeger-ui/src/types/tracking.tsx
+++ b/packages/jaeger-ui/src/types/tracking.tsx
@@ -14,6 +14,11 @@
 
 import { RavenStatic } from 'raven-js';
 import { TNil } from '.';
+import { Config } from './config';
+
+export interface IWebAnalyticsFunc {
+  (config: Config, versionShort: string, versionLong: string): IWebAnalytics;
+}
 
 export default interface IWebAnalytics {
   init: () => void;

--- a/packages/jaeger-ui/src/types/tracking.tsx
+++ b/packages/jaeger-ui/src/types/tracking.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { RavenStatic } from 'raven-js';
+import { TNil } from '.';
+
+export default interface IWebAnalytics {
+  init: () => void;
+  context: boolean | RavenStatic | null;
+  isEnabled: () => boolean;
+  trackPageView: (pathname: string, search: string | TNil) => void;
+  trackError: (description: string) => void;
+  trackEvent: (
+    category: string,
+    action: string,
+    labelOrValue?: string | number | TNil,
+    value?: number | TNil
+  ) => void;
+}

--- a/packages/jaeger-ui/src/types/tracking.tsx
+++ b/packages/jaeger-ui/src/types/tracking.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2021 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/utils/tracking/ga.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/ga.test.js
@@ -46,18 +46,51 @@ describe('google analytics tracking', () => {
         tracking: {
           gaID: 'UA-123456',
           trackErrors: true,
+          cookiesToDimensions: [{ cookie: 'page', dimension: 'dimension1' }],
         },
       },
-      'unknown',
-      'unknown'
+      'c0mm1ts',
+      'c0mm1tL'
     );
-
-    tracking.init();
   });
 
   beforeEach(() => {
     calls = ReactGA.testModeAPI.calls;
     calls.length = 0;
+  });
+
+  describe('init', () => {
+    it('check init function (no cookies)', () => {
+      tracking.init();
+      expect(calls).toEqual([
+        ['create', 'UA-123456', 'auto'],
+        [
+          'set',
+          {
+            appId: 'github.com/jaegertracing/jaeger-ui',
+            appName: 'Jaeger UI',
+            appVersion: 'c0mm1tL',
+          },
+        ],
+      ]);
+    });
+
+    it('check init function (no cookies)', () => {
+      document.cookie = 'page=1;';
+      tracking.init();
+      expect(calls).toEqual([
+        ['create', 'UA-123456', 'auto'],
+        [
+          'set',
+          {
+            appId: 'github.com/jaegertracing/jaeger-ui',
+            appName: 'Jaeger UI',
+            appVersion: 'c0mm1tL',
+          },
+        ],
+        ['set', { dimension1: '1' }],
+      ]);
+    });
   });
 
   describe('trackPageView', () => {

--- a/packages/jaeger-ui/src/utils/tracking/ga.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/ga.test.js
@@ -20,20 +20,13 @@ jest.mock('./conv-raven-to-ga', () => () => ({
 }));
 
 jest.mock('./index', () => {
-  process.env.REACT_APP_VSN_STATE = '{}';
+  global.process.env.REACT_APP_VSN_STATE = '{}';
   return require.requireActual('./index');
 });
 
-jest.mock('../config/get-config', () => () => ({
-  tracking: {
-    gaID: 'UA-123456',
-    trackErrors: true,
-  },
-}));
-
 import ReactGA from 'react-ga';
 
-import * as tracking from './index';
+import GA from './ga';
 
 let longStr = '---';
 function getStr(len) {
@@ -45,6 +38,22 @@ function getStr(len) {
 
 describe('google analytics tracking', () => {
   let calls;
+  let tracking;
+
+  beforeAll(() => {
+    tracking = GA(
+      {
+        tracking: {
+          gaID: 'UA-123456',
+          trackErrors: true,
+        },
+      },
+      'unknown',
+      'unknown'
+    );
+
+    tracking.init();
+  });
 
   beforeEach(() => {
     calls = ReactGA.testModeAPI.calls;

--- a/packages/jaeger-ui/src/utils/tracking/ga.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/ga.test.js
@@ -24,6 +24,13 @@ jest.mock('./index', () => {
   return require.requireActual('./index');
 });
 
+jest.mock('../config/get-config', () => () => ({
+  tracking: {
+    gaID: 'UA-123456',
+    trackErrors: true,
+  },
+}));
+
 import ReactGA from 'react-ga';
 
 import * as tracking from './index';
@@ -36,7 +43,7 @@ function getStr(len) {
   return longStr.slice(0, len);
 }
 
-describe('tracking', () => {
+describe('google analytics tracking', () => {
   let calls;
 
   beforeEach(() => {

--- a/packages/jaeger-ui/src/utils/tracking/ga.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/ga.tsx
@@ -21,19 +21,10 @@ import convRavenToGa from './conv-raven-to-ga';
 import { TNil } from '../../types';
 import { Config } from '../../types/config';
 import { IWebAnalyticsFunc } from '../../types/tracking';
+import { logTrackingCalls } from './utils';
 
 const isTruish = (value?: string | string[]) => {
   return Boolean(value) && value !== '0' && value !== 'false';
-};
-
-/* istanbul ignore next */
-const logTrackingCalls = () => {
-  const calls = ReactGA.testModeAPI.calls;
-  for (let i = 0; i < calls.length; i++) {
-    // eslint-disable-next-line no-console
-    console.log('[react-ga]', ...calls[i]);
-  }
-  calls.length = 0;
 };
 
 const GA: IWebAnalyticsFunc = (config: Config, versionShort: string, versionLong: string) => {

--- a/packages/jaeger-ui/src/utils/tracking/ga.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/ga.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2021 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,70 +18,111 @@ import ReactGA from 'react-ga';
 import Raven, { RavenOptions, RavenTransportOptions } from 'raven-js';
 
 import convRavenToGa from './conv-raven-to-ga';
-import { TNil, IWebAnalytics } from '../../types';
+import { TNil } from '../../types';
+import { Config } from '../../types/config';
+import { IWebAnalyticsFunc } from '../../types/tracking';
 
-export default class GA implements IWebAnalytics {
-  isDebugMode = false;
-  context = null;
-  isProd = process.env.NODE_ENV === 'production';
-  isDev = process.env.NODE_ENV === 'development';
-  isTest = process.env.NODE_ENV === 'test';
-  gaID = null;
-  isErrorsEnabled = false;
+const isTruish = (value?: string | string[]) => {
+  return Boolean(value) && value !== '0' && value !== 'false';
+};
 
-  private cookiesToDimensions = undefined;
-  private EVENT_LENGTHS = {
+const logTrackingCalls = () => {
+  const calls = ReactGA.testModeAPI.calls;
+  for (let i = 0; i < calls.length; i++) {
+    // eslint-disable-next-line no-console
+    console.log('[react-ga]', ...calls[i]);
+  }
+  calls.length = 0;
+};
+
+const GA: IWebAnalyticsFunc = (config: Config, versionShort: string, versionLong: string) => {
+  const isProd = process.env.NODE_ENV === 'production';
+  const isDev = process.env.NODE_ENV === 'development';
+  const isTest = process.env.NODE_ENV === 'test';
+  const isDebugMode =
+    (isDev && isTruish(process.env.REACT_APP_GA_DEBUG)) ||
+    isTruish(queryString.parse(_get(window, 'location.search'))['ga-debug']);
+
+  const gaID = _get(config, 'tracking.gaID');
+  const isErrorsEnabled = isDebugMode || Boolean(_get(config, 'tracking.trackErrors'));
+  const cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');
+  const context = isErrorsEnabled ? Raven : (null as any);
+  const EVENT_LENGTHS = {
     action: 499,
     category: 149,
     label: 499,
   };
 
-  constructor(config: any) {
-    this.isDebugMode =
-      (this.isDev && GA.isTruish(process.env.REACT_APP_GA_DEBUG)) ||
-      GA.isTruish(queryString.parse(_get(window, 'location.search'))['ga-debug']);
+  const isEnabled = () => {
+    return isTest || isDebugMode || (isProd && Boolean(gaID));
+  };
 
-    this.gaID = _get(config, 'tracking.gaID');
-    this.isErrorsEnabled = this.isDebugMode || Boolean(_get(config, 'tracking.trackErrors'));
-    this.cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');
-
-    this.context = this.isErrorsEnabled ? Raven : (null as any);
-  }
-
-  isEnabled() {
-    return this.isTest || this.isDebugMode || (this.isProd && Boolean(this.gaID));
-  }
-
-  init() {
-    let versionShort;
-    let versionLong;
-    if (process.env.REACT_APP_VSN_STATE) {
-      try {
-        const data = JSON.parse(process.env.REACT_APP_VSN_STATE);
-        const joiner = [data.objName];
-        if (data.changed.hasChanged) {
-          joiner.push(data.changed.pretty);
-        }
-        versionShort = joiner.join(' ');
-        versionLong = data.pretty;
-      } catch (_) {
-        versionShort = process.env.REACT_APP_VSN_STATE;
-        versionLong = process.env.REACT_APP_VSN_STATE;
-      }
-      versionLong = versionLong.length > 99 ? `${versionLong.slice(0, 96)}...` : versionLong;
-    } else {
-      versionShort = 'unknown';
-      versionLong = 'unknown';
+  const trackError = (description: string) => {
+    let msg = description;
+    if (!/^jaeger/i.test(msg)) {
+      msg = `jaeger/${msg}`;
     }
-    const gaConfig = { testMode: this.isTest || this.isDebugMode, titleCase: false, debug: true };
-    ReactGA.initialize(this.gaID || 'debug-mode', gaConfig);
+    msg = msg.slice(0, 149);
+    ReactGA.exception({ description: msg, fatal: false });
+    if (isDebugMode) {
+      logTrackingCalls();
+    }
+  };
+
+  const trackEvent = (
+    category: string,
+    action: string,
+    labelOrValue?: string | number | TNil,
+    value?: number | TNil
+  ) => {
+    const event: {
+      action: string;
+      category: string;
+      label?: string;
+      value?: number;
+    } = {
+      category: !/^jaeger/i.test(category)
+        ? `jaeger/${category}`.slice(0, EVENT_LENGTHS.category)
+        : category.slice(0, EVENT_LENGTHS.category),
+      action: action.slice(0, EVENT_LENGTHS.action),
+    };
+    if (labelOrValue != null) {
+      if (typeof labelOrValue === 'string') {
+        event.label = labelOrValue.slice(0, EVENT_LENGTHS.action);
+      } else {
+        // value should be an int
+        event.value = Math.round(labelOrValue);
+      }
+    }
+    if (value != null) {
+      event.value = Math.round(value);
+    }
+    ReactGA.event(event);
+    if (isDebugMode) {
+      logTrackingCalls();
+    }
+  };
+
+  const trackRavenError = (ravenData: RavenTransportOptions) => {
+    const { message, category, action, label, value } = convRavenToGa(ravenData);
+    trackError(message);
+    trackEvent(category, action, label, value);
+  };
+
+  const init = () => {
+    if (!isEnabled()) {
+      return;
+    }
+
+    const gaConfig = { testMode: isTest || isDebugMode, titleCase: false, debug: true };
+    ReactGA.initialize(gaID || 'debug-mode', gaConfig);
     ReactGA.set({
       appId: 'github.com/jaegertracing/jaeger-ui',
       appName: 'Jaeger UI',
       appVersion: versionLong,
     });
-    if (this.cookiesToDimensions !== undefined) {
-      ((this.cookiesToDimensions as unknown) as Array<{ cookie: string; dimension: string }>).forEach(
+    if (cookiesToDimensions !== undefined) {
+      ((cookiesToDimensions as unknown) as Array<{ cookie: string; dimension: string }>).forEach(
         ({ cookie, dimension }: { cookie: string; dimension: string }) => {
           const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookie}=([^\\s;]*)`));
           if (match) ReactGA.set({ [dimension]: match[1] });
@@ -90,7 +131,7 @@ export default class GA implements IWebAnalytics {
         }
       );
     }
-    if (this.isErrorsEnabled) {
+    if (isErrorsEnabled) {
       const ravenConfig: RavenOptions = {
         autoBreadcrumbs: {
           xhr: true,
@@ -99,7 +140,7 @@ export default class GA implements IWebAnalytics {
           location: true,
         },
         environment: process.env.NODE_ENV || 'unkonwn',
-        transport: this.trackRavenError.bind(this),
+        transport: trackRavenError,
       };
       if (versionShort && versionShort !== 'unknown') {
         ravenConfig.tags = {
@@ -111,77 +152,27 @@ export default class GA implements IWebAnalytics {
         Raven.captureException(evt.reason);
       };
     }
-    if (this.isDebugMode) {
-      this.logTrackingCalls();
+    if (isDebugMode) {
+      logTrackingCalls();
     }
-  }
+  };
 
-  trackPageView(pathname: string, search: string | TNil) {
+  const trackPageView = (pathname: string, search: string | TNil) => {
     const pagePath = search ? `${pathname}${search}` : pathname;
     ReactGA.pageview(pagePath);
-    if (this.isDebugMode) {
-      this.logTrackingCalls();
+    if (isDebugMode) {
+      logTrackingCalls();
     }
-  }
+  };
 
-  trackError(description: string) {
-    let msg = description;
-    if (!/^jaeger/i.test(msg)) {
-      msg = `jaeger/${msg}`;
-    }
-    msg = msg.slice(0, 149);
-    ReactGA.exception({ description: msg, fatal: false });
-    if (this.isDebugMode) {
-      this.logTrackingCalls();
-    }
-  }
+  return {
+    isEnabled,
+    init,
+    context,
+    trackPageView,
+    trackError,
+    trackEvent,
+  };
+};
 
-  trackEvent(category: string, action: string, labelOrValue?: string | number | TNil, value?: number | TNil) {
-    const event: {
-      action: string;
-      category: string;
-      label?: string;
-      value?: number;
-    } = {
-      category: !/^jaeger/i.test(category)
-        ? `jaeger/${category}`.slice(0, this.EVENT_LENGTHS.category)
-        : category.slice(0, this.EVENT_LENGTHS.category),
-      action: action.slice(0, this.EVENT_LENGTHS.action),
-    };
-    if (labelOrValue != null) {
-      if (typeof labelOrValue === 'string') {
-        event.label = labelOrValue.slice(0, this.EVENT_LENGTHS.action);
-      } else {
-        // value should be an int
-        event.value = Math.round(labelOrValue);
-      }
-    }
-    if (value != null) {
-      event.value = Math.round(value);
-    }
-    ReactGA.event(event);
-    if (this.isDebugMode) {
-      this.logTrackingCalls();
-    }
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  private logTrackingCalls() {
-    const calls = ReactGA.testModeAPI.calls;
-    for (let i = 0; i < calls.length; i++) {
-      // eslint-disable-next-line no-console
-      console.log('[react-ga]', ...calls[i]);
-    }
-    calls.length = 0;
-  }
-
-  private trackRavenError(ravenData: RavenTransportOptions) {
-    const { message, category, action, label, value } = convRavenToGa(ravenData);
-    this.trackError(message);
-    this.trackEvent(category, action, label, value);
-  }
-
-  static isTruish(value?: string | string[]) {
-    return Boolean(value) && value !== '0' && value !== 'false';
-  }
-}
+export default GA;

--- a/packages/jaeger-ui/src/utils/tracking/ga.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/ga.tsx
@@ -26,6 +26,7 @@ const isTruish = (value?: string | string[]) => {
   return Boolean(value) && value !== '0' && value !== 'false';
 };
 
+/* istanbul ignore next */
 const logTrackingCalls = () => {
   const calls = ReactGA.testModeAPI.calls;
   for (let i = 0; i < calls.length; i++) {
@@ -42,7 +43,6 @@ const GA: IWebAnalyticsFunc = (config: Config, versionShort: string, versionLong
   const isDebugMode =
     (isDev && isTruish(process.env.REACT_APP_GA_DEBUG)) ||
     isTruish(queryString.parse(_get(window, 'location.search'))['ga-debug']);
-
   const gaID = _get(config, 'tracking.gaID');
   const isErrorsEnabled = isDebugMode || Boolean(_get(config, 'tracking.trackErrors'));
   const cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');

--- a/packages/jaeger-ui/src/utils/tracking/ga.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/ga.tsx
@@ -1,0 +1,187 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import _get from 'lodash/get';
+import queryString from 'query-string';
+import ReactGA from 'react-ga';
+import Raven, { RavenOptions, RavenTransportOptions } from 'raven-js';
+
+import convRavenToGa from './conv-raven-to-ga';
+import { TNil, IWebAnalytics } from '../../types';
+
+export default class GA implements IWebAnalytics {
+  isDebugMode = false;
+  context = null;
+  isProd = process.env.NODE_ENV === 'production';
+  isDev = process.env.NODE_ENV === 'development';
+  isTest = process.env.NODE_ENV === 'test';
+  gaID = null;
+  isErrorsEnabled = false;
+
+  private cookiesToDimensions = undefined;
+  private EVENT_LENGTHS = {
+    action: 499,
+    category: 149,
+    label: 499,
+  };
+
+  constructor(config: any) {
+    this.isDebugMode =
+      (this.isDev && GA.isTruish(process.env.REACT_APP_GA_DEBUG)) ||
+      GA.isTruish(queryString.parse(_get(window, 'location.search'))['ga-debug']);
+
+    this.gaID = _get(config, 'tracking.gaID');
+    this.isErrorsEnabled = this.isDebugMode || Boolean(_get(config, 'tracking.trackErrors'));
+    this.cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');
+
+    this.context = this.isErrorsEnabled ? Raven : (null as any);
+  }
+
+  isEnabled() {
+    return this.isTest || this.isDebugMode || (this.isProd && Boolean(this.gaID));
+  }
+
+  init() {
+    let versionShort;
+    let versionLong;
+    if (process.env.REACT_APP_VSN_STATE) {
+      try {
+        const data = JSON.parse(process.env.REACT_APP_VSN_STATE);
+        const joiner = [data.objName];
+        if (data.changed.hasChanged) {
+          joiner.push(data.changed.pretty);
+        }
+        versionShort = joiner.join(' ');
+        versionLong = data.pretty;
+      } catch (_) {
+        versionShort = process.env.REACT_APP_VSN_STATE;
+        versionLong = process.env.REACT_APP_VSN_STATE;
+      }
+      versionLong = versionLong.length > 99 ? `${versionLong.slice(0, 96)}...` : versionLong;
+    } else {
+      versionShort = 'unknown';
+      versionLong = 'unknown';
+    }
+    const gaConfig = { testMode: this.isTest || this.isDebugMode, titleCase: false, debug: true };
+    ReactGA.initialize(this.gaID || 'debug-mode', gaConfig);
+    ReactGA.set({
+      appId: 'github.com/jaegertracing/jaeger-ui',
+      appName: 'Jaeger UI',
+      appVersion: versionLong,
+    });
+    if (this.cookiesToDimensions !== undefined) {
+      ((this.cookiesToDimensions as unknown) as Array<{ cookie: string; dimension: string }>).forEach(
+        ({ cookie, dimension }: { cookie: string; dimension: string }) => {
+          const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookie}=([^\\s;]*)`));
+          if (match) ReactGA.set({ [dimension]: match[1] });
+          // eslint-disable-next-line no-console
+          else console.warn(`${cookie} not present in cookies, could not set dimension: ${dimension}`);
+        }
+      );
+    }
+    if (this.isErrorsEnabled) {
+      const ravenConfig: RavenOptions = {
+        autoBreadcrumbs: {
+          xhr: true,
+          console: false,
+          dom: true,
+          location: true,
+        },
+        environment: process.env.NODE_ENV || 'unkonwn',
+        transport: this.trackRavenError.bind(this),
+      };
+      if (versionShort && versionShort !== 'unknown') {
+        ravenConfig.tags = {
+          git: versionShort,
+        };
+      }
+      Raven.config('https://fakedsn@omg.com/1', ravenConfig).install();
+      window.onunhandledrejection = function trackRejectedPromise(evt: PromiseRejectionEvent) {
+        Raven.captureException(evt.reason);
+      };
+    }
+    if (this.isDebugMode) {
+      this.logTrackingCalls();
+    }
+  }
+
+  trackPageView(pathname: string, search: string | TNil) {
+    const pagePath = search ? `${pathname}${search}` : pathname;
+    ReactGA.pageview(pagePath);
+    if (this.isDebugMode) {
+      this.logTrackingCalls();
+    }
+  }
+
+  trackError(description: string) {
+    let msg = description;
+    if (!/^jaeger/i.test(msg)) {
+      msg = `jaeger/${msg}`;
+    }
+    msg = msg.slice(0, 149);
+    ReactGA.exception({ description: msg, fatal: false });
+    if (this.isDebugMode) {
+      this.logTrackingCalls();
+    }
+  }
+
+  trackEvent(category: string, action: string, labelOrValue?: string | number | TNil, value?: number | TNil) {
+    const event: {
+      action: string;
+      category: string;
+      label?: string;
+      value?: number;
+    } = {
+      category: !/^jaeger/i.test(category)
+        ? `jaeger/${category}`.slice(0, this.EVENT_LENGTHS.category)
+        : category.slice(0, this.EVENT_LENGTHS.category),
+      action: action.slice(0, this.EVENT_LENGTHS.action),
+    };
+    if (labelOrValue != null) {
+      if (typeof labelOrValue === 'string') {
+        event.label = labelOrValue.slice(0, this.EVENT_LENGTHS.action);
+      } else {
+        // value should be an int
+        event.value = Math.round(labelOrValue);
+      }
+    }
+    if (value != null) {
+      event.value = Math.round(value);
+    }
+    ReactGA.event(event);
+    if (this.isDebugMode) {
+      this.logTrackingCalls();
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private logTrackingCalls() {
+    const calls = ReactGA.testModeAPI.calls;
+    for (let i = 0; i < calls.length; i++) {
+      // eslint-disable-next-line no-console
+      console.log('[react-ga]', ...calls[i]);
+    }
+    calls.length = 0;
+  }
+
+  private trackRavenError(ravenData: RavenTransportOptions) {
+    const { message, category, action, label, value } = convRavenToGa(ravenData);
+    this.trackError(message);
+    this.trackEvent(category, action, label, value);
+  }
+
+  static isTruish(value?: string | string[]) {
+    return Boolean(value) && value !== '0' && value !== 'false';
+  }
+}

--- a/packages/jaeger-ui/src/utils/tracking/index.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/index.test.js
@@ -1,0 +1,147 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const mockGA = {
+  init: jest.fn(),
+  context: jest.fn(),
+  isEnabled: jest.fn(),
+};
+
+const mockNoopWebAnalytics = {
+  init: jest.fn(),
+  context: jest.fn(),
+  isEnabled: jest.fn(),
+};
+
+jest.mock('./ga', () => ({
+  __esModule: true,
+  default: () => {
+    return mockGA;
+  },
+}));
+let internalVersionShort;
+let internalVersionLong;
+
+jest.mock('./noopWebAnalytics', () => ({
+  __esModule: true,
+  default: (config, versionShort, versionLong) => {
+    internalVersionShort = versionShort;
+    internalVersionLong = versionLong;
+    return mockNoopWebAnalytics;
+  },
+}));
+
+describe('generic analytics tracking', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+  });
+
+  it('no web analytic test', () => {
+    jest.doMock('../config/get-config', () => {
+      return {
+        __esModule: true,
+        default: () => ({}),
+      };
+    });
+
+    return import('.').then(() => {
+      expect(internalVersionShort).toBe('unknown');
+      expect(internalVersionLong).toBe('unknown');
+      expect(mockNoopWebAnalytics.init).toHaveBeenCalled();
+      expect(mockGA.init).not.toHaveBeenCalled();
+    });
+  });
+
+  it('Google Analytics test', () => {
+    jest.doMock('../config/get-config', () => {
+      return {
+        __esModule: true,
+        default: () => ({
+          tracking: {
+            gaID: 'UA123',
+          },
+        }),
+      };
+    });
+
+    return import('.').then(() => {
+      expect(mockNoopWebAnalytics.init).not.toHaveBeenCalled();
+      expect(mockGA.init).toHaveBeenCalled();
+    });
+  });
+
+  it('Custom Web Analytics test', () => {
+    const mockCustomWA = {
+      init: jest.fn(),
+      context: jest.fn(),
+      isEnabled: jest.fn(),
+    };
+
+    jest.doMock('../config/get-config', () => {
+      return {
+        __esModule: true,
+        default: () => ({
+          tracking: {
+            gaID: 'UA123',
+            customWebAnalytics: () => mockCustomWA,
+          },
+        }),
+      };
+    });
+
+    return import('.').then(() => {
+      expect(mockNoopWebAnalytics.init).not.toHaveBeenCalled();
+      expect(mockGA.init).not.toHaveBeenCalled();
+      expect(mockCustomWA.init).toHaveBeenCalled();
+    });
+  });
+
+  it('get versions as a string or bad JSON test', () => {
+    const version = '123456';
+    process.env.REACT_APP_VSN_STATE = version;
+    jest.doMock('../config/get-config', () => {
+      return {
+        __esModule: true,
+        default: () => ({}),
+      };
+    });
+
+    return import('.').then(() => {
+      expect(internalVersionShort).toBe(version);
+      expect(internalVersionLong).toBe(version);
+      expect(mockNoopWebAnalytics.init).toHaveBeenCalled();
+      expect(mockGA.init).not.toHaveBeenCalled();
+    });
+  });
+
+  it('get versions as an object test', () => {
+    const vShot = '48956d5';
+    const vLong = ' | github.com/jaegertracing/jaeger-ui | 48956d5 | master';
+    process.env.REACT_APP_VSN_STATE = `{"remote":"github.com/jaegertracing/jaeger-ui","objName":"${vShot}","changed":{"hasChanged":false,"files":0,"insertions":0,"deletions":0,"untracked":0,"pretty":""},"refName":"master","pretty":"${vLong}"}`;
+    jest.doMock('../config/get-config', () => {
+      return {
+        __esModule: true,
+        default: () => ({}),
+      };
+    });
+
+    return import('.').then(() => {
+      expect(internalVersionShort).toBe(vShot);
+      expect(internalVersionLong).toBe(vLong);
+      expect(mockNoopWebAnalytics.init).toHaveBeenCalled();
+      expect(mockGA.init).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/jaeger-ui/src/utils/tracking/index.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/index.tsx
@@ -15,6 +15,7 @@
 import { TNil } from '../../types';
 import { IWebAnalyticsFunc } from '../../types/tracking';
 import GA from './ga';
+import NoopWebAnalytics from './noopWebAnalytics';
 import getConfig from '../config/get-config';
 
 const TrackingImplementation = () => {
@@ -40,15 +41,6 @@ const TrackingImplementation = () => {
     versionShort = 'unknown';
     versionLong = 'unknown';
   }
-
-  const NoopWebAnalytics: IWebAnalyticsFunc = () => ({
-    init: () => {},
-    trackPageView: () => {},
-    trackError: () => {},
-    trackEvent: () => {},
-    context: null,
-    isEnabled: () => false,
-  });
 
   let webAnalyticsFunc = NoopWebAnalytics;
 

--- a/packages/jaeger-ui/src/utils/tracking/index.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/index.tsx
@@ -12,71 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import _get from 'lodash/get';
-import queryString from 'query-string';
-import ReactGA from 'react-ga';
-import Raven, { RavenOptions, RavenTransportOptions } from 'raven-js';
-
-import convRavenToGa from './conv-raven-to-ga';
+import { TNil, IWebAnalytics } from '../../types';
+import GA from './ga';
 import getConfig from '../config/get-config';
-import { TNil } from '../../types';
 
-const EVENT_LENGTHS = {
-  action: 499,
-  category: 149,
-  label: 499,
+const TrackingImplementation = () => {
+  const config = getConfig();
+
+  const GenericWebAnalytics: IWebAnalytics = {
+    init: () => {},
+    trackPageView: () => {},
+    trackError: () => {},
+    trackEvent: () => {},
+    context: null,
+    isEnabled: () => false,
+  };
+
+  let webAnalytics = GenericWebAnalytics;
+
+  if (config.tracking && config.tracking.customWebAnalytics) {
+    webAnalytics = config.tracking.customWebAnalytics(config) as IWebAnalytics;
+  } else if (config.tracking && config.tracking.gaID) {
+    webAnalytics = new GA(config);
+  }
+
+  if (webAnalytics.isEnabled()) {
+    webAnalytics.init();
+
+    return webAnalytics;
+  }
+
+  return webAnalytics;
 };
 
-// Util so "0" and "false" become false
-const isTruish = (value?: string | string[]) => Boolean(value) && value !== '0' && value !== 'false';
-
-const isProd = process.env.NODE_ENV === 'production';
-const isDev = process.env.NODE_ENV === 'development';
-const isTest = process.env.NODE_ENV === 'test';
-
-// In test mode if development and envvar REACT_APP_GA_DEBUG is true-ish
-const isDebugMode =
-  (isDev && isTruish(process.env.REACT_APP_GA_DEBUG)) ||
-  isTruish(queryString.parse(_get(window, 'location.search'))['ga-debug']);
-
-const config = getConfig();
-const gaID = _get(config, 'tracking.gaID');
-// enable for tests, debug or if in prod with a GA ID
-export const isGaEnabled = isTest || isDebugMode || (isProd && Boolean(gaID));
-const isErrorsEnabled = isDebugMode || (isGaEnabled && Boolean(_get(config, 'tracking.trackErrors')));
-
-/* istanbul ignore next */
-function logTrackingCalls() {
-  const calls = ReactGA.testModeAPI.calls;
-  for (let i = 0; i < calls.length; i++) {
-    // eslint-disable-next-line no-console
-    console.log('[react-ga]', ...calls[i]);
-  }
-  calls.length = 0;
-}
+const tracker = TrackingImplementation();
 
 export function trackPageView(pathname: string, search: string | TNil) {
-  if (isGaEnabled) {
-    const pagePath = search ? `${pathname}${search}` : pathname;
-    ReactGA.pageview(pagePath);
-    if (isDebugMode) {
-      logTrackingCalls();
-    }
-  }
+  return tracker.trackPageView(pathname, search);
 }
 
 export function trackError(description: string) {
-  if (isGaEnabled) {
-    let msg = description;
-    if (!/^jaeger/i.test(msg)) {
-      msg = `jaeger/${msg}`;
-    }
-    msg = msg.slice(0, 149);
-    ReactGA.exception({ description: msg, fatal: false });
-    if (isDebugMode) {
-      logTrackingCalls();
-    }
-  }
+  return tracker.trackError(description);
 }
 
 export function trackEvent(
@@ -85,107 +61,8 @@ export function trackEvent(
   labelOrValue?: string | number | TNil,
   value?: number | TNil
 ) {
-  if (isGaEnabled) {
-    const event: {
-      action: string;
-      category: string;
-      label?: string;
-      value?: number;
-    } = {
-      category: !/^jaeger/i.test(category)
-        ? `jaeger/${category}`.slice(0, EVENT_LENGTHS.category)
-        : category.slice(0, EVENT_LENGTHS.category),
-      action: action.slice(0, EVENT_LENGTHS.action),
-    };
-    if (labelOrValue != null) {
-      if (typeof labelOrValue === 'string') {
-        event.label = labelOrValue.slice(0, EVENT_LENGTHS.action);
-      } else {
-        // value should be an int
-        event.value = Math.round(labelOrValue);
-      }
-    }
-    if (value != null) {
-      event.value = Math.round(value);
-    }
-    ReactGA.event(event);
-    if (isDebugMode) {
-      logTrackingCalls();
-    }
-  }
+  return tracker.trackEvent(category, action, labelOrValue, value);
 }
 
-function trackRavenError(ravenData: RavenTransportOptions) {
-  const { message, category, action, label, value } = convRavenToGa(ravenData);
-  trackError(message);
-  trackEvent(category, action, label, value);
-}
-
-// Tracking needs to be initialized when this file is imported, e.g. early in
-// the process of initializing the app, so Raven can wrap various resources,
-// like `fetch()`, and generate breadcrumbs from them.
-
-if (isGaEnabled) {
-  let versionShort;
-  let versionLong;
-  if (process.env.REACT_APP_VSN_STATE) {
-    try {
-      const data = JSON.parse(process.env.REACT_APP_VSN_STATE);
-      const joiner = [data.objName];
-      if (data.changed.hasChanged) {
-        joiner.push(data.changed.pretty);
-      }
-      versionShort = joiner.join(' ');
-      versionLong = data.pretty;
-    } catch (_) {
-      versionShort = process.env.REACT_APP_VSN_STATE;
-      versionLong = process.env.REACT_APP_VSN_STATE;
-    }
-    versionLong = versionLong.length > 99 ? `${versionLong.slice(0, 96)}...` : versionLong;
-  } else {
-    versionShort = 'unknown';
-    versionLong = 'unknown';
-  }
-  const gaConfig = { testMode: isTest || isDebugMode, titleCase: false };
-  ReactGA.initialize(gaID || 'debug-mode', gaConfig);
-  ReactGA.set({
-    appId: 'github.com/jaegertracing/jaeger-ui',
-    appName: 'Jaeger UI',
-    appVersion: versionLong,
-  });
-  const cookiesToDimensions = _get(config, 'tracking.cookiesToDimensions');
-  if (cookiesToDimensions) {
-    cookiesToDimensions.forEach(({ cookie, dimension }: { cookie: string; dimension: string }) => {
-      const match = ` ${document.cookie}`.match(new RegExp(`[; ]${cookie}=([^\\s;]*)`));
-      if (match) ReactGA.set({ [dimension]: match[1] });
-      // eslint-disable-next-line no-console
-      else console.warn(`${cookie} not present in cookies, could not set dimension: ${dimension}`);
-    });
-  }
-  if (isErrorsEnabled) {
-    const ravenConfig: RavenOptions = {
-      autoBreadcrumbs: {
-        xhr: true,
-        console: false,
-        dom: true,
-        location: true,
-      },
-      environment: process.env.NODE_ENV || 'unkonwn',
-      transport: trackRavenError,
-    };
-    if (versionShort && versionShort !== 'unknown') {
-      ravenConfig.tags = {
-        git: versionShort,
-      };
-    }
-    Raven.config('https://fakedsn@omg.com/1', ravenConfig).install();
-    window.onunhandledrejection = function trackRejectedPromise(evt) {
-      Raven.captureException(evt.reason);
-    };
-  }
-  if (isDebugMode) {
-    logTrackingCalls();
-  }
-}
-
-export const context = isErrorsEnabled ? Raven : null;
+export const context = tracker.context;
+export const isWaEnabled = tracker.isEnabled();

--- a/packages/jaeger-ui/src/utils/tracking/noopWebAnalytics.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/noopWebAnalytics.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { IWebAnalyticsFunc } from '../../types/tracking';
+
+const NoopWebAnalytics: IWebAnalyticsFunc = () => ({
+  init: () => {},
+  trackPageView: () => {},
+  trackError: () => {},
+  trackEvent: () => {},
+  context: null,
+  isEnabled: () => false,
+});
+
+export default NoopWebAnalytics;

--- a/packages/jaeger-ui/src/utils/tracking/utils.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/utils.test.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as utils from './utils';
+
+describe('utils', () => {
+  describe('logTrackingCalls', () => {
+    it('dry run', () => {
+      expect(utils.logTrackingCalls()).toBeUndefined();
+    });
+  });
+});

--- a/packages/jaeger-ui/src/utils/tracking/utils.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/utils.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ReactGA from 'react-ga';
+
+export const logTrackingCalls = () => {
+  const calls = ReactGA.testModeAPI.calls;
+  for (let i = 0; i < calls.length; i++) {
+    // eslint-disable-next-line no-console
+    console.log('[react-ga]', ...calls[i]);
+  }
+  calls.length = 0;
+};


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- resolves #652 

## Short description of the changes
- GA module was transferred to a separate class and will be invoked once UI configuration property `UIConfig.tracking.gaID` will be added
- if will be provided `customWebAnalytics` implementation via UI configuration property `UIConfig.tracking.customWebAnalytics` it will be used as web analytic in jaeger UI
- if any of UI configuration will not be provided - empty mock(`() => {}`) will be used
- only one web analytic system can work. Priority: Custom Web Analytic -> Google Analytics -> Mock
- `UIConfig.tracking.customWebAnalytics` format(also described in `IWebAnalytics` in types):
```
const CustomWebAnalytics: IWebAnalytics = {
    init: () => {},
    trackPageView: () => {},
    trackError: () => {},
    trackEvent: () => {},
    context: null,
    isEnabled: () => false,
};
```

`UIconfig.js`:
```
function UIConfig() {
  return {
     ...other properties
     tracking: {
       customWebAnalytics: function () {
         return {
           init: () => { /* initialization actions */ },
           trackPageView: (pathname, search) => {},
           trackError: (description) => {},
           trackEvent: (category, action, labelOrValue, value) => {},
           context: null,
           isEnabled: () => false,
         }
       }
     }
  }
}
```


