### PR TITLE
Prepare to rename master to main

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,8 +1,0 @@
-pull_request_rules:
-  - name: automatic merge for dependabot pull requests
-    conditions:
-      - author~=^dependabot(|-preview)\[bot\]$
-    actions:
-      merge:
-        method: squash
-        commit_message: title+body

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - main
+
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - main
 
 jobs:
   codeql-analyze:
@@ -14,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,17 +1,25 @@
 name: "Unit Tests"
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - main
+
+  pull_request:
+    branches:
+      - master
+      - main
 
 jobs:
   unit-tests:
-    strategy:
-      fail-fast: true
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2.5.0
         with:
-          node-version: '10'
+          node-version: "10"
       - name: install yarn
         run: |
           curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ See the [configuration guide](https://www.jaegertracing.io/docs/latest/frontend-
 
 [Apache 2.0 License](./LICENSE).
 
-[ci-img]: https://github.com/jaegertracing/jaeger-ui/workflows/Unit%20Tests/badge.svg?branch=master
+[ci-img]: https://github.com/jaegertracing/jaeger-ui/workflows/Unit%20Tests/badge.svg?branch=main
 [ci]: https://github.com/jaegertracing/jaeger-ui/actions
-[cov-img]: https://codecov.io/gh/jaegertracing/jaeger-ui/branch/master/graph/badge.svg
+[cov-img]: https://codecov.io/gh/jaegertracing/jaeger-ui/branch/main/graph/badge.svg
 [cov]: https://codecov.io/gh/jaegertracing/jaeger-ui
 [aio-docs]: https://www.jaegertracing.io/docs/latest/getting-started/
 [fossa-img]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjaegertracing%2Fjaeger-ui.svg?type=shield


### PR DESCRIPTION
This PR adds 'main' to the list of branches to run workflows for, in addition to master. It also replaces a couple of occurences of 'master' in the readme.
It also removes mergify, which doesn't seem to be in use anymore for this repo.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
