### PR TITLE
[test] Migrate DAG.test.js from Enzyme to RTL

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.jsx
@@ -110,6 +110,7 @@ export default class DAG extends React.Component {
           left: 0,
           top: 0,
         }}
+        data-testid="cy"
         ref={this.cytoscapeRef}
       />
     );

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import DAG from './DAG';
 
 // mock canvas API (we don't care about canvas results)
@@ -63,7 +63,8 @@ describe('<DAG>', () => {
         parent: 'parent-id',
       },
     ];
-    expect(mount(<DAG serviceCalls={serviceCalls} />)).toBeDefined();
+    render(<DAG serviceCalls={serviceCalls} />);
+    expect(screen.getByTestId('cy')).toBeDefined();
   });
 
   it('does not explode with empty strings or string with only spaces', () => {
@@ -74,6 +75,7 @@ describe('<DAG>', () => {
         parent: ' ',
       },
     ];
-    expect(mount(<DAG serviceCalls={serviceCalls} />)).toBeDefined();
+    render(<DAG serviceCalls={serviceCalls} />);
+    expect(screen.getByTestId('cy')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- This PR migrates the `DAG.test.js` from Enzyme to RTL
- part of: https://github.com/jaegertracing/jaeger-ui/issues/1668

## How was this change tested?
- Using `yarn test-ci`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
