### PR TITLE
Add error icon to errored services in trace list view

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.css
@@ -27,4 +27,15 @@ limitations under the License.
 .ResultItem--serviceTag {
   border-left-width: 15px;
   margin: 0;
+  display: flex;
+  align-items: center;
+}
+
+.ResultItem--errorIcon {
+  background: #db2828;
+  border-radius: 6.5px;
+  color: #fff;
+  font-size: 0.85em;
+  margin-right: 0.25rem;
+  padding: 1px;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
@@ -40,3 +40,10 @@ it('<ResultItem /> should not render any ServiceTags when there are no services'
   const serviceTags = wrapper.find(`[data-test="${markers.SERVICE_TAGS}"]`).find(Tag);
   expect(serviceTags).toHaveLength(0);
 });
+
+it('<ResultItem /> should render error icon on ServiceTags that have an error tag', () => {
+  trace.spans[0].tags.push({ key: 'error', value: true });
+  const wrapper = shallow(<ResultItem trace={trace} durationPercent={50} linkTo="" />);
+  const errorServiceTags = wrapper.find('.ResultItem--errorIcon').getElements();
+  expect(errorServiceTags).toHaveLength(1);
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -20,8 +20,8 @@ import { sortBy } from 'lodash';
 import moment from 'moment';
 
 import IoAlert from 'react-icons/lib/io/alert';
-import { trackConversions, EAltViewActions } from './index.track';
 
+import { trackConversions, EAltViewActions } from './index.track';
 import * as markers from './ResultItem.markers';
 import ResultItemTitle from './ResultItemTitle';
 import colorGenerator from '../../../utils/color-generator';

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -20,6 +20,7 @@ import { sortBy } from 'lodash';
 import moment from 'moment';
 
 import IoAlert from 'react-icons/lib/io/alert';
+import { trackConversions, EAltViewActions } from './index.track';
 
 import * as markers from './ResultItem.markers';
 import ResultItemTitle from './ResultItemTitle';
@@ -48,6 +49,7 @@ type State = {
 };
 
 const isErrorTag = ({ key, value }: KeyValuePair) => key === 'error' && (value === true || value === 'true');
+const trackTraceConversions = () => trackConversions(EAltViewActions.Traces);
 
 export default class ResultItem extends React.PureComponent<Props, State> {
   constructor(props: Props) {
@@ -86,7 +88,7 @@ export default class ResultItem extends React.PureComponent<Props, State> {
     } = this.props;
     const { duration, services, startTime, traceName, traceID } = trace;
     return (
-      <div className="ResultItem">
+      <div className="ResultItem" onClick={trackTraceConversions} role="button">
         <ResultItemTitle
           duration={duration}
           durationPercent={durationPercent}
@@ -117,9 +119,7 @@ export default class ResultItem extends React.PureComponent<Props, State> {
                     <li key={name} className="ub-inline-block ub-m1">
                       <Tag
                         className="ResultItem--serviceTag"
-                        style={{
-                          borderLeftColor: colorGenerator.getColorByKey(name),
-                        }}
+                        style={{ borderLeftColor: colorGenerator.getColorByKey(name) }}
                       >
                         {this.state.erroredServices.has(name) && (
                           <IoAlert className="ResultItem--errorIcon" />

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -52,8 +52,8 @@ const isErrorTag = ({ key, value }: KeyValuePair) => key === 'error' && (value =
 const trackTraceConversions = () => trackConversions(EAltViewActions.Traces);
 
 export default class ResultItem extends React.PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props);
+  constructor(props: Props, state: State) {
+    super(props, state);
     const { startTime, spans } = props.trace;
 
     const mDate = moment(startTime / 1000);


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #925 
## Short description of the changes
- Add an error icon to errored services in `ResultItem.tsx`.
![image](https://user-images.githubusercontent.com/26532014/163077212-4fd88182-5a3f-4ee0-a1a7-ace8c2fe44f8.png)
- Refactor existing constants to state.
