### PR TITLE
Make Plexus output ESM

### DIFF
--- a/packages/plexus/babel.config.js
+++ b/packages/plexus/babel.config.js
@@ -32,6 +32,8 @@ function getBabelConfig(api) {
       [
         '@babel/preset-env',
         {
+          // Don't transform ES modules
+          modules: false,
           // this should match the settings in jaeger-ui/package.json
           targets: ['>0.5%', 'not dead', 'not ie <= 11', 'not op_mini all'],
         },

--- a/packages/plexus/webpack-factory.js
+++ b/packages/plexus/webpack-factory.js
@@ -195,13 +195,14 @@ function makeCommonProdConfig() {
 function makeWorkerConfig() {
   const layoutDir = join(__dirname, 'src/LayoutManager');
   const config = {
+    experiments: {
+      outputModule: true,
+    },
     output: {
       path: layoutDir,
       publicPath: '/',
       filename: '[name].bundled.js',
-      library: 'layout.worker.bundled',
-      libraryTarget: 'umd',
-      umdNamedDefine: true,
+      libraryTarget: 'module',
     },
     entry: {
       'layout.worker': join(layoutDir, 'layout.worker.tsx'),


### PR DESCRIPTION




## Which problem is this PR solving?
Split from https://github.com/jaegertracing/jaeger-ui/pull/1212

## Short description of the changes
Plexus currently outputs a Universal Module Definition, which seems to cause issues during the Vite build as it results in "ambiguous exports". Have Plexus output ESM instead to avoid the issue.
