### PR TITLE
Recognize uninstrumented services via both `producer` and `client` span kinds

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
@@ -357,21 +357,33 @@ describe('<VirtualizedTraceViewImpl>', () => {
       ).toBe(true);
     });
 
-    it('renders a SpanBarRow with a client span and no instrumented server span', () => {
+    it('renders a SpanBarRow with a client or producer span and no instrumented server span', () => {
       const externServiceName = 'externalServiceTest';
       const leafSpan = trace.spans.find(span => !span.hasChildren);
       const leafSpanIndex = trace.spans.indexOf(leafSpan);
-      const clientTags = [
-        { key: 'span.kind', value: 'client' },
-        { key: 'peer.service', value: externServiceName },
-        ...leafSpan.tags,
+      const tags = [
+        [
+          // client span
+          { key: 'span.kind', value: 'client' },
+          { key: 'peer.service', value: externServiceName },
+          ...leafSpan.tags,
+        ],
+        [
+          // producer span
+          { key: 'span.kind', value: 'producer' },
+          { key: 'peer.service', value: externServiceName },
+          ...leafSpan.tags,
+        ],
       ];
-      const altTrace = updateSpan(trace, leafSpanIndex, { tags: clientTags });
-      wrapper.setProps({ trace: altTrace });
-      const rowWrapper = mount(instance.renderRow('some-key', {}, leafSpanIndex, {}));
-      const spanBarRow = rowWrapper.find(SpanBarRow);
-      expect(spanBarRow.length).toBe(1);
-      expect(spanBarRow.prop('noInstrumentedServer')).not.toBeNull();
+
+      tags.forEach(tag => {
+        const altTrace = updateSpan(trace, leafSpanIndex, { tags: tag });
+        wrapper.setProps({ trace: altTrace });
+        const rowWrapper = mount(instance.renderRow('some-key', {}, leafSpanIndex, {}));
+        const spanBarRow = rowWrapper.find(SpanBarRow);
+        expect(spanBarRow.length).toBe(1);
+        expect(spanBarRow.prop('noInstrumentedServer')).not.toBeNull();
+      });
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -32,6 +32,7 @@ import {
   findServerChildSpan,
   isErrorSpan,
   isKindClient,
+  isKindProducer,
   spanContainsErredSpan,
   ViewedBoundsFunctionType,
 } from './utils';
@@ -369,7 +370,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     // Leaf, kind == client and has peer.service tag, is likely a client span that does a request
     // to an uninstrumented/external service
     let noInstrumentedServer = null;
-    if (!span.hasChildren && peerServiceKV && isKindClient(span)) {
+    if (!span.hasChildren && peerServiceKV && (isKindClient(span) || isKindProducer(span))) {
       noInstrumentedServer = {
         serviceName: peerServiceKV.value,
         color: colorGenerator.getColorByKey(peerServiceKV.value),

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
@@ -120,4 +120,7 @@ export function findServerChildSpan(spans: Span[]) {
 export const isKindClient = (span: Span): Boolean =>
   span.tags.some(({ key, value }) => key === 'span.kind' && value === 'client');
 
+export const isKindProducer = (span: Span): Boolean =>
+  span.tags.some(({ key, value }) => key === 'span.kind' && value === 'producer');
+
 export { formatDuration } from '../../../utils/date';


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #660 

## Description of the changes
VirtualizedTraceView now checks if kind is producer.

## How was this change tested?
I changed HotROD MySQL kind to producer and then tested it. 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
  
![image](https://github.com/jaegertracing/jaeger-ui/assets/110763795/a28ca271-a4f7-422c-be28-49323ab3b62e)
