### PR TITLE
babel : migrate to the top level setPublicClassFields assumption

### DIFF
--- a/packages/plexus/babel.config.js
+++ b/packages/plexus/babel.config.js
@@ -15,6 +15,9 @@
 function getBabelConfig(api) {
   const env = api.env();
   return {
+    assumptions: {
+      setPublicClassFields: true,
+    },
     plugins: [
       '@babel/plugin-syntax-dynamic-import',
       [
@@ -23,12 +26,7 @@ function getBabelConfig(api) {
           removeImport: true,
         },
       ],
-      [
-        '@babel/plugin-proposal-class-properties',
-        {
-          loose: true,
-        },
-      ],
+      '@babel/plugin-proposal-class-properties',
     ],
     presets: [
       [


### PR DESCRIPTION
Follow https://babeljs.io/docs/en/babel-plugin-proposal-class-properties#loose recommandation. 

It also removes a lot of warning traces

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>

