### PR TITLE
Add more time ranges

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
@@ -79,8 +79,8 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
               "className": "select-a-timeframe-input",
               "clearable": false,
               "defaultValue": Object {
-                "label": "Last 5 minutes",
-                "value": 300000,
+                "label": "Last Hour",
+                "value": 3600000,
               },
               "disabled": null,
               "options": Array [
@@ -484,8 +484,8 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
               "className": "select-a-timeframe-input",
               "clearable": false,
               "defaultValue": Object {
-                "label": "Last 5 minutes",
-                "value": 300000,
+                "label": "Last Hour",
+                "value": 3600000,
               },
               "disabled": null,
               "options": Array [
@@ -808,8 +808,8 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
               "className": "select-a-timeframe-input",
               "clearable": false,
               "defaultValue": Object {
-                "label": "Last 5 minutes",
-                "value": 300000,
+                "label": "Last Hour",
+                "value": 3600000,
               },
               "disabled": null,
               "options": Array [

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
@@ -79,11 +79,23 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
               "className": "select-a-timeframe-input",
               "clearable": false,
               "defaultValue": Object {
-                "label": "Last Hour",
-                "value": 3600000,
+                "label": "Last 5 minutes",
+                "value": 300000,
               },
               "disabled": null,
               "options": Array [
+                Object {
+                  "label": "Last 5 minutes",
+                  "value": 300000,
+                },
+                Object {
+                  "label": "Last 15 minutes",
+                  "value": 900000,
+                },
+                Object {
+                  "label": "Last 30 minutes",
+                  "value": 1800000,
+                },
                 Object {
                   "label": "Last Hour",
                   "value": 3600000,
@@ -472,11 +484,23 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
               "className": "select-a-timeframe-input",
               "clearable": false,
               "defaultValue": Object {
-                "label": "Last Hour",
-                "value": 3600000,
+                "label": "Last 5 minutes",
+                "value": 300000,
               },
               "disabled": null,
               "options": Array [
+                Object {
+                  "label": "Last 5 minutes",
+                  "value": 300000,
+                },
+                Object {
+                  "label": "Last 15 minutes",
+                  "value": 900000,
+                },
+                Object {
+                  "label": "Last 30 minutes",
+                  "value": 1800000,
+                },
                 Object {
                   "label": "Last Hour",
                   "value": 3600000,
@@ -784,11 +808,23 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
               "className": "select-a-timeframe-input",
               "clearable": false,
               "defaultValue": Object {
-                "label": "Last Hour",
-                "value": 3600000,
+                "label": "Last 5 minutes",
+                "value": 300000,
               },
               "disabled": null,
               "options": Array [
+                Object {
+                  "label": "Last 5 minutes",
+                  "value": 300000,
+                },
+                Object {
+                  "label": "Last 15 minutes",
+                  "value": 900000,
+                },
+                Object {
+                  "label": "Last 30 minutes",
+                  "value": 1800000,
+                },
                 Object {
                   "label": "Last Hour",
                   "value": 3600000,

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
@@ -55,7 +55,7 @@ limitations under the License.
 
 .select-a-timeframe-input {
   font-size: 14px;
-  width: 128px;
+  width: 135px;
 }
 
 .over-the-last {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -86,7 +86,11 @@ const AdaptedVirtualSelect = reduxFormFieldAdapter({
 
 const serviceFormSelector = formValueSelector('serviceForm');
 const oneHourInMilliSeconds = 3600000;
+const fiveMinutesInMilliSeconds = 300000;
 export const timeFrameOptions = [
+  { label: 'Last 5 minutes', value: fiveMinutesInMilliSeconds },
+  { label: 'Last 15 minutes', value: fiveMinutesInMilliSeconds * 3 },
+  { label: 'Last 30 minutes', value: fiveMinutesInMilliSeconds * 6 },
   { label: 'Last Hour', value: oneHourInMilliSeconds },
   { label: 'Last 2 hours', value: 2 * oneHourInMilliSeconds },
   { label: 'Last 6 hours', value: 6 * oneHourInMilliSeconds },

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -86,11 +86,11 @@ const AdaptedVirtualSelect = reduxFormFieldAdapter({
 
 const serviceFormSelector = formValueSelector('serviceForm');
 const oneHourInMilliSeconds = 3600000;
-const fiveMinutesInMilliSeconds = 300000;
+const oneMinuteInMilliSeconds = 60000;
 export const timeFrameOptions = [
-  { label: 'Last 5 minutes', value: fiveMinutesInMilliSeconds },
-  { label: 'Last 15 minutes', value: fiveMinutesInMilliSeconds * 3 },
-  { label: 'Last 30 minutes', value: fiveMinutesInMilliSeconds * 6 },
+  { label: 'Last 5 minutes', value: oneMinuteInMilliSeconds * 5 },
+  { label: 'Last 15 minutes', value: oneMinuteInMilliSeconds * 15 },
+  { label: 'Last 30 minutes', value: oneMinuteInMilliSeconds * 30 },
   { label: 'Last Hour', value: oneHourInMilliSeconds },
   { label: 'Last 2 hours', value: 2 * oneHourInMilliSeconds },
   { label: 'Last 6 hours', value: 6 * oneHourInMilliSeconds },
@@ -315,7 +315,7 @@ export class MonitorATMServicesViewImpl extends React.PureComponent<TProps, Stat
                 }}
                 props={{
                   className: 'select-a-timeframe-input',
-                  defaultValue: timeFrameOptions[0],
+                  defaultValue: timeFrameOptions[3],
                   value: selectedTimeFrame,
                   disabled: metrics.operationMetricsLoading,
                   clearable: false,

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -88,9 +88,9 @@ const serviceFormSelector = formValueSelector('serviceForm');
 const oneHourInMilliSeconds = 3600000;
 const oneMinuteInMilliSeconds = 60000;
 export const timeFrameOptions = [
-  { label: 'Last 5 minutes', value: oneMinuteInMilliSeconds * 5 },
-  { label: 'Last 15 minutes', value: oneMinuteInMilliSeconds * 15 },
-  { label: 'Last 30 minutes', value: oneMinuteInMilliSeconds * 30 },
+  { label: 'Last 5 minutes', value: 5 * oneMinuteInMilliSeconds },
+  { label: 'Last 15 minutes', value: 15 * oneMinuteInMilliSeconds },
+  { label: 'Last 30 minutes', value: 30 * oneMinuteInMilliSeconds },
   { label: 'Last Hour', value: oneHourInMilliSeconds },
   { label: 'Last 2 hours', value: 2 * oneHourInMilliSeconds },
   { label: 'Last 6 hours', value: 6 * oneHourInMilliSeconds },

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.js
@@ -84,6 +84,18 @@ export function lookbackToTimestamp(lookback, from) {
 
 const lookbackOptions = [
   {
+    label: '5 Minutes',
+    value: '5m',
+  },
+  {
+    label: '15 Minutes',
+    value: '15m',
+  },
+  {
+    label: '30 Minutes',
+    value: '30m',
+  },
+  {
     label: 'Hour',
     value: '1h',
   },

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.js
@@ -176,6 +176,18 @@ describe('lookback utils', () => {
   describe('optionsWithinMaxLookback', () => {
     const threeHoursOfExpectedOptions = [
       {
+        label: '5 Minutes',
+        value: '5m',
+      },
+      {
+        label: '15 Minutes',
+        value: '15m',
+      },
+      {
+        label: '30 Minutes',
+        value: '30m',
+      },
+      {
         label: 'Hour',
         value: '1h',
       },
@@ -198,7 +210,7 @@ describe('lookback utils', () => {
     });
 
     it('returns options within config.search.maxLookback', () => {
-      const configValue = threeHoursOfExpectedOptions[2];
+      const configValue = threeHoursOfExpectedOptions[threeHoursOfExpectedOptions.length - 1];
       const options = optionsWithinMaxLookback(configValue);
 
       expect(options.length).toBe(threeHoursOfExpectedOptions.length);
@@ -228,7 +240,8 @@ describe('lookback utils', () => {
         label: '180 minutes is equivalent to 3 hours',
         value: '180m',
       };
-      const expectedOptions = [threeHoursOfExpectedOptions[0], threeHoursOfExpectedOptions[1], configValue];
+
+      const expectedOptions = [...threeHoursOfExpectedOptions.slice(0, -1), configValue];
       const options = optionsWithinMaxLookback(configValue);
 
       expect(options.length).toBe(expectedOptions.length);


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #969

## Short description of the changes
- Add 5, 15 and 30 minutes time ranges to SPM (defaults to 1h)
- Add 5, 15 and 30 minutes time ranges to traces search form (defaults to 1h)

SPM:
<img width="1404" alt="Screenshot 2022-07-13 at 11 17 17" src="https://user-images.githubusercontent.com/5461414/178700263-b8e54202-f3e8-4f0f-b7d6-146cd94e32d6.png">

Search form:
<img width="350" alt="Screenshot 2022-07-13 at 11 17 07" src="https://user-images.githubusercontent.com/5461414/178700326-15e8fa4e-937f-440b-8b3d-5a40823d2738.png">

