### PR TITLE
[test] Migrate NewWindowIcon.test.js from Enzyme to RTL

### DIFF
--- a/packages/jaeger-ui/src/components/common/NewWindowIcon.test.js
+++ b/packages/jaeger-ui/src/components/common/NewWindowIcon.test.js
@@ -33,7 +33,7 @@ describe('NewWindowIcon', () => {
     expect(container.querySelector('.is-large')).toBeNull();
 
     // Re-render with isLarge prop set to true
-    rerender(<NewWindowIcon notIsLarge="not is large" isLarge={true} />);
+    rerender(<NewWindowIcon {...props} isLarge />);
 
     // After re-render, is-large should be true
     expect(container.querySelector('.is-large')).toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/common/NewWindowIcon.test.js
+++ b/packages/jaeger-ui/src/components/common/NewWindowIcon.test.js
@@ -13,27 +13,29 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
-
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/';
 import NewWindowIcon from './NewWindowIcon';
 
 describe('NewWindowIcon', () => {
   const props = {
     notIsLarge: 'not is large',
   };
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = shallow(<NewWindowIcon {...props} />);
-  });
-
-  it('renders as expected', () => {
-    expect(wrapper).toMatchSnapshot();
+  it('renders without is-large className when props.isLarge is false', () => {
+    const { container } = render(<NewWindowIcon {...props} />);
+    expect(container.querySelector('.is-large')).toBeNull();
   });
 
   it('adds is-large className when props.isLarge is true', () => {
-    expect(wrapper.hasClass('is-large')).toBe(false);
-    wrapper.setProps({ isLarge: true });
-    expect(wrapper.hasClass('is-large')).toBe(true);
+    const { rerender, container } = render(<NewWindowIcon {...props} />);
+
+    // Initial render, is-large should be false
+    expect(container.querySelector('.is-large')).toBeNull();
+
+    // Re-render with isLarge prop set to true
+    rerender(<NewWindowIcon notIsLarge="not is large" isLarge={true} />);
+
+    // After re-render, is-large should be true
+    expect(container.querySelector('.is-large')).toBeInTheDocument();
   });
 });

--- a/packages/jaeger-ui/src/components/common/__snapshots__/NewWindowIcon.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/NewWindowIcon.test.js.snap
@@ -1,8 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`NewWindowIcon renders as expected 1`] = `
-<IoAndroidOpen
-  className="NewWindowIcon"
-  notIsLarge="not is large"
-/>
-`;


### PR DESCRIPTION
## Which problem is this PR solving?
- This PR migrates the test `NewWindowIcon.test.js` from Enzyme to RTL
- part of: https://github.com/jaegertracing/jaeger-ui/issues/1668

## How was this change tested?
- using `yarn test-ci`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
