### PR TITLE
Monitor Tab - Error rate graph in operation table is always a straight line

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
@@ -223,7 +223,7 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
         yDomain={
           Array [
             0,
-            100,
+            1,
           ]
         }
       />

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -316,7 +316,7 @@ export class MonitorATMServicesViewImpl extends React.PureComponent<TProps, Stat
               metricsData={convertServiceErrorRateToPercentages(serviceErrorRate)}
               marginClassName="error-rate-margins"
               color="#CD513A"
-              yDomain={[0, 100]}
+              yDomain={[0, 1]}
               xDomain={this.state.graphXDomain}
             />
           </Col>


### PR DESCRIPTION
Signed-off-by: nofar9792 <nofar.cohen@logz.io>

## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/jaeger-ui/issues/908

## Short description of the changes
The values of this graph are between 0 to 1, but the yDomain is hardcode 1-100

before:
<img width="178" alt="Screen Shot 2022-03-10 at 23 49 42" src="https://user-images.githubusercontent.com/11076023/157762546-00bb77d8-56b0-4705-8547-bbe4c73aab6e.png">

after:
<img width="194" alt="Screen Shot 2022-03-10 at 23 49 28" src="https://user-images.githubusercontent.com/11076023/157762533-61a6a26c-8d17-4dfa-82ed-e2d2a0ae8796.png">

