### PR TITLE
Upgrade antd to v4.24.13 from v4.16.0

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -53,7 +53,7 @@
     "@types/react-redux": "^5.0.6",
     "@types/react-router-dom": "^4.3.1",
     "@types/redux-actions": "2.2.1",
-    "antd": "4.16.0",
+    "antd": "4.24.13",
     "chance": "^1.0.10",
     "classnames": "^2.2.5",
     "combokeys": "^3.0.0",

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
@@ -1384,12 +1384,8 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
               value={null}
             />
           }
-          mouseEnterDelay={0.1}
-          mouseLeaveDelay={0.1}
-          overlayStyle={Object {}}
           placement="bottom"
           title="Select Operation to Filter Graph"
-          trigger="hover"
         >
           <span>
             4 Operations

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/__snapshots__/Selector.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/__snapshots__/Selector.test.js.snap
@@ -80,12 +80,8 @@ exports[`Selector renders buttons with expected text and classNames 1`] = `
       </button>,
     ]
   }
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
-  overlayStyle={Object {}}
   placement="bottom"
   title="Visible downstream hops"
-  trigger="hover"
 >
   <span
     className="HopsSelector--Selector"
@@ -209,12 +205,8 @@ exports[`Selector renders upstream hops with negative distance correctly 1`] = `
       </button>,
     ]
   }
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
-  overlayStyle={Object {}}
   placement="bottom"
   title="Visible upstream hops"
-  trigger="hover"
 >
   <span
     className="HopsSelector--Selector"

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Input, Tooltip } from 'antd';
+import { InputRef, Tooltip } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
 
