### PR TITLE
Add draft-release.py script

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,10 @@
       - If necessary, add a note detailing any impact to externally facing APIs.
    1. Update `packages/jaeger-ui/package.json#version` to refer to the version being released.
 1. Create a GitHub release.
-   - The tag and release must refer to the commit created when the PR from the previous step was merged.
-   - The tag name for the GitHub release should be the version for the release. It should include the "v", e.g. `v1.0.0`.
-   - The title of the release match the format "Jaeger UI vX.Y.Z".
-   - Copy the new CHANGELOG.md section into the release notes.
+   - Automated (requires [gh](https://cli.github.com/manual/installation)):
+     - `python ./scripts/draft-release.py`
+   - Manual:
+     - The tag and release must refer to the commit created when the PR from the previous step was merged.
+     - The tag name for the GitHub release should be the version for the release. It should include the "v", e.g. `v1.0.0`.
+     - The title of the release match the format "Jaeger UI vX.Y.Z".
+     - Copy the new CHANGELOG.md section into the release notes.

--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -2,7 +2,7 @@ import re
 import subprocess
 
 
-pattern = re.compile(r"## (v[\d]+\.[\d]+\.[\d]) \([\d]{4}-[\d]{2}-[\d]{2}\)", flags=0)
+release_header_pattern = re.compile(r"## (v[\d]+\.[\d]+\.[\d]) \([\d]{4}-[\d]{2}-[\d]{2}\)", flags=0)
 
 
 def main():
@@ -27,7 +27,7 @@ def get_changelog():
     version = ""
     with open("CHANGELOG.md") as f:
         for line in f:
-            m = pattern.match(line)
+            m = release_header_pattern.match(line)
 
             if m is not None:
                 # Found the first release.

--- a/scripts/draft-release.py
+++ b/scripts/draft-release.py
@@ -1,0 +1,47 @@
+import re
+import subprocess
+
+
+pattern = re.compile(r"## (v[\d]+\.[\d]+\.[\d]) \([\d]{4}-[\d]{2}-[\d]{2}\)", flags=0)
+
+
+def main():
+    changelog_text, version = get_changelog()
+    print(changelog_text)
+    output_string = subprocess.check_output(
+        ["gh", "release", "create", version,
+         "--draft",
+         "--title", f"Jaeger UI {version}",
+         "--repo", "jaegertracing/jaeger-ui",
+         "-F", "-"],
+        input=changelog_text,
+        text=True,
+    )
+    print(f"Draft created at: {output_string}")
+    print("Please review, then edit it and click 'Publish release'.")
+
+
+def get_changelog():
+    changelog_text = ""
+    in_changelog_text = False
+    version = ""
+    with open("CHANGELOG.md") as f:
+        for line in f:
+            m = pattern.match(line)
+
+            if m is not None:
+                # Found the first release.
+                if not in_changelog_text:
+                    in_changelog_text = True
+                    version = m.group(1)
+                else:
+                    # Found the next release.
+                    break
+            elif in_changelog_text:
+                changelog_text += line
+
+    return changelog_text, version
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

## Which problem is this PR solving?
- Tag and release creation are manual steps which are prone to human error.

## Short description of the changes
- Proposal to automate this process given there seems to be little value with manual human interaction since all the inputs can be derived from the CHANGELOG (assuming it's correctly formatted in the first place).
- For cases where there are errors in CHANGELOG preventing this script from working correctly, the release is created as a draft to provide the release engineer the opportunity to make fixes prior to publishing the release.

## Testing
Used to create the v1.25.0 release of jaeger-ui.
