### PR TITLE
Add text label to copy buttons on tags

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -153,12 +153,14 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                     className="KeyValueTable--copyIcon"
                     copyText={row.value}
                     tooltipTitle="Copy value"
+                    buttonText="Copy"
                   />
                   <CopyIcon
-                    className="KeyValueTable--copyIcon"
+                    className="KeyValueTable--copyIcon copyIcon"
                     icon="snippets"
                     copyText={JSON.stringify(row, null, 2)}
                     tooltipTitle="Copy JSON"
+                    buttonText="JSON"
                   />
                 </td>
               </tr>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -156,7 +156,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                     buttonText="Copy"
                   />
                   <CopyIcon
-                    className="KeyValueTable--copyIcon copyIcon"
+                    className="KeyValueTable--copyIcon"
                     icon="snippets"
                     copyText={JSON.stringify(row, null, 2)}
                     tooltipTitle="Copy JSON"

--- a/packages/jaeger-ui/src/components/common/CopyIcon.css
+++ b/packages/jaeger-ui/src/components/common/CopyIcon.css
@@ -17,11 +17,14 @@ limitations under the License.
 .CopyIcon,
 .CopyIcon:hover {
   background-color: transparent;
-  border: none;
+  border: 1px solid inherit;
   color: inherit;
   height: 100%;
   overflow: hidden;
-  padding: 0px;
+  padding: 1px;
+  font-size: 13px;
+  margin-left: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .CopyIcon:focus {

--- a/packages/jaeger-ui/src/components/common/CopyIcon.tsx
+++ b/packages/jaeger-ui/src/components/common/CopyIcon.tsx
@@ -27,6 +27,7 @@ type PropsType = {
   icon?: string;
   placement?: TooltipPlacement;
   tooltipTitle: string;
+  buttonText: string;
 };
 
 type StateType = {
@@ -73,7 +74,9 @@ export default class CopyIcon extends React.PureComponent<PropsType, StateType> 
           htmlType="button"
           icon={this.props.icon}
           onClick={this.handleClick}
-        />
+        >
+          {this.props.buttonText}
+        </Button>
       </Tooltip>
     );
   }


### PR DESCRIPTION
## Which problem is this PR solving?
-  Resolves #1506 

## Short description of the changes
- Previously there we only have icons to copy text and JSON. But now we have implemented plain text along with the icons.
![Screenshot from 2023-07-06 13-23-12](https://github.com/jaegertracing/jaeger-ui/assets/112748914/5c5e9558-d63a-4a59-9776-79d800999d16)
