### PR TITLE
Use red on scatterplot for traces if any spans have an error=true tag

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.js
@@ -34,6 +34,7 @@ function ScatterPlotImpl(props) {
           left: 50,
         }}
         width={containerWidth}
+        colorType="literal"
         height={200}
       >
         <XAxis

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -39,6 +39,7 @@ import reduxFormFieldAdapter from '../../../utils/redux-form-field-adapter';
 
 import type { FetchedTrace } from '../../../types';
 import type { SearchQuery } from '../../../types/search';
+import type { KeyValuePair } from '../../../types/trace';
 
 import './index.css';
 
@@ -155,6 +156,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
     }
     const cohortIds = new Set(diffCohort.map(datum => datum.id));
     const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
+    const isErrorTag = ({ key, value }: KeyValuePair) => key === 'error' && (value === true || value === 'true');
     return (
       <div className="SearchResults">
         <div className="SearchResults--header">
@@ -167,6 +169,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
                   traceID: t.traceID,
                   size: t.spans.length,
                   name: t.traceName,
+                  color: t.spans.some(sp => sp.tags.some(isErrorTag)) ? "red" : "#12939A",
                 }))}
                 onValueClick={t => {
                   goToTrace(t.traceID);

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.js
@@ -156,7 +156,8 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
     }
     const cohortIds = new Set(diffCohort.map(datum => datum.id));
     const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
-    const isErrorTag = ({ key, value }: KeyValuePair) => key === 'error' && (value === true || value === 'true');
+    const isErrorTag = ({ key, value }: KeyValuePair) =>
+      key === 'error' && (value === true || value === 'true');
     return (
       <div className="SearchResults">
         <div className="SearchResults--header">
@@ -169,7 +170,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
                   traceID: t.traceID,
                   size: t.spans.length,
                   name: t.traceName,
-                  color: t.spans.some(sp => sp.tags.some(isErrorTag)) ? "red" : "#12939A",
+                  color: t.spans.some(sp => sp.tags.some(isErrorTag)) ? 'red' : '#12939A',
                 }))}
                 onValueClick={t => {
                   goToTrace(t.traceID);


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

Show error traces in red on the scatterplot.

To test this it can be handy to have a source of good-looking traces with errors.  I used synthentic data generated by `docker run -it --env JAEGER_COLLECTOR_URL=http://docker.for.mac.localhost:14268 omnition/synthetic-load-generator`.

Note that this is my first Jaeger-UI PR.  When I tried to commit I got a warnings.  Resolving them needed some help: I didn't know that I needed to run `yarn prettier` to clean my code, nor `yarn lint` to lint it.  Is this in the docs?  I couldn't find it.

<img width="968" alt="jaeger-with-red-errors" src="https://user-images.githubusercontent.com/3237651/168316538-3cf22a6a-d77a-4c4b-9969-f08e4511afa4.png">

