### PR TITLE
Remove unused src parameter in process method

### DIFF
--- a/packages/jaeger-ui/test/generic-file-transform.js
+++ b/packages/jaeger-ui/test/generic-file-transform.js
@@ -16,7 +16,7 @@ const path = require('path');
 
 // Simple Jest transform that stubs out CSS files and returns the file name as the mock content for other file types.
 module.exports = {
-  process(src, filename) {
+  process(filename) {
     const fileExtension = path.extname(filename);
     if (fileExtension === 'css') {
       return { code: 'module.exports = "";' };


### PR DESCRIPTION
## Which problem is this PR solving?
- The PR removes unused `src` parameter used in the `process` method. The `src` parameter is declared but remains unused within the transformation logic.
- Purpose: just a quick fix

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
