### PR TITLE
Avoid use of require() in default-config.tsx

### DIFF
--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -17,7 +17,7 @@ import deepFreeze from 'deep-freeze';
 import { FALLBACK_DAG_MAX_NUM_SERVICES } from './index';
 import getVersion from '../utils/version/get-version';
 
-const { version } = require('../../package.json');
+import { version } from '../../package.json';
 
 export default deepFreeze(
   Object.defineProperty(

--- a/packages/jaeger-ui/tsconfig.lint.json
+++ b/packages/jaeger-ui/tsconfig.lint.json
@@ -52,6 +52,7 @@
     "src/selectors/trace.js",
     "src/utils/configure-store.js",
     "src/utils/sort.js",
-    "src/utils/TreeNode.js"
+    "src/utils/TreeNode.js",
+    "package.json"
   ]
 }


### PR DESCRIPTION


## Which problem is this PR solving?
- Split from https://github.com/jaegertracing/jaeger-ui/pull/1212

## Short description of the changes
This needs to be an import for an eventual build system switch, since Vite uses ES modules. It also helps make things more consistent.

The UI package version in the About Jaeger dropdown still shows up.
