### PR TITLE
Abstract access to injected globals

### DIFF
--- a/packages/jaeger-ui/src/site-prefix.tsx
+++ b/packages/jaeger-ui/src/site-prefix.tsx
@@ -15,8 +15,10 @@
 // Per the resolution of https://github.com/jaegertracing/jaeger-ui/issues/42,
 // package.json#homepage is set to "." and the document MUST have a <base>
 // element to define a usable base URL.
+import { getAppEnvironment } from './utils/constants';
+
 const baseNode = document.querySelector('base');
-if (!baseNode && process.env.NODE_ENV !== 'test') {
+if (!baseNode && getAppEnvironment() !== 'test') {
   throw new Error('<base> element not found');
 }
 

--- a/packages/jaeger-ui/src/utils/configure-store.js
+++ b/packages/jaeger-ui/src/utils/configure-store.js
@@ -14,13 +14,13 @@
 
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
-import { window } from 'global';
 
 import traceDiff from '../components/TraceDiff/duck';
 import archive from '../components/TracePage/ArchiveNotifier/duck';
 import traceTimeline from '../components/TracePage/TraceTimelineViewer/duck';
 import jaegerReducers from '../reducers';
 import * as jaegerMiddlewares from '../middlewares';
+import { getAppEnvironment } from './constants';
 
 export default function configureStore(history) {
   return createStore(
@@ -38,7 +38,7 @@ export default function configureStore(history) {
           .filter(Boolean),
         routerMiddleware(history)
       ),
-      process.env.NODE_ENV !== 'production' && window && window.__REDUX_DEVTOOLS_EXTENSION__
+      getAppEnvironment() !== 'production' && window && window.__REDUX_DEVTOOLS_EXTENSION__
         ? window.__REDUX_DEVTOOLS_EXTENSION__()
         : noop => noop
     )

--- a/packages/jaeger-ui/src/utils/constants.tsx
+++ b/packages/jaeger-ui/src/utils/constants.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Provides access to constants injected by the build system.
+ */
+
+/**
+ * Get the current execution environment, as inferred from NODE_ENV at build time.
+ */
+export function getAppEnvironment() {
+  return process.env.NODE_ENV;
+}
+
+/**
+ * Get injected version details as a JSON-formatted string.
+ */
+export function getVersionInfo() {
+  return process.env.REACT_APP_VSN_STATE;
+}
+
+export function shouldDebugGoogleAnalytics() {
+  return process.env.REACT_APP_GA_DEBUG;
+}

--- a/packages/jaeger-ui/src/utils/prefix-url.tsx
+++ b/packages/jaeger-ui/src/utils/prefix-url.tsx
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import sitePrefix from '../site-prefix';
+import { getAppEnvironment } from './constants';
 
-const origin = process.env.NODE_ENV === 'test' ? global.location.origin : window.location.origin;
+const origin = getAppEnvironment() === 'test' ? global.location.origin : window.location.origin;
 
 /**
  * Generate the URL prefix from `sitePrefix` and use it for all subsequent calls

--- a/packages/jaeger-ui/src/utils/tracking/ga.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/ga.test.js
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* eslint-disable import/first */
+import ReactGA from 'react-ga';
+import * as GA from './ga';
+import * as utils from './utils';
+import { getVersionInfo, getAppEnvironment } from '../constants';
+
 jest.mock('./conv-raven-to-ga', () => () => ({
   category: 'jaeger/a',
   action: 'some-action',
   message: 'jaeger/a',
 }));
 
-jest.mock('./index', () => {
-  global.process.env.REACT_APP_VSN_STATE = '{}';
-  return require.requireActual('./index');
-});
-
-import ReactGA from 'react-ga';
-import * as GA from './ga';
-import * as utils from './utils';
+jest.mock('../constants');
 
 let longStr = '---';
+
 function getStr(len) {
   while (longStr.length < len) {
     longStr += longStr.slice(0, len - longStr.length);
@@ -41,6 +39,7 @@ describe('google analytics tracking', () => {
   let tracking;
 
   beforeAll(() => {
+    getAppEnvironment.mockReturnValue('test');
     tracking = GA.default(
       {
         tracking: {
@@ -55,6 +54,7 @@ describe('google analytics tracking', () => {
   });
 
   beforeEach(() => {
+    getVersionInfo.mockReturnValue('{}');
     calls = ReactGA.testModeAPI.calls;
     calls.length = 0;
   });

--- a/packages/jaeger-ui/src/utils/tracking/ga.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/ga.tsx
@@ -22,17 +22,19 @@ import { TNil } from '../../types';
 import { Config } from '../../types/config';
 import { IWebAnalyticsFunc } from '../../types/tracking';
 import { logTrackingCalls } from './utils';
+import { getAppEnvironment, shouldDebugGoogleAnalytics } from '../constants';
 
 const isTruish = (value?: string | string[]) => {
   return Boolean(value) && value !== '0' && value !== 'false';
 };
 
 const GA: IWebAnalyticsFunc = (config: Config, versionShort: string, versionLong: string) => {
-  const isProd = process.env.NODE_ENV === 'production';
-  const isDev = process.env.NODE_ENV === 'development';
-  const isTest = process.env.NODE_ENV === 'test';
+  const appEnv = getAppEnvironment();
+  const isProd = appEnv === 'production';
+  const isDev = appEnv === 'development';
+  const isTest = appEnv === 'test';
   const isDebugMode =
-    (isDev && isTruish(process.env.REACT_APP_GA_DEBUG)) ||
+    (isDev && isTruish(shouldDebugGoogleAnalytics())) ||
     isTruish(queryString.parse(_get(window, 'location.search'))['ga-debug']);
   const gaID = _get(config, 'tracking.gaID');
   const isErrorsEnabled = isDebugMode || Boolean(_get(config, 'tracking.trackErrors'));
@@ -130,7 +132,7 @@ const GA: IWebAnalyticsFunc = (config: Config, versionShort: string, versionLong
           dom: true,
           location: true,
         },
-        environment: process.env.NODE_ENV || 'unkonwn',
+        environment: getAppEnvironment() || 'unkonwn',
         transport: trackRavenError,
       };
       if (versionShort && versionShort !== 'unknown') {

--- a/packages/jaeger-ui/src/utils/tracking/index.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/index.test.js
@@ -126,13 +126,17 @@ describe('generic analytics tracking', () => {
 
   it('get versions as a string or bad JSON test', () => {
     const version = '123456';
-    process.env.REACT_APP_VSN_STATE = version;
+
     jest.doMock('../config/get-config', () => {
       return {
         __esModule: true,
         default: () => ({}),
       };
     });
+
+    jest.doMock('../constants', () => ({
+      getVersionInfo: () => version,
+    }));
 
     return import('.').then(() => {
       expect(internalVersionShort).toBe(version);
@@ -145,13 +149,17 @@ describe('generic analytics tracking', () => {
   it('get versions as an object test', () => {
     const vShot = '48956d5';
     const vLong = ' | github.com/jaegertracing/jaeger-ui | 48956d5 | main';
-    process.env.REACT_APP_VSN_STATE = `{"remote":"github.com/jaegertracing/jaeger-ui","objName":"${vShot}","changed":{"hasChanged":false,"files":0,"insertions":0,"deletions":0,"untracked":0,"pretty":""},"refName":"main","pretty":"${vLong}"}`;
+    const rawVersion = `{"remote":"github.com/jaegertracing/jaeger-ui","objName":"${vShot}","changed":{"hasChanged":false,"files":0,"insertions":0,"deletions":0,"untracked":0,"pretty":""},"refName":"main","pretty":"${vLong}"}`;
     jest.doMock('../config/get-config', () => {
       return {
         __esModule: true,
         default: () => ({}),
       };
     });
+
+    jest.doMock('../constants', () => ({
+      getVersionInfo: () => rawVersion,
+    }));
 
     return import('.').then(() => {
       expect(internalVersionShort).toBe(vShot);
@@ -165,13 +173,17 @@ describe('generic analytics tracking', () => {
     const vShotCommitSHA = '48956d5';
     const vShotChanges = '2f +20 -3 1?';
     const vLong = ' | github.com/jaegertracing/jaeger-ui | 48956d5 | main';
-    process.env.REACT_APP_VSN_STATE = `{"remote":"github.com/jaegertracing/jaeger-ui","objName":"${vShotCommitSHA}","changed":{"hasChanged":true,"files":2,"insertions":20,"deletions":3,"untracked":1,"pretty":"${vShotChanges}"},"refName":"main","pretty":"${vLong}"}`;
+    const rawVersion = `{"remote":"github.com/jaegertracing/jaeger-ui","objName":"${vShotCommitSHA}","changed":{"hasChanged":true,"files":2,"insertions":20,"deletions":3,"untracked":1,"pretty":"${vShotChanges}"},"refName":"main","pretty":"${vLong}"}`;
     jest.doMock('../config/get-config', () => {
       return {
         __esModule: true,
         default: () => ({}),
       };
     });
+
+    jest.doMock('../constants', () => ({
+      getVersionInfo: () => rawVersion,
+    }));
 
     return import('.').then(() => {
       expect(internalVersionShort).toBe(`${vShotCommitSHA} ${vShotChanges}`);

--- a/packages/jaeger-ui/src/utils/tracking/index.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/index.tsx
@@ -17,15 +17,18 @@ import { IWebAnalyticsFunc } from '../../types/tracking';
 import GA from './ga';
 import NoopWebAnalytics from './noopWebAnalytics';
 import getConfig from '../config/get-config';
+import { getVersionInfo } from '../constants';
 
 const TrackingImplementation = () => {
   const config = getConfig();
   let versionShort;
   let versionLong;
 
-  if (process.env.REACT_APP_VSN_STATE) {
+  const versionInfo = getVersionInfo();
+
+  if (versionInfo) {
     try {
-      const data = JSON.parse(process.env.REACT_APP_VSN_STATE);
+      const data = JSON.parse(versionInfo);
       const joiner = [data.objName];
       if (data.changed.hasChanged) {
         joiner.push(data.changed.pretty);
@@ -33,8 +36,8 @@ const TrackingImplementation = () => {
       versionShort = joiner.join(' ');
       versionLong = data.pretty;
     } catch (_) {
-      versionShort = process.env.REACT_APP_VSN_STATE;
-      versionLong = process.env.REACT_APP_VSN_STATE;
+      versionShort = versionInfo;
+      versionLong = versionInfo;
     }
     versionLong = versionLong.length > 99 ? `${versionLong.slice(0, 96)}...` : versionLong;
   } else {

--- a/packages/jaeger-ui/src/utils/version/get-version.test.js
+++ b/packages/jaeger-ui/src/utils/version/get-version.test.js
@@ -34,9 +34,9 @@ describe('getVersion()', () => {
     console.warn = oldWarn;
   });
 
-  describe('`window.getVersion` is not a function', () => {
+  describe('`window.getJaegerVersion` is not a function', () => {
     beforeAll(() => {
-      window.getVersion = undefined;
+      window.getJaegerVersion = undefined;
     });
 
     it('warns once', () => {
@@ -51,7 +51,7 @@ describe('getVersion()', () => {
     });
   });
 
-  describe('`window.getVersion` is a function', () => {
+  describe('`window.getJaegerVersion` is a function', () => {
     let embedded;
     let getJaegerVersion;
 


### PR DESCRIPTION




## Which problem is this PR solving?
- Split from https://github.com/jaegertracing/jaeger-ui/pull/1212

## Short description of the changes
Create a wrapper module for accessing globals injected by the build system. This makes it easier to rename or adjust those later.
