### PR TITLE
Reduce ratePer window

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -154,7 +154,7 @@ export class MonitorATMServicesViewImpl extends React.PureComponent<TProps, Stat
         endTs: this.endTime,
         lookback: selectedTimeFrame,
         step: 60 * 1000,
-        ratePer: 60 * 60 * 1000,
+        ratePer: 10 * 60 * 1000,
       };
 
       fetchAllServiceMetrics(currentService, metricQueryPayload);


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Which problem is this PR solving?
- Resolves #879

## Short description of the changes
- Reduces the ratePer window from `1hr` to `10m`, to reduce confusion when users run the ATM demo (at `docker-compose/monitor/docker-compose.yaml`).
