### PR TITLE
[fix]: deep dependency header overlaps page header (#731)

### DIFF
--- a/packages/jaeger-ui/src/components/App/Page.css
+++ b/packages/jaeger-ui/src/components/App/Page.css
@@ -19,7 +19,7 @@ limitations under the License.
   padding: 0;
   position: fixed;
   width: 100%;
-  z-index: 3;
+  z-index: 11;
 }
 
 .Page--content {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #731

## Short description of the changes
- Bump up the `z-index` of page header element so that the deep dependency header doesn't overlap when scrolling down.
