### PR TITLE
[CI]: Add Concurrency Grouping to GitHub Workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,15 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches-ignore:
+      - '*'
 
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   codeql-analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,8 @@ name: "CodeQL"
 
 on:
   push:
-    branches-ignore:
-      - '*'
+    branches:
+      - '**'
 
   pull_request:
     branches: [main]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,8 @@ name: "Unit Tests"
 
 on:
   push:
-    branches: [main]
+    branches-ignore:
+      - '*'
 
   pull_request:
     branches: [main]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,8 +2,8 @@ name: "Unit Tests"
 
 on:
   push:
-    branches-ignore:
-      - '*'
+    branches:
+      - '**'
 
   pull_request:
     branches: [main]


### PR DESCRIPTION
## Which problem is this PR solving?
- fixes #1709 

## Description of the changes
- Whenever we push commits to a PR, workflows are triggered for that commit. After that, if we push additional commits to this PR, workflows in Github Actions run on both commits.
- We need to cancel the previous run and run only on the most recent pushed commit. This would help save some GitHub Action Minutes and unexpected workflow failures on subsequent commits.

## How was this change tested?
- It was checked in forked repo, and is working fine there. Following is the run, which was cancelled due to subsequent commit
- https://github.com/anshgoyalevil/jaeger-ui/actions/runs/5930202449

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
