### PR TITLE
Respect BASE_URL in Trace Tabular View

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -21,6 +21,7 @@ import './index.css';
 import { TNil } from '../../../types';
 import { Trace, Span } from '../../../types/trace';
 import { timeConversion } from '../../../utils/date';
+import prefixUrl from '../../../utils/prefix-url';
 
 const Option = Select.Option;
 
@@ -143,7 +144,11 @@ export default class TraceSpanView extends Component<Props, State> {
         dataIndex: 'spanID',
         render: (text: any, record: Span) => {
           return (
-            <a href={`/trace/${record.traceID}?uiFind=${text}`} target="_blank" rel="noopener noreferrer">
+            <a
+              href={prefixUrl(`/trace/${record.traceID}?uiFind=${text}`)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {text}
             </a>
           );


### PR DESCRIPTION
Fix #847

Calling `prefixUrl` when populating the hyperlinks in the table.