### PR TITLE
Replace $npm_execpath with yarn

### DIFF
--- a/packages/plexus/package.json
+++ b/packages/plexus/package.json
@@ -65,7 +65,7 @@
     "_tasks/dev-server": "webpack-dev-server --mode $NODE_ENV --config webpack.dev.config.js",
     "build": "NODE_ENV=production npm-run-all -ln --serial _tasks/clean/* _tasks/bundle-worker --parallel _tasks/build/**",
     "coverage": "echo 'NO TESTS YET'",
-    "prepublishOnly": "$npm_execpath build",
+    "prepublishOnly": "yarn build",
     "start": "NODE_ENV='development' npm-run-all -ln --serial _tasks/clean/worker _tasks/bundle-worker --parallel '_tasks/bundle-worker --watch' _tasks/dev-server",
     "test": "echo 'NO TESTS YET'"
   }


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #1603
- `$npm_execpath` does not resolve on Windows

## Short description of the changes
- replace `$npm_execpath` with `yarn`
