### PR TITLE
Store preferred span name column width in localStorage

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.tsx
@@ -52,7 +52,7 @@ export function newInitialState(): TTraceTimeline {
     detailStates: new Map(),
     hoverIndentGuideIds: new Set(),
     shouldScrollToFirstUiFindMatch: false,
-    spanNameColumnWidth: 0.25,
+    spanNameColumnWidth: parseFloat(localStorage.getItem('spanNameColumnWidth') || '0.25'),
     traceID: null,
   };
 }
@@ -162,6 +162,7 @@ function setTrace(state: TTraceTimeline, { uiFind, trace }: TTraceUiFindValue) {
 }
 
 function setColumnWidth(state: TTraceTimeline, { width }: TWidthValue): TTraceTimeline {
+  localStorage.setItem('spanNameColumnWidth', width.toString());
   return { ...state, spanNameColumnWidth: width };
 }
 


### PR DESCRIPTION
Different developers tend to look at different kinds of traces, meaning that they often prefer some set width of span name column in trace view.

Without this patch, the width is set at 25% and it resets on refresh. With this patch the width is remembered in localStorage and preserved on refresh, making it less necessary to adjust.

Posting it without a backing issue since it's a tiny change.