### PR TITLE
Update redux-form to 8.3.10

### DIFF
--- a/packages/jaeger-ui/index.html
+++ b/packages/jaeger-ui/index.html
@@ -37,8 +37,6 @@
 
       // Workaround some legacy NPM dependencies that assume this is always defined.
       window.global = {};
-      // Avoid noise from redux-form until https://github.com/redux-form/redux-form/pull/4723 is released.
-      window.module = {};
     </script>
   </head>
   <body>

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -106,7 +106,7 @@
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-async-middleware": "^0.0.0",
-    "redux-form": "^8.3.9",
+    "redux-form": "^8.3.10",
     "redux-promise-middleware": "^5.1.1",
     "reselect": "^4.1.6",
     "store": "^2.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11356,10 +11356,10 @@ redux-async-middleware@^0.0.0:
     redux "^3.0.2"
     redux-standard-action "0.0.0"
 
-redux-form@^8.3.9:
-  version "8.3.9"
-  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-8.3.9.tgz#bffd5c90b16c1559466f765374ecdd6cf4529155"
-  integrity sha512-PsBDydvGq+OfYNmk4AVlUMs1S9oBsBxKHikS6AfE59Kyx3NMNO7A6N4yTANRWu7D/FDu6y5LtbloLEeunFOJbw==
+redux-form@^8.3.10:
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-8.3.10.tgz#335657fafd4b26b91b4ce65371cd9dabe3648158"
+  integrity sha512-Eeog8dJYUxCSZI/oBoy7VkprvMjj1lpUnHa3LwjVNZvYDNeiRZMoZoaAT+6nlK2YQ4aiBopKUMiLe4ihUOHCGg==
   dependencies:
     "@babel/runtime" "^7.9.2"
     es6-error "^4.1.1"


### PR DESCRIPTION
## Which problem is this PR solving?
- Removes a corresponding workaround from index.html and also fixes some logspam in local development from deprecated React lifecycle methods.

## Short description of the changes
Bump redux-form to 8.3.10 and remove the corresponding shim from index.html.