### PR TITLE
Proposal: Render user tooltips near operation

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -123,6 +123,11 @@ limitations under the License.
   color: #000;
 }
 
+.tooltip {
+  color: #808080;
+  margin-left: 1ch;
+}
+
 .span-svc-name {
   padding: 0 0.25rem 0 0.5rem;
   font-size: 1.05em;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -111,14 +111,26 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
     const viewStart = viewBounds.start;
     const viewEnd = viewBounds.end;
 
+    let labelTooltip;
+    const tooltipProp = span && span.tags && span.tags.find(({ key }) => key === 'span.tooltip');
+    if (tooltipProp) {
+      labelTooltip = tooltipProp.value;
+    }
+
     const labelDetail = `${serviceName}::${operationName}`;
     let longLabel;
     let hintSide;
     if (viewStart > 1 - viewEnd) {
       longLabel = `${labelDetail} | ${label}`;
+      if (labelTooltip) {
+        longLabel = `${labelTooltip} | ${longLabel}`;
+      }
       hintSide = 'left';
     } else {
       longLabel = `${label} | ${labelDetail}`;
+      if (labelTooltip) {
+        longLabel = `${longLabel} | ${labelTooltip}`;
+      }
       hintSide = 'right';
     }
 
@@ -170,6 +182,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                 )}
               </span>
               <small className="endpoint-name">{rpc ? rpc.operationName : operationName}</small>
+              {labelTooltip && <small className="tooltip">{labelTooltip}</small>}
             </a>
             {span.references && span.references.length > 1 && (
               <ReferencesButton


### PR DESCRIPTION
## Which problem is this PR solving?

Feature proposal: Allow the client library to label each span, and show that label prominently, but not as prominently as the operation name. This allows some higher cardinality data into the UI, in a way that isn't three clicks away for every span, and doesn't mess with the core data model, or the low-cardinality indexing on operation name.

`span.tooltip` is an intentionally awful straw-man proposal for a tag name, suggestions welcome.

## Short description of the changes

In the single trace view, look for a tag named `span.tooltip`, and show it next to the operation (called "endpoint name" in some places), both in the sidebar, and in the hover on the bar graph (next to the time). Note, it is not part of the operation name, which is still e.g. `pg.query:SELECT`.

![image](https://user-images.githubusercontent.com/328180/110235475-16a0fa00-7f28-11eb-9605-4cbff4c4bd22.png)
