### PR TITLE
Add boolean property to config

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
@@ -25,6 +25,7 @@ import { FetchedState, TNil } from '../../../types';
 import { ApiError } from '../../../types/api-error';
 
 import './ResultItemTitle.css';
+import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 
 type Props = {
   duration?: number;
@@ -80,7 +81,7 @@ export default class ResultItemTitle extends React.PureComponent<Props> {
       wrapperProps.to = linkTo;
       WrapperComponent = Link;
       if (targetBlank) {
-        wrapperProps.target = '_blank';
+        wrapperProps.target = getTargetEmptyOrBlank();
         wrapperProps.rel = 'noopener noreferrer';
       }
     }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -43,6 +43,7 @@ import { SearchQuery } from '../../../types/search';
 import { KeyValuePair, Trace, TraceData } from '../../../types/trace';
 
 import './index.css';
+import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 
 type SearchResultsProps = {
   cohortAddTrace: (traceId: string) => void;
@@ -200,7 +201,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
               <Link
                 className="u-tx-inherit ub-nowrap ub-ml3"
                 to={searchUrl}
-                target="_blank"
+                target={getTargetEmptyOrBlank()}
                 rel="noopener noreferrer"
               >
                 <NewWindowIcon isLarge />

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceTimelineLink.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceTimelineLink.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 
 import { getUrl } from '../../TracePage/url';
 import NewWindowIcon from '../../common/NewWindowIcon';
+import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 
 type PropsType = {
   traceID: string;
@@ -27,7 +28,12 @@ function stopPropagation(event: React.MouseEvent<HTMLAnchorElement>) {
 
 export default function TraceTimelineLink({ traceID }: PropsType) {
   return (
-    <a href={getUrl(traceID)} onClick={stopPropagation} rel="noopener noreferrer" target="_blank">
+    <a
+      href={getUrl(traceID)}
+      onClick={stopPropagation}
+      rel="noopener noreferrer"
+      target={getTargetEmptyOrBlank()}
+    >
       <NewWindowIcon />
     </a>
   );

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -27,6 +27,7 @@ import {
 } from './TracePageHeader.track';
 import prefixUrl from '../../../utils/prefix-url';
 import { ETraceViewType } from '../types';
+import { getTargetBlankOrTop } from '../../../utils/config/get-target';
 
 type Props = {
   onTraceViewChange: (viewType: ETraceViewType) => void;
@@ -88,7 +89,7 @@ export default function AltViewOptions(props: Props) {
           <Link
             to={prefixUrl(`/api/traces/${traceID}?prettyPrint=true`)}
             rel="noopener noreferrer"
-            target="_blank"
+            target={getTargetBlankOrTop()}
             onClick={trackJsonView}
           >
             Trace JSON
@@ -100,7 +101,7 @@ export default function AltViewOptions(props: Props) {
           <Link
             to={prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`)}
             rel="noopener noreferrer"
-            target="_blank"
+            target={getTargetBlankOrTop()}
             onClick={trackRawJsonView}
           >
             Trace JSON (unadjusted)

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -38,6 +38,7 @@ import { getTraceLinks } from '../../../model/link-patterns';
 
 import './TracePageHeader.css';
 import ExternalLinks from '../../common/ExternalLinks';
+import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 
 type TracePageHeaderEmbedProps = {
   canCollapse: boolean;
@@ -210,7 +211,7 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
           <Link
             className="u-tx-inherit ub-nowrap ub-mx2"
             to={linkToStandalone}
-            target="_blank"
+            target={getTargetEmptyOrBlank()}
             rel="noopener noreferrer"
           >
             <NewWindowIcon isLarge />

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -22,6 +22,7 @@ import { TNil } from '../../../types';
 import { Trace, Span } from '../../../types/trace';
 import { timeConversion } from '../../../utils/date';
 import prefixUrl from '../../../utils/prefix-url';
+import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 
 const Option = Select.Option;
 
@@ -149,7 +150,7 @@ export default class TraceSpanView extends Component<Props, State> {
           return (
             <a
               href={prefixUrl(`/trace/${record.traceID}?uiFind=${text}`)}
-              target="_blank"
+              target={getTargetEmptyOrBlank()}
               rel="noopener noreferrer"
             >
               {text}

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -103,6 +103,7 @@ const defaultConfig: Config = {
   },
   disableFileUploadControl: false,
   disableJsonView: false,
+  forbidNewPage: false,
   traceGraph: {
     layoutManagerMemory: undefined,
   },

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -172,6 +172,10 @@ export type Config = {
   // Disables the json view.
   disableJsonView: boolean;
 
+  // Alters all targets of links to empty or top to
+  // prevent the creation of a new page.
+  forbidNewPage: boolean;
+
   // The following features are experimental / undocumented.
 
   deepDependencies?: {

--- a/packages/jaeger-ui/src/utils/config/get-target.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-target.test.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as getConfig from './get-config';
+import { getTargetBlankOrTop, getTargetEmptyOrBlank } from './get-target';
+
+let getConfigValueSpy;
+
+beforeAll(() => {
+  getConfigValueSpy = jest.spyOn(getConfig, 'getConfigValue');
+});
+
+describe('getTarget', () => {
+  it('getTargetEmptyOrBlank returns empty because forbidNewPage is true', () => {
+    getConfigValueSpy.mockReturnValue(true);
+    const target = getTargetEmptyOrBlank();
+    expect(target).toBe('');
+  });
+  it('getTargetEmptyOrBlank returns _blank because forbidNewPage is true', () => {
+    getConfigValueSpy.mockReturnValue(false);
+    const target = getTargetEmptyOrBlank();
+    expect(target).toBe('_blank');
+  });
+  it('getTargetBlankOrTop returns _top because forbidNewPage is true', () => {
+    getConfigValueSpy.mockReturnValue(true);
+    const target = getTargetBlankOrTop();
+    expect(target).toBe('_top');
+  });
+  it('getTargetBlankOrTop returns _blank because forbidNewPage is true', () => {
+    getConfigValueSpy.mockReturnValue(false);
+    const target = getTargetBlankOrTop();
+    expect(target).toBe('_blank');
+  });
+});

--- a/packages/jaeger-ui/src/utils/config/get-target.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-target.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/utils/config/get-target.tsx
+++ b/packages/jaeger-ui/src/utils/config/get-target.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getConfigValue } from './get-config';
+
+export function getTargetEmptyOrBlank() {
+  return getConfigValue('forbidNewPage') ? '' : '_blank';
+}
+
+export function getTargetBlankOrTop() {
+  return getConfigValue('forbidNewPage') ? '_top' : '_blank';
+}

--- a/packages/jaeger-ui/src/utils/config/get-target.tsx
+++ b/packages/jaeger-ui/src/utils/config/get-target.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pull request resolves the issue #1211 

This property is later used to prevent the popup of a new page. When set to true, it will alter all _blank targets for links to empty. A utils function is provided.