### PR TITLE
Fix: Endless loop while calculating overlay between spans in traceStatistics View

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.tsx
@@ -201,6 +201,9 @@ function calculateContent(trace: Trace, span: Span, allSpans: Span[], resultValu
                 overlayWithout[i].relativeStartTime +
                 overlayWithout[i].duration -
                 earliestLongerAsParent.relativeStartTime;
+              if (overlayWithout[i].duration < 0) {
+                overlayWithout[i].duration = 0;
+              }
             }
           }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #840 

## Short description of the changes
- Added a condition for duration to be not negative
