### PR TITLE
[fix]URL tag encoding issue

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -115,7 +115,9 @@ const JaegerAPI = {
     return getJSON(`${this.apiRoot}traces/${id}`);
   },
   searchTraces(query) {
-    return getJSON(`${this.apiRoot}traces`, { query });
+    const encodedTags = encodeURIComponent(JSON.stringify(query.tags)); 
+    const encodedQuery = { ...query, tags: encodedTags }; 
+    return getJSON(`${this.apiRoot}traces`, { query: encodedQuery });
   },
   fetchMetrics(metricType, serviceNameList, query) {
     const servicesName = serviceNameList.map(serviceName => `service=${serviceName}`).join(',');

--- a/packages/jaeger-ui/src/api/jaeger.test.js
+++ b/packages/jaeger-ui/src/api/jaeger.test.js
@@ -242,3 +242,30 @@ describe('fetchMetrics', () => {
     expect(resp.quantile).toBe(query.quantile);
   });
 });
+
+describe('searchTraces', () => {
+  it('GETs the specified query with encoded tags', () => {
+    const query = {
+      tags: {"http.url":"http://0.0.0.0:8081/customer?customer567"},
+      start: 1692952866480000,
+      end: 1692956466480000,
+      limit: 20,
+      lookback: 1,
+      maxDuration: null,
+      minDuration: null,
+      service: 'frontend'
+    };
+
+    const encodedTags = encodeURIComponent(JSON.stringify(query.tags));
+    const encodedQuery = { ...query, tags: encodedTags };
+
+    JaegerAPI.searchTraces(query);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      `${DEFAULT_API_ROOT}traces`,
+      {
+        query: encodedQuery,
+        ...defaultOptions,
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1733 

## Description of the changes
- In the JaegerAPI module, the `searchTraces` function was revised to ensure proper encoding of special characters within tag values before constructing URLs. The changes involve:

1. Extracting the `tags` object from the query.
2. Encoding the `tags` object using `encodeURIComponent(JSON.stringify(tags))`.
3. Replacing the original `tags` in the query with the encoded tags.
4. Utilizing the updated query object in the HTTP request.

These modifications ensure correct URL construction for API requests, rectifying the problem of misinterpreted tags that contain special characters such as `=` and `:`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
