### PR TITLE
Fix: service operations fetch by URL query params

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -62,7 +62,7 @@ export class SearchTracePageImpl extends Component {
       fetchMultipleTraces(needForDiffs);
     }
     fetchServices();
-    const { service } = store.get('lastSearch') || {};
+    const { service } = urlQueryParams || store.get('lastSearch') || {};
     if (service && service !== '-') {
       fetchServiceOperations(service);
     }

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.js
@@ -62,7 +62,10 @@ export class SearchTracePageImpl extends Component {
       fetchMultipleTraces(needForDiffs);
     }
     fetchServices();
-    const { service } = urlQueryParams || store.get('lastSearch') || {};
+    let { service } = store.get('lastSearch') || {};
+    if (urlQueryParams && urlQueryParams.service) {
+      service = urlQueryParams.service;
+    }
     if (service && service !== '-') {
       fetchServiceOperations(service);
     }

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
@@ -79,11 +79,28 @@ describe('<SearchTracePage>', () => {
     store.get = jest.fn(() => ({ service: 'svc-b' }));
     wrapper = mount(
       <MemoryRouter>
+        <SearchTracePage {...{ ...props, urlQueryParams: {} }} />
+      </MemoryRouter>
+    );
+    expect(props.fetchServices.mock.calls.length).toBe(1);
+    expect(props.fetchServiceOperations.mock.calls.length).toBe(1);
+    expect(props.fetchServiceOperations.mock.calls[0][0]).toBe('svc-b');
+    store.get = oldFn;
+  });
+
+  it('loads the operations linked to the URL service parameter if present', () => {
+    props.fetchServices.mockClear();
+    props.fetchServiceOperations.mockClear();
+    const oldFn = store.get;
+    store.get = jest.fn(() => ({ service: 'svc-b' }));
+    wrapper = mount(
+      <MemoryRouter>
         <SearchTracePage {...props} />
       </MemoryRouter>
     );
     expect(props.fetchServices.mock.calls.length).toBe(1);
     expect(props.fetchServiceOperations.mock.calls.length).toBe(1);
+    expect(props.fetchServiceOperations.mock.calls[0][0]).toBe('svc-a');
     store.get = oldFn;
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #920

## Short description of the changes
If query parameters are provided to the search page, the system now fetches the correct set of operations linked to the specified service.

This fixes the current behavior on fetching the operations linked to the last searched service, ignoring all specified URL parameters.
