### PR TITLE
Make coverage results more stable

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
@@ -20,6 +20,12 @@ const traceSpanAmongEachOther = require('./tableValuesTestTrace/spansAmongEachOt
 const traceSpanAmongEachOtherGrouped = require('./tableValuesTestTrace/spansAmongEachOtherGrouped.json');
 const traceSpanAmongEachOtherGroupedAndSpans = require('./tableValuesTestTrace/spanAmongEachOtherGroupedAndSpans.json');
 const traceSpanLongerAsParent = require('./tableValuesTestTrace/spanLongerAsParent.json');
+const traceWithOverlappingChildrenLongerThanParent = require('./tableValuesTestTrace/traceWithOverlappingChildrenLongerThanParent.json');
+const traceWithTwoNonOverlappingChildren = require('./tableValuesTestTrace/traceWithTwoNonOverlappingChildren.json');
+const traceWithOverlappingChildren = require('./tableValuesTestTrace/traceWithOverlappingChildren.json');
+const traceWithSingleChildSpanLongerThanParent = require('./tableValuesTestTrace/traceWithSingleChildSpanLongerThanParent.json');
+const traceWithThreeShortChildren = require('./tableValuesTestTrace/traceWithThreeShortChildren.json');
+const traceWithTwoChildrenStartedAtTraceStart = require('./tableValuesTestTrace/traceWithTwoChildrenStartedAtTraceStart.json');
 
 const transformedTrace = transformTraceData(testTraceNormal);
 const transformedTraceSpanAmongEachOthe = transformTraceData(traceSpanAmongEachOther);
@@ -28,6 +34,18 @@ const transformedTraceSpanAmongEachOtheGroupedAndSpans = transformTraceData(
   traceSpanAmongEachOtherGroupedAndSpans
 );
 const transformedTraceSpanLongerAsParent = transformTraceData(traceSpanLongerAsParent);
+const transformedTraceWithOverlappingChildrenLongerThanParent = transformTraceData(
+  traceWithOverlappingChildrenLongerThanParent
+);
+const transformedTraceWithTwoNonOverlappingChildren = transformTraceData(traceWithTwoNonOverlappingChildren);
+const transformedTraceWithOverlappingChildren = transformTraceData(traceWithOverlappingChildren);
+const transformedTraceWithSingleChildSpanLongerThanParent = transformTraceData(
+  traceWithSingleChildSpanLongerThanParent
+);
+const transformedTraceWithThreeShortChildren = transformTraceData(traceWithThreeShortChildren);
+const transformedTraceWithTwoChildrenStartedAtTraceStart = transformTraceData(
+  traceWithTwoChildrenStartedAtTraceStart
+);
 
 describe('tableValues', () => {
   it('get values only first nameSelector is selected (Service Name)', () => {
@@ -481,5 +499,38 @@ describe('check self time', () => {
     );
 
     expect(resultArray[2].selfTotal).toBe(1.22);
+  });
+
+  it('span with two overlapping children longer than their parent and a third short child span', () => {
+    const [serviceOne] = getColumnValues(
+      'Service Name',
+      transformedTraceWithOverlappingChildrenLongerThanParent
+    );
+    expect(serviceOne.selfTotal).toBe(10.33);
+  });
+
+  it('span with two children that do not overlap and one is longer than its parent', () => {
+    const [serviceOne] = getColumnValues('Service Name', transformedTraceWithTwoNonOverlappingChildren);
+    expect(serviceOne.selfTotal).toBe(1.51);
+  });
+
+  it('span with two overlapping children where one is longer than its parent', () => {
+    const [serviceOne] = getColumnValues('Service Name', transformedTraceWithOverlappingChildren);
+    expect(serviceOne.selfTotal).toBe(0);
+  });
+
+  it('span with single child span longer than its parent', () => {
+    const [serviceOne] = getColumnValues('Service Name', transformedTraceWithSingleChildSpanLongerThanParent);
+    expect(serviceOne.selfTotal).toBe(1.34);
+  });
+
+  it('span with three children shorter than their parent, two of which overlap', () => {
+    const [serviceOne] = getColumnValues('Service Name', transformedTraceWithThreeShortChildren);
+    expect(serviceOne.selfTotal).toBe(0.01);
+  });
+
+  it('span with two children started at trace start time', () => {
+    const [serviceOne] = getColumnValues('Service Name', transformedTraceWithTwoChildrenStartedAtTraceStart);
+    expect(serviceOne.selfTotal).toBe(0);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.tsx
@@ -209,7 +209,7 @@ function calculateContent(trace: Trace, span: Span, allSpans: Span[], resultValu
 
           tempSelf = onlyOverlay(overlayWithout, allChildrenWithout, tempSelf, span);
           const diff = span.relativeStartTime + span.duration - earliestLongerAsParent.relativeStartTime;
-          tempSelf -= diff;
+          tempSelf = Math.max(0, tempSelf - diff);
         }
       } else if (longerAsParent) {
         // span is longer as Parent

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithOverlappingChildren.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithOverlappingChildren.json
@@ -1,0 +1,95 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 1679437737490189,
+      "duration": 36,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "5d423585b4c63d48",
+      "flags": 1,
+      "operationName": "async task 1",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490192,
+      "duration": 40,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "shorter than parent",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490194,
+      "duration": 8,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-two",
+      "tags": []
+    }
+  },
+  "warnings": null
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithOverlappingChildrenLongerThanParent.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithOverlappingChildrenLongerThanParent.json
@@ -1,0 +1,125 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 1679437737490189,
+      "duration": 36,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "4570ab68826f43f9",
+      "flags": 1,
+      "operationName": "short child span",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490205,
+      "duration": 8,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "async task 1",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737500529,
+      "duration": 79182,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "5d423585b4c63d48",
+      "flags": 1,
+      "operationName": "async task 2",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737500706,
+      "duration": 78941,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-two",
+      "tags": []
+    }
+  },
+  "warnings": null
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithSingleChildSpanLongerThanParent.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithSingleChildSpanLongerThanParent.json
@@ -1,0 +1,65 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 1679437737490189,
+      "duration": 36,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "async task 1",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737491529,
+      "duration": 79182,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-two",
+      "tags": []
+    }
+  },
+  "warnings": null
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithThreeShortChildren.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithThreeShortChildren.json
@@ -1,0 +1,125 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 1679437737490189,
+      "duration": 36,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "overlapping child 1",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490192,
+      "duration": 10,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "5d423585b4c63d48",
+      "flags": 1,
+      "operationName": "overlapping child 2",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490198,
+      "duration": 8,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "4570ab68826f43f9",
+      "flags": 1,
+      "operationName": "longer child",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490205,
+      "duration": 18,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-two",
+      "tags": []
+    }
+  },
+  "warnings": null
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithThreeShortOverlappingChildren.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithThreeShortOverlappingChildren.json
@@ -1,0 +1,125 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 1679437737490189,
+      "duration": 36,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "overlapping child 1",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490192,
+      "duration": 12,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "5d423585b4c63d48",
+      "flags": 1,
+      "operationName": "overlapping child 2",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490198,
+      "duration": 8,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "4570ab68826f43f9",
+      "flags": 1,
+      "operationName": "overlapping child 3",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490202,
+      "duration": 6,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-two",
+      "tags": []
+    }
+  },
+  "warnings": null
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithTwoChildrenStartedAtTraceStart.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithTwoChildrenStartedAtTraceStart.json
@@ -1,0 +1,95 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 1679437737490189,
+      "duration": 36,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "async task 1",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490189,
+      "duration": 79182,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "5d423585b4c63d48",
+      "flags": 1,
+      "operationName": "async task 2",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490189,
+      "duration": 12,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-two",
+      "tags": []
+    }
+  },
+  "warnings": null
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithTwoNonOverlappingChildren.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithTwoNonOverlappingChildren.json
@@ -1,0 +1,95 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 1679437737490189,
+      "duration": 36,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "non-overlapping child",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737490192,
+      "duration": 10,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "5d423585b4c63d48",
+      "flags": 1,
+      "operationName": "async task 2",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceID": "006c3cf93508f205",
+          "spanID": "006c3cf93508f205"
+        }
+      ],
+      "startTime": 1679437737491706,
+      "duration": 78941,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        }
+      ],
+      "logs": [],
+      "processID": "p2",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    },
+    "p2": {
+      "serviceName": "service-two",
+      "tags": []
+    }
+  },
+  "warnings": null
+}


### PR DESCRIPTION



## Which problem is this PR solving?
- Makes coverage checks more stable

## Short description of the changes
Coverage results are currently flaky because
src/components/TracePage/index.test.js uses randomly generated trace data to integration test the page, which sometimes covers code paths in tableValues.tsx not covered by its own unit tests. Attempt to make things more stable by extending unit test coverage for tableValues.tsx.

