### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,3 +26,8 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+          # Using upload token helps against rate limiting errors.
+          # Cannot define it as secret as we need it accessible from forks.
+          # See https://github.com/codecov/codecov-action/issues/837
+          token: 31c3122b-7b49-4267-a117-8c9354a97119
+


### PR DESCRIPTION
Codecov sporadically fails to upload, the existing workaround is to hardcode our token. It has to be in free-form to make it available to PRs from forks, but according to codecov the risk is low.