### PR TITLE
Prevent wrapping of the timeline tick label text

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.css
@@ -32,6 +32,7 @@ limitations under the License.
 .Ticks--tickLabel {
   left: 0.25rem;
   position: absolute;
+  white-space: nowrap;
 }
 
 .Ticks--tickLabel.isEndAnchor {


### PR DESCRIPTION
When the timeline is more than one minute, the ticks would line wrap:
<img width="92" alt="image" src="https://user-images.githubusercontent.com/19623715/207576318-501f7536-e84f-4e26-8157-e589ca82eff8.png">

Setting `width` to `max-content` solves this problem:
<img width="149" alt="image" src="https://user-images.githubusercontent.com/19623715/207576397-be4084d0-2046-4afa-8983-52e605eb5b41.png">


<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->