@@ -47,7 +47,7 @@ type TProps = {
   visEncoding?: string;
 };
 export default class Header extends React.PureComponent<TProps> {
-  private _uiFindInput: React.RefObject<Input> = React.createRef();
+  private _uiFindInput: React.RefObject<InputRef> = React.createRef();
 
   static defaultProps = {
     showParameters: true,

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/DetailsPanel.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/DetailsPanel.test.js.snap
@@ -66,10 +66,6 @@ exports[`<SidePanel> render renders detailLink 1`] = `
     </span>
     <Tooltip
       arrowPointAtCenter={true}
-      autoAdjustOverflow={true}
-      mouseEnterDelay={0.1}
-      mouseLeaveDelay={0.1}
-      placement="top"
       title="More Info"
     >
       <a

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<SidePanel> info button  opens info modal 1`] = `
 Object {
-  "content": <Table
+  "content": <ForwardRef(InternalTable)
     columns={
       Array [
         Object {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ exports[`<OperationTableDetails> Table rendered successfully 1`] = `
 <Col
   span={24}
 >
-  <Table
+  <ForwardRef(InternalTable)
     columns={
       Array [
         Object {
@@ -78,10 +78,6 @@ exports[`<OperationTableDetails> Table rendered successfully 1`] = `
               Impact
                 
               <Tooltip
-                arrowPointAtCenter={false}
-                autoAdjustOverflow={true}
-                mouseEnterDelay={0.1}
-                mouseLeaveDelay={0.1}
                 overlayClassName="impact-tooltip"
                 placement="top"
                 title="The result of multiplying avg. duration and requests per minute, showing the most used and slowest endpoints"
@@ -107,7 +103,6 @@ exports[`<OperationTableDetails> Table rendered successfully 1`] = `
       }
     }
     rowClassName={[Function]}
-    rowKey="key"
   />
 </Col>
 `;
@@ -151,11 +146,16 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -163,7 +163,9 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -175,7 +177,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -196,7 +198,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -219,11 +221,16 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -231,7 +238,9 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -243,7 +252,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -264,7 +273,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -287,11 +296,16 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -299,7 +313,9 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -311,7 +327,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -332,7 +348,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -355,11 +371,16 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -367,7 +388,9 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -379,7 +402,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -400,7 +423,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -423,11 +446,16 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -435,7 +463,9 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -493,7 +523,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -514,7 +544,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -552,6 +582,8 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                     <td
                       className="ant-table-cell"
                       colSpan={5}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -598,7 +630,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                         <div
                           className="ant-empty-description"
                         >
-                          No Data
+                          No data
                         </div>
                       </div>
                     </td>
@@ -653,11 +685,16 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -665,7 +702,9 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -677,7 +716,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -698,7 +737,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -721,11 +760,16 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -733,7 +777,9 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -745,7 +791,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -766,7 +812,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -789,11 +835,16 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -801,7 +852,9 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -813,7 +866,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -834,7 +887,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -857,11 +910,16 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -869,7 +927,9 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -881,7 +941,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -902,7 +962,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -925,11 +985,16 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -937,7 +1002,9 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -995,7 +1062,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1016,7 +1083,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1054,6 +1121,8 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -1062,6 +1131,8 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -1143,6 +1214,8 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -1224,6 +1297,8 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -1305,6 +1380,8 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -1313,12 +1390,19 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-success ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -1348,7 +1432,6 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -1468,6 +1551,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}
@@ -1576,11 +1660,16 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -1588,7 +1677,9 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -1600,7 +1691,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1621,7 +1712,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1644,11 +1735,16 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -1656,7 +1752,9 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -1668,7 +1766,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1689,7 +1787,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1712,11 +1810,16 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -1724,7 +1827,9 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -1736,7 +1841,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1757,7 +1862,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1780,11 +1885,16 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -1792,7 +1902,9 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -1804,7 +1916,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1825,7 +1937,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1848,11 +1960,16 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -1860,7 +1977,9 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -1918,7 +2037,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1939,7 +2058,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1977,6 +2096,8 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -1985,6 +2106,8 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -2066,6 +2189,8 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -2147,6 +2272,8 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -2228,6 +2355,8 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -2236,12 +2365,19 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-success ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -2271,7 +2407,6 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -2391,6 +2526,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}
@@ -2499,11 +2635,16 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -2511,7 +2652,9 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -2523,7 +2666,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2544,7 +2687,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2567,11 +2710,16 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -2579,7 +2727,9 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -2591,7 +2741,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2612,7 +2762,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2635,11 +2785,16 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -2647,7 +2802,9 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -2659,7 +2816,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2680,7 +2837,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2703,11 +2860,16 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -2715,7 +2877,9 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -2727,7 +2891,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2748,7 +2912,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2771,11 +2935,16 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -2783,7 +2952,9 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -2841,7 +3012,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2862,7 +3033,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2900,6 +3071,8 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -2908,6 +3081,8 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -2989,6 +3164,8 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -3070,6 +3247,8 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -3151,6 +3330,8 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -3159,12 +3340,19 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-success ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -3194,7 +3382,6 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -3314,6 +3501,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}
@@ -3422,11 +3610,16 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -3434,7 +3627,9 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -3446,7 +3641,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3467,7 +3662,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3490,11 +3685,16 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -3502,7 +3702,9 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -3514,7 +3716,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3535,7 +3737,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3558,11 +3760,16 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -3570,7 +3777,9 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -3582,7 +3791,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3603,7 +3812,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3626,11 +3835,16 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -3638,7 +3852,9 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -3650,7 +3866,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3671,7 +3887,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3694,11 +3910,16 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -3706,7 +3927,9 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -3764,7 +3987,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3785,7 +4008,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3823,6 +4046,8 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -3831,6 +4056,8 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -3912,6 +4139,8 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -3993,6 +4222,8 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -4074,6 +4305,8 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -4082,12 +4315,19 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-success ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -4117,7 +4357,6 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -4237,6 +4476,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}
@@ -4345,11 +4585,16 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -4357,7 +4602,9 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -4369,7 +4616,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4390,7 +4637,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4413,11 +4660,16 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -4425,7 +4677,9 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -4437,7 +4691,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4458,7 +4712,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4481,11 +4735,16 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -4493,7 +4752,9 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -4505,7 +4766,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4526,7 +4787,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4549,11 +4810,16 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -4561,7 +4827,9 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -4573,7 +4841,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4594,7 +4862,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4617,11 +4885,16 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -4629,7 +4902,9 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -4687,7 +4962,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4708,7 +4983,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4746,6 +5021,8 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -4754,6 +5031,8 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -4835,6 +5114,8 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -4916,6 +5197,8 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -4997,6 +5280,8 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -5005,12 +5290,19 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-success ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -5040,7 +5332,6 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -5160,6 +5451,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}
@@ -5268,11 +5560,16 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -5280,7 +5577,9 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -5292,7 +5591,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5313,7 +5612,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5336,11 +5635,16 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -5348,7 +5652,9 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -5360,7 +5666,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5381,7 +5687,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5404,11 +5710,16 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -5416,7 +5727,9 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -5428,7 +5741,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5449,7 +5762,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5472,11 +5785,16 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -5484,7 +5802,9 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -5496,7 +5816,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5517,7 +5837,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5540,11 +5860,16 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -5552,7 +5877,9 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -5610,7 +5937,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5631,7 +5958,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5669,6 +5996,8 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -5677,6 +6006,8 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -5758,6 +6089,8 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -5839,6 +6172,8 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -5920,6 +6255,8 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -5928,12 +6265,19 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-success ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -5963,7 +6307,6 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -6083,6 +6426,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}
@@ -6191,11 +6535,16 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -6203,7 +6552,9 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -6215,7 +6566,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6236,7 +6587,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6259,11 +6610,16 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -6271,7 +6627,9 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -6283,7 +6641,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6304,7 +6662,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6327,11 +6685,16 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -6339,7 +6702,9 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -6351,7 +6716,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6372,7 +6737,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6395,11 +6760,16 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -6407,7 +6777,9 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -6419,7 +6791,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6440,7 +6812,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6463,11 +6835,16 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -6475,7 +6852,9 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -6533,7 +6912,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6554,7 +6933,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6592,6 +6971,8 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -6600,6 +6981,8 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -6681,6 +7064,8 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -6762,6 +7147,8 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -6843,6 +7230,8 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -6851,12 +7240,19 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-success ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -6886,7 +7282,6 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -7006,6 +7401,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}
@@ -7114,11 +7510,16 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                 >
                   <tr>
                     <th
+                      aria-label="Name"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -7126,7 +7527,9 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Name
                         </span>
                         <span
@@ -7138,7 +7541,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7159,7 +7562,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7182,11 +7585,16 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="P95 Latency"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -7194,7 +7602,9 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           P95 Latency
                         </span>
                         <span
@@ -7206,7 +7616,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7227,7 +7637,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7250,11 +7660,16 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Request rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -7262,7 +7677,9 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Request rate
                         </span>
                         <span
@@ -7274,7 +7691,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7295,7 +7712,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7318,11 +7735,16 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-label="Error rate"
                       className="ant-table-cell header-item ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -7330,7 +7752,9 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           Error rate
                         </span>
                         <span
@@ -7342,7 +7766,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7363,7 +7787,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7386,11 +7810,16 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                       </div>
                     </th>
                     <th
+                      aria-sort="descending"
                       className="ant-table-cell header-item ant-table-column-sort ant-table-column-has-sorters"
                       colSpan={null}
                       onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
+                      tabIndex={0}
                     >
                       <div
                         className="ant-table-column-sorters"
@@ -7398,7 +7827,9 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span>
+                        <span
+                          className="ant-table-column-title"
+                        >
                           <div
                             style={
                               Object {
@@ -7456,7 +7887,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-up"
                               className="anticon anticon-caret-up ant-table-column-sorter-up"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7477,7 +7908,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             <span
                               aria-label="caret-down"
                               className="anticon anticon-caret-down ant-table-column-sorter-down active"
-                              role="img"
+                              role="presentation"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7514,12 +7945,16 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     />
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -7539,6 +7974,8 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -7558,6 +7995,8 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                     <td
                       className="ant-table-cell header-item"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -7577,6 +8016,8 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                     <td
                       className="ant-table-cell header-item ant-table-column-sort"
                       colSpan={null}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       rowSpan={null}
                       style={Object {}}
                     >
@@ -7585,12 +8026,19 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                       >
                         <div
                           className="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default impact"
+                          role="progressbar"
                         >
                           <div
                             className="ant-progress-outer"
                           >
                             <div
                               className="ant-progress-inner"
+                              style={
+                                Object {
+                                  "backgroundColor": undefined,
+                                  "borderRadius": 0,
+                                }
+                              }
                             >
                               <div
                                 className="ant-progress-bg"
@@ -7620,7 +8068,6 @@ exports[`<OperationTableDetails> test column render function 1`] = `
         <ul
           className="ant-pagination ant-table-pagination ant-table-pagination-right"
           style={Object {}}
-          unselectable="unselectable"
         >
           <li
             aria-disabled={true}
@@ -7740,6 +8187,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                       aria-owns="undefined_list"
                       autoComplete="off"
                       className="ant-select-selection-search-input"
+                      disabled={false}
                       onChange={[Function]}
                       onCompositionEnd={[Function]}
                       onCompositionStart={[Function]}

--- a/packages/jaeger-ui/src/components/QualityMetrics/Header.test.js
+++ b/packages/jaeger-ui/src/components/QualityMetrics/Header.test.js
@@ -77,7 +77,7 @@ describe('Header', () => {
   describe('setting lookback', () => {
     it('no-ops for string values', () => {
       wrapper.find(InputNumber).prop('onChange')('foo');
-      expect(wrapper.state('ownInputValue')).toBe(undefined);
+      expect(wrapper.state('ownInputValue')).toBe(null);
     });
 
     it('updates state with numeric value, then clears state and calls props.setLookback after debounce', () => {
@@ -89,7 +89,7 @@ describe('Header', () => {
       expect(props.setLookback).not.toHaveBeenCalled();
 
       callDebouncedFn();
-      expect(wrapper.state('ownInputValue')).toBe(undefined);
+      expect(wrapper.state('ownInputValue')).toBe(null);
       expect(props.setLookback).toHaveBeenCalledWith(42);
     });
   });

--- a/packages/jaeger-ui/src/components/QualityMetrics/Header.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/Header.tsx
@@ -24,25 +24,25 @@ type TProps = {
   lookback: number;
   service?: string;
   services?: string[] | null;
-  setLookback: (lookback: number | string | undefined) => void;
+  setLookback: (lookback: number | null) => void;
   setService: (service: string) => void;
 };
 
 type TState = {
-  ownInputValue: number | undefined;
+  ownInputValue: number | null;
 };
 
 export default class Header extends React.PureComponent<TProps, TState> {
   state: TState = {
-    ownInputValue: undefined,
+    ownInputValue: null,
   };
 
-  setLookback = _debounce((lookback: number | string | undefined) => {
-    this.setState({ ownInputValue: undefined });
+  setLookback = _debounce((lookback: number | null) => {
+    this.setState({ ownInputValue: null });
     this.props.setLookback(lookback);
   }, 350);
 
-  handleInputChange = (value: string | number | undefined) => {
+  handleInputChange = (value: number | null) => {
     if (typeof value === 'string') return;
     this.setState({ ownInputValue: value });
     this.setLookback(value);
@@ -51,7 +51,7 @@ export default class Header extends React.PureComponent<TProps, TState> {
   render() {
     const { lookback, service, services, setService } = this.props;
     const { ownInputValue } = this.state;
-    const lookbackValue = ownInputValue !== undefined ? ownInputValue : lookback;
+    const lookbackValue = ownInputValue !== null ? ownInputValue : lookback;
 
     return (
       <header className="QualityMetrics--Header">

--- a/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/MetricCard.test.js.snap
+++ b/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/MetricCard.test.js.snap
@@ -25,10 +25,6 @@ exports[`MetricCard renders as expected when passCount is zero 1`] = `
        
       <Tooltip
         arrowPointAtCenter={true}
-        autoAdjustOverflow={true}
-        mouseEnterDelay={0.1}
-        mouseLeaveDelay={0.1}
-        placement="top"
         title="Metric Documentation"
       >
         <a
@@ -106,10 +102,6 @@ exports[`MetricCard renders as expected with details 1`] = `
        
       <Tooltip
         arrowPointAtCenter={true}
-        autoAdjustOverflow={true}
-        mouseEnterDelay={0.1}
-        mouseLeaveDelay={0.1}
-        placement="top"
         title="Metric Documentation"
       >
         <a
@@ -229,10 +221,6 @@ exports[`MetricCard renders as expected without details 1`] = `
        
       <Tooltip
         arrowPointAtCenter={true}
-        autoAdjustOverflow={true}
-        mouseEnterDelay={0.1}
-        mouseLeaveDelay={0.1}
-        placement="top"
         title="Metric Documentation"
       >
         <a
@@ -310,10 +298,6 @@ exports[`MetricCard renders as expected without details 2`] = `
        
       <Tooltip
         arrowPointAtCenter={true}
-        autoAdjustOverflow={true}
-        mouseEnterDelay={0.1}
-        mouseLeaveDelay={0.1}
-        placement="top"
         title="Metric Documentation"
       >
         <a

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.tsx
@@ -102,8 +102,8 @@ export class UnconnectedQualityMetrics extends React.PureComponent<TProps, TStat
       });
   }
 
-  setLookback = (lookback: number | string | undefined) => {
-    if (!lookback || typeof lookback === 'string') return;
+  setLookback = (lookback: number | null) => {
+    if (!lookback) return;
     if (lookback < 1 || lookback !== Math.floor(lookback)) return;
 
     const { history, service = '' } = this.props;

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
@@ -42,11 +42,7 @@ exports[`drawNode diffNode renders as expected when props.a and props.b are the 
     </table>
   }
   mouseEnterDelay={0.25}
-  mouseLeaveDelay={0.1}
   overlayClassName="DiffNode--popover is-same"
-  overlayStyle={Object {}}
-  placement="top"
-  trigger="hover"
 >
   <table
     className="DiffNode is-same"
@@ -150,11 +146,7 @@ exports[`drawNode diffNode renders as expected when props.a is 0 1`] = `
     </table>
   }
   mouseEnterDelay={0.25}
-  mouseLeaveDelay={0.1}
   overlayClassName="DiffNode--popover is-changed is-added"
-  overlayStyle={Object {}}
-  placement="top"
-  trigger="hover"
 >
   <table
     className="DiffNode is-changed is-added"
@@ -278,11 +270,7 @@ exports[`drawNode diffNode renders as expected when props.a is less than props.b
     </table>
   }
   mouseEnterDelay={0.25}
-  mouseLeaveDelay={0.1}
   overlayClassName="DiffNode--popover is-changed is-more"
-  overlayStyle={Object {}}
-  placement="top"
-  trigger="hover"
 >
   <table
     className="DiffNode is-changed is-more"
@@ -406,11 +394,7 @@ exports[`drawNode diffNode renders as expected when props.a is more than props.b
     </table>
   }
   mouseEnterDelay={0.25}
-  mouseLeaveDelay={0.1}
   overlayClassName="DiffNode--popover is-changed is-less"
-  overlayStyle={Object {}}
-  placement="top"
-  trigger="hover"
 >
   <table
     className="DiffNode is-changed is-less"
@@ -534,11 +518,7 @@ exports[`drawNode diffNode renders as expected when props.b is 0 1`] = `
     </table>
   }
   mouseEnterDelay={0.25}
-  mouseLeaveDelay={0.1}
   overlayClassName="DiffNode--popover is-changed is-removed"
-  overlayStyle={Object {}}
-  placement="top"
-  trigger="hover"
 >
   <table
     className="DiffNode is-changed is-removed"
@@ -642,11 +622,7 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
     </table>
   }
   mouseEnterDelay={0.25}
-  mouseLeaveDelay={0.1}
   overlayClassName="DiffNode--popover is-same"
-  overlayStyle={Object {}}
-  placement="top"
-  trigger="hover"
 >
   <table
     className="DiffNode is-same"

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/CohortTable.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/CohortTable.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CohortTable renders as expected 1`] = `
 Array [
-  <Table
+  <ForwardRef(InternalTable)
     dataSource={
       Array [
         Object {
@@ -104,7 +104,7 @@ Array [
       key="link"
       render={[Function]}
     />
-  </Table>,
+  </ForwardRef(InternalTable)>,
   "",
 ]
 `;

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceDiffHeader.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceDiffHeader.test.js.snap
@@ -88,11 +88,8 @@ exports[`TraceDiffHeader handles absent a & b 1`] = `
         selection={Object {}}
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -201,11 +198,8 @@ exports[`TraceDiffHeader handles absent a & b 1`] = `
         selection={Object {}}
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -318,11 +312,8 @@ exports[`TraceDiffHeader handles absent a 1`] = `
         }
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -438,11 +429,8 @@ exports[`TraceDiffHeader handles absent a 1`] = `
         }
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -564,11 +552,8 @@ exports[`TraceDiffHeader handles absent b 1`] = `
         }
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -691,11 +676,8 @@ exports[`TraceDiffHeader handles absent b 1`] = `
         }
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -812,11 +794,8 @@ exports[`TraceDiffHeader renders as expected 1`] = `
         }
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -943,11 +922,8 @@ exports[`TraceDiffHeader renders as expected 1`] = `
         }
       />
     }
-    mouseEnterDelay={0.1}
-    mouseLeaveDelay={0.1}
     onVisibleChange={[Function]}
     overlayClassName="TraceDiffHeader--popover"
-    overlayStyle={Object {}}
     placement="bottomLeft"
     title={
       <TraceIdInput

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Button, Input } from 'antd';
+import { Button, InputRef } from 'antd';
 import _get from 'lodash/get';
 import _maxBy from 'lodash/maxBy';
 import _values from 'lodash/values';
@@ -107,7 +107,7 @@ export const HEADER_ITEMS = [
   },
 ];
 
-export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwardedRef: React.Ref<Input> }) {
+export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwardedRef: React.Ref<InputRef> }) {
   const {
     canCollapse,
     clearSearch,
@@ -231,6 +231,6 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
   );
 }
 
-export default React.forwardRef((props: TracePageHeaderEmbedProps, ref: React.Ref<Input>) => (
+export default React.forwardRef((props: TracePageHeaderEmbedProps, ref: React.Ref<InputRef>) => (
   <TracePageHeaderFn {...props} forwardedRef={ref} />
 ));

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import { CloseOutlined, DownOutlined, UpOutlined } from '@ant-design/icons';
-import { Button, Input, Tooltip } from 'antd';
+import { Button, Input, InputRef, Tooltip } from 'antd';
 import cx from 'classnames';
 import { IoLocate, IoHelp } from 'react-icons/io5';
 
@@ -34,7 +34,7 @@ type TracePageSearchBarProps = {
   navigable: boolean;
 };
 
-export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwardedRef: React.Ref<Input> }) {
+export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwardedRef: React.Ref<InputRef> }) {
   const {
     clearSearch,
     focusUiFindMatches,
@@ -139,6 +139,6 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
   );
 }
 
-export default React.forwardRef((props: TracePageSearchBarProps, ref: React.Ref<Input>) => (
+export default React.forwardRef((props: TracePageSearchBarProps, ref: React.Ref<InputRef>) => (
   <TracePageSearchBarFn {...props} forwardedRef={ref} />
 ));

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`AltViewOptions renders correctly 1`] = `
 <Dropdown
-  mouseEnterDelay={0.15}
-  mouseLeaveDelay={0.1}
   overlay={
     <Menu>
       <MenuItem>

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/KeyboardShortcutsHelp.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/KeyboardShortcutsHelp.test.js.snap
@@ -26,15 +26,12 @@ exports[`KeyboardShortcutsHelp renders as expected 1`] = `
         },
       }
     }
-    confirmLoading={false}
-    okType="primary"
     onCancel={[Function]}
     onOk={[Function]}
     title="Keyboard Shortcuts"
     visible={false}
-    width={520}
   >
-    <Table
+    <ForwardRef(InternalTable)
       className="KeyboardShortcutsHelp--table u-simple-scrollbars"
       dataSource={
         Array [
@@ -196,7 +193,6 @@ exports[`KeyboardShortcutsHelp renders as expected 1`] = `
       }
       pagination={false}
       rowClassName={[Function]}
-      rowKey="key"
       showHeader={false}
       size="middle"
     >
@@ -213,7 +209,7 @@ exports[`KeyboardShortcutsHelp renders as expected 1`] = `
         render={[Function]}
         title="Key(s)"
       />
-    </Table>
+    </ForwardRef(InternalTable)>
   </Modal>
 </Fragment>
 `;

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Input } from 'antd';
+import { Input, InputRef } from 'antd';
 import { Location, History as RouterHistory } from 'history';
 import _clamp from 'lodash/clamp';
 import _get from 'lodash/get';
@@ -130,7 +130,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
 
   _headerElm: HTMLElement | TNil;
   _filterSpans: typeof filterSpans;
-  _searchBar: React.RefObject<Input>;
+  _searchBar: React.RefObject<InputRef>;
   _scrollManager: ScrollManager;
   traceDagEV: TEv | TNil;
 

--- a/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailList.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailList.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`DetailList renders item as expected 1`] = `
 <div>
-  <Item>
+  <ForwardRef(InternalItem)>
     <span>
       foo
     </span>
-  </Item>
+  </ForwardRef(InternalItem)>
 </div>
 `;
 

--- a/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTable.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTable.test.js.snap
@@ -11,7 +11,7 @@ exports[`DetailTable _makeColumns function props _renderCell renders a regular l
 `;
 
 exports[`DetailTable render does not duplicate columns 1`] = `
-<Table
+<ForwardRef(InternalTable)
   columns={
     Array [
       Object {
@@ -60,7 +60,7 @@ exports[`DetailTable render does not duplicate columns 1`] = `
 `;
 
 exports[`DetailTable render infers all columns 1`] = `
-<Table
+<ForwardRef(InternalTable)
   columns={
     Array [
       Object {
@@ -105,7 +105,7 @@ exports[`DetailTable render infers all columns 1`] = `
 `;
 
 exports[`DetailTable render infers missing columns 1`] = `
-<Table
+<ForwardRef(InternalTable)
   columns={
     Array [
       Object {
@@ -150,7 +150,7 @@ exports[`DetailTable render infers missing columns 1`] = `
 `;
 
 exports[`DetailTable render renders given rows and columns 1`] = `
-<Table
+<ForwardRef(InternalTable)
   columns={
     Array [
       Object {

--- a/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
@@ -25,12 +25,7 @@ exports[`DetailTable render renders as expected 1`] = `
     className="DetailTableDropdown--Footer"
   >
     <Tooltip
-      arrowPointAtCenter={false}
-      autoAdjustOverflow={true}
-      mouseEnterDelay={0.1}
-      mouseLeaveDelay={0.1}
       overlayClassName="DetailTableDropdown--Tooltip"
-      placement="top"
       title="Remove filter from this column"
     >
       <Button
@@ -47,12 +42,7 @@ exports[`DetailTable render renders as expected 1`] = `
       className="DetailTableDropdown--Footer--CancelConfirm"
     >
       <Tooltip
-        arrowPointAtCenter={false}
-        autoAdjustOverflow={true}
-        mouseEnterDelay={0.1}
-        mouseLeaveDelay={0.1}
         overlayClassName="DetailTableDropdown--Tooltip"
-        placement="top"
         title="Cancel changes to this column's filter"
       >
         <Button
@@ -66,12 +56,7 @@ exports[`DetailTable render renders as expected 1`] = `
         </Button>
       </Tooltip>
       <Tooltip
-        arrowPointAtCenter={false}
-        autoAdjustOverflow={true}
-        mouseEnterDelay={0.1}
-        mouseLeaveDelay={0.1}
         overlayClassName="DetailTableDropdown--Tooltip"
-        placement="top"
         title={
           <div
             className="DetailTableDropdown--Tooltip--Body"

--- a/packages/jaeger-ui/src/components/common/UiFindInput.tsx
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Input } from 'antd';
+import { Input, InputRef } from 'antd';
 import { CloseOutlined } from '@ant-design/icons';
 import { History as RouterHistory, Location } from 'history';
 import _debounce from 'lodash/debounce';
@@ -27,7 +27,7 @@ import { TNil, ReduxState } from '../../types/index';
 
 type TOwnProps = RouteComponentProps<any> & {
   allowClear?: boolean;
-  forwardedRef?: React.Ref<Input>;
+  forwardedRef?: React.Ref<InputRef>;
   inputProps: Record<string, any>;
   history: RouterHistory;
   location: Location;

--- a/packages/jaeger-ui/src/components/common/__snapshots__/CopyIcon.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/CopyIcon.test.js.snap
@@ -3,8 +3,6 @@
 exports[`<CopyIcon /> renders as expected 1`] = `
 <Tooltip
   arrowPointAtCenter={true}
-  autoAdjustOverflow={true}
-  mouseEnterDelay={0.1}
   mouseLeaveDelay={0}
   onVisibleChange={[Function]}
   placement="top"

--- a/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
@@ -16,11 +16,8 @@ exports[`<NameSelector> clear renders with clear icon when not required and with
       value="foo"
     />
   }
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
   onVisibleChange={[Function]}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
-  overlayStyle={Object {}}
   placement="bottomLeft"
   trigger="click"
   visible={false}
@@ -66,11 +63,8 @@ exports[`<NameSelector> renders with is-invalid when required and without a valu
       value={null}
     />
   }
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
   onVisibleChange={[Function]}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
-  overlayStyle={Object {}}
   placement="bottomLeft"
   trigger="click"
   visible={false}
@@ -106,11 +100,8 @@ exports[`<NameSelector> renders without exploding 1`] = `
       value={null}
     />
   }
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
   onVisibleChange={[Function]}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
-  overlayStyle={Object {}}
   placement="bottomLeft"
   trigger="click"
   visible={false}
@@ -146,11 +137,8 @@ exports[`<NameSelector> renders without is-invalid when not required and without
       value={null}
     />
   }
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
   onVisibleChange={[Function]}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
-  overlayStyle={Object {}}
   placement="bottomLeft"
   trigger="click"
   visible={false}

--- a/packages/jaeger-ui/src/components/common/__snapshots__/UiFindInput.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/UiFindInput.test.js.snap
@@ -1,11 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UiFind rendering renders as expected 1`] = `
-<Input
+<ForwardRef
   onBlur={[Function]}
   onChange={[Function]}
   placeholder="Find..."
   suffix={<React.Fragment />}
-  type="text"
 />
 `;

--- a/packages/jaeger-ui/src/utils/__snapshots__/redux-form-field-adapter.test.js.snap
+++ b/packages/jaeger-ui/src/utils/__snapshots__/redux-form-field-adapter.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`reduxFormFieldAdapter not validated input should render as expected 1`] = `
-<Input
+<ForwardRef
   className=""
   meta={
     Object {
@@ -12,7 +12,6 @@ exports[`reduxFormFieldAdapter not validated input should render as expected 1`]
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
-  type="text"
   value="inputValue"
 />
 `;
@@ -20,15 +19,11 @@ exports[`reduxFormFieldAdapter not validated input should render as expected 1`]
 exports[`reduxFormFieldAdapter validate input should render Popover as invisible if there is an error but the field is active 1`] = `
 <Popover
   content="error content"
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
-  overlayStyle={Object {}}
   placement="bottomLeft"
   title="error title"
-  trigger="hover"
   visible={false}
 >
-  <Input
+  <ForwardRef
     className="AdaptedReduxFormField--isValidatedInput"
     meta={
       Object {
@@ -42,7 +37,6 @@ exports[`reduxFormFieldAdapter validate input should render Popover as invisible
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
-    type="text"
     value="inputValue"
   />
 </Popover>
@@ -51,15 +45,11 @@ exports[`reduxFormFieldAdapter validate input should render Popover as invisible
 exports[`reduxFormFieldAdapter validate input should render Popover as visible if there is an error and the field is not active 1`] = `
 <Popover
   content="error content"
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
-  overlayStyle={Object {}}
   placement="bottomLeft"
   title="error title"
-  trigger="hover"
   visible={true}
 >
-  <Input
+  <ForwardRef
     className="is-invalid AdaptedReduxFormField--isValidatedInput"
     meta={
       Object {
@@ -73,7 +63,6 @@ exports[`reduxFormFieldAdapter validate input should render Popover as visible i
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
-    type="text"
     value="inputValue"
   />
 </Popover>
@@ -81,14 +70,10 @@ exports[`reduxFormFieldAdapter validate input should render Popover as visible i
 
 exports[`reduxFormFieldAdapter validate input should render as expected when there is not an error 1`] = `
 <Popover
-  mouseEnterDelay={0.1}
-  mouseLeaveDelay={0.1}
-  overlayStyle={Object {}}
   placement="bottomLeft"
-  trigger="hover"
   visible={false}
 >
-  <Input
+  <ForwardRef
     className="AdaptedReduxFormField--isValidatedInput"
     meta={
       Object {
@@ -99,7 +84,6 @@ exports[`reduxFormFieldAdapter validate input should render as expected when the
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
-    type="text"
     value="inputValue"
   />
 </Popover>

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,7 +70,7 @@
     insert-css "^2.0.0"
     rc-util "^4.9.0"
 
-"@ant-design/icons@^4.0.0", "@ant-design/icons@^4.6.2":
+"@ant-design/icons@^4.0.0", "@ant-design/icons@^4.7.0":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.8.1.tgz#44f6c81f609811d68d48a123eb5dcc477f8fbcb7"
   integrity sha512-JRAuiqllnMsiZIO8OvBOeFconprC3cnMpJ9MvXrHh+H5co9rlg8/aSHQfLf5jKKe18lUgRaIwC2pz8YxH9VuCA==
@@ -82,16 +82,16 @@
     lodash "^4.17.15"
     rc-util "^5.9.4"
 
-"@ant-design/react-slick@~0.28.1":
-  version "0.28.4"
-  resolved "https://registry.yarnpkg.com/@ant-design/react-slick/-/react-slick-0.28.4.tgz#8b296b87ad7c7ae877f2a527b81b7eebd9dd29a9"
-  integrity sha512-j9eAHTn7GxbXUFNknJoHS2ceAsqrQi2j8XykjZE1IXCD8kJF+t28EvhBLniDpbOsBk/3kjalnhriTfZcjBHNqg==
+"@ant-design/react-slick@~1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ant-design/react-slick/-/react-slick-1.0.2.tgz#241bb412aeacf7ff5d50c61fa5db66773fde6b56"
+  integrity sha512-Wj8onxL/T8KQLFFiCA4t8eIRGpRR+UPgOdac2sYzonv+i0n3kXHmvHLLiOYL655DQx2Umii9Y9nNgL7ssu5haQ==
   dependencies:
     "@babel/runtime" "^7.10.4"
     classnames "^2.2.5"
     json2mq "^0.2.0"
-    lodash "^4.17.21"
-    resize-observer-polyfill "^1.5.0"
+    resize-observer-polyfill "^1.5.1"
+    throttle-debounce "^5.0.0"
 
 "@babel/cli@7.22.10":
   version "7.22.10"
@@ -1251,7 +1251,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.18.0", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.0", "@babel/runtime@^7.21.0":
+"@babel/runtime@^7.10.1", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.16.7", "@babel/runtime@^7.18.0", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.0", "@babel/runtime@^7.21.0":
   version "7.22.11"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.11.tgz#7a9ba3bbe406ad6f9e8dd4da2ece453eb23a77a4"
   integrity sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==
@@ -2181,7 +2181,7 @@
   resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.21.4.tgz#4b185854ee50767d5279baa16b58a29f9fcb3de1"
   integrity sha512-/wkTHhBNapnnuLWQ40PyHa1pz8jVMmiLYO12Ak7qq1JhgVEccE39XrQMTkcFlM4FdpqM4/1w6U7fm4xebUAzZw==
 
-"@rc-component/portal@^1.1.0":
+"@rc-component/portal@^1.0.0-8", "@rc-component/portal@^1.0.2", "@rc-component/portal@^1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@rc-component/portal/-/portal-1.1.2.tgz#55db1e51d784e034442e9700536faaa6ab63fc71"
   integrity sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==
@@ -2189,19 +2189,6 @@
     "@babel/runtime" "^7.18.0"
     classnames "^2.3.2"
     rc-util "^5.24.4"
-
-"@rc-component/trigger@^1.6.2":
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/@rc-component/trigger/-/trigger-1.15.6.tgz#ccb71f16229e832e15b3869817cbe24f5e59b54c"
-  integrity sha512-Tl19KaGsShf4yzqxumsXVT4c7j0l20Dxe5hgP5S0HmxyhCg3oKen28ntGavRCIPW7cl7wgsGotntqcIokgDHzg==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    "@rc-component/portal" "^1.1.0"
-    classnames "^2.3.2"
-    rc-align "^4.0.0"
-    rc-motion "^2.0.0"
-    rc-resize-observer "^1.3.1"
-    rc-util "^5.33.0"
 
 "@sigstore/protobuf-specs@^0.1.0":
   version "0.1.0"
@@ -3234,53 +3221,54 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
-antd@4.16.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/antd/-/antd-4.16.0.tgz#35b03f42a0710edd2153f3fd33f8f93298b12bc7"
-  integrity sha512-wJU0CQdbpBTD8SGI8ksBifIdjORkNk5pHYVyuiQ20KquDdpzsfBOvsd3ZeluBxgt5XPobVxv+YYUAuDchfiHnQ==
+antd@4.24.13:
+  version "4.24.13"
+  resolved "https://registry.yarnpkg.com/antd/-/antd-4.24.13.tgz#a6f376e851f97511b72274f142da8974fc574fbc"
+  integrity sha512-N2odRsbomseCE3U845Whf+RdgmQbiWbKvWS6ggH/xHjXojHx951rmZXW4nMqAeSoUp66sQOASGtrP/SUsdA2oQ==
   dependencies:
     "@ant-design/colors" "^6.0.0"
-    "@ant-design/icons" "^4.6.2"
-    "@ant-design/react-slick" "~0.28.1"
-    "@babel/runtime" "^7.12.5"
-    array-tree-filter "^2.1.0"
+    "@ant-design/icons" "^4.7.0"
+    "@ant-design/react-slick" "~1.0.0"
+    "@babel/runtime" "^7.18.3"
+    "@ctrl/tinycolor" "^3.4.0"
     classnames "^2.2.6"
     copy-to-clipboard "^3.2.0"
     lodash "^4.17.21"
-    moment "^2.25.3"
-    rc-cascader "~1.4.0"
-    rc-checkbox "~2.3.0"
-    rc-collapse "~3.1.0"
-    rc-dialog "~8.5.1"
-    rc-drawer "~4.3.0"
-    rc-dropdown "~3.2.0"
-    rc-field-form "~1.20.0"
-    rc-image "~5.2.4"
-    rc-input-number "~7.1.0"
-    rc-mentions "~1.6.1"
-    rc-menu "~9.0.0"
-    rc-motion "^2.4.0"
-    rc-notification "~4.5.2"
-    rc-pagination "~3.1.6"
-    rc-picker "~2.5.10"
-    rc-progress "~3.1.0"
+    moment "^2.29.2"
+    rc-cascader "~3.7.0"
+    rc-checkbox "~3.0.0"
+    rc-collapse "~3.4.2"
+    rc-dialog "~9.0.2"
+    rc-drawer "~6.3.0"
+    rc-dropdown "~4.0.0"
+    rc-field-form "~1.34.0"
+    rc-image "~5.13.0"
+    rc-input "~0.1.4"
+    rc-input-number "~7.3.9"
+    rc-mentions "~1.13.1"
+    rc-menu "~9.8.0"
+    rc-motion "^2.6.1"
+    rc-notification "~4.6.0"
+    rc-pagination "~3.2.0"
+    rc-picker "~2.7.0"
+    rc-progress "~3.4.1"
     rc-rate "~2.9.0"
-    rc-resize-observer "^1.0.0"
-    rc-select "~12.1.6"
-    rc-slider "~9.7.1"
-    rc-steps "~4.1.0"
+    rc-resize-observer "^1.2.0"
+    rc-segmented "~2.1.0"
+    rc-select "~14.1.17"
+    rc-slider "~10.0.0"
+    rc-steps "~5.0.0-alpha.2"
     rc-switch "~3.2.0"
-    rc-table "~7.15.1"
-    rc-tabs "~11.9.1"
-    rc-textarea "~0.3.0"
-    rc-tooltip "~5.1.1"
-    rc-tree "~4.1.0"
-    rc-tree-select "~4.3.0"
-    rc-trigger "^5.2.1"
+    rc-table "~7.26.0"
+    rc-tabs "~12.5.6"
+    rc-textarea "~0.4.5"
+    rc-tooltip "~5.2.0"
+    rc-tree "~5.7.0"
+    rc-tree-select "~5.5.0"
+    rc-trigger "^5.2.10"
     rc-upload "~4.3.0"
-    rc-util "^5.13.1"
+    rc-util "^5.22.5"
     scroll-into-view-if-needed "^2.2.25"
-    warning "^4.0.3"
 
 anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.2"
@@ -3466,10 +3454,10 @@ ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
-async-validator@^3.0.3:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/async-validator/-/async-validator-3.5.2.tgz#68e866a96824e8b2694ff7a831c1a25c44d5e500"
-  integrity sha512-8eLCg00W9pIRZSB781UUX/H6Oskmm8xloZfr09lz5bikRpBVDlJ3hRVuxxP1SxcwsEYfJ4IU8Q19Y8/893r3rQ==
+async-validator@^4.1.0:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/async-validator/-/async-validator-4.2.5.tgz#c96ea3332a521699d0afaaceed510a54656c6339"
+  integrity sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==
 
 async-validator@~1.11.3:
   version "1.11.5"
@@ -8784,7 +8772,7 @@ modify-values@^1.0.1:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.18.1, moment@^2.24.0, moment@^2.25.3:
+moment@^2.18.1, moment@^2.24.0, moment@^2.29.2:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -10026,29 +10014,31 @@ rc-animate@^2.10.2, rc-animate@^2.3.0:
     rc-util "^4.15.3"
     react-lifecycles-compat "^3.0.4"
 
-rc-cascader@~1.4.0:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-1.4.3.tgz#d91b0dcf8157b60ebe9ec3e58b4db054d5299464"
-  integrity sha512-Q4l9Mv8aaISJ+giVnM9IaXxDeMqHUGLvi4F+LksS6pHlaKlN4awop/L+IMjIXpL+ug/ojaCyv/ixcVopJYYCVA==
+rc-cascader@~3.7.0:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-3.7.3.tgz#1e2ad238b283f7226ce4c9f3a420a35cb63fcc82"
+  integrity sha512-KBpT+kzhxDW+hxPiNk4zaKa99+Lie2/8nnI11XF+FIOPl4Bj9VlFZi61GrnWzhLGA7VEN+dTxAkNOjkySDa0dA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     array-tree-filter "^2.1.0"
-    rc-trigger "^5.0.4"
-    rc-util "^5.0.1"
-    warning "^4.0.1"
+    classnames "^2.3.1"
+    rc-select "~14.1.0"
+    rc-tree "~5.7.0"
+    rc-util "^5.6.1"
 
-rc-checkbox@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/rc-checkbox/-/rc-checkbox-2.3.2.tgz#f91b3678c7edb2baa8121c9483c664fa6f0aefc1"
-  integrity sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==
+rc-checkbox@~3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rc-checkbox/-/rc-checkbox-3.0.1.tgz#f978771329be339d479cd81465eb2e2f8c82bc87"
+  integrity sha512-k7nxDWxYF+jDI0ZcCvuvj71xONmWRVe5+1MKcERRR9MRyP3tZ69b+yUCSXXh+sik4/Hc9P5wHr2nnUoGS2zBjA==
   dependencies:
     "@babel/runtime" "^7.10.1"
-    classnames "^2.2.1"
+    classnames "^2.3.2"
+    rc-util "^5.25.2"
 
-rc-collapse@~3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-3.1.4.tgz#063e33fcc427a378e63da757898cd1fba6269679"
-  integrity sha512-WayrhswKMwuJab9xbqFxXTgV0m6X8uOPEO6zm/GJ5YJiJ/wIh/Dd2VtWeI06HYUEnTFv0HNcYv+zWbB+p6OD2A==
+rc-collapse@~3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-3.4.2.tgz#1310be7ad4cd0dcfc622c45f6c3b5ffdee403ad7"
+  integrity sha512-jpTwLgJzkhAgp2Wpi3xmbTbbYExg6fkptL67Uu5LCRVEj6wqmy0DHTjjeynsjOLsppHGHu41t1ELntZ0lEvS/Q==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
@@ -10056,53 +10046,37 @@ rc-collapse@~3.1.0:
     rc-util "^5.2.1"
     shallowequal "^1.1.0"
 
-rc-dialog@~8.5.1:
-  version "8.5.3"
-  resolved "https://registry.yarnpkg.com/rc-dialog/-/rc-dialog-8.5.3.tgz#84fb1f7637dd8aadd709ba905eac2a3a2e07d21b"
-  integrity sha512-zoamT8L6+rBwnwjPlrZRxiHCHQXrTcWZD3a6ruoqEdUKP1KgO0eSjMDH9WlF3WEPYMVnb2G5SrjHrhnwgPDu5w==
+rc-dialog@~9.0.0, rc-dialog@~9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/rc-dialog/-/rc-dialog-9.0.2.tgz#aadfebdeba145f256c1fac9b9f509f893cdbb5b8"
+  integrity sha512-s3U+24xWUuB6Bn2Lk/Qt6rufy+uT+QvWkiFhNBcO9APLxcFFczWamaq7x9h8SCuhfc1nHcW4y8NbMsnAjNnWyg==
   dependencies:
     "@babel/runtime" "^7.10.1"
+    "@rc-component/portal" "^1.0.0-8"
     classnames "^2.2.6"
     rc-motion "^2.3.0"
-    rc-util "^5.6.1"
+    rc-util "^5.21.0"
 
-rc-dialog@~8.6.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/rc-dialog/-/rc-dialog-8.6.0.tgz#3b228dac085de5eed8c6237f31162104687442e7"
-  integrity sha512-GSbkfqjqxpZC5/zc+8H332+q5l/DKUhpQr0vdX2uDsxo5K0PhvaMEVjyoJUTkZ3+JstEADQji1PVLVb/2bJeOQ==
+rc-drawer@~6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/rc-drawer/-/rc-drawer-6.3.0.tgz#f8af5fafbab19b83722360dcf93e966d8a2875ad"
+  integrity sha512-uBZVb3xTAR+dBV53d/bUhTctCw3pwcwJoM7g5aX+7vgwt2zzVzoJ6aqFjYJpBlZ9zp0dVYN8fV+hykFE7c4lig==
   dependencies:
     "@babel/runtime" "^7.10.1"
+    "@rc-component/portal" "^1.1.1"
     classnames "^2.2.6"
-    rc-motion "^2.3.0"
-    rc-util "^5.6.1"
+    rc-motion "^2.6.1"
+    rc-util "^5.21.2"
 
-rc-drawer@~4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/rc-drawer/-/rc-drawer-4.3.1.tgz#356333a7af01b777abd685c96c2ce62efb44f3f3"
-  integrity sha512-GMfFy4maqxS9faYXEhQ+0cA1xtkddEQzraf6SAdzWbn444DrrLogwYPk1NXSpdXjLCLxgxOj9MYtyYG42JsfXg==
+rc-dropdown@~4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/rc-dropdown/-/rc-dropdown-4.0.1.tgz#f65d9d3d89750241057db59d5a75e43cd4576b68"
+  integrity sha512-OdpXuOcme1rm45cR0Jzgfl1otzmU4vuBVb+etXM8vcaULGokAKVpKlw8p6xzspG7jGd/XxShvq+N3VNEfk/l5g==
   dependencies:
-    "@babel/runtime" "^7.10.1"
+    "@babel/runtime" "^7.18.3"
     classnames "^2.2.6"
-    rc-util "^5.7.0"
-
-rc-dropdown@^3.2.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/rc-dropdown/-/rc-dropdown-3.6.2.tgz#d23b8b2762941ac39e665673946f67ca9c39118f"
-  integrity sha512-Wsw7GkVbUXADEs8FPL0v8gd+3mWQiydPFXBlr2imMScQaf8hh79pG9KrBc1DwK+nqHmYOpQfK2gn6jG2AQw9Pw==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "^2.2.6"
-    rc-trigger "^5.0.4"
+    rc-trigger "^5.3.1"
     rc-util "^5.17.0"
-
-rc-dropdown@~3.2.0:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/rc-dropdown/-/rc-dropdown-3.2.5.tgz#c211e571d29d15e7f725b5a75fc8c7f371fc3348"
-  integrity sha512-dVO2eulOSbEf+F4OyhCY5iGiMVhUYY/qeXxL7Ex2jDBt/xc89jU07mNoowV6aWxwVOc70pxEINff0oM2ogjluA==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "^2.2.6"
-    rc-trigger "^5.0.4"
 
 rc-editor-core@~0.8.3:
   version "0.8.10"
@@ -10131,14 +10105,14 @@ rc-editor-mention@^1.1.13:
     rc-animate "^2.3.0"
     rc-editor-core "~0.8.3"
 
-rc-field-form@~1.20.0:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/rc-field-form/-/rc-field-form-1.20.1.tgz#d1c51888107cf075b42704b7b575bef84c359291"
-  integrity sha512-f64KEZop7zSlrG4ef/PLlH12SLn6iHDQ3sTG+RfKBM45hikwV1i8qMf53xoX12NvXXWg1VwchggX/FSso4bWaA==
+rc-field-form@~1.34.0:
+  version "1.34.2"
+  resolved "https://registry.yarnpkg.com/rc-field-form/-/rc-field-form-1.34.2.tgz#8463b79a44842a341899195f364e952c401ab7f1"
+  integrity sha512-BdciU5C7dBO51/9ZKcMvK2f8zaaO12Lt1eBhlAo8nNv+6htlNcgY9DAkUlZ7gfyWjnCc1Oo4hHIXau1m6tLw1A==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    async-validator "^3.0.3"
-    rc-util "^5.8.0"
+    "@babel/runtime" "^7.18.0"
+    async-validator "^4.1.0"
+    rc-util "^5.32.2"
 
 rc-form@^2.4.10:
   version "2.4.12"
@@ -10155,76 +10129,61 @@ rc-form@^2.4.10:
     react-is "^16.13.1"
     warning "^4.0.3"
 
-rc-image@~5.2.4:
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/rc-image/-/rc-image-5.2.5.tgz#44e6ffc842626827960e7ab72e1c0d6f3a8ce440"
-  integrity sha512-qUfZjYIODxO0c8a8P5GeuclYXZjzW4hV/5hyo27XqSFo1DmTCs2HkVeQObkcIk5kNsJtgsj1KoPThVsSc/PXOw==
+rc-image@~5.13.0:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/rc-image/-/rc-image-5.13.0.tgz#1ed9b852a40b5eff34786ba7d2f0e9d26eeab874"
+  integrity sha512-iZTOmw5eWo2+gcrJMMcnd7SsxVHl3w5xlyCgsULUdJhJbnuI8i/AL0tVOsE7aLn9VfOh1qgDT3mC2G75/c7mqg==
   dependencies:
     "@babel/runtime" "^7.11.2"
+    "@rc-component/portal" "^1.0.2"
     classnames "^2.2.6"
-    rc-dialog "~8.6.0"
+    rc-dialog "~9.0.0"
+    rc-motion "^2.6.2"
     rc-util "^5.0.6"
 
-rc-input-number@~7.1.0:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/rc-input-number/-/rc-input-number-7.1.4.tgz#9d7410c91ff8dc6384d0233c20df278982989f9a"
-  integrity sha512-EG4iqkqyqzLRu/Dq+fw2od7nlgvXLEatE+J6uhi3HXE1qlM3C7L6a7o/hL9Ly9nimkES2IeQoj3Qda3I0izj3Q==
+rc-input-number@~7.3.9:
+  version "7.3.11"
+  resolved "https://registry.yarnpkg.com/rc-input-number/-/rc-input-number-7.3.11.tgz#c7089705a220e1a59ba974fabf89693e00dd2442"
+  integrity sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.5"
-    rc-util "^5.9.8"
+    rc-util "^5.23.0"
 
-rc-mentions@~1.6.1:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/rc-mentions/-/rc-mentions-1.6.5.tgz#d9516abd19a757c674df1c88a3459628fe95a149"
-  integrity sha512-CUU4+q+awG2pA0l/tG2kPB2ytWbKQUkFxVeKwacr63w7crE/yjfzrFXxs/1fxhyEbQUWdAZt/L25QBieukYQ5w==
+rc-input@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/rc-input/-/rc-input-0.1.4.tgz#45cb4ba209ae6cc835a2acb8629d4f8f0cb347e0"
+  integrity sha512-FqDdNz+fV2dKNgfXzcSLKvC+jEs1709t7nD+WdfjrdSaOcefpgc7BUJYadc3usaING+b7ediMTfKxuJBsEFbXA==
+  dependencies:
+    "@babel/runtime" "^7.11.1"
+    classnames "^2.2.1"
+    rc-util "^5.18.1"
+
+rc-mentions@~1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/rc-mentions/-/rc-mentions-1.13.1.tgz#c884b70e1505a197f1b32a7c6b39090db6992a72"
+  integrity sha512-FCkaWw6JQygtOz0+Vxz/M/NWqrWHB9LwqlY2RtcuFqWJNFK9njijOOzTSsBGANliGufVUzx/xuPHmZPBV0+Hgw==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.6"
-    rc-menu "~9.3.2"
-    rc-textarea "^0.3.0"
+    rc-menu "~9.8.0"
+    rc-textarea "^0.4.0"
     rc-trigger "^5.0.4"
-    rc-util "^5.0.1"
+    rc-util "^5.22.5"
 
-rc-menu@^9.0.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-9.12.0.tgz#4d5c9c57a7658d50256a4000c3bc6260021c7541"
-  integrity sha512-Apr/fRf5EcqWJ4nphHV6dTGZcLPaPzwY44q9hAtLJysY4rkC9Eg+ekj3uFx6opPWVruV2sJNWq/Po+HHtO48CA==
+rc-menu@~9.8.0:
+  version "9.8.4"
+  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-9.8.4.tgz#58bf19d471e3c74ff4bcfdb0f02a3826ebe2553b"
+  integrity sha512-lmw2j8I2fhdIzHmC9ajfImfckt0WDb2KVJJBBRIsxPEw2kGkEfjLMUoB1NgiNT/Q5cC8PdjGOGQjHJIJMwyNMw==
   dependencies:
     "@babel/runtime" "^7.10.1"
-    "@rc-component/trigger" "^1.6.2"
     classnames "2.x"
     rc-motion "^2.4.3"
-    rc-overflow "^1.3.1"
+    rc-overflow "^1.2.8"
+    rc-trigger "^5.1.2"
     rc-util "^5.27.0"
 
-rc-menu@~9.0.0:
-  version "9.0.14"
-  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-9.0.14.tgz#289bda4a2f6c5ebb3248e2e305d52cf0c73cb9d5"
-  integrity sha512-CIox5mZeLDAi32SlHrV7UeSjv7tmJJhwRyxQtZCKt351w3q59XlL4WMFOmtT9gwIfP9h0XoxdBZUMe/xzkp78A==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "2.x"
-    rc-motion "^2.4.3"
-    rc-overflow "^1.2.0"
-    rc-trigger "^5.1.2"
-    rc-util "^5.12.0"
-    shallowequal "^1.1.0"
-
-rc-menu@~9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-9.3.2.tgz#bb842d37ebf71da912bea201cf7ef0a27267ad49"
-  integrity sha512-h3m45oY1INZyqphGELkdT0uiPnFzxkML8m0VMhJnk2fowtqfiT7F5tJLT3znEVaPIY80vMy1bClCkgq8U91CzQ==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "2.x"
-    rc-motion "^2.4.3"
-    rc-overflow "^1.2.0"
-    rc-trigger "^5.1.2"
-    rc-util "^5.12.0"
-    shallowequal "^1.1.0"
-
-rc-motion@^2.0.0, rc-motion@^2.0.1, rc-motion@^2.2.0, rc-motion@^2.3.0, rc-motion@^2.3.4, rc-motion@^2.4.0, rc-motion@^2.4.3:
+rc-motion@^2.0.0, rc-motion@^2.0.1, rc-motion@^2.2.0, rc-motion@^2.3.0, rc-motion@^2.3.4, rc-motion@^2.4.3, rc-motion@^2.4.4, rc-motion@^2.6.1, rc-motion@^2.6.2:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.8.0.tgz#5a8231632d7f5304873661424f293d6ee389854b"
   integrity sha512-9gWWzlPvx/IJANj+t+ArqLCQ43rCWYLpOUe6+WJSAGb+b+fqBcfx81qPhg6b+ewa6g3mGNDhkTpBrVrCC4gcXA==
@@ -10233,17 +10192,17 @@ rc-motion@^2.0.0, rc-motion@^2.0.1, rc-motion@^2.2.0, rc-motion@^2.3.0, rc-motio
     classnames "^2.2.1"
     rc-util "^5.21.0"
 
-rc-notification@~4.5.2:
-  version "4.5.7"
-  resolved "https://registry.yarnpkg.com/rc-notification/-/rc-notification-4.5.7.tgz#265e6e6a0c1a0fac63d6abd4d832eb8ff31522f1"
-  integrity sha512-zhTGUjBIItbx96SiRu3KVURcLOydLUHZCPpYEn1zvh+re//Tnq/wSxN4FKgp38n4HOgHSVxcLEeSxBMTeBBDdw==
+rc-notification@~4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/rc-notification/-/rc-notification-4.6.1.tgz#068e8674f4bd7926a447eca512915d4b41b15c91"
+  integrity sha512-NSmFYwrrdY3+un1GvDAJQw62Xi9LNMSsoQyo95tuaYrcad5Bn9gJUL8AREufRxSQAQnr64u3LtP3EUyLYT6bhw==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
     rc-motion "^2.2.0"
-    rc-util "^5.0.1"
+    rc-util "^5.20.1"
 
-rc-overflow@^1.0.0, rc-overflow@^1.2.0, rc-overflow@^1.3.1:
+rc-overflow@^1.0.0, rc-overflow@^1.2.8:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/rc-overflow/-/rc-overflow-1.3.2.tgz#72ee49e85a1308d8d4e3bd53285dc1f3e0bcce2c"
   integrity sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==
@@ -10253,18 +10212,18 @@ rc-overflow@^1.0.0, rc-overflow@^1.2.0, rc-overflow@^1.3.1:
     rc-resize-observer "^1.0.0"
     rc-util "^5.37.0"
 
-rc-pagination@~3.1.6:
-  version "3.1.17"
-  resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-3.1.17.tgz#91e690aa894806e344cea88ea4a16d244194a1bd"
-  integrity sha512-/BQ5UxcBnW28vFAcP2hfh+Xg15W0QZn8TWYwdCApchMH1H0CxiaUUcULP8uXcFM1TygcdKWdt3JqsL9cTAfdkQ==
+rc-pagination@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-3.2.0.tgz#4f2fdba9fdac0f48e5c9fb1141973818138af7e1"
+  integrity sha512-5tIXjB670WwwcAJzAqp2J+cOBS9W3cH/WU1EiYwXljuZ4vtZXKlY2Idq8FZrnYBz8KhN3vwPo9CoV/SJS6SL1w==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
 
-rc-picker@~2.5.10:
-  version "2.5.19"
-  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-2.5.19.tgz#73d07546fac3992f0bfabf2789654acada39e46f"
-  integrity sha512-u6myoCu/qiQ0vLbNzSzNrzTQhs7mldArCpPHrEI6OUiifs+IPXmbesqSm0zilJjfzrZJLgYeyyOMSznSlh0GKA==
+rc-picker@~2.7.0:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/rc-picker/-/rc-picker-2.7.3.tgz#84d5d3f4932e7ff14f2ce63047f84af64924a7b1"
+  integrity sha512-LuuU4ECPYmfIQD3NXTdoiHTH9xnc6Cb69Ad62ggX34Dy60RJmrchNhj6Gjp0puf/l1oIhFKO190slGcHob6ALA==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
@@ -10275,13 +10234,14 @@ rc-picker@~2.5.10:
     rc-util "^5.4.0"
     shallowequal "^1.1.0"
 
-rc-progress@~3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/rc-progress/-/rc-progress-3.1.4.tgz#66040d0fae7d8ced2b38588378eccb2864bad615"
-  integrity sha512-XBAif08eunHssGeIdxMXOmRQRULdHaDdIFENQ578CMb4dyewahmmfJRyab+hw4KH4XssEzzYOkAInTLS7JJG+Q==
+rc-progress@~3.4.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/rc-progress/-/rc-progress-3.4.2.tgz#f8df9ee95e790490171ab6b31bf07303cdc79980"
+  integrity sha512-iAGhwWU+tsayP+Jkl9T4+6rHeQTG9kDz8JAHZk4XtQOcYN5fj9H34NXNEdRdZx94VUDHMqCb1yOIvi8eJRh67w==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.6"
+    rc-util "^5.16.1"
 
 rc-rate@~2.9.0:
   version "2.9.3"
@@ -10292,7 +10252,7 @@ rc-rate@~2.9.0:
     classnames "^2.2.5"
     rc-util "^5.0.1"
 
-rc-resize-observer@^1.0.0, rc-resize-observer@^1.3.1:
+rc-resize-observer@^1.0.0, rc-resize-observer@^1.1.0, rc-resize-observer@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/rc-resize-observer/-/rc-resize-observer-1.3.1.tgz#b61b9f27048001243617b81f95e53d7d7d7a6a3d"
   integrity sha512-iFUdt3NNhflbY3mwySv5CA1TC06zdJ+pfo0oc27xpf4PIOvfZwZGtD9Kz41wGYqC4SLio93RVAirSSpYlV/uYg==
@@ -10302,38 +10262,47 @@ rc-resize-observer@^1.0.0, rc-resize-observer@^1.3.1:
     rc-util "^5.27.0"
     resize-observer-polyfill "^1.5.1"
 
-rc-select@^12.0.0, rc-select@~12.1.6:
-  version "12.1.13"
-  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-12.1.13.tgz#c33560ccb9339d30695b52458f55efc35af35273"
-  integrity sha512-cPI+aesP6dgCAaey4t4upDbEukJe+XN0DK6oO/6flcCX5o28o7KNZD7JAiVtC/6fCwqwI/kSs7S/43dvHmBl+A==
+rc-segmented@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/rc-segmented/-/rc-segmented-2.1.2.tgz#14c9077a1dae9c2ccb2ef5fbc5662c1c48c7ce8e"
+  integrity sha512-qGo1bCr83ESXpXVOCXjFe1QJlCAQXyi9KCiy8eX3rIMYlTeJr/ftySIaTnYsitL18SvWf5ZEHsfqIWoX0EMfFQ==
+  dependencies:
+    "@babel/runtime" "^7.11.1"
+    classnames "^2.2.1"
+    rc-motion "^2.4.4"
+    rc-util "^5.17.0"
+
+rc-select@~14.1.0, rc-select@~14.1.17:
+  version "14.1.18"
+  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-14.1.18.tgz#f1d95233132cda9c1485963254255b83e97a37a9"
+  integrity sha512-4JgY3oG2Yz68ECMUSCON7mtxuJvCSj+LJpHEg/AONaaVBxIIrmI/ZTuMJkyojall/X50YdBe5oMKqHHPNiPzEg==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
     rc-motion "^2.0.1"
     rc-overflow "^1.0.0"
     rc-trigger "^5.0.4"
-    rc-util "^5.9.8"
+    rc-util "^5.16.1"
     rc-virtual-list "^3.2.0"
 
-rc-slider@~9.7.1:
-  version "9.7.5"
-  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-9.7.5.tgz#193141c68e99b1dc3b746daeb6bf852946f5b7f4"
-  integrity sha512-LV/MWcXFjco1epPbdw1JlLXlTgmWpB9/Y/P2yinf8Pg3wElHxA9uajN21lJiWtZjf5SCUekfSP6QMJfDo4t1hg==
+rc-slider@~10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-10.0.1.tgz#7058c68ff1e1aa4e7c3536e5e10128bdbccb87f9"
+  integrity sha512-igTKF3zBet7oS/3yNiIlmU8KnZ45npmrmHlUUio8PNbIhzMcsh+oE/r2UD42Y6YD2D/s+kzCQkzQrPD6RY435Q==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.5"
-    rc-tooltip "^5.0.1"
-    rc-util "^5.16.1"
+    rc-util "^5.18.1"
     shallowequal "^1.1.0"
 
-rc-steps@~4.1.0:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/rc-steps/-/rc-steps-4.1.4.tgz#0ba82db202d59ca52d0693dc9880dd145b19dc23"
-  integrity sha512-qoCqKZWSpkh/b03ASGx1WhpKnuZcRWmvuW+ZUu4mvMdfvFzVxblTwUM+9aBd0mlEUFmt6GW8FXhMpHkK3Uzp3w==
+rc-steps@~5.0.0-alpha.2:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/rc-steps/-/rc-steps-5.0.0.tgz#2e2403f2dd69eb3966d65f461f7e3a8ee1ef69fe"
+  integrity sha512-9TgRvnVYirdhbV0C3syJFj9EhCRqoJAsxt4i1rED5o8/ZcSv5TLIYyo4H8MCjLPvbe2R+oBAm/IYBEtC+OS1Rw==
   dependencies:
-    "@babel/runtime" "^7.10.2"
+    "@babel/runtime" "^7.16.7"
     classnames "^2.2.3"
-    rc-util "^5.0.1"
+    rc-util "^5.16.1"
 
 rc-switch@~3.2.0:
   version "3.2.2"
@@ -10344,91 +10313,73 @@ rc-switch@~3.2.0:
     classnames "^2.2.1"
     rc-util "^5.0.1"
 
-rc-table@~7.15.1:
-  version "7.15.2"
-  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-7.15.2.tgz#f6ab73b2cfb1c76f3cf9682c855561423c6b5b22"
-  integrity sha512-TAs7kCpIZwc2mtvD8CMrXSM6TqJDUsy0rUEV1YgRru33T8bjtAtc+9xW/KC1VWROJlHSpU0R0kXjFs9h/6+IzQ==
+rc-table@~7.26.0:
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-7.26.0.tgz#9d517e7fa512e7571fdcc453eb1bf19edfac6fbc"
+  integrity sha512-0cD8e6S+DTGAt5nBZQIPFYEaIukn17sfa5uFL98faHlH/whZzD8ii3dbFL4wmUDEL4BLybhYop+QUfZJ4CPvNQ==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.5"
-    rc-resize-observer "^1.0.0"
-    rc-util "^5.13.0"
+    rc-resize-observer "^1.1.0"
+    rc-util "^5.22.5"
     shallowequal "^1.1.0"
 
-rc-tabs@~11.9.1:
-  version "11.9.1"
-  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-11.9.1.tgz#5b2e74da9a276978c2172ef9a05ae8af14da74cb"
-  integrity sha512-CLNx3qaWnO8KBWPd+7r52Pfk0MoPyKtlr+2ltWq2I9iqAjd1nZu6iBpQP7wbWBwIomyeFNw/WjHdRN7VcX5Qtw==
+rc-tabs@~12.5.6:
+  version "12.5.10"
+  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-12.5.10.tgz#0e41c723fac66c4f0bcad3271429fff6653b0721"
+  integrity sha512-Ay0l0jtd4eXepFH9vWBvinBjqOpqzcsJTerBGwJy435P2S90Uu38q8U/mvc1sxUEVOXX5ZCFbxcWPnfG3dH+tQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
     classnames "2.x"
-    rc-dropdown "^3.2.0"
-    rc-menu "^9.0.0"
+    rc-dropdown "~4.0.0"
+    rc-menu "~9.8.0"
+    rc-motion "^2.6.2"
     rc-resize-observer "^1.0.0"
-    rc-util "^5.5.0"
+    rc-util "^5.16.0"
 
-rc-textarea@^0.3.0, rc-textarea@~0.3.0:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/rc-textarea/-/rc-textarea-0.3.7.tgz#987142891efdedb774883c07e2f51b318fde5a11"
-  integrity sha512-yCdZ6binKmAQB13hc/oehh0E/QRwoPP1pjF21aHBxlgXO3RzPF6dUu4LG2R4FZ1zx/fQd2L1faktulrXOM/2rw==
+rc-textarea@^0.4.0, rc-textarea@~0.4.5:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/rc-textarea/-/rc-textarea-0.4.7.tgz#627f662d46f99e0059d1c1ebc8db40c65339fe90"
+  integrity sha512-IQPd1CDI3mnMlkFyzt2O4gQ2lxUsnBAeJEoZGJnkkXgORNqyM9qovdrCj9NzcRfpHgLdzaEbU3AmobNFGUznwQ==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "^2.2.1"
     rc-resize-observer "^1.0.0"
-    rc-util "^5.7.0"
+    rc-util "^5.24.4"
     shallowequal "^1.1.0"
 
-rc-tooltip@^5.0.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-5.3.1.tgz#3dde4e1865f79cd23f202bba4e585c2a1173024b"
-  integrity sha512-e6H0dMD38EPaSPD2XC8dRfct27VvT2TkPdoBSuNl3RRZ5tspiY/c5xYEmGC0IrABvMBgque4Mr2SMZuliCvoiQ==
+rc-tooltip@~5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-5.2.2.tgz#e5cafa8ecebf78108936a0bcb93c150fa81ac93b"
+  integrity sha512-jtQzU/18S6EI3lhSGoDYhPqNpWajMtS5VV/ld1LwyfrDByQpYmw/LW6U7oFXXLukjfDHQ7Ju705A82PRNFWYhg==
   dependencies:
     "@babel/runtime" "^7.11.2"
     classnames "^2.3.1"
-    rc-trigger "^5.3.1"
-
-rc-tooltip@~5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-5.1.1.tgz#94178ed162d0252bc4993b725f5dc2ac0fccf154"
-  integrity sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==
-  dependencies:
-    "@babel/runtime" "^7.11.2"
     rc-trigger "^5.0.0"
 
-rc-tree-select@~4.3.0:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-4.3.3.tgz#28eba4d8a8dc8c0f9b61d83ce465842a6915eca4"
-  integrity sha512-0tilOHLJA6p+TNg4kD559XnDX3PTEYuoSF7m7ryzFLAYvdEEPtjn0QZc5z6L0sMKBiBlj8a2kf0auw8XyHU3lA==
+rc-tree-select@~5.5.0:
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-5.5.5.tgz#d28b3b45da1e820cd21762ba0ee93c19429bb369"
+  integrity sha512-k2av7jF6tW9bIO4mQhaVdV4kJ1c54oxV3/hHVU+oD251Gb5JN+m1RbJFTMf1o0rAFqkvto33rxMdpafaGKQRJw==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
-    rc-select "^12.0.0"
-    rc-tree "^4.0.0"
-    rc-util "^5.0.5"
+    rc-select "~14.1.0"
+    rc-tree "~5.7.0"
+    rc-util "^5.16.1"
 
-rc-tree@^4.0.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.2.2.tgz#4429187cbbfbecbe989714a607e3de8b3ab7763f"
-  integrity sha512-V1hkJt092VrOVjNyfj5IYbZKRMHxWihZarvA5hPL/eqm7o2+0SNkeidFYm7LVVBrAKBpOpa0l8xt04uiqOd+6w==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "2.x"
-    rc-motion "^2.0.1"
-    rc-util "^5.0.0"
-    rc-virtual-list "^3.0.1"
-
-rc-tree@~4.1.0:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.1.5.tgz#734ab1bfe835e78791be41442ca0e571147ab6fa"
-  integrity sha512-q2vjcmnBDylGZ9/ZW4F9oZMKMJdbFWC7um+DAQhZG1nqyg1iwoowbBggUDUaUOEryJP+08bpliEAYnzJXbI5xQ==
+rc-tree@~5.7.0:
+  version "5.7.10"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-5.7.10.tgz#3d66c2a81ffd24cbb8b816e7a747f626e57cb0fc"
+  integrity sha512-n4UkMQY3bzvJUNnbw6e3YI7sy2kE9c9vAYbSt94qAhcPKtMOThONNr1LIaFB/M5XeFYYrWVbvRVoT8k38eFuSQ==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
     rc-motion "^2.0.1"
-    rc-util "^5.0.0"
-    rc-virtual-list "^3.0.1"
+    rc-util "^5.16.1"
+    rc-virtual-list "^3.5.1"
 
-rc-trigger@^5.0.0, rc-trigger@^5.0.4, rc-trigger@^5.1.2, rc-trigger@^5.2.1, rc-trigger@^5.3.1:
+rc-trigger@^5.0.0, rc-trigger@^5.0.4, rc-trigger@^5.1.2, rc-trigger@^5.2.10, rc-trigger@^5.3.1:
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-5.3.4.tgz#6b4b26e32825677c837d1eb4d7085035eecf9a61"
   integrity sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==
@@ -10459,7 +10410,7 @@ rc-util@^4.10.0, rc-util@^4.15.3, rc-util@^4.9.0:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.1.0"
 
-rc-util@^5.0.0, rc-util@^5.0.1, rc-util@^5.0.5, rc-util@^5.0.6, rc-util@^5.12.0, rc-util@^5.13.0, rc-util@^5.13.1, rc-util@^5.16.1, rc-util@^5.17.0, rc-util@^5.19.2, rc-util@^5.2.0, rc-util@^5.2.1, rc-util@^5.21.0, rc-util@^5.24.4, rc-util@^5.26.0, rc-util@^5.27.0, rc-util@^5.33.0, rc-util@^5.36.0, rc-util@^5.37.0, rc-util@^5.4.0, rc-util@^5.5.0, rc-util@^5.6.1, rc-util@^5.7.0, rc-util@^5.8.0, rc-util@^5.9.4, rc-util@^5.9.8:
+rc-util@^5.0.1, rc-util@^5.0.6, rc-util@^5.16.0, rc-util@^5.16.1, rc-util@^5.17.0, rc-util@^5.18.1, rc-util@^5.19.2, rc-util@^5.2.0, rc-util@^5.2.1, rc-util@^5.20.1, rc-util@^5.21.0, rc-util@^5.21.2, rc-util@^5.22.5, rc-util@^5.23.0, rc-util@^5.24.4, rc-util@^5.25.2, rc-util@^5.26.0, rc-util@^5.27.0, rc-util@^5.32.2, rc-util@^5.36.0, rc-util@^5.37.0, rc-util@^5.4.0, rc-util@^5.6.1, rc-util@^5.9.4:
   version "5.37.0"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.37.0.tgz#6df9a55cb469b41b6995530a45b5f3dd3219a4ea"
   integrity sha512-cPMV8DzaHI1KDaS7XPRXAf4J7mtBqjvjikLpQieaeOO7+cEbqY2j7Kso/T0R0OiEZTNcLS/8Zl9YrlXiO9UbjQ==
@@ -10467,7 +10418,7 @@ rc-util@^5.0.0, rc-util@^5.0.1, rc-util@^5.0.5, rc-util@^5.0.6, rc-util@^5.12.0,
     "@babel/runtime" "^7.18.3"
     react-is "^16.12.0"
 
-rc-virtual-list@^3.0.1, rc-virtual-list@^3.2.0:
+rc-virtual-list@^3.2.0, rc-virtual-list@^3.5.1:
   version "3.10.5"
   resolved "https://registry.yarnpkg.com/rc-virtual-list/-/rc-virtual-list-3.10.5.tgz#a203ca60bf3334e16193f641db1e99a48ae76574"
   integrity sha512-Vc89TL3JHfRlLVQXVj5Hmv0dIflgwmHDcbjt9lrZjOG3wNUDkTF5zci8kFDU/CzdmmqgKu+CUktEpT10VUKYSQ==
@@ -10978,7 +10929,7 @@ reselect@^4.1.6:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
-resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
@@ -11910,6 +11861,11 @@ text-extensions@^1.0.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+throttle-debounce@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.0.tgz#a17a4039e82a2ed38a5e7268e4132d6960d41933"
+  integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
## Which problem is this PR solving?
- part of: https://github.com/jaegertracing/jaeger-ui/pull/1734
- part of the ant-design dependency upgrade process

## Description of the changes
- This PR changes the type from `Input` to `InputRef` as per antd typescript changes.
- InputNumber now guarantees the type of input to be `number | null` which was previously `string | number | undefined`
- Tests related to these change are updated accordingly.

## How was this change tested?
- manually, and automated testing

## What's next?
- This is the final PR for antd upgrade to version 4.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
