### PR TITLE
Fix json logs escape sequence

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/jsonMarkup.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/jsonMarkup.js
@@ -42,7 +42,7 @@ function type(doc) {
 }
 
 function escape(str) {
-  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace('{', '{\\').replace('":', '\\":');
 }
 
 export function jsonMarkup(doc, styleFile) {


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #1570 

## Description of the changes
- This PR resolves the invalid JSON value that was appearing in UI. An extra replace function is added to handle the escape sequences if there is an object inside string value.


## How was this change tested?
- yarn start
- json.test.txt file that was provided with the issue
<img width="404" alt="Screenshot 2023-08-08 at 8 16 42 PM" src="https://github.com/jaegertracing/jaeger-ui/assets/77684943/15e5a0e7-71da-481e-a351-7ad8bf49317c">


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality

