### PR TITLE
Split lint and test CI and suppress warnings

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -1,4 +1,4 @@
-name: "Unit Tests"
+name: "Lint and Build"
 
 on:
   push:
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests:
+  lint-build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -1,0 +1,30 @@
+name: "Unit Tests"
+
+on:
+  push:
+    branches: [main]
+
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: '16'
+      - run: yarn install --frozen-lockfile
+      - name: Run depcheck
+        run: |
+          yarn global add depcheck
+          yarn run depcheck
+      - run: yarn lint
+      - run: yarn build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,12 +22,6 @@ jobs:
           cache: yarn
           node-version: '16'
       - run: yarn install --frozen-lockfile
-      - name: Run depcheck
-        run: |
-          yarn global add depcheck
-          yarn run depcheck
-      - run: yarn lint
-      - run: yarn build
       - run: yarn coverage
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v3

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -107,7 +107,7 @@
     "start:ga-debug": "REACT_APP_GA_DEBUG=1 REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) vite",
     "start": "vite",
     "test": "jest",
-    "test-ci": "CI=1 jest --color"
+    "test-ci": "CI=1 jest --silent --color"
   },
   "jest": {
     "globalSetup": "./test/jest.global-setup.js",


### PR DESCRIPTION
## Which problem is this PR solving?
- Sometimes we get the `coverage` step failures that are very hard to diagnose because the logs are spammed by warnings, while the real errors are not showing (for some reason local test runs look differently)
- We also run linters and coverage sequentially, instead of in parallel, to speed things up

## Description of the changes
- split the workflow into lint-build and unit-tests
- use `jest --silent` in CI to suppress warnings and not obfuscate the error output

## How was this change tested?
- CI

