### PR TITLE
fix: link to docs on the monitor tab

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
@@ -371,7 +371,11 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
         <Link
           replace={false}
           target="_blank"
-          to="//https://www.jaegertracing.io/docs/latest/spm/"
+          to={
+            Object {
+              "pathname": "https://www.jaegertracing.io/docs/latest/spm/",
+            }
+          }
         >
            instructions 
         </Link>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -243,7 +243,7 @@ export class MonitorATMServicesViewImpl extends React.PureComponent<TProps, Stat
             message={
               <>
                 No data yet! Please see these
-                <Link to={`//${this.docsLink}`} target="_blank">
+                <Link to={{ pathname: this.docsLink }} target="_blank">
                   &nbsp;instructions&nbsp;
                 </Link>
                 on how to set up your span metrics.


### PR DESCRIPTION

## Which problem is this PR solving?
Resolves #928

## Short description of the changes
- This commit fixes a broken link on the empty state banner of the monitor page.
