### PR TITLE
Use One node per resource as default option

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/LayoutSettings/index.test.js
@@ -23,7 +23,7 @@ import { EDdgDensity } from '../../../../model/ddg/types';
 
 describe('LayoutSettings', () => {
   const props = {
-    density: EDdgDensity.PreventPathEntanglement,
+    density: EDdgDensity.MostConcise,
     setDensity: jest.fn(),
     showOperations: true,
     toggleShowOperations: jest.fn(),

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
@@ -140,11 +140,11 @@ describe('DeepDependencyGraph/url', () => {
       });
     });
 
-    it("defaults `density` to 'ppe'", () => {
+    it("defaults `density` to 'mc'", () => {
       const { density: unused, ...rest } = expectedParams;
       const { density: alsoUnused, ...rv } = acceptableParams;
       parseSpy.mockReturnValue(rv);
-      expect(getUrlState(getSearch())).toEqual({ ...rest, density: 'ppe' });
+      expect(getUrlState(getSearch())).toEqual({ ...rest, density: 'mc' });
     });
 
     it('ignores extraneous query parameters', () => {

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
@@ -53,7 +53,7 @@ function firstParam(arg: string | string[]): string {
 
 export const getUrlState = memoizeOne(function getUrlState(search: string): TDdgSparseUrlState {
   const {
-    density = EDdgDensity.PreventPathEntanglement,
+    density = EDdgDensity.MostConcise,
     decoration,
     end,
     hash,


### PR DESCRIPTION


## Which problem is this PR solving?
- Resolves #600 

## Short description of the changes
- the default option for graph density has been replaced with **One node per resource**


https://user-images.githubusercontent.com/48093317/155391399-710429a6-7760-468a-ae6a-c9864ec4cce2.mp4


