### PR TITLE
[Part of] Self time Calculation to be unified across multiple screens

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.tsx
+++ b/packages/jaeger-ui/src/model/transform-trace-data.tsx
@@ -135,6 +135,7 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
     span.relativeStartTime = span.startTime - traceStartTime;
     span.depth = depth - 1;
     span.hasChildren = node.children.length > 0;
+    span.childSpanIds = node.children.map(each => each.value);
     span.warnings = span.warnings || [];
     span.tags = span.tags || [];
     span.references = span.references || [];

--- a/packages/jaeger-ui/src/types/trace.tsx
+++ b/packages/jaeger-ui/src/types/trace.tsx
@@ -61,6 +61,7 @@ export type SpanData = {
 export type Span = SpanData & {
   depth: number;
   hasChildren: boolean;
+  childSpanIds: string[];
   process: Process;
   relativeStartTime: number;
   tags: NonNullable<SpanData['tags']>;

--- a/packages/jaeger-ui/src/utils/getChildOfSpans.tsx
+++ b/packages/jaeger-ui/src/utils/getChildOfSpans.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Span } from '../types/trace';
+/**
+ * Removes child spans whose refType is FOLLOWS_FROM and their descendants.
+ * @param spanMap - The map containing spans.
+ * @returns - A map with spans whose refType is CHILD_OF.
+ */
+const getChildOfSpans = (spanMap: Map<string, Span>): Map<string, Span> => {
+  const followFromSpanIds: string[] = [];
+  const followFromSpansDescendantIds: string[] = [];
+
+  // First find all FOLLOWS_FROM refType spans
+  spanMap.forEach(each => {
+    if (each.references[0]?.refType === 'FOLLOWS_FROM') {
+      followFromSpanIds.push(each.spanID);
+      // Remove the spanId from childSpanIds array of its parentSpan
+      const parentSpan = spanMap.get(each.references[0].spanID)!;
+      parentSpan.childSpanIds = parentSpan.childSpanIds.filter(a => a !== each.spanID);
+      spanMap.set(parentSpan.spanID, { ...parentSpan });
+    }
+  });
+
+  // Recursively find all Descendants of FOLLOWS_FROM spans
+  const findDescendantSpans = (spanIds: string[]) => {
+    spanIds.forEach(spanId => {
+      const span = spanMap.get(spanId)!;
+      if (span.hasChildren) {
+        followFromSpansDescendantIds.push(...span.childSpanIds);
+        findDescendantSpans(span.childSpanIds);
+      }
+    });
+  };
+  findDescendantSpans(followFromSpanIds);
+  // Delete all FOLLOWS_FROM spans and its descendants
+  const idsToBeDeleted = [...followFromSpanIds, ...followFromSpansDescendantIds];
+  idsToBeDeleted.forEach(id => spanMap.delete(id));
+
+  return spanMap;
+};
+export default getChildOfSpans;


### PR DESCRIPTION
## Which problem is this PR solving? Resolves #1263 

## Description of the changes
- Added getChilOfSpans function which ignores both followFrom spans and its descendants in selfTime Calculation

## Checklist
- [x] Improve the selfTime logic in TraceGraph view
- [ ]  To add unit tests to the getChildOfSpans function
- [ ] Implement similar selfTime logic in TraceStatistics view
    - Also solves #1592 
 
