### PR TITLE
Fix tracePage crash in browser

### DIFF
--- a/packages/jaeger-ui/src/utils/span-ancestor-ids.tsx
+++ b/packages/jaeger-ui/src/utils/span-ancestor-ids.tsx
@@ -22,7 +22,11 @@ function getFirstAncestor(span: Span): Span | TNil {
   return _get(
     _find(
       span.references,
-      ({ span: ref, refType }) => ref && ref.spanID && (refType === 'CHILD_OF' || refType === 'FOLLOWS_FROM')
+      ({ span: ref, refType }) =>
+        ref &&
+        ref.spanID &&
+        ref.spanID !== span.spanID &&
+        (refType === 'CHILD_OF' || refType === 'FOLLOWS_FROM')
     ),
     'span'
   );


### PR DESCRIPTION
## Which problem is this PR solving?
https://github.com/jaegertracing/jaeger-ui/issues/821

## Short description of the changes
- Add condition judgment in `getFirstAncestor`
```
function getFirstAncestor(span: Span): Span | TNil {
  return _get(
    _find(
      span.references,
      ({ span: ref, refType }) =>
        ref &&
        ref.spanID &&
        ref.spanID !== span.spanID &&
        (refType === 'CHILD_OF' || refType === 'FOLLOWS_FROM')
    ),
    'span'
  );
}
```
