### PR TITLE
[tests] Add tests for formatRelativeDate

### DIFF
--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -18,6 +18,7 @@ import {
   getSuitableTimeUnit,
   convertTimeUnitToShortTerm,
   convertToTimeUnit,
+  formatRelativeDate,
   ONE_MILLISECOND,
   ONE_SECOND,
   ONE_MINUTE,
@@ -182,5 +183,38 @@ describe('convertToTimeUnit', () => {
   it('convert duration to days', () => {
     const input = 172800000000;
     expect(convertToTimeUnit(input, 'days')).toBe(2);
+  });
+});
+
+describe('formatRelativeDate', () => {
+  const currentTimestamp = Date.now();
+  const currentDate = new Date(currentTimestamp);
+
+  it('Displays Date MM-DD-YYY (Different Year) ', () => {
+    const input = new Date(currentTimestamp);
+    input.setFullYear(currentDate.getFullYear() - 2);
+    const output = input.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+    expect(formatRelativeDate(input)).toBe(output);
+  });
+  it('Displays Today (Todays date)', () => {
+    expect(formatRelativeDate(currentDate)).toBe('Today');
+  });
+  it('Displays YESTERDAY (Yesterday date)', () => {
+    const input = new Date(currentTimestamp);
+    input.setDate(currentDate.getDate() - 1);
+    expect(formatRelativeDate(input)).toBe('Yesterday');
+  });
+  it('Displays MM-DAY (Same month different date)', () => {
+    const input = new Date(currentTimestamp);
+    input.setDate(currentDate.getDate() - 4);
+    const output = input.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+    expect(formatRelativeDate(input)).toBe(output);
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1747

## Description of the changes
- added test coverage for formatRelativeDate in /src/utils/date.test.js

## How was this change tested?
-  manually on my local envrionment

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
