### PR TITLE
[test] Migrate SpanBar.test.js from Enzyme to RTL

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
@@ -76,13 +76,13 @@ describe('<SpanBar>', () => {
     render(<SpanBar {...props} />);
     const labelElm = screen.getByText(shortLabel);
     expect(labelElm).toBeInTheDocument();
-    expect(screen.queryByText(longLabel)).not.toBeInTheDocument();
+    expect(screen.queryByText(longLabel)).toBeNull();
     fireEvent.mouseOver(labelElm);
     expect(screen.getByText(longLabel)).toBeInTheDocument();
-    expect(screen.queryByText(shortLabel)).not.toBeInTheDocument();
+    expect(screen.queryByText(shortLabel)).toBeNull();
     fireEvent.mouseOut(labelElm);
     expect(screen.getByText(shortLabel)).toBeInTheDocument();
-    expect(screen.queryByText(longLabel)).not.toBeInTheDocument();
+    expect(screen.queryByText(longLabel)).toBeNull();
   });
 
   it('log markers count', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
@@ -76,6 +76,7 @@ describe('<SpanBar>', () => {
     render(<SpanBar {...props} />);
     const labelElm = screen.getByText(shortLabel);
     expect(labelElm).toBeInTheDocument();
+    expect(screen.queryByText(longLabel)).not.toBeInTheDocument();
     fireEvent.mouseOver(labelElm);
     expect(screen.getByText(longLabel)).toBeInTheDocument();
     expect(screen.queryByText(shortLabel)).not.toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import React from 'react';
-import { mount } from 'enzyme';
-import { Popover } from 'antd';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/';
 
 import SpanBar from './SpanBar';
 
@@ -73,20 +73,18 @@ describe('<SpanBar>', () => {
   };
 
   it('renders without exploding', () => {
-    const wrapper = mount(<SpanBar {...props} />);
-    expect(wrapper).toBeDefined();
-    const { onMouseOver, onMouseOut } = wrapper.find('.SpanBar--wrapper').props();
-    const labelElm = wrapper.find('.SpanBar--label');
-    expect(labelElm.text()).toBe(shortLabel);
-    onMouseOver();
-    expect(labelElm.text()).toBe(longLabel);
-    onMouseOut();
-    expect(labelElm.text()).toBe(shortLabel);
+    render(<SpanBar {...props} />);
+    const labelElm = screen.getByText(shortLabel);
+    expect(screen.getByText(shortLabel)).toBeInTheDocument();
+    fireEvent.mouseOver(labelElm);
+    expect(screen.getByText(longLabel)).toBeInTheDocument();
+    fireEvent.mouseOut(labelElm);
+    expect(screen.getByText(shortLabel)).toBeInTheDocument();
   });
 
   it('log markers count', () => {
     // 3 log entries, two grouped together with the same timestamp
-    const wrapper = mount(<SpanBar {...props} />);
-    expect(wrapper.find(Popover).length).toEqual(2);
+    render(<SpanBar {...props} />);
+    expect(screen.getAllByTestId('SpanBar--logMarker').length).toEqual(2);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.test.js
@@ -75,11 +75,13 @@ describe('<SpanBar>', () => {
   it('renders without exploding', () => {
     render(<SpanBar {...props} />);
     const labelElm = screen.getByText(shortLabel);
-    expect(screen.getByText(shortLabel)).toBeInTheDocument();
+    expect(labelElm).toBeInTheDocument();
     fireEvent.mouseOver(labelElm);
     expect(screen.getByText(longLabel)).toBeInTheDocument();
+    expect(screen.queryByText(shortLabel)).not.toBeInTheDocument();
     fireEvent.mouseOut(labelElm);
     expect(screen.getByText(shortLabel)).toBeInTheDocument();
+    expect(screen.queryByText(longLabel)).not.toBeInTheDocument();
   });
 
   it('log markers count', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
@@ -115,7 +115,11 @@ function SpanBar(props: TCommonProps) {
               />
             }
           >
-            <div className="SpanBar--logMarker" style={{ left: positionKey }} />
+            <div
+              data-testid="SpanBar--logMarker"
+              className="SpanBar--logMarker"
+              style={{ left: positionKey }}
+            />
           </Popover>
         ))}
       </div>


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- This PR Migrates `SpanBar.test.js` from Enzyme to RTL
- part of: https://github.com/jaegertracing/jaeger-ui/issues/1668

## How was this change tested?
- using `yarn test-ci`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
