### PR TITLE
Combine typescript-eslint and eslint dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,10 @@ updates:
         patterns:
           - "jest*"
           - "babel-jest"
-      typescript-eslint:
+      eslint:
         patterns:
           - "@typescript-eslint/*"
+          - "^eslint*"
       vite:
         patterns:
           - "vite"


### PR DESCRIPTION
Lint errors are generally all related, no reason to upgrade separately