### PR TITLE
[chore]: gitignore the generated unit test report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 # reports
 coverage
 .nyc_output
+junit.xml
 
 # misc
 .DS_Store


### PR DESCRIPTION
Signed-off-by: Meenal Trivedi <meenaltrivedi6102@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Since the PR #723, there is a junit report generated each time with pre-commit hooks, this PR adds them into the gitignore.

