### PR TITLE
Flamegraph visualisation works with sub-second units

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@jaegertracing/plexus": "0.2.0",
-    "@pyroscope/flamegraph": "0.18.4",
+    "@pyroscope/flamegraph": "0.21.1-1458-c3eb418.0",
     "@types/classnames": "^2.2.7",
     "@types/deep-freeze": "^0.1.1",
     "@types/history": "^4.7.2",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@jaegertracing/plexus": "0.2.0",
-    "@pyroscope/flamegraph": "0.21.1-1458-c3eb418.0",
+    "@pyroscope/flamegraph": "0.21.1",
     "@types/classnames": "^2.2.7",
     "@types/deep-freeze": "^0.1.1",
     "@types/history": "^4.7.2",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@jaegertracing/plexus": "0.2.0",
-    "@pyroscope/flamegraph": "0.21.1",
+    "@pyroscope/flamegraph": "0.21.4",
     "@types/classnames": "^2.2.7",
     "@types/deep-freeze": "^0.1.1",
     "@types/history": "^4.7.2",

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`<TraceFlamegraph /> renders as expected 1`] = `
 <div
   className="Flamegraph-wrapper"
 >
-  <dg
+  <Fg
     colorMode="light"
     profile={
       Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,10 +1517,10 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@pyroscope/flamegraph@0.21.1-1458-c3eb418.0":
-  version "0.21.1-1458-c3eb418.0"
-  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.21.1-1458-c3eb418.0.tgz#737593e8c1c8ede37fd58c020b9d0c450fe3827e"
-  integrity sha512-KDK7QldqbalFL1IJK8pBZjyKH2akRf0gsat3IoVKLnv9wJkKPUH/zD2X0EoxzoIyS6L1uIGs5LSnUVa00FGNfQ==
+"@pyroscope/flamegraph@0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.21.1.tgz#7447d0cc20368f862ac7b7c3fd7388f9e20ccc0a"
+  integrity sha512-XSJoHMuV4rhwRD+NS6ELSm8TIv3HtunWCLY6PiPqz9wYPxld+0Vbylg7BxCDwlXulSLP+bMVPwMginyGr/WrBA==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,10 +1517,10 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@pyroscope/flamegraph@0.21.1":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.21.1.tgz#7447d0cc20368f862ac7b7c3fd7388f9e20ccc0a"
-  integrity sha512-XSJoHMuV4rhwRD+NS6ELSm8TIv3HtunWCLY6PiPqz9wYPxld+0Vbylg7BxCDwlXulSLP+bMVPwMginyGr/WrBA==
+"@pyroscope/flamegraph@0.21.4":
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.21.4.tgz#4b185854ee50767d5279baa16b58a29f9fcb3de1"
+  integrity sha512-/wkTHhBNapnnuLWQ40PyHa1pz8jVMmiLYO12Ak7qq1JhgVEccE39XrQMTkcFlM4FdpqM4/1w6U7fm4xebUAzZw==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,10 +1517,10 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@pyroscope/flamegraph@0.18.4":
-  version "0.18.4"
-  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.18.4.tgz#23159efc9edaab7f41c99d298fc9ac1c53152277"
-  integrity sha512-9wnzajNx5Uw9bQy1ocmx7LkJA6BNaBwWjSkHf3I73GUar2sMf4GOrkBkrb1Cy7CWdNpEHn3+nOz1lU/1Rehnfg==
+"@pyroscope/flamegraph@0.21.1-1458-c3eb418.0":
+  version "0.21.1-1458-c3eb418.0"
+  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.21.1-1458-c3eb418.0.tgz#737593e8c1c8ede37fd58c020b9d0c450fe3827e"
+  integrity sha512-KDK7QldqbalFL1IJK8pBZjyKH2akRf0gsat3IoVKLnv9wJkKPUH/zD2X0EoxzoIyS6L1uIGs5LSnUVa00FGNfQ==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
Signed-off-by: pavelpashkovsky <pavelpashkovsky@gmail.com>

## Which problem is this PR solving?
- Flamegraph Visualisation works with sub-second units
- bump @pyroscope/flamegraph
- [here is the link to our tests for sub-second rendering](https://github.com/pyroscope-io/pyroscope/pull/1418/files#diff-e726bd03f9a833f21dd0464cf333a31cd08a0ef0146d002f711966a7bfc04b68R74)

## Short description of the changes
- bump @pyroscope/flamegraph
![image](https://user-images.githubusercontent.com/7372044/188439953-cb8a0eab-9e7f-40c5-97c6-10a6da076e92.png)
