### PR TITLE
Workaround antd v3 error in the production build

### DIFF
--- a/packages/jaeger-ui/vite.config.ts
+++ b/packages/jaeger-ui/vite.config.ts
@@ -34,6 +34,13 @@ export default defineConfig({
     __REACT_APP_VSN_STATE__: JSON.stringify(process.env.REACT_APP_VSN_STATE || ''),
     __APP_ENVIRONMENT__: JSON.stringify(process.env.NODE_ENV || 'development'),
   },
+  // Workaround an imports issue with antd v3 that causes an error in the production build.
+  // https://github.com/ant-design/ant-design/issues/19002
+  resolve: {
+    alias: {
+      '@ant-design/icons/lib/dist': '@ant-design/icons/lib/index.es.js',
+    },
+  },
   plugins: [
     react(),
     legacy({


### PR DESCRIPTION

## Which problem is this PR solving?
- Unbreak the UI in the production build (closes #1275)
## Short description of the changes
It seems that the antd v3 upgrade in
cda1746aa10dad4105cff06c7b279dec367f8b00 causes an error in the production build, apparently due to a bad interplay with vite/esbuild bundling. As a workaround, provide an import alias for the antd icon sprite file that's causing the issue.[1]

---
[1] https://github.com/ant-design/ant-design/issues/19002#issuecomment-965958565