### PR TITLE
Bump @pyroscope/flamegraph to 0.18.4

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@jaegertracing/plexus": "0.2.0",
-    "@pyroscope/flamegraph": "0.18.4-1379-557f0b4.0",
+    "@pyroscope/flamegraph": "0.18.4",
     "@types/classnames": "^2.2.7",
     "@types/deep-freeze": "^0.1.1",
     "@types/history": "^4.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,10 +1517,10 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@pyroscope/flamegraph@0.18.4-1379-557f0b4.0":
-  version "0.18.4-1379-557f0b4.0"
-  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.18.4-1379-557f0b4.0.tgz#146078de39a57487bf8d585efb044dbd82ae9656"
-  integrity sha512-G6EfVBj0F3fhBw3UMtXzLPboV5K3HkLBzLUb5ZaOeJAw2X25sCbiEzBUJNNxUDygYMlkZMNZbleBjKQbXYGU0g==
+"@pyroscope/flamegraph@0.18.4":
+  version "0.18.4"
+  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.18.4.tgz#23159efc9edaab7f41c99d298fc9ac1c53152277"
+  integrity sha512-9wnzajNx5Uw9bQy1ocmx7LkJA6BNaBwWjSkHf3I73GUar2sMf4GOrkBkrb1Cy7CWdNpEHn3+nOz1lU/1Rehnfg==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
Signed-off-by: pavelpashkovsky <pavelpashkovsky@gmail.com>

## Which problem is this PR solving?
- Bumping `@pyroscope/flamegraph` to `0.18.4`


## Short description of the changes
- As a follow up to some of the comments from [[#976]()](https://github.com/jaegertracing/jaeger-ui/pull/976):
☑︎ Added indication of which column is sorted visually
☑︎ When "self" is 0 then table will show 0.00
