### PR TITLE
[feat]: add upload widget into the search form tab 

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
@@ -14,37 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.SearchTracePage--row {
-  display: flex;
-  flex-grow: 1;
+.FileLoader--upload {
+  background-color: #11939a;
+  color: white;
+  float: right;
 }
 
-.SearchTracePage--column {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  padding: 1rem 0.5rem;
-}
-
-.SearchTracePage--column:first-child {
-  padding-left: 1rem;
-}
-
-.SearchTracePage--column:last-child {
-  padding-right: 1rem;
-}
-
-.SearchTracePage--fileload {
-  height: 8rem;
-}
-
-.SearchTracePage--find {
-  background-color: #f5f5f5;
-  border: 1px solid #e6e6e6;
-  padding: 1rem;
-}
-
-.SearchTracePage--logo {
-  display: block;
-  margin: 13rem auto 0 auto;
+.FileLoader--helper-text {
+  padding-top: 1rem;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Upload, Icon } from 'antd';
-
-const Dragger = Upload.Dragger;
+import { Upload, Button, Row, Col } from 'antd';
+import './FileLoader.css';
 
 type FileLoaderProps = {
   loadJsonTraces: (fileList: FileList) => void;
@@ -23,12 +22,13 @@ type FileLoaderProps = {
 
 export default function FileLoader(props: FileLoaderProps) {
   return (
-    <Dragger accept=".json" customRequest={props.loadJsonTraces} multiple>
-      <p className="ant-upload-drag-icon">
-        <Icon type="file-add" />
-      </p>
-      <p className="ant-upload-text">Click or drag files to this area.</p>
-      <p className="ant-upload-hint">JSON files containing one or more traces are supported.</p>
-    </Dragger>
+    <Upload accept=".jpg" customRequest={props.loadJsonTraces} multiple>
+      <Row>
+        <Col span={12} offset={6}>
+          <Button className="FileLoader--upload">Click to Upload</Button>
+        </Col>
+      </Row>
+      <p className="FileLoader--helper-text">JSON files containing one or more traces are supported.</p>
+    </Upload>
   );
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/__snapshots__/FileLoader.test.js.snap
+++ b/packages/jaeger-ui/src/components/SearchTracePage/__snapshots__/FileLoader.test.js.snap
@@ -1,26 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FileLoader /> matches the snapshot 1`] = `
-<Dragger
-  accept=".json"
+<Upload
+  accept=".jpg"
+  action=""
+  beforeUpload={[Function]}
+  className=""
+  data={Object {}}
+  disabled={false}
+  listType="text"
   multiple={true}
+  prefixCls="ant-upload"
+  showUploadList={true}
+  supportServerRender={true}
+  type="select"
 >
-  <p
-    className="ant-upload-drag-icon"
+  <Row
+    gutter={0}
   >
-    <Icon
-      type="file-add"
-    />
-  </p>
+    <Col
+      offset={6}
+      span={12}
+    >
+      <Button
+        block={false}
+        className="FileLoader--upload"
+        ghost={false}
+        loading={false}
+        prefixCls="ant-btn"
+      >
+        Click to Upload
+      </Button>
+    </Col>
+  </Row>
   <p
-    className="ant-upload-text"
-  >
-    Click or drag files to this area.
-  </p>
-  <p
-    className="ant-upload-hint"
+    className="FileLoader--helper-text"
   >
     JSON files containing one or more traces are supported.
   </p>
-</Dragger>
+</Upload>
 `;

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -15,7 +15,7 @@
 /* eslint-disable react/require-default-props */
 
 import React, { Component } from 'react';
-import { Col, Row, Tabs } from 'antd';
+import { Col, Row, Tabs, Divider } from 'antd';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -101,14 +101,13 @@ export class SearchTracePageImpl extends Component {
             <div className="SearchTracePage--find">
               <Tabs size="large">
                 <TabPane tab="Search" key="searchForm">
-                  {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
-                </TabPane>
-                <TabPane tab="JSON File" key="fileLoader">
                   <FileLoader
                     loadJsonTraces={(fileList: FileList) => {
                       loadJsonTraces(fileList);
                     }}
                   />
+                  <Divider />
+                  {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
                 </TabPane>
               </Tabs>
             </div>


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- fixes #683
- reference https://github.com/jaegertracing/jaeger-ui/issues/683#issuecomment-814222170

## Short description of the changes
- Combined upload json and search form page into a single tab

## Screenshot
<img width="273" alt="Screenshot 2021-04-09 at 1 18 49 AM" src="https://user-images.githubusercontent.com/79007582/114087487-9298b400-98d1-11eb-84da-d096bf6eec52.png">

