### PR TITLE
Revert upgrade to viz.js, v2.1.2 -> v1.8.1

### DIFF
--- a/packages/plexus/package.json
+++ b/packages/plexus/package.json
@@ -53,7 +53,7 @@
     "d3-selection": "^1.3.0",
     "d3-zoom": "^1.7.1",
     "memoize-one": "6.0.0",
-    "viz.js": "2.1.2"
+    "viz.js": "1.8.1"
   },
   "scripts": {
     "_tasks/build/lib/js": "node_modules/.bin/babel src --extensions '.tsx,.js' --out-dir lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17891,10 +17891,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viz.js@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/viz.js/-/viz.js-2.1.2.tgz#6f09cd4e10af28754a6d50b055bd2e4a7693983a"
-  integrity sha512-UO6CPAuEMJ8oNR0gLLNl+wUiIzQUsyUOp8SyyDKTqVRBtq7kk1VnFmIZW8QufjxGrGEuI+LVR7p/C7uEKy0LQw==
+viz.js@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/viz.js/-/viz.js-1.8.1.tgz#277ab3cf4367c608a95b281a7472083c3e2ee6cf"
+  integrity sha512-KrSNgnIxec+JCAqDPliO6xYA69ToH2WTYB2Kbt8Bp/XRUvm23rTyfffFi4rvQLFkIRNUz/xCnnqhh/gChhsgGA==
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
Resolves #1077.

The upgrade was introduced in #1001. Sadly, we have no unit tests in `/plexus/` module, so the break was not caught.

In #1001 the dependency viz.js was upgraded to the next major version (2.1.2), however it had breaking changes which were not accounted for.

Alternative paths tracked in #1081.
