### PR TITLE
Move alt view dropdown to a button

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Dropdown, Icon, Menu } from 'antd';
+import { Dropdown, Icon, Menu, Button } from 'antd';
 import { Link } from 'react-router-dom';
 import './AltViewOptions.css';
 
@@ -109,10 +109,10 @@ export default function AltViewOptions(props: Props) {
   const dropdownText = currentItem ? currentItem.label : 'Alternate Views';
   return (
     <Dropdown overlay={menu}>
-      <div className="AltViewOptions">
+      <Button className="AltViewOptions">
         {`${dropdownText} `}
         <Icon type="down" />
-      </div>
+      </Button>
     </Dropdown>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
@@ -70,13 +70,17 @@ exports[`AltViewOptions renders correctly 1`] = `
   placement="bottomLeft"
   prefixCls="ant-dropdown"
 >
-  <div
+  <Button
+    block={false}
     className="AltViewOptions"
+    ghost={false}
+    loading={false}
+    prefixCls="ant-btn"
   >
     Trace Timeline 
     <Icon
       type="down"
     />
-  </div>
+  </Button>
 </Dropdown>
 `;


### PR DESCRIPTION
Alt View dropdown is currently a `div` which does not display a pointer cursor when hovering and you sometimes end selecting text in it.

## Which problem is this PR solving?
- Alt View button gets its text selected sometimes when clicking
- Alt View dropdown shows text cursor instead of pointer cursor

## Short description of the changes
- Move Alt View dropdown to a button as shown in Ant Design examples: https://ant.design/components/dropdown

<img width="426" alt="Screenshot 2023-02-04 at 15 48 30" src="https://user-images.githubusercontent.com/2519238/216774061-c2cf6a4e-2dc0-4ca4-a2ae-41906737e5bd.png">
