### PR TITLE
Allow disabling the json view via site config

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.js
@@ -68,6 +68,13 @@ describe('AltViewOptions', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('disables json links because disableJsonView is true', () => {
+    wrapper.setProps({ disableJsonView: true });
+
+    expect(() => getLink('Trace JSON')).toThrow("Could not find \"Trace JSON\"");
+    expect(() => getLink('Trace JSON (unadjusted)')).toThrow("Could not find \"Trace JSON (unadjusted)\"");
+  });
+
   it('tracks viewing JSONs', () => {
     expect(trackJsonView).not.toHaveBeenCalled();
     getLink('Trace JSON').simulate('click');

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -31,6 +31,7 @@ import { ETraceViewType } from '../types';
 type Props = {
   onTraceViewChange: (viewType: ETraceViewType) => void;
   traceID: string;
+  disableJsonView: boolean;
   viewType: ETraceViewType;
 };
 
@@ -58,7 +59,7 @@ const MENU_ITEMS = [
 ];
 
 export default function AltViewOptions(props: Props) {
-  const { onTraceViewChange, viewType, traceID } = props;
+  const { onTraceViewChange, viewType, traceID, disableJsonView } = props;
 
   const handleSelectView = (item: ETraceViewType) => {
     if (item === ETraceViewType.TraceTimelineViewer) {
@@ -82,26 +83,31 @@ export default function AltViewOptions(props: Props) {
           </a>
         </Menu.Item>
       ))}
-      <Menu.Item>
-        <Link
-          to={prefixUrl(`/api/traces/${traceID}?prettyPrint=true`)}
-          rel="noopener noreferrer"
-          target="_blank"
-          onClick={trackJsonView}
-        >
-          Trace JSON
-        </Link>
-      </Menu.Item>
-      <Menu.Item>
-        <Link
-          to={prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`)}
-          rel="noopener noreferrer"
-          target="_blank"
-          onClick={trackRawJsonView}
-        >
-          Trace JSON (unadjusted)
-        </Link>
-      </Menu.Item>
+      {!disableJsonView && (
+        <Menu.Item>
+          <Link
+            to={prefixUrl(`/api/traces/${traceID}?prettyPrint=true`)}
+            rel="noopener noreferrer"
+            target="_blank"
+            onClick={trackJsonView}
+          >
+            Trace JSON
+          </Link>
+        </Menu.Item>
+      )}
+      {!disableJsonView && (
+        <Menu.Item>
+          <Link
+            to={prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`)}
+            rel="noopener noreferrer"
+            target="_blank"
+            onClick={trackRawJsonView}
+          >
+            Trace JSON (unadjusted)
+          </Link>
+        </Menu.Item>
+      )}
+     
     </Menu>
   );
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -55,6 +55,7 @@ type TracePageHeaderEmbedProps = {
   showArchiveButton: boolean;
   showShortcutsHelp: boolean;
   showStandaloneLink: boolean;
+  disableJsonView: boolean;
   showViewOptions: boolean;
   slimView: boolean;
   textFilter: string | TNil;
@@ -124,6 +125,7 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
     showShortcutsHelp,
     showStandaloneLink,
     showViewOptions,
+    disableJsonView,
     slimView,
     textFilter,
     toSearch,
@@ -191,7 +193,7 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
         />
         {showShortcutsHelp && <KeyboardShortcutsHelp className="ub-m2" />}
         {showViewOptions && (
-          <AltViewOptions onTraceViewChange={onTraceViewChange} traceID={trace.traceID} viewType={viewType} />
+          <AltViewOptions disableJsonView={disableJsonView} onTraceViewChange={onTraceViewChange} traceID={trace.traceID} viewType={viewType} />
         )}
         {showArchiveButton && (
           <Button className="ub-mr2 ub-flex ub-items-center" htmlType="button" onClick={onArchiveClicked}>

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -81,6 +81,7 @@ type TReduxProps = {
   embedded: null | EmbeddedState;
   id: string;
   searchUrl: null | string;
+  disableJsonView: boolean;
   trace: FetchedTrace | TNil;
   uiFind: string | TNil;
   traceGraphConfig?: TraceGraphConfig;
@@ -328,6 +329,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
       id,
       uiFind,
       trace,
+      disableJsonView,
       traceGraphConfig,
       location: { state: locationState },
     } = this.props;
@@ -374,6 +376,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
       prevResult: this.prevResult,
       ref: this._searchBar,
       resultCount: findCount,
+      disableJsonView,
       showArchiveButton: !isEmbedded && archiveEnabled,
       showShortcutsHelp: !isEmbedded,
       showStandaloneLink: isEmbedded,
@@ -437,6 +440,7 @@ export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxP
   const trace = id ? traces[id] : null;
   const archiveTraceState = id ? archive[id] : null;
   const archiveEnabled = Boolean(config.archiveEnabled);
+  const { disableJsonView } = config;
   const { state: locationState } = router.location;
   const searchUrl = (locationState && locationState.fromSearch) || null;
   const { traceGraph: traceGraphConfig } = config;
@@ -448,6 +452,7 @@ export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxP
     embedded,
     id,
     searchUrl,
+    disableJsonView,
     trace,
     traceGraphConfig,
   };

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -102,6 +102,7 @@ const defaultConfig: Config = {
     docsLink: 'https://www.jaegertracing.io/docs/latest/spm/',
   },
   disableFileUploadControl: false,
+  disableJsonView: false,
   traceGraph: {
     layoutManagerMemory: undefined,
   },

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -169,6 +169,9 @@ export type Config = {
   // Disables the file upload control.
   disableFileUploadControl: boolean;
 
+  // Disables the json view.
+  disableJsonView: boolean;
+
   // The following features are experimental / undocumented.
 
   deepDependencies?: {


### PR DESCRIPTION
- This PR splits one single feature from #1229 
- Adds a new configuration option `disableJsonView`
- Addresses part of #1211 

