### PR TITLE
WIP: Distinguish traces by service namespace and instance.id

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
@@ -34,6 +34,7 @@ type Props = {
   percentSelfTime: number;
   operation: string;
   service: string;
+  cacheKey: string,
   mode: string;
 };
 
@@ -66,7 +67,7 @@ export function round2(percent: number) {
 
 export default class OpNode extends React.PureComponent<Props> {
   render() {
-    const { count, errors, time, percent, selfTime, percentSelfTime, operation, service, mode } = this.props;
+    const { count, errors, time, percent, selfTime, percentSelfTime, operation, service, cacheKey, mode } = this.props;
 
     // Spans over 20 % time are full red - we have probably to reconsider better approach
     let backgroundColor;
@@ -77,7 +78,7 @@ export default class OpNode extends React.PureComponent<Props> {
       backgroundColor = [255, 0, 0, percentSelfTime / 100].join();
     } else {
       backgroundColor = colorGenerator
-        .getRgbColorByKey(service)
+        .getRgbColorByKey(cacheKey)
         .concat(0.8)
         .join();
     }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/CanvasSpanGraph.tsx
@@ -21,7 +21,8 @@ import { TNil } from '../../../../types';
 import './CanvasSpanGraph.css';
 
 type CanvasSpanGraphProps = {
-  items: { valueWidth: number; valueOffset: number; serviceName: string }[];
+  // TODO: Unclear why this is not the `SpanItem` type
+  items: { valueWidth: number; valueOffset: number; serviceName: string, cacheKey: string, rgbColor: [number, number, number] }[];
   valueWidth: number;
 };
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/index.tsx
@@ -20,6 +20,7 @@ import TickLabels from './TickLabels';
 import ViewingLayer from './ViewingLayer';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../../types';
 import { Span, Trace } from '../../../../types/trace';
+import { getColorKey, getRGBColorForSpan } from '../../TraceTimelineViewer/VirtualizedTraceView';
 
 const DEFAULT_HEIGHT = 60;
 const TIMELINE_TICK_INTERVAL = 4;
@@ -36,6 +37,8 @@ type SpanItem = {
   valueOffset: number;
   valueWidth: number;
   serviceName: string;
+  cacheKey: string,
+  rgbColor: [number, number, number];
 };
 
 function getItem(span: Span): SpanItem {
@@ -43,6 +46,8 @@ function getItem(span: Span): SpanItem {
     valueOffset: span.relativeStartTime,
     valueWidth: span.duration,
     serviceName: span.process.serviceName,
+    cacheKey: getColorKey(span),
+    rgbColor: getRGBColorForSpan(span),
   };
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/render-into-canvas.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/render-into-canvas.tsx
@@ -25,7 +25,7 @@ export const MAX_ITEM_HEIGHT = 6;
 
 export default function renderIntoCanvas(
   canvas: HTMLCanvasElement,
-  items: { valueWidth: number; valueOffset: number; serviceName: string }[],
+  items: { valueWidth: number; valueOffset: number; serviceName: string, cacheKey: string, rgbColor: [number, number, number] }[],
   totalValueWidth: number,
   getFillColor: (serviceName: string) => [number, number, number]
 ) {
@@ -50,9 +50,11 @@ export default function renderIntoCanvas(
     if (width < MIN_ITEM_WIDTH) {
       width = MIN_ITEM_WIDTH;
     }
-    let fillStyle = fillCache.get(serviceName);
+    let fillStyle = fillCache.get(items[i].cacheKey);
+    const color = items[i].rgbColor;
+    console.log(color);
     if (!fillStyle) {
-      fillStyle = `rgba(${getFillColor(serviceName)
+      fillStyle = `rgba(${color
         .concat(ITEM_ALPHA)
         .join()})`;
       fillCache.set(serviceName, fillStyle);

--- a/packages/jaeger-ui/src/model/trace-dag/TraceDag.tsx
+++ b/packages/jaeger-ui/src/model/trace-dag/TraceDag.tsx
@@ -17,6 +17,8 @@ import { ancestralPathParentOrLeaf, TIdFactory } from './id-factories';
 import { TDenseSpan, TDiffCounts, NodeID, TDenseSpanMembers } from './types';
 import TDagNode from './types/TDagNode';
 import { Trace } from '../../types/trace';
+import { getColorKey } from '../../components/TracePage/TraceTimelineViewer/VirtualizedTraceView';
+import colorGenerator from '../../utils/color-generator';
 
 export default class TraceDag<TData extends { [k: string]: unknown } = {}> {
   static newFromTrace(trace: Trace, idFactory: TIdFactory = ancestralPathParentOrLeaf) {
@@ -39,6 +41,7 @@ export default class TraceDag<TData extends { [k: string]: unknown } = {}> {
           dag.addNode(id, parentNodeID, {
             operation,
             service,
+            cacheKey: getColorKey(denseSpan.span),
             members: [],
           });
         node.members.push(denseSpan);
@@ -66,6 +69,7 @@ export default class TraceDag<TData extends { [k: string]: unknown } = {}> {
         b: nodeB ? nodeB.members : null,
         operation: (nodeA && nodeA.operation) || (nodeB && nodeB.operation) || '__UNSET__',
         service: (nodeA && nodeA.service) || (nodeB && nodeB.service) || '__UNSET__',
+        cacheKey: (nodeA && nodeA.cacheKey) || (nodeB && nodeB.cacheKey) || colorGenerator.getColorByKey('__UNSET__')
       });
     }
 

--- a/packages/jaeger-ui/src/model/trace-dag/types/index.tsx
+++ b/packages/jaeger-ui/src/model/trace-dag/types/index.tsx
@@ -32,6 +32,7 @@ export type TDenseSpanMembers = {
   members: TDenseSpan[];
   operation: string;
   service: string;
+  cacheKey: string;
 };
 
 export type TDiffCounts = TDenseSpanMembers & {

--- a/packages/jaeger-ui/src/utils/color-generator.tsx
+++ b/packages/jaeger-ui/src/utils/color-generator.tsx
@@ -74,6 +74,8 @@ export class ColorGenerator {
    * If the key has been used already, it will
    * use the same color.
    */
+  // HexColor might make sense as its own type. Or a Color type with rgb,rgba,
+  // hex() methods
   getColorByKey(key: string) {
     const i = this._getColorIndex(key);
     return this.colorsHex[i];
@@ -84,6 +86,7 @@ export class ColorGenerator {
    * it with a color if the key is not recognized.
    * @return {number[]} An array of three ints [0, 255] representing a color.
    */
+  // TODO: RgbColor might make sense as its own type
   getRgbColorByKey(key: string): [number, number, number] {
     const i = this._getColorIndex(key);
     return this.colorsRgb[i];


### PR DESCRIPTION
When displaying / distinguishing traces by name or colour consider the
service.namespace and service.instance.id tags if present.

This helps distinguishes traces that span multiple process that make up
the same logical service where different instances have different IDs.

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

https://github.com/jaegertracing/jaeger-ui/issues/721

## Short description of the changes

This is not yet ready to merge, I've opened the PR because I think there are a few ways to proceed and I wanted to get consensus on whatever approach is acceptable to the Jaeger maintainers. I'll add comments to this PR with additional information.
