### PR TITLE
Render HTTP header tags as comma-separated strings

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -53,7 +53,11 @@ describe('<KeyValuesTable>', () => {
     { key: 'numeric', value: 123456789, expected: '123456789' },
     { key: 'jsonkey', value: JSON.stringify(jsonkeyValue), expected: JSON.stringify(jsonkeyValue, null, 4) },
     { key: 'http.request.header.accept', value: ['application/json'], expected: 'application/json' },
-    { key: 'http.response.header.set_cookie', value: JSON.stringify(['name=mos-def', 'code=12345']), expected: 'name=mos-def, code=12345' },
+    {
+      key: 'http.response.header.set_cookie',
+      value: JSON.stringify(['name=mos-def', 'code=12345']),
+      expected: 'name=mos-def, code=12345',
+    },
   ];
 
   beforeEach(() => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -45,14 +45,15 @@ describe('LinkValue', () => {
 describe('<KeyValuesTable>', () => {
   let wrapper;
 
+  const jsonkeyValue = { hello: 'world' };
   const data = [
     { key: 'span.kind', value: 'client', expected: 'client' },
     { key: 'omg', value: 'mos-def', expected: 'mos-def' },
     { key: 'numericString', value: '12345678901234567890', expected: '12345678901234567890' },
     { key: 'numeric', value: 123456789, expected: '123456789' },
-    { key: 'jsonkey', value: JSON.stringify({ hello: 'world' }) },
-    { key: 'http.request.header.accept', value: ['application/json'] },
-    { key: 'http.response.header.set_cookie', value: JSON.stringify(['name=mos-def', 'code=12345']) },
+    { key: 'jsonkey', value: JSON.stringify(jsonkeyValue), expected: JSON.stringify(jsonkeyValue, null, 4) },
+    { key: 'http.request.header.accept', value: ['application/json'], expected: 'application/json' },
+    { key: 'http.response.header.set_cookie', value: JSON.stringify(['name=mos-def', 'code=12345']), expected: 'name=mos-def, code=12345' },
   ];
 
   beforeEach(() => {
@@ -124,31 +125,13 @@ describe('<KeyValuesTable>', () => {
     });
   });
 
-  it('renders a span value containing numeric string correctly', () => {
+  it('renders the expected text for each span value', () => {
     const el = wrapper.find('.ub-inline-block');
     expect(el.length).toBe(data.length);
     el.forEach((valueDiv, i) => {
       if (data[i].expected) {
-        expect(valueDiv.html()).toMatch(data[i].expected);
+        expect(valueDiv.render().text()).toBe(data[i].expected);
       }
     });
   });
-
-  it('renders HTTP headers as multiple string spans', () => {
-    const el = wrapper.find('.ub-inline-block');
-    expect(el.length).toBe(data.length);
-    el.forEach((valueDiv, i) => {
-      if (/http\.(request|response)\.header\./.test(data[i].key)) {
-        let value = data[i].value;
-        if (typeof value === 'string') {
-          value = JSON.parse(value);
-        }
-        const spans = valueDiv.find('div.json-markup > span.json-markup-string');
-        expect(spans.length).toBe(value.length);
-        spans.forEach((span, j) => {
-          expect(span.text()).toBe(value[j]);
-        });
-      }
-    });
-  })
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -51,6 +51,8 @@ describe('<KeyValuesTable>', () => {
     { key: 'numericString', value: '12345678901234567890', expected: '12345678901234567890' },
     { key: 'numeric', value: 123456789, expected: '123456789' },
     { key: 'jsonkey', value: JSON.stringify({ hello: 'world' }) },
+    { key: 'http.request.header.accept', value: ['application/json'] },
+    { key: 'http.response.header.set_cookie', value: JSON.stringify(['name=mos-def', 'code=12345']) },
   ];
 
   beforeEach(() => {
@@ -126,9 +128,27 @@ describe('<KeyValuesTable>', () => {
     const el = wrapper.find('.ub-inline-block');
     expect(el.length).toBe(data.length);
     el.forEach((valueDiv, i) => {
-      if (data[i].key !== 'jsonkey') {
+      if (data[i].expected) {
         expect(valueDiv.html()).toMatch(data[i].expected);
       }
     });
   });
+
+  it('renders HTTP headers as multiple string spans', () => {
+    const el = wrapper.find('.ub-inline-block');
+    expect(el.length).toBe(data.length);
+    el.forEach((valueDiv, i) => {
+      if (/http\.(request|response)\.header\./.test(data[i].key)) {
+        let value = data[i].value;
+        if (typeof value === 'string') {
+          value = JSON.parse(value);
+        }
+        const spans = valueDiv.find('div.json-markup > span.json-markup-string');
+        expect(spans.length).toBe(value.length);
+        spans.forEach((span, j) => {
+          expect(span.text()).toBe(value[j]);
+        });
+      }
+    });
+  })
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -76,7 +76,7 @@ function formatValue(key: string, value: any) {
   } else if (Array.isArray(parsed) && shouldDisplayAsStringList(key)) {
     content = stringListMarkup(parsed);
   } else {
-    content = _jsonMarkup(value);
+    content = _jsonMarkup(parsed);
   }
 
   return <div className="ub-inline-block">{content}</div>;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -36,15 +36,17 @@ function tryParseJson(value: string) {
 }
 
 function shouldDisplayAsStringList(key: string) {
-  return (
-    key.startsWith('http.request.header.') ||
-    key.startsWith('http.response.header.')
-  );
+  return key.startsWith('http.request.header.') || key.startsWith('http.response.header.');
 }
 
 const stringListMarkup = (value: any[]) => (
   <div className="json-markup">
-    {value.map((item, i) => <>{i > 0 && ', '}<span className="json-markup-string">{item}</span></>)}
+    {value.map((item, i) => (
+      <>
+        {i > 0 && ', '}
+        <span className="json-markup-string">{item}</span>
+      </>
+    ))}
   </div>
 );
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -35,6 +35,19 @@ function tryParseJson(value: string) {
   }
 }
 
+function shouldDisplayAsStringList(key: string) {
+  return (
+    key.startsWith('http.request.header.') ||
+    key.startsWith('http.response.header.')
+  );
+}
+
+const stringListMarkup = (value: any[]) => (
+  <div className="json-markup">
+    {value.map((item, i) => <>{i > 0 && ', '}<span className="json-markup-string">{item}</span></>)}
+  </div>
+);
+
 const stringMarkup = (value: string) => (
   <div className="json-markup">
     <span className="json-markup-string">{value}</span>
@@ -50,12 +63,18 @@ function _jsonMarkup(value: any) {
   );
 }
 
-function formatValue(value: any) {
+function formatValue(key: string, value: any) {
   let content;
+  let parsed = value;
 
   if (typeof value === 'string') {
-    const parsed = tryParseJson(value);
-    content = typeof parsed === 'string' ? stringMarkup(parsed) : _jsonMarkup(parsed);
+    parsed = tryParseJson(value);
+  }
+
+  if (typeof parsed === 'string') {
+    content = stringMarkup(parsed);
+  } else if (Array.isArray(parsed) && shouldDisplayAsStringList(key)) {
+    content = stringListMarkup(parsed);
   } else {
     content = _jsonMarkup(value);
   }
@@ -97,7 +116,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
       <table className="u-width-100">
         <tbody className="KeyValueTable--body">
           {data.map((row, i) => {
-            const jsonTable = formatValue(row.value);
+            const jsonTable = formatValue(row.key, row.value);
             const links = linksGetter ? linksGetter(data, i) : null;
             let valueMarkup;
             if (links && links.length === 1) {


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #1294

## Short description of the changes

Change `formatValue` to check whether the (de-serialized) value is an array and, if so, whether the key should be rendered as a comma-separated list of strings. When both conditions are true, render the value like so:

```html
<div class="json-markup">
  <span class="json-markup-string">value1</span>, <span class="json-markup-string">value2</span>
</div>
```
![image](https://user-images.githubusercontent.com/62573/227103539-aeaf81cd-d5e3-4d4e-a878-f4f68a1503e8.png)

Currently, tag keys starting with `http.request.header.` and `http.response.header.` render as string lists. Please let me know if there are any other attributes I should include.