### PR TITLE
Allow a tag to be displayed next to operation name (revamp #487)

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
@@ -20,10 +20,9 @@ import { mount, shallow } from 'enzyme';
 import SpanBarRow from './SpanBarRow';
 import SpanTreeOffset from './SpanTreeOffset';
 import ReferencesButton from './ReferencesButton';
-import { getConfigValue } from '../../../utils/config/get-config';
+import * as getConfig from '../../../utils/config/get-config';
 
 jest.mock('./SpanTreeOffset');
-jest.mock('../../../utils/config/get-config');
 
 describe('<SpanBarRow>', () => {
   const spanID = 'some-id';
@@ -64,7 +63,6 @@ describe('<SpanBarRow>', () => {
   beforeEach(() => {
     props.onDetailToggled.mockReset();
     props.onChildrenToggled.mockReset();
-    getConfigValue.mockReset();
     wrapper = mount(<SpanBarRow {...props} />);
   });
 
@@ -170,21 +168,33 @@ describe('<SpanBarRow>', () => {
     expect(refButton.at(0).props().tooltipText).toEqual('This span is referenced by multiple other spans');
   });
 
-  it('has expected lebel when pattern is set and tags exist', () => {
-    getConfigValue.mockReturnValue('(#{opLabelTag})');
-    wrapper = mount(<SpanBarRow {...props} />);
-    expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name (#id)');
-  });
+  describe('operation label', () => {
+    let getConfigValueSpy;
 
-  it('hides unless every tag exists', () => {
-    getConfigValue.mockReturnValue('#{opLabelTag} #{http.status_code}');
-    wrapper = mount(<SpanBarRow {...props} />);
-    expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name');
-  });
+    beforeAll(() => {
+      getConfigValueSpy = jest.spyOn(getConfig, 'getConfigValue');
+    });
 
-  it('has expected lebel when no rpc', () => {
-    const norpc = _omit(props, 'rpc');
-    wrapper = mount(<SpanBarRow {...norpc} />);
-    expect(wrapper.find('.endpoint-name').text()).toBe('op-name');
+    beforeEach(() => {
+      getConfigValueSpy.mockReset();
+    });
+
+    it('has expected lebel when pattern is set and tags exist', () => {
+      getConfigValueSpy.mockReturnValue('(#{opLabelTag})');
+      wrapper = mount(<SpanBarRow {...props} />);
+      expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name (#id)');
+    });
+
+    it('hides unless every tag exists', () => {
+      getConfigValueSpy.mockReturnValue('#{opLabelTag} #{http.status_code}');
+      wrapper = mount(<SpanBarRow {...props} />);
+      expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name');
+    });
+
+    it('has expected lebel when no rpc', () => {
+      const norpc = _omit(props, 'rpc');
+      wrapper = mount(<SpanBarRow {...norpc} />);
+      expect(wrapper.find('.endpoint-name').text()).toBe('op-name');
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
@@ -181,14 +181,14 @@ describe('<SpanBarRow>', () => {
 
     const tagKey = props.span.tags[0].key;
 
-    it('has expected lebel when pattern is set and tags exist', () => {
+    it('has expected level when pattern is set and tags exist', () => {
       getConfigValueSpy.mockReturnValue(`(#{${tagKey}})`);
       wrapper = mount(<SpanBarRow {...props} />);
       expect(wrapper.find('.endpoint-name').text()).toBe(`${props.rpc.operationName} (${props.span.tags[0].value})`);
     });
 
     it('hides unless every tag exists', () => {
-      getConfigValueSpy.mockReturnValue('#{opLabelTag} #{http.status_code}');
+      getConfigValueSpy.mockReturnValue('#{opLabelTag} #{ABSENT_KEY}');
       wrapper = mount(<SpanBarRow {...props} />);
       expect(wrapper.find('.endpoint-name').text()).toBe(props.rpc.operationName);
     });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
@@ -68,7 +68,7 @@ describe('<SpanBarRow>', () => {
 
   it('renders without exploding', () => {
     expect(wrapper).toBeDefined();
-    expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name');
+    expect(wrapper.find('.endpoint-name').text()).toBe(props.rpc.operationName);
   });
 
   it('escalates detail toggling', () => {
@@ -179,22 +179,24 @@ describe('<SpanBarRow>', () => {
       getConfigValueSpy.mockReset();
     });
 
+    const tagKey = props.span.tags[0].key;
+
     it('has expected lebel when pattern is set and tags exist', () => {
-      getConfigValueSpy.mockReturnValue('(#{opLabelTag})');
+      getConfigValueSpy.mockReturnValue(`(#{${tagKey}})`);
       wrapper = mount(<SpanBarRow {...props} />);
-      expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name (#id)');
+      expect(wrapper.find('.endpoint-name').text()).toBe(`${props.rpc.operationName} (${props.span.tags[0].value})`);
     });
 
     it('hides unless every tag exists', () => {
       getConfigValueSpy.mockReturnValue('#{opLabelTag} #{http.status_code}');
       wrapper = mount(<SpanBarRow {...props} />);
-      expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name');
+      expect(wrapper.find('.endpoint-name').text()).toBe(props.rpc.operationName);
     });
 
     it('has expected lebel when no rpc', () => {
       const norpc = _omit(props, 'rpc');
       wrapper = mount(<SpanBarRow {...norpc} />);
-      expect(wrapper.find('.endpoint-name').text()).toBe('op-name');
+      expect(wrapper.find('.endpoint-name').text()).toBe(props.span.operationName);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import _omit from 'lodash/omit';
+
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 
 import SpanBarRow from './SpanBarRow';
 import SpanTreeOffset from './SpanTreeOffset';
 import ReferencesButton from './ReferencesButton';
+import { getConfigValue } from '../../../utils/config/get-config';
 
 jest.mock('./SpanTreeOffset');
+jest.mock('../../../utils/config/get-config');
 
 describe('<SpanBarRow>', () => {
   const spanID = 'some-id';
@@ -32,7 +36,6 @@ describe('<SpanBarRow>', () => {
     isFilteredOut: false,
     onDetailToggled: jest.fn(),
     onChildrenToggled: jest.fn(),
-    operationName: 'op-name',
     numTicks: 5,
     rpc: {
       viewStart: 0.25,
@@ -45,12 +48,14 @@ describe('<SpanBarRow>', () => {
     getViewedBounds: () => ({ start: 0, end: 1 }),
     span: {
       duration: 'test-duration',
+      operationName: 'op-name',
       hasChildren: true,
       process: {
         serviceName: 'service-name',
       },
       spanID,
       logs: [],
+      tags: [{ key: 'opLabelTag', value: '#id' }],
     },
   };
 
@@ -59,11 +64,13 @@ describe('<SpanBarRow>', () => {
   beforeEach(() => {
     props.onDetailToggled.mockReset();
     props.onChildrenToggled.mockReset();
+    getConfigValue.mockReset();
     wrapper = mount(<SpanBarRow {...props} />);
   });
 
   it('renders without exploding', () => {
     expect(wrapper).toBeDefined();
+    expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name');
   });
 
   it('escalates detail toggling', () => {
@@ -161,5 +168,23 @@ describe('<SpanBarRow>', () => {
     const refButton = spanRow.find(ReferencesButton);
     expect(refButton.length).toEqual(1);
     expect(refButton.at(0).props().tooltipText).toEqual('This span is referenced by multiple other spans');
+  });
+
+  it('has expected lebel when pattern is set and tags exist', () => {
+    getConfigValue.mockReturnValue('(#{opLabelTag})');
+    wrapper = mount(<SpanBarRow {...props} />);
+    expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name (#id)');
+  });
+
+  it('hides unless every tag exists', () => {
+    getConfigValue.mockReturnValue('#{opLabelTag} #{http.status_code}');
+    wrapper = mount(<SpanBarRow {...props} />);
+    expect(wrapper.find('.endpoint-name').text()).toBe('rpc-op-name');
+  });
+
+  it('has expected lebel when no rpc', () => {
+    const norpc = _omit(props, 'rpc');
+    wrapper = mount(<SpanBarRow {...norpc} />);
+    expect(wrapper.find('.endpoint-name').text()).toBe('op-name');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -26,6 +26,8 @@ import Ticks from './Ticks';
 
 import { TNil } from '../../../types';
 import { Span } from '../../../types/trace';
+import { getConfigValue } from '../../../utils/config/get-config';
+import { computeSingleTagPattern } from '../../../model/link-patterns';
 
 import './SpanBarRow.css';
 
@@ -110,6 +112,8 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
     const viewBounds = getViewedBounds(span.startTime, span.startTime + span.duration);
     const viewStart = viewBounds.start;
     const viewEnd = viewBounds.end;
+    const opLabelPattern = getConfigValue('opLabel');
+    const opLabel = opLabelPattern && computeSingleTagPattern(opLabelPattern, span);
 
     const labelDetail = `${serviceName}::${operationName}`;
     let longLabel;
@@ -169,7 +173,10 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                   </span>
                 )}
               </span>
-              <small className="endpoint-name">{rpc ? rpc.operationName : operationName}</small>
+              <small className="endpoint-name">
+                {rpc ? rpc.operationName : operationName}
+                {opLabel ? ` ${opLabel}` : ''}
+              </small>
             </a>
             {span.references && span.references.length > 1 && (
               <ReferencesButton

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -175,7 +175,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
               </span>
               <small className="endpoint-name">
                 {rpc ? rpc.operationName : operationName}
-                {opLabel ? ` ${opLabel}` : ''}
+                {opLabel && ` ${opLabel}`}
               </small>
             </a>
             {span.references && span.references.length > 1 && (

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -87,6 +87,7 @@ export default deepFreeze(
         trackErrors: true,
         customWebAnalytics: null,
       },
+      opLabel: null,
     },
     // fields that should be individually merged vs wholesale replaced
     '__mergeFields',

--- a/packages/jaeger-ui/src/model/link-patterns.test.js
+++ b/packages/jaeger-ui/src/model/link-patterns.test.js
@@ -19,6 +19,7 @@ import {
   getParameterInAncestor,
   processLinkPattern,
   computeLinks,
+  computeSingleTagPattern,
   createGetLinks,
   computeTraceLink,
 } from './link-patterns';
@@ -390,6 +391,22 @@ describe('computeLinks()', () => {
         text: 'second link (valueOfMy+Other+Key)',
       },
     ]);
+  });
+});
+
+describe('computeSingleTagPattern()', () => {
+  const span = { process: {}, tags: [{ key: 'myKey', value: 'v1' }, { key: 'myKey2', value: 'v2' }] };
+  it('correctly computes single tag pattern', () => {
+    expect(computeSingleTagPattern('#{myKey} - #{myKey}(#{myKey2})', span)).toBe('v1 - v1(v2)');
+  });
+  it('any non-existent tag yields undefined', () => {
+    expect(computeSingleTagPattern('#{myKey} - #{myKey}(#{myKey3})', span)).toBe(false);
+  });
+  it('invalid pattern yields undefined', () => {
+    expect(computeSingleTagPattern('#{myK(#{myKey3})', span)).toBe(false);
+  });
+  it('invalid pattern', () => {
+    expect(computeSingleTagPattern(null, span)).toBe(false);
   });
 });
 

--- a/packages/jaeger-ui/src/model/link-patterns.tsx
+++ b/packages/jaeger-ui/src/model/link-patterns.tsx
@@ -20,6 +20,7 @@ import { encodedStringSupplant, getParamNames } from '../utils/stringSupplant';
 import { getParent } from './span';
 import { TNil } from '../types';
 import { Span, Link, KeyValuePair, Trace } from '../types/trace';
+import pluckTruthy from '../utils/ts/pluckTruthy';
 
 type ProcessedTemplate = {
   parameters: string[];
@@ -157,12 +158,36 @@ export function computeTraceLink(linkPatterns: ProcessedLinkPattern[], trace: Tr
   return result;
 }
 
+function renderPattern(
+  pattern: ProcessedLinkPattern,
+  items: KeyValuePair[],
+  findInAncestorsFn: (_: string) => KeyValuePair | undefined,
+  onMissingFn: (_: string) => void
+) {
+  const parameterValues: Record<string, any> = {};
+  const allParameters = pattern.parameters.every(parameter => {
+    const entry = getParameterInArray(parameter, items) || findInAncestorsFn(parameter);
+    if (entry) {
+      parameterValues[parameter] = entry.value;
+      return true;
+    }
+    onMissingFn(parameter);
+    return false;
+  });
+  return (
+    allParameters && {
+      url: callTemplate(pattern.url, parameterValues),
+      text: callTemplate(pattern.text, parameterValues),
+    }
+  );
+}
+
 export function computeLinks(
   linkPatterns: ProcessedLinkPattern[],
   span: Span,
   items: KeyValuePair[],
   itemIndex: number
-) {
+): { url: string; text: string }[] {
   const item = items[itemIndex];
   let type = 'logs';
   const processTags = span.process.tags === items;
@@ -173,37 +198,43 @@ export function computeLinks(
   if (spanTags) {
     type = 'tags';
   }
-  const result: { url: string; text: string }[] = [];
-  linkPatterns.forEach(pattern => {
-    if (pattern.type(type) && pattern.key(item.key) && pattern.value(item.value)) {
-      const parameterValues: Record<string, any> = {};
-      const allParameters = pattern.parameters.every(parameter => {
-        let entry = getParameterInArray(parameter, items);
-        if (!entry && !processTags) {
-          // do not look in ancestors for process tags because the same object may appear in different places in the hierarchy
-          // and the cache in getLinks uses that object as a key
-          entry = getParameterInAncestor(parameter, span);
-        }
-        if (entry) {
-          parameterValues[parameter] = entry.value;
-          return true;
-        }
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Skipping link pattern, missing parameter ${parameter} for key ${item.key} in ${type}.`,
-          pattern.object
-        );
-        return false;
-      });
-      if (allParameters) {
-        result.push({
-          url: callTemplate(pattern.url, parameterValues),
-          text: callTemplate(pattern.text, parameterValues),
-        });
-      }
-    }
+  return pluckTruthy(
+    linkPatterns.map(
+      pattern =>
+        pattern.type(type) &&
+        pattern.key(item.key) &&
+        pattern.value(item.value) &&
+        renderPattern(
+          pattern,
+          items,
+          parameter => {
+            // do not look in ancestors for process tags because the same object may appear in different
+            // places in the hierarchy and the cache in getLinks uses that object as a key
+            return !processTags ? getParameterInAncestor(parameter, span) : undefined;
+          },
+          parameter => {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `Skipping link pattern, missing parameter ${parameter} for key ${item.key} in ${type}.`,
+              pattern.object
+            );
+          }
+        )
+    )
+  );
+}
+
+export function computeSingleTagPattern(pattern: String, span: Span) {
+  const linkPattern = processLinkPattern({
+    type: 'tags',
+    url: '',
+    text: pattern,
   });
-  return result;
+  if (!linkPattern) {
+    return false;
+  }
+  const link = renderPattern(linkPattern, span.tags, () => undefined, () => {});
+  return link && link.text;
 }
 
 export function createGetLinks(linkPatterns: ProcessedLinkPattern[], cache: WeakMap<KeyValuePair, Link[]>) {

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -63,4 +63,5 @@ export type Config = {
     trackErrors: boolean | TNil;
   };
   linkPatterns?: LinkPatternsConfig;
+  opLabel?: string | TNil;
 };


### PR DESCRIPTION
This PR takes the change in #487 from @lookfwd, rebases it against latest, and applies the suggested changes from @everett980.

> ## Which problem is this PR solving?
> * There is a need to display additional information for each _Span_ in a prominent position (next to operation name). For example, with the following `config.json`:
> 
> ```
> {
>   "opLabelTag": "http.status_code"
> }
> ```
> 
> we get:
> <img alt="8E0BC66E-B4F4-4598-A945-FDF80FE2052C" width="648" src="https://user-images.githubusercontent.com/789359/69221502-6c8c3b80-0b45-11ea-88b3-94a4e6b98b2b.png">
>
> ## Short description of the changes
>
> Adds a configuration option `opLabelTag` which, when set, shows the value of the specified `opLabelTag` _Tag_ for a _Span_, if set, in parenthesis next to the operation name in the trace view.

I signed the extra commits as myself because I don't want to impersonate someone without permission, but the code is from @everett980. Some small changes were needed to let tests pass.
