### PR TITLE
Monitor Tab - error rates - yDomain

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
@@ -223,7 +223,7 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
         yDomain={
           Array [
             0,
-            1,
+            100,
           ]
         }
       />

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -316,7 +316,7 @@ export class MonitorATMServicesViewImpl extends React.PureComponent<TProps, Stat
               metricsData={convertServiceErrorRateToPercentages(serviceErrorRate)}
               marginClassName="error-rate-margins"
               color="#CD513A"
-              yDomain={[0, 1]}
+              yDomain={[0, 100]}
               xDomain={this.state.graphXDomain}
             />
           </Col>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
@@ -920,7 +920,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             >
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-series-example ops-graph-style"
-                                d="M0,11.88L100,11.88L100,12L0,12Z"
+                                d="M0,0L100,0L100,12L0,12Z"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -936,7 +936,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                               />
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-elevated-line-series"
-                                d="M0,11.88L100,11.88"
+                                d="M0,0L100,0"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -1610,7 +1610,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             >
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-series-example ops-graph-style"
-                                d="M0,11.88L100,11.88L100,12L0,12Z"
+                                d="M0,0L100,0L100,12L0,12Z"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -1626,7 +1626,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                               />
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-elevated-line-series"
-                                d="M0,11.88L100,11.88"
+                                d="M0,0L100,0"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -2300,7 +2300,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             >
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-series-example ops-graph-style"
-                                d="M0,11.88L100,11.88L100,12L0,12Z"
+                                d="M0,0L100,0L100,12L0,12Z"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -2316,7 +2316,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                               />
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-elevated-line-series"
-                                d="M0,11.88L100,11.88"
+                                d="M0,0L100,0"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -2990,7 +2990,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             >
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-series-example ops-graph-style"
-                                d="M0,11.88L100,11.88L100,12L0,12Z"
+                                d="M0,0L100,0L100,12L0,12Z"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -3006,7 +3006,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                               />
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-elevated-line-series"
-                                d="M0,11.88L100,11.88"
+                                d="M0,0L100,0"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -3680,7 +3680,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             >
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-series-example ops-graph-style"
-                                d="M0,11.88L100,11.88L100,12L0,12Z"
+                                d="M0,0L100,0L100,12L0,12Z"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -3696,7 +3696,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                               />
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-elevated-line-series"
-                                d="M0,11.88L100,11.88"
+                                d="M0,0L100,0"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -4370,7 +4370,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             >
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-series-example ops-graph-style"
-                                d="M0,11.88L100,11.88L100,12L0,12Z"
+                                d="M0,0L100,0L100,12L0,12Z"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -4386,7 +4386,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                               />
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-elevated-line-series"
-                                d="M0,11.88L100,11.88"
+                                d="M0,0L100,0"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -5060,7 +5060,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             >
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-series-example ops-graph-style"
-                                d="M0,11.88L100,11.88L100,12L0,12Z"
+                                d="M0,0L100,0L100,12L0,12Z"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}
@@ -5076,7 +5076,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                               />
                               <path
                                 className="rv-xy-plot__series rv-xy-plot__series--line area-elevated-line-series"
-                                d="M0,11.88L100,11.88"
+                                d="M0,0L100,0"
                                 onClick={[Function]}
                                 onContextMenu={[Function]}
                                 onMouseOut={[Function]}

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -132,7 +132,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
             <REDGraph
               dataPoints={row.dataPoints.service_operation_error_rate}
               color="#CD513A"
-              yDomain={[0, 100]}
+              yDomain={[0, 1]}
               error={error.opsErrors}
             />
             <div className="table-graph-avg">


### PR DESCRIPTION
Signed-off-by: nofar9792 <nofar.cohen@logz.io>

## Which problem is this PR solving?
 Resolves https://github.com/jaegertracing/jaeger-ui/issues/912

## Short description of the changes
I changed the wrong yDomain.
it affected the main error graph domain
before:
![image](https://user-images.githubusercontent.com/11076023/158413468-5aedf147-bf75-4ca2-9a99-7f5b79f3f123.png)

after:
![image](https://user-images.githubusercontent.com/11076023/158413497-bbbef83e-be1f-492f-9693-8cc23a6f332c.png)
