### PR TITLE
Add dummy version to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "jaeger-ui-monorepo",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>


The Red Hat productization process requires every `package.json` to contain the `version` attribute. This patch adds "dummy" version to satisfy this criteria. 

The workaround would be to fork Jaeger apply patch there and productize the forked version. This is less preferred approach as it requires maintaining a fork for a simple patch.

Also `name` and `version` are mandatory fields of every package.json https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields