### PR TITLE
Replaced all uncontroversial icons from various icon sets to io5

### DIFF
--- a/packages/jaeger-ui/src/components/App/TopNav.css
+++ b/packages/jaeger-ui/src/components/App/TopNav.css
@@ -14,36 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.TimelineCollapser {
-  align-items: center;
+.Dropdown--icon-container {
   display: flex;
-  flex: none;
+  color: white;
+  margin-right: 30px;
+  flex-direction: row;
+  align-items: center;
   justify-content: center;
-  margin-right: 0.5rem;
 }
 
-.TimelineCollapser--tooltipTitle {
-  white-space: pre;
+.Dropdown--icon-container:hover {
+  color: white;
 }
 
-.TimelineCollapser--btn,
-.TimelineCollapser--btn-expand {
-  color: rgba(0, 0, 0, 0.5);
-  cursor: pointer;
-  margin-right: 0.3rem;
-  padding: 0.1rem;
-}
-
-.TimelineCollapser--btn:hover,
-.TimelineCollapser--btn-expand:hover {
-  color: rgba(0, 0, 0, 0.85);
-}
-
-.TimelineCollapser--btn-expand {
-  transform: rotate(90deg);
-}
-
-.TimelineCollapser--btn-expand,
-.TimelineCollapser--btn {
-  font-size: 20px;
+.Dropdown--icon-container .Dropdown--icon {
+  margin-left: 5px;
 }

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { Dropdown, Menu } from 'antd';
-import { DownOutlined } from '@ant-design/icons';
+import { IoChevronDown } from 'react-icons/io5';
 import _has from 'lodash/has';
 import { connect } from 'react-redux';
 import { RouteComponentProps, Link, withRouter } from 'react-router-dom';
@@ -30,6 +30,8 @@ import { ReduxState } from '../../types';
 import { ConfigMenuItem, ConfigMenuGroup } from '../../types/config';
 import { getConfigValue } from '../../utils/config/get-config';
 import prefixUrl from '../../utils/prefix-url';
+
+import './TopNav.css';
 
 type Props = RouteComponentProps<any> & ReduxState;
 
@@ -96,9 +98,9 @@ function getItem(item: ConfigMenuItem) {
 function CustomNavDropdown({ label, items }: ConfigMenuGroup) {
   const menuItems = <Menu>{items.map(getItem)}</Menu>;
   return (
-    <Dropdown overlay={menuItems} overlayStyle={{ paddingRight: '20px' }} placement="bottomRight">
-      <a style={{ color: 'white' }}>
-        {label} <DownOutlined style={{ paddingRight: '30px' }} />
+    <Dropdown overlay={menuItems} placement="bottomRight">
+      <a className="Dropdown--icon-container">
+        {label} <IoChevronDown className="Dropdown--icon" />
       </a>
     </Dropdown>
   );

--- a/packages/jaeger-ui/src/components/App/TraceIDSearchInput.tsx
+++ b/packages/jaeger-ui/src/components/App/TraceIDSearchInput.tsx
@@ -17,7 +17,7 @@ import * as React from 'react';
 import { Form } from '@ant-design/compatible';
 import '@ant-design/compatible/assets/index.css';
 import { Input } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { IoSearch } from 'react-icons/io5';
 import { RouteComponentProps, Router as RouterHistory, withRouter } from 'react-router-dom';
 
 import { getUrl } from '../TracePage/url';
@@ -50,7 +50,7 @@ class TraceIDSearchInput extends React.PureComponent<Props> {
           data-testid="idInput"
           name="idInput"
           placeholder="Lookup by Trace ID..."
-          prefix={<SearchOutlined />}
+          prefix={<IoSearch />}
         />
       </Form>
     );

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
@@ -189,7 +189,7 @@ exports[`<DdgNodeContent> omits the operation if it is null 1`] = `
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -325,7 +325,7 @@ exports[`<DdgNodeContent> omits the operation if it is null 2`] = `
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -476,7 +476,7 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 1`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -627,7 +627,7 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 2`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -778,7 +778,7 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 1`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -932,7 +932,7 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 2`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -1083,7 +1083,7 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -1312,7 +1312,7 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -1480,7 +1480,7 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <MdVisibilityOff />
+        <IoEyeOff />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
@@ -16,8 +16,7 @@ import * as React from 'react';
 import { Checkbox, Popover } from 'antd';
 import cx from 'classnames';
 import { TLayoutVertex } from '@jaegertracing/plexus/lib/types';
-import { MdVisibilityOff } from 'react-icons/md';
-import { IoLocate } from 'react-icons/io5';
+import { IoLocate, IoEyeOff } from 'react-icons/io5';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -334,7 +333,7 @@ export class UnconnectedDdgNodeContent extends React.PureComponent<TProps, TStat
           {!isFocalNode && (
             <a className="DdgNodeContent--actionsItem" onClick={this.hideVertex} role="button">
               <span className="DdgNodeContent--actionsItemIconWrapper">
-                <MdVisibilityOff />
+                <IoEyeOff />
               </span>
               <span className="DdgNodeContent--actionsItemText">Hide node</span>
             </a>

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/Selector.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/Selector.tsx
@@ -15,7 +15,7 @@
 import React, { PureComponent } from 'react';
 import { Popover } from 'antd';
 import { ImSortAmountAsc } from 'react-icons/im';
-import { FaChevronRight } from 'react-icons/fa';
+import { IoChevronForward } from 'react-icons/io5';
 
 import ChevronDown from '../ChevronDown';
 import { trackHopChange } from '../../index.track';
@@ -48,7 +48,7 @@ export default class Selector extends PureComponent<TProps> {
     const { direction } = this.props;
     return (
       <React.Fragment key={`${distance} ${direction} ${suffix}`}>
-        {Boolean(showChevron) && <FaChevronRight className={`${CLASSNAME}--ChevronRight is-${fullness}`} />}
+        {Boolean(showChevron) && <IoChevronForward className={`${CLASSNAME}--ChevronRight is-${fullness}`} />}
         <button
           className={`${CLASSNAME}--btn is-${fullness} ${CLASSNAME}--${suffix}`}
           type="button"

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/__snapshots__/Selector.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/__snapshots__/Selector.test.js.snap
@@ -23,7 +23,7 @@ exports[`Selector renders buttons with expected text and classNames 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-partial"
         />
         <button
@@ -35,7 +35,7 @@ exports[`Selector renders buttons with expected text and classNames 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-full"
         />
         <button
@@ -47,7 +47,7 @@ exports[`Selector renders buttons with expected text and classNames 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-empty"
         />
         <button
@@ -59,7 +59,7 @@ exports[`Selector renders buttons with expected text and classNames 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-empty"
         />
         <button
@@ -148,7 +148,7 @@ exports[`Selector renders upstream hops with negative distance correctly 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-partial"
         />
         <button
@@ -160,7 +160,7 @@ exports[`Selector renders upstream hops with negative distance correctly 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-full"
         />
         <button
@@ -172,7 +172,7 @@ exports[`Selector renders upstream hops with negative distance correctly 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-empty"
         />
         <button
@@ -184,7 +184,7 @@ exports[`Selector renders upstream hops with negative distance correctly 1`] = `
         </button>
       </React.Fragment>,
       <React.Fragment>
-        <FaChevronRight
+        <IoChevronForward
           className="HopsSelector--Selector--ChevronRight is-empty"
         />
         <button

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
@@ -33,7 +33,7 @@ exports[`<Header> renders the hops selector if distanceToPathElems is provided 1
         onClick={[Function]}
         role="button"
       >
-        <ForwardRef(SearchOutlined)
+        <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
         <withRouter(Connect(UnconnectedUiFindInput))
@@ -99,7 +99,7 @@ exports[`<Header> renders the operation selector iff a service is selected 1`] =
         onClick={[Function]}
         role="button"
       >
-        <ForwardRef(SearchOutlined)
+        <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
         <withRouter(Connect(UnconnectedUiFindInput))
@@ -169,7 +169,7 @@ exports[`<Header> renders the operation selector iff a service is selected 2`] =
         onClick={[Function]}
         role="button"
       >
-        <ForwardRef(SearchOutlined)
+        <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
         <withRouter(Connect(UnconnectedUiFindInput))
@@ -223,7 +223,7 @@ exports[`<Header> renders with minimal props 1`] = `
         onClick={[Function]}
         role="button"
       >
-        <ForwardRef(SearchOutlined)
+        <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
         <withRouter(Connect(UnconnectedUiFindInput))

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.js
@@ -15,7 +15,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Tooltip } from 'antd';
-import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import { IoEye, IoEyeOff } from 'react-icons/io5';
 
 import Header from './index';
 import HopsSelector from './HopsSelector';
@@ -119,16 +119,16 @@ describe('<Header>', () => {
       expect(getMatchesInfo().text()).not.toEqual(expectedHiddenCount);
       expect(getTooltip().prop('title')).toBe(expectedTitle);
       expect(getBtn().prop('disabled')).toBe(true);
-      expect(wrapper.find(MdVisibility)).toHaveLength(1);
-      expect(wrapper.find(MdVisibilityOff)).toHaveLength(0);
+      expect(wrapper.find(IoEye)).toHaveLength(1);
+      expect(wrapper.find(IoEyeOff)).toHaveLength(0);
 
       wrapper.setProps({ hiddenUiFindMatches: new Set() });
       expect(getMatchesInfo().text()).toEqual(expectedFindCount);
       expect(getMatchesInfo().text()).not.toEqual(expectedHiddenCount);
       expect(getTooltip().prop('title')).toBe(expectedTitle);
       expect(getBtn().prop('disabled')).toBe(true);
-      expect(wrapper.find(MdVisibility)).toHaveLength(1);
-      expect(wrapper.find(MdVisibilityOff)).toHaveLength(0);
+      expect(wrapper.find(IoEye)).toHaveLength(1);
+      expect(wrapper.find(IoEyeOff)).toHaveLength(0);
     });
 
     it('renders both visible and hidden counts if both are provided', () => {
@@ -138,8 +138,8 @@ describe('<Header>', () => {
       expect(getMatchesInfo().text()).toEqual(expectedHiddenCount);
       expect(getTooltip().prop('title')).toBe(expectedHiddenTitle);
       expect(getBtn().prop('disabled')).toBe(false);
-      expect(wrapper.find(MdVisibility)).toHaveLength(1);
-      expect(wrapper.find(MdVisibilityOff)).toHaveLength(1);
+      expect(wrapper.find(IoEye)).toHaveLength(1);
+      expect(wrapper.find(IoEyeOff)).toHaveLength(1);
     });
 
     it('renders 0 with correct tooltip if there are no visible nor hidden matches', () => {
@@ -149,8 +149,8 @@ describe('<Header>', () => {
       expect(getMatchesInfo().text()).toBe('0');
       expect(getTooltip().prop('title')).toBe(expectedTitle);
       expect(getBtn().prop('disabled')).toBe(true);
-      expect(wrapper.find(MdVisibility)).toHaveLength(0);
-      expect(wrapper.find(MdVisibilityOff)).toHaveLength(0);
+      expect(wrapper.find(IoEye)).toHaveLength(0);
+      expect(wrapper.find(IoEyeOff)).toHaveLength(0);
     });
 
     it('renders 0 with correct tooltip if there are no matches but there are hidden matches', () => {
@@ -161,8 +161,8 @@ describe('<Header>', () => {
       expect(getMatchesInfo().text()).toEqual(expectedHiddenCount);
       expect(getTooltip().prop('title')).toBe(expectedHiddenTitle);
       expect(getBtn().prop('disabled')).toBe(false);
-      expect(wrapper.find(MdVisibility)).toHaveLength(1);
-      expect(wrapper.find(MdVisibilityOff)).toHaveLength(1);
+      expect(wrapper.find(IoEye)).toHaveLength(1);
+      expect(wrapper.find(IoEyeOff)).toHaveLength(1);
     });
 
     it('renders correct plurality in tooltip', () => {

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -14,8 +14,7 @@
 
 import * as React from 'react';
 import { InputRef, Tooltip } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
-import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import { IoSearch, IoEye, IoEyeOff } from 'react-icons/io5';
 
 import HopsSelector from './HopsSelector';
 import NameSelector from '../../common/NameSelector';
@@ -74,7 +73,7 @@ export default class Header extends React.PureComponent<TProps> {
       hiddenInfo = (
         <span className="DdgHeader--uiFindInfo--hidden">
           {size}
-          <MdVisibilityOff className="DdgHeader--uiFindInfo--icon" />
+          <IoEyeOff className="DdgHeader--uiFindInfo--icon" />
         </span>
       );
     }
@@ -90,7 +89,7 @@ export default class Header extends React.PureComponent<TProps> {
             type="button"
           >
             {uiFindCount}
-            {(uiFindCount !== 0 || hasHidden) && <MdVisibility className="DdgHeader--uiFindInfo--icon" />}
+            {(uiFindCount !== 0 || hasHidden) && <IoEye className="DdgHeader--uiFindInfo--icon" />}
             {hiddenInfo}
           </button>
         </span>
@@ -165,7 +164,7 @@ export default class Header extends React.PureComponent<TProps> {
           />
           <div className="DdgHeader--findWrapper">
             <div className="DdgHeader--uiFind" role="button" onClick={this.focusUiFindInput}>
-              <SearchOutlined className="DdgHeader--uiFindSearchIcon" />
+              <IoSearch className="DdgHeader--uiFindSearchIcon" />
               <UiFindInput
                 allowClear
                 forwardedRef={this._uiFindInput}

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/index.test.js.snap
@@ -56,7 +56,7 @@ exports[`<SidePanel> render ignores selectedVertex without selected decoration 1
       onClick={[Function]}
       type="button"
     >
-      <MdExitToApp />
+      <IoExitOutline />
     </button>
     <div
       className="Ddg--SidePanel--DecorationBtns"
@@ -99,7 +99,7 @@ exports[`<SidePanel> render ignores selectedVertex without selected decoration 1
       onClick={[Function]}
       type="button"
     >
-      <MdInfoOutline />
+      <IoInformationCircleOutline />
     </button>
   </div>
   <div
@@ -120,7 +120,7 @@ exports[`<SidePanel> render renders config decorations with clear button 1`] = `
       onClick={[Function]}
       type="button"
     >
-      <MdExitToApp />
+      <IoExitOutline />
     </button>
     <div
       className="Ddg--SidePanel--DecorationBtns"
@@ -163,7 +163,7 @@ exports[`<SidePanel> render renders config decorations with clear button 1`] = `
       onClick={[Function]}
       type="button"
     >
-      <MdInfoOutline />
+      <IoInformationCircleOutline />
     </button>
   </div>
   <div
@@ -184,7 +184,7 @@ exports[`<SidePanel> render renders selected decoration 1`] = `
       onClick={[Function]}
       type="button"
     >
-      <MdExitToApp />
+      <IoExitOutline />
     </button>
     <div
       className="Ddg--SidePanel--DecorationBtns"
@@ -227,7 +227,7 @@ exports[`<SidePanel> render renders selected decoration 1`] = `
       onClick={[Function]}
       type="button"
     >
-      <MdInfoOutline />
+      <IoInformationCircleOutline />
     </button>
   </div>
   <div
@@ -248,7 +248,7 @@ exports[`<SidePanel> render renders sidePanel and closeBtn when vertex and decor
       onClick={[Function]}
       type="button"
     >
-      <MdExitToApp />
+      <IoExitOutline />
     </button>
     <div
       className="Ddg--SidePanel--DecorationBtns"
@@ -291,7 +291,7 @@ exports[`<SidePanel> render renders sidePanel and closeBtn when vertex and decor
       onClick={[Function]}
       type="button"
     >
-      <MdInfoOutline />
+      <IoInformationCircleOutline />
     </button>
   </div>
   <div

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/index.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import { Modal, Table } from 'antd';
-import { MdExitToApp, MdInfoOutline } from 'react-icons/md';
+import { IoExitOutline, IoInformationCircleOutline } from 'react-icons/io5';
 
 import { TDdgVertex } from '../../../model/ddg/types';
 import { TPathAgnosticDecorationSchema } from '../../../model/path-agnostic-decorations/types';
@@ -101,7 +101,7 @@ export default class SidePanel extends React.PureComponent<TProps> {
             type="button"
             onClick={this.clearSelected}
           >
-            <MdExitToApp />
+            <IoExitOutline />
           </button>
           <div className="Ddg--SidePanel--DecorationBtns">
             {this.decorations.map(({ acronym, id }) => (
@@ -124,7 +124,7 @@ export default class SidePanel extends React.PureComponent<TProps> {
             </button>
           </div>
           <button className="Ddg--SidePanel--infoBtn" onClick={this.openInfoModal} type="button">
-            <MdInfoOutline />
+            <IoInformationCircleOutline />
           </button>
         </div>
         <div className={`Ddg--SidePanel--Details ${selectedVertex && selectedSchema ? '.is-expanded' : ''}`}>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
@@ -82,7 +82,7 @@ exports[`<OperationTableDetails> Table rendered successfully 1`] = `
                 placement="top"
                 title="The result of multiplying avg. duration and requests per minute, showing the most used and slowest endpoints"
               >
-                <ForwardRef(InfoCircleOutlined) />
+                <IoInformationCircleOutline />
               </Tooltip>
             </span>
           </div>,
@@ -483,34 +483,50 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -1022,34 +1038,50 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -1997,34 +2029,50 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -2972,34 +3020,50 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -3947,34 +4011,50 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -4922,34 +5002,50 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -5897,34 +5993,50 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -6872,34 +6984,50 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>
@@ -7847,34 +7975,50 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                             >
                               Impact
                                 
-                              <span
-                                aria-label="info-circle"
-                                className="anticon anticon-info-circle"
+                              <svg
+                                fill="currentColor"
+                                height="1em"
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                role="img"
+                                stroke="currentColor"
+                                strokeWidth="0"
+                                style={
+                                  Object {
+                                    "color": undefined,
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  className=""
-                                  data-icon="info-circle"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  key="svg-info-circle"
-                                  viewBox="64 64 896 896"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                    key="svg-info-circle-svg-0"
-                                  />
-                                  <path
-                                    d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                                    key="svg-info-circle-svg-1"
-                                  />
-                                </svg>
-                              </span>
+                                <path
+                                  d="M248 64C146.39 64 64 146.39 64 248s82.39 184 184 184 184-82.39 184-184S349.61 64 248 64z"
+                                  fill="none"
+                                  key="0"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M220 220h32v116"
+                                  fill="none"
+                                  key="1"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M208 340h88"
+                                  fill="none"
+                                  key="2"
+                                  strokeLinecap="round"
+                                  strokeMiterlimit="10"
+                                  strokeWidth="32"
+                                />
+                                <path
+                                  d="M248 130a26 26 0 1026 26 26 26 0 00-26-26z"
+                                  key="3"
+                                />
+                              </svg>
                             </span>
                           </div>
                         </span>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 import isEqual from 'lodash/isEqual';
 import isArray from 'lodash/isArray';
 import { Table, Progress, Button, Tooltip, Col } from 'antd';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { IoInformationCircleOutline } from 'react-icons/io5';
 import REDGraph from './opsGraph';
 import LoadingIndicator from '../../../common/LoadingIndicator';
 import { MetricsReduxState, ServiceOpsMetrics } from '../../../../types/metrics';
@@ -172,7 +172,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
                 placement="top"
                 title="The result of multiplying avg. duration and requests per minute, showing the most used and slowest endpoints"
               >
-                <InfoCircleOutlined />
+                <IoInformationCircleOutline />
               </Tooltip>
             </span>
           </div>

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
@@ -1,11 +1,12 @@
 /*
-Copyright (c) 2020 The Jaeger Authors.
+Copyright (c) 2017 Uber Technologies, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,17 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.AltViewOptions {
-  border: 1px solid #d9d9d9;
-  border-radius: 4px;
-  height: 32px;
-  line-height: 30px;
-  margin-right: 1rem;
-  padding: 0 8px;
-  display: flex;
-  align-items: center;
-}
-
-.AltViewOptions svg {
-  margin-left: 3px;
+.Dragger--icon {
+  font-size: 60px;
+  color: rgb(197, 197, 197);
+  margin: 10px 0;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 .Dragger--icon {
-  font-size: 60px;
-  color: rgb(197, 197, 197);
+  font-size: 56px;
+  color: #2DA6A2;
   margin: 10px 0;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.css
@@ -16,6 +16,6 @@ limitations under the License.
 
 .Dragger--icon {
   font-size: 56px;
-  color: #2DA6A2;
+  color: #2da6a2;
   margin: 10px 0;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
@@ -14,7 +14,9 @@
 
 import * as React from 'react';
 import { Upload } from 'antd';
-import { FileAddOutlined } from '@ant-design/icons';
+import { IoDocumentAttachOutline } from 'react-icons/io5';
+
+import './FileLoader.css';
 
 const Dragger = Upload.Dragger;
 
@@ -29,9 +31,7 @@ export default function FileLoader(props: FileLoaderProps) {
       beforeUpload={(file, fileList) => fileList.forEach(file => props.loadJsonTraces({ file }))}
       multiple
     >
-      <p className="ant-upload-drag-icon">
-        <FileAddOutlined />
-      </p>
+      <IoDocumentAttachOutline className="Dragger--icon" />
       <p className="ant-upload-text">Click or drag files to this area.</p>
       <p className="ant-upload-hint">JSON files containing one or more traces are supported.</p>
     </Dragger>

--- a/packages/jaeger-ui/src/components/SearchTracePage/__snapshots__/FileLoader.test.js.snap
+++ b/packages/jaeger-ui/src/components/SearchTracePage/__snapshots__/FileLoader.test.js.snap
@@ -6,11 +6,9 @@ exports[`<FileLoader /> matches the snapshot 1`] = `
   beforeUpload={[Function]}
   multiple={true}
 >
-  <p
-    className="ant-upload-drag-icon"
-  >
-    <ForwardRef(FileAddOutlined) />
-  </p>
+  <IoDocumentAttachOutline
+    className="Dragger--icon"
+  />
   <p
     className="ant-upload-text"
   >

--- a/packages/jaeger-ui/src/components/TracePage/ArchiveNotifier/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/ArchiveNotifier/index.test.js
@@ -15,7 +15,8 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { notification } from 'antd';
-import { ClockCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { LoadingOutlined } from '@ant-design/icons';
+import { IoTimeOutline } from 'react-icons/io5';
 import ArchiveNotifier from './index';
 import { Details, Message } from '../../common/ErrorMessage';
 
@@ -61,7 +62,7 @@ describe('<ArchiveNotifier>', () => {
         key: 'ENotifiedState.Outcome',
         description: null,
         duration: null,
-        icon: <ClockCircleOutlined className="ArchiveNotifier--doneIcon" />,
+        icon: <IoTimeOutline className="ArchiveNotifier--doneIcon" />,
         message: 'This trace has been archived.',
         onClose: defaultProps.acknowledge,
       })
@@ -143,7 +144,7 @@ describe('<ArchiveNotifier>', () => {
         className: 'ArchiveNotifier--errorNotification',
         description: <Details error="This is an error string" wrap />,
         duration: null,
-        icon: <ClockCircleOutlined className="ArchiveNotifier--errorIcon" />,
+        icon: <IoTimeOutline className="ArchiveNotifier--errorIcon" />,
         message: <Message error="This is an error string" wrap />,
         onClose: props.acknowledge,
       })

--- a/packages/jaeger-ui/src/components/TracePage/ArchiveNotifier/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/ArchiveNotifier/index.tsx
@@ -14,7 +14,8 @@
 
 import * as React from 'react';
 import { notification } from 'antd';
-import { ClockCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { LoadingOutlined } from '@ant-design/icons';
+import { IoTimeOutline } from 'react-icons/io5';
 
 import { Details, Message } from '../../common/ErrorMessage';
 import { TNil } from '../../../types';
@@ -74,7 +75,7 @@ function updateNotification(oldState: ENotifiedState | null, nextState: ENotifie
         message: <Message error={error} wrap />,
         description: <Details error={error} wrap />,
         duration: null,
-        icon: <ClockCircleOutlined className="ArchiveNotifier--errorIcon" />,
+        icon: <IoTimeOutline className="ArchiveNotifier--errorIcon" />,
         onClose: acknowledge,
       });
     } else if (archivedState && archivedState.isArchived) {
@@ -82,7 +83,7 @@ function updateNotification(oldState: ENotifiedState | null, nextState: ENotifie
         key: ENotifiedState.Outcome,
         description: null,
         duration: null,
-        icon: <ClockCircleOutlined className="ArchiveNotifier--doneIcon" />,
+        icon: <IoTimeOutline className="ArchiveNotifier--doneIcon" />,
         message: 'This trace has been archived.',
         onClose: acknowledge,
       });

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import { Card, Button, Tooltip } from 'antd';
-import { CloseOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { IoClose, IoHelpCircleOutline } from 'react-icons/io5';
 import cx from 'classnames';
 import { Digraph, LayoutManager } from '@jaegertracing/plexus';
 import cacheAs from '@jaegertracing/plexus/lib/cacheAs';
@@ -216,7 +216,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
         <div className="TraceGraph--sidebar-container">
           <ul className="TraceGraph--menu">
             <li>
-              <QuestionCircleOutlined onClick={this.showHelp} />
+              <IoHelpCircleOutline onClick={this.showHelp} />
             </li>
             <li>
               <Tooltip placement="left" title="Service">
@@ -264,7 +264,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
               bordered={false}
               extra={
                 <a onClick={this.closeSidebar} role="button">
-                  <CloseOutlined />
+                  <IoClose />
                 </a>
               }
             >

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import { Dropdown, Menu, Button } from 'antd';
-import { DownOutlined } from '@ant-design/icons';
+import { IoChevronDown } from 'react-icons/io5';
 import { Link } from 'react-router-dom';
 import './AltViewOptions.css';
 
@@ -118,7 +118,7 @@ export default function AltViewOptions(props: Props) {
     <Dropdown overlay={menu}>
       <Button className="AltViewOptions">
         {`${dropdownText} `}
-        <DownOutlined />
+        <IoChevronDown />
       </Button>
     </Dropdown>
   );

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
@@ -70,7 +70,8 @@ limitations under the License.
 }
 
 .TracePageHeader--detailToggle {
-  font-size: 2.5rem;
+  font-size: 2rem;
+  margin: 0 12px;
   transition: transform 0.07s ease-out;
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -17,9 +17,7 @@ import { Button, InputRef } from 'antd';
 import _get from 'lodash/get';
 import _maxBy from 'lodash/maxBy';
 import _values from 'lodash/values';
-import { IoArrowBack } from 'react-icons/io5';
-import { IoIosFiling } from 'react-icons/io';
-import { MdKeyboardArrowRight } from 'react-icons/md';
+import { IoArrowBack, IoFileTrayFull, IoChevronForward } from 'react-icons/io5';
 import { Link } from 'react-router-dom';
 
 import AltViewOptions from './AltViewOptions';
@@ -174,9 +172,7 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
             role="switch"
             aria-checked={!slimView}
           >
-            <MdKeyboardArrowRight
-              className={`TracePageHeader--detailToggle ${!slimView ? 'is-expanded' : ''}`}
-            />
+            <IoChevronForward className={`TracePageHeader--detailToggle ${!slimView ? 'is-expanded' : ''}`} />
             {title}
           </a>
         ) : (
@@ -203,7 +199,7 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
         )}
         {showArchiveButton && (
           <Button className="ub-mr2 ub-flex ub-items-center" htmlType="button" onClick={onArchiveClicked}>
-            <IoIosFiling className="TracePageHeader--archiveIcon" />
+            <IoFileTrayFull className="TracePageHeader--archiveIcon" />
             Archive Trace
           </Button>
         )}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.css
@@ -32,7 +32,7 @@ limitations under the License.
 }
 
 .TracePageSearchBar--btn {
-  border-left: none;
+  border-left: 1px solid #d9d9d9;
   transition: 0.2s;
 }
 
@@ -40,12 +40,11 @@ limitations under the License.
   opacity: 0.5;
 }
 
-.TracePageSearchBar--locateBtn {
-  padding: 1px 8px 4px;
-}
-.help-btn-container {
+.ant-input-group.ant-input-group-compact .help-btn-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid gainsboro;
-  padding: 3px 7px;
 }
 .help-btn-container:hover {
   border-top-color: rgb(23, 184, 190);
@@ -57,4 +56,21 @@ limitations under the License.
   color: #999;
   cursor: pointer;
   padding: 1px;
+  margin: 0 10px;
+  font-size: 18px;
+}
+
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--locateBtn,
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--ButtonUp,
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--ButtonDown,
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--ButtonClose {
+  display: flex;
+  align-items: center;
+}
+
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--locateBtn svg,
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--ButtonUp svg,
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--ButtonDown svg,
+.ant-input-group.ant-input-group-compact .TracePageSearchBar--ButtonClose svg {
+  font-size: 18px;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { CloseOutlined, DownOutlined, UpOutlined } from '@ant-design/icons';
 import { Button, Input, InputRef, Tooltip } from 'antd';
 import cx from 'classnames';
-import { IoLocate, IoHelp } from 'react-icons/io5';
+import { IoLocate, IoHelp, IoClose, IoChevronDown, IoChevronUp } from 'react-icons/io5';
 
 import * as markers from './TracePageSearchBar.markers';
 import { trackFilter } from '../index.track';
@@ -109,31 +108,34 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
               <IoLocate />
             </Button>
             <Button
-              className={btnClass}
+              className={cx(btnClass, 'TracePageSearchBar--ButtonUp')}
               disabled={!textFilter}
               htmlType="button"
-              icon={<UpOutlined />}
               data-testid="UpOutlined"
               onClick={prevResult}
-            />
+            >
+              <IoChevronUp />
+            </Button>
             <Button
-              className={btnClass}
+              className={cx(btnClass, 'TracePageSearchBar--ButtonDown')}
               disabled={!textFilter}
               htmlType="button"
-              icon={<DownOutlined />}
               data-testid="DownOutlined"
               onClick={nextResult}
-            />
+            >
+              <IoChevronDown />
+            </Button>
           </>
         )}
         <Button
-          className={btnClass}
+          className={cx(btnClass, 'TracePageSearchBar--ButtonClose')}
           disabled={!textFilter}
           htmlType="button"
-          icon={<CloseOutlined />}
           data-testid="CloseOutlined"
           onClick={clearSearch}
-        />
+        >
+          <IoClose />
+        </Button>
       </Input.Group>
     </div>
   );

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
@@ -65,7 +65,7 @@ exports[`AltViewOptions renders correctly 1`] = `
     className="AltViewOptions"
   >
     Trace Timeline 
-    <ForwardRef(DownOutlined) />
+    <IoChevronDown />
   </Button>
 </Dropdown>
 `;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { IoAlert, IoChevronForward, IoGitNetwork, IoCloudUploadOutline } from 'react-icons/io5';
+import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDuration, ViewedBoundsFunctionType } from './utils';
@@ -152,14 +152,14 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                 {serviceName}{' '}
                 {rpc && (
                   <span>
-                    <IoChevronForward />{' '}
+                    <IoArrowForward />{' '}
                     <i className="SpanBarRow--rpcColorMarker" style={{ background: rpc.color }} />
                     {rpc.serviceName}
                   </span>
                 )}
                 {noInstrumentedServer && (
                   <span>
-                    <IoChevronForward />{' '}
+                    <IoArrowForward />{' '}
                     <i
                       className="SpanBarRow--rpcColorMarker"
                       style={{ background: noInstrumentedServer.color }}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { IoAlert } from 'react-icons/io5';
-import { ImArrowRight } from 'react-icons/im';
-import { IoMdGitNetwork } from 'react-icons/io';
-import { MdFileUpload } from 'react-icons/md';
+import { IoAlert, IoChevronForward, IoGitNetwork, IoCloudUploadOutline } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDuration, ViewedBoundsFunctionType } from './utils';
@@ -155,14 +152,14 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                 {serviceName}{' '}
                 {rpc && (
                   <span>
-                    <ImArrowRight />{' '}
+                    <IoChevronForward />{' '}
                     <i className="SpanBarRow--rpcColorMarker" style={{ background: rpc.color }} />
                     {rpc.serviceName}
                   </span>
                 )}
                 {noInstrumentedServer && (
                   <span>
-                    <ImArrowRight />{' '}
+                    <IoChevronForward />{' '}
                     <i
                       className="SpanBarRow--rpcColorMarker"
                       style={{ background: noInstrumentedServer.color }}
@@ -179,7 +176,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                 tooltipText="Contains multiple references"
                 focusSpan={focusSpan}
               >
-                <IoMdGitNetwork />
+                <IoGitNetwork />
               </ReferencesButton>
             )}
             {span.subsidiarilyReferencedBy && span.subsidiarilyReferencedBy.length > 0 && (
@@ -190,7 +187,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
                 }`}
                 focusSpan={focusSpan}
               >
-                <MdFileUpload />
+                <IoCloudUploadOutline />
               </ReferencesButton>
             )}
           </div>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import cx from 'classnames';
-import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io';
+import { IoChevronDown, IoChevronForward } from 'react-icons/io5';
 
 import * as markers from './AccordianKeyValues.markers';
 import KeyValuesTable from './KeyValuesTable';
@@ -66,7 +66,7 @@ export default function AccordianKeyValues(props: AccordianKeyValuesProps) {
   let arrow: React.ReactNode | null = null;
   let headerProps: Object | null = null;
   if (interactive) {
-    arrow = isOpen ? <IoIosArrowDown className={iconCls} /> : <IoIosArrowForward className={iconCls} />;
+    arrow = isOpen ? <IoChevronDown className={iconCls} /> : <IoChevronForward className={iconCls} />;
     headerProps = {
       'aria-checked': isOpen,
       onClick: isEmpty ? null : onToggle,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
@@ -15,7 +15,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 import _sortBy from 'lodash/sortBy';
-import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io';
+import { IoChevronDown, IoChevronForward } from 'react-icons/io5';
 
 import AccordianKeyValues from './AccordianKeyValues';
 import { formatDuration } from '../utils';
@@ -42,9 +42,9 @@ export default function AccordianLogs(props: AccordianLogsProps) {
   let headerProps: Object | null = null;
   if (interactive) {
     arrow = isOpen ? (
-      <IoIosArrowDown className="u-align-icon" />
+      <IoChevronDown className="u-align-icon" />
     ) : (
-      <IoIosArrowForward className="u-align-icon" />
+      <IoChevronForward className="u-align-icon" />
     );
     HeaderComponent = 'a';
     headerProps = {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianReferences.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianReferences.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import cx from 'classnames';
-import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io';
+import { IoChevronDown, IoChevronForward } from 'react-icons/io5';
 import './AccordianReferences.css';
 import { SpanReference } from '../../../../types/trace';
 import ReferenceLink from '../../url/ReferenceLink';
@@ -85,7 +85,7 @@ export default class AccordianReferences extends React.PureComponent<AccordianRe
     let arrow: React.ReactNode | null = null;
     let headerProps: Object | null = null;
     if (interactive) {
-      arrow = isOpen ? <IoIosArrowDown className={iconCls} /> : <IoIosArrowForward className={iconCls} />;
+      arrow = isOpen ? <IoChevronDown className={iconCls} /> : <IoChevronForward className={iconCls} />;
       headerProps = {
         'aria-checked': isOpen,
         onClick: isEmpty ? null : onToggle,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianText.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import cx from 'classnames';
-import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io';
+import { IoChevronDown, IoChevronForward } from 'react-icons/io5';
 import TextList from './TextList';
 import { TNil } from '../../../../types';
 
@@ -38,7 +38,7 @@ export default function AccordianText(props: AccordianTextProps) {
   let arrow: React.ReactNode | null = null;
   let headerProps: Object | null = null;
   if (interactive) {
-    arrow = isOpen ? <IoIosArrowDown className={iconCls} /> : <IoIosArrowForward className={iconCls} />;
+    arrow = isOpen ? <IoChevronDown className={iconCls} /> : <IoChevronForward className={iconCls} />;
     headerProps = {
       'aria-checked': isOpen,
       onClick: isEmpty ? null : onToggle,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.js
@@ -15,7 +15,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Dropdown } from 'antd';
-import { ExportOutlined } from '@ant-design/icons';
+import { IoOpenOutline } from 'react-icons/io5';
 
 import CopyIcon from '../../../common/CopyIcon';
 
@@ -38,7 +38,7 @@ describe('LinkValue', () => {
   });
 
   it('renders correct Icon', () => {
-    expect(wrapper.find(ExportOutlined).hasClass('KeyValueTable--linkIcon')).toBe(true);
+    expect(wrapper.find(IoOpenOutline).hasClass('KeyValueTable--linkIcon')).toBe(true);
   });
 });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -15,7 +15,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import * as React from 'react';
 import { Dropdown, Menu } from 'antd';
-import { ExportOutlined, ProfileOutlined } from '@ant-design/icons';
+import { IoOpenOutline, IoList } from 'react-icons/io5';
 import { JsonView, allExpanded, collapseAllNested, defaultStyles } from 'react-json-view-lite';
 
 import CopyIcon from '../../../common/CopyIcon';
@@ -100,7 +100,7 @@ function formatValue(key: string, value: any) {
 
 export const LinkValue = (props: { href: string; title?: string; children: React.ReactNode }) => (
   <a href={props.href} title={props.title} target="_blank" rel="noopener noreferrer">
-    {props.children} <ExportOutlined className="KeyValueTable--linkIcon" />
+    {props.children} <IoOpenOutline className="KeyValueTable--linkIcon" />
   </a>
 );
 
@@ -149,7 +149,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                 <div>
                   <Dropdown overlay={linkValueList(links)} placement="bottomRight" trigger={['click']}>
                     <a>
-                      {jsonTable} <ProfileOutlined className="KeyValueTable--linkIcon" />
+                      {jsonTable} <IoList className="KeyValueTable--linkIcon" />
                     </a>
                   </Dropdown>
                 </div>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.js
@@ -14,8 +14,7 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
-import { FaChevronRight } from 'react-icons/fa';
-import { IoIosArrowDown } from 'react-icons/io';
+import { IoChevronForward, IoChevronDown } from 'react-icons/io5';
 
 import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
 import spanAncestorIdsSpy from '../../../utils/span-ancestor-ids';
@@ -108,25 +107,25 @@ describe('SpanTreeOffset', () => {
 
     it('does not render icon if props.span.hasChildren is false', () => {
       wrapper.setProps({ span: { ...props.span, hasChildren: false } });
-      expect(wrapper.find(FaChevronRight).length).toBe(0);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(0);
+      expect(wrapper.find(IoChevronForward).length).toBe(0);
+      expect(wrapper.find(IoChevronDown).length).toBe(0);
     });
 
     it('does not render icon if props.span.hasChildren is true and showChildrenIcon is false', () => {
       wrapper.setProps({ showChildrenIcon: false });
-      expect(wrapper.find(FaChevronRight).length).toBe(0);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(0);
+      expect(wrapper.find(IoChevronForward).length).toBe(0);
+      expect(wrapper.find(IoChevronDown).length).toBe(0);
     });
 
     it('renders IoChevronRight if props.span.hasChildren is true and props.childrenVisible is false', () => {
-      expect(wrapper.find(FaChevronRight).length).toBe(1);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(0);
+      expect(wrapper.find(IoChevronForward).length).toBe(1);
+      expect(wrapper.find(IoChevronDown).length).toBe(0);
     });
 
     it('renders IoIosArrowDown if props.span.hasChildren is true and props.childrenVisible is true', () => {
       wrapper.setProps({ childrenVisible: true });
-      expect(wrapper.find(FaChevronRight).length).toBe(0);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(1);
+      expect(wrapper.find(IoChevronForward).length).toBe(0);
+      expect(wrapper.find(IoChevronDown).length).toBe(1);
     });
 
     it('calls props.addHoverIndentGuideId on mouse enter', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -15,8 +15,7 @@
 import React from 'react';
 import cx from 'classnames';
 import _get from 'lodash/get';
-import { FaChevronRight } from 'react-icons/fa';
-import { IoIosArrowDown } from 'react-icons/io';
+import { IoChevronDown, IoChevronForward } from 'react-icons/io5';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -99,7 +98,7 @@ export class UnconnectedSpanTreeOffset extends React.PureComponent<TProps> {
     const { hasChildren, spanID } = span;
     const wrapperProps = hasChildren ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
     const icon =
-      showChildrenIcon && hasChildren && (childrenVisible ? <IoIosArrowDown /> : <FaChevronRight />);
+      showChildrenIcon && hasChildren && (childrenVisible ? <IoChevronDown /> : <IoChevronForward />);
     return (
       <span className={`SpanTreeOffset ${hasChildren ? 'is-parent' : ''}`} {...wrapperProps}>
         {this.ancestorIds.map(ancestorId => (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.css
@@ -43,7 +43,6 @@ limitations under the License.
   transform: rotate(90deg);
 }
 
-.TimelineCollapser--btn-expand,
-.TimelineCollapser--btn {
+.TimelineCollapser--btn-size {
   font-size: 20px;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
@@ -14,7 +14,8 @@
 
 import React from 'react';
 import { Tooltip } from 'antd';
-import { DoubleRightOutlined, RightOutlined } from '@ant-design/icons';
+import { DoubleRightOutlined } from '@ant-design/icons';
+import { IoChevronForward } from 'react-icons/io5';
 
 import './TimelineCollapser.css';
 
@@ -45,10 +46,10 @@ export default class TimelineCollapser extends React.PureComponent<CollapserProp
     return (
       <div className="TimelineCollapser" ref={this.containerRef}>
         <Tooltip title={getTitle('Expand +1')} getPopupContainer={this.getContainer}>
-          <RightOutlined onClick={onExpandOne} className="TimelineCollapser--btn-expand" />
+          <IoChevronForward onClick={onExpandOne} className="TimelineCollapser--btn-expand" />
         </Tooltip>
         <Tooltip title={getTitle('Collapse +1')} getPopupContainer={this.getContainer}>
-          <RightOutlined onClick={onCollapseOne} className="TimelineCollapser--btn" />
+          <IoChevronForward onClick={onCollapseOne} className="TimelineCollapser--btn" />
         </Tooltip>
         <Tooltip title={getTitle('Expand All')} getPopupContainer={this.getContainer}>
           <DoubleRightOutlined onClick={onExpandAll} className="TimelineCollapser--btn-expand" />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
@@ -46,10 +46,16 @@ export default class TimelineCollapser extends React.PureComponent<CollapserProp
     return (
       <div className="TimelineCollapser" ref={this.containerRef}>
         <Tooltip title={getTitle('Expand +1')} getPopupContainer={this.getContainer}>
-          <IoChevronForward onClick={onExpandOne} className="TimelineCollapser--btn-expand" />
+          <IoChevronForward
+            onClick={onExpandOne}
+            className="TimelineCollapser--btn-expand TimelineCollapser--btn-size"
+          />
         </Tooltip>
         <Tooltip title={getTitle('Collapse +1')} getPopupContainer={this.getContainer}>
-          <IoChevronForward onClick={onCollapseOne} className="TimelineCollapser--btn" />
+          <IoChevronForward
+            onClick={onCollapseOne}
+            className="TimelineCollapser--btn TimelineCollapser--btn-size"
+          />
         </Tooltip>
         <Tooltip title={getTitle('Expand All')} getPopupContainer={this.getContainer}>
           <DoubleRightOutlined onClick={onExpandAll} className="TimelineCollapser--btn-expand" />

--- a/packages/jaeger-ui/src/components/common/DetailsCard/DetailTable.test.js
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/DetailTable.test.js
@@ -14,8 +14,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { FilterOutlined } from '@ant-design/icons';
-import { FaFilter } from 'react-icons/fa';
+import { IoFunnel, IoFunnelOutline } from 'react-icons/io5';
 
 import ExamplesLink from '../ExamplesLink';
 import DetailTableDropdown from './DetailTableDropdown';
@@ -171,12 +170,12 @@ describe('DetailTable', () => {
 
       it('renders filter icon without filter set', () => {
         const icon = makeColumn(stringColumn).filterIcon();
-        expect(icon.type).toBe(FilterOutlined);
+        expect(icon.type).toBe(IoFunnelOutline);
       });
 
       it('renders filter icon with filter set', () => {
         const icon = makeColumn(stringColumn).filterIcon(true);
-        expect(icon.type).toBe(FaFilter);
+        expect(icon.type).toBe(IoFunnel);
       });
 
       it('renders filterable column if there are filterable values', () => {

--- a/packages/jaeger-ui/src/components/common/DetailsCard/DetailTable.tsx
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/DetailTable.tsx
@@ -14,8 +14,7 @@
 
 import * as React from 'react';
 import { Table } from 'antd';
-import { FilterOutlined } from '@ant-design/icons';
-import { FaFilter } from 'react-icons/fa';
+import { IoFunnel, IoFunnelOutline } from 'react-icons/io5';
 import _isEmpty from 'lodash/isEmpty';
 
 import ExamplesLink, { TExample } from '../ExamplesLink';
@@ -113,8 +112,8 @@ export const _makeColumns = ({ defs, rows }: { defs: TColumnDefs; rows: TRow[] }
       title,
       filterDropdown: Boolean(options.size) && _makeFilterDropdown(dataIndex, options),
       filterIcon: (filtered: boolean) => {
-        if (filtered) return <FaFilter />;
-        return <FilterOutlined />;
+        if (filtered) return <IoFunnel />;
+        return <IoFunnelOutline />;
       },
       onCell: _onCell(dataIndex),
       onHeaderCell: () => ({

--- a/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
@@ -14,8 +14,7 @@
 
 import * as React from 'react';
 import { Button, Tooltip } from 'antd';
-import { FaCheck, FaTrash } from 'react-icons/fa';
-import { TiCancel } from 'react-icons/ti';
+import { IoCheckmarkCircle, IoTrash, IoBan } from 'react-icons/io5';
 
 import FilteredList from '../FilteredList';
 
@@ -84,7 +83,7 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
         <div className="DetailTableDropdown--Footer">
           <Tooltip overlayClassName="DetailTableDropdown--Tooltip" title="Remove filter from this column">
             <Button className="DetailTableDropdown--Btn Clear" onClick={clearFilters}>
-              <FaTrash size={18} />
+              <IoTrash size={18} />
               Clear Filter
             </Button>
           </Tooltip>
@@ -94,7 +93,7 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
               title="Cancel changes to this column's filter"
             >
               <Button className="DetailTableDropdown--Btn Cancel" onClick={this.cancel}>
-                <TiCancel size={20} />
+                <IoBan size={20} />
                 Cancel
               </Button>
             </Tooltip>
@@ -108,7 +107,7 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
               }
             >
               <Button className="DetailTableDropdown--Btn Apply" onClick={confirm}>
-                <FaCheck size={18} />
+                <IoCheckmarkCircle size={18} />
                 Apply
               </Button>
             </Tooltip>

--- a/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import { Button, Tooltip } from 'antd';
-import { IoCheckmarkCircle, IoTrash, IoBan } from 'react-icons/io5';
+import { IoTrash, IoBan, IoCheckmark } from 'react-icons/io5';
 
 import FilteredList from '../FilteredList';
 
@@ -107,7 +107,7 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
               }
             >
               <Button className="DetailTableDropdown--Btn Apply" onClick={confirm}>
-                <IoCheckmarkCircle size={18} />
+                <IoCheckmark size={18} />
                 Apply
               </Button>
             </Tooltip>

--- a/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
@@ -74,7 +74,7 @@ exports[`DetailTable render renders as expected 1`] = `
           className="DetailTableDropdown--Btn Apply"
           onClick={[MockFunction]}
         >
-          <IoCheckmarkCircle
+          <IoCheckmark
             size={18}
           />
           Apply

--- a/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
@@ -32,7 +32,7 @@ exports[`DetailTable render renders as expected 1`] = `
         className="DetailTableDropdown--Btn Clear"
         onClick={[MockFunction]}
       >
-        <FaTrash
+        <IoTrash
           size={18}
         />
         Clear Filter
@@ -49,7 +49,7 @@ exports[`DetailTable render renders as expected 1`] = `
           className="DetailTableDropdown--Btn Cancel"
           onClick={[Function]}
         >
-          <TiCancel
+          <IoBan
             size={20}
           />
           Cancel
@@ -74,7 +74,7 @@ exports[`DetailTable render renders as expected 1`] = `
           className="DetailTableDropdown--Btn Apply"
           onClick={[MockFunction]}
         >
-          <FaCheck
+          <IoCheckmarkCircle
             size={18}
           />
           Apply

--- a/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/index.test.js.snap
@@ -35,7 +35,7 @@ exports[`DetailsCard renders as collapsible 1`] = `
       onClick={[Function]}
       type="button"
     >
-      <MdKeyboardArrowDown />
+      <IoChevronDown />
     </button>
     <div
       className="DetailsCard--HeaderWrapper"

--- a/packages/jaeger-ui/src/components/common/DetailsCard/index.tsx
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/index.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import cx from 'classnames';
-import { MdKeyboardArrowDown } from 'react-icons/md';
+import { IoChevronDown } from 'react-icons/io5';
 
 import { TColumnDefs, TDetails, TRow } from './types';
 import DetailTable from './DetailTable';
@@ -80,7 +80,7 @@ export default class DetailsCard extends React.PureComponent<TProps> {
               type="button"
               className={cx('DetailsCard--Collapser', { 'is-collapsed': collapsed })}
             >
-              <MdKeyboardArrowDown />
+              <IoChevronDown />
             </button>
           )}
           <div className="DetailsCard--HeaderWrapper">

--- a/packages/jaeger-ui/src/components/common/FilteredList/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/FilteredList/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`<FilteredList> renders without exploding 1`] = `
     <label
       className="FilteredList--inputWrapper"
     >
-      <IoIosSearch
+      <IoSearch
         className="FilteredList--filterIcon"
       />
       <input

--- a/packages/jaeger-ui/src/components/common/FilteredList/index.tsx
+++ b/packages/jaeger-ui/src/components/common/FilteredList/index.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 import { Checkbox, Tooltip } from 'antd';
 import _debounce from 'lodash/debounce';
 import matchSorter from 'match-sorter';
-import { IoIosSearch } from 'react-icons/io';
+import { IoSearch } from 'react-icons/io5';
 import { FixedSizeList as VList, ListOnItemsRenderedProps, ListOnScrollProps } from 'react-window';
 import { Key as EKey } from 'ts-key-enum';
 
@@ -194,7 +194,7 @@ export default class FilteredList extends React.PureComponent<TProps, TState> {
         <div className="FilteredList--filterWrapper">
           {filteredCheckbox}
           <label className="FilteredList--inputWrapper">
-            <IoIosSearch className="FilteredList--filterIcon" />
+            <IoSearch className="FilteredList--filterIcon" />
             <input
               className="FilteredList--filterInput"
               placeholder="Filter..."

--- a/packages/jaeger-ui/src/components/common/NameSelector.test.js
+++ b/packages/jaeger-ui/src/components/common/NameSelector.test.js
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { Popover } from 'antd';
-import { CloseOutlined } from '@ant-design/icons';
+import { IoClose } from 'react-icons/io5';
 import { shallow } from 'enzyme';
 
 import BreakableText from './BreakableText';
@@ -145,7 +145,7 @@ describe('<NameSelector>', () => {
 
     it('clicking clear icon clears value when not required without opening popover', () => {
       const stopPropagation = jest.fn();
-      wrapper.find(CloseOutlined).simulate('click', { stopPropagation });
+      wrapper.find(IoClose).simulate('click', { stopPropagation });
 
       expect(clearValue).toHaveBeenCalled();
       expect(wrapper.state('popoverVisible')).toBe(false);

--- a/packages/jaeger-ui/src/components/common/NameSelector.tsx
+++ b/packages/jaeger-ui/src/components/common/NameSelector.tsx
@@ -14,9 +14,8 @@
 
 import * as React from 'react';
 import { Popover } from 'antd';
-import { CloseOutlined } from '@ant-design/icons';
 import cx from 'classnames';
-import { IoChevronDown } from 'react-icons/io5';
+import { IoChevronDown, IoClose } from 'react-icons/io5';
 
 import BreakableText from './BreakableText';
 import FilteredList from './FilteredList';
@@ -71,7 +70,7 @@ export default class NameSelector extends React.PureComponent<TProps, TState> {
     });
   }
 
-  private clearValue = (evt: React.MouseEvent<HTMLElement>) => {
+  private clearValue = (evt: React.MouseEvent<any>) => {
     if (this.props.required) throw new Error('Cannot clear value of required NameSelector');
 
     evt.stopPropagation();
@@ -132,9 +131,7 @@ export default class NameSelector extends React.PureComponent<TProps, TState> {
           {useLabel && <span className="NameSelector--label">{label}:</span>}
           <BreakableText className="NameSelector--value" text={text} />
           <IoChevronDown className="NameSelector--chevron" />
-          {!required && value && (
-            <CloseOutlined className="NameSelector--clearIcon" onClick={this.clearValue} />
-          )}
+          {!required && value && <IoClose className="NameSelector--clearIcon" onClick={this.clearValue} />}
         </h2>
       </Popover>
     );

--- a/packages/jaeger-ui/src/components/common/NewWindowIcon.css
+++ b/packages/jaeger-ui/src/components/common/NewWindowIcon.css
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.NewWindowIcon {
+  font-size: 1em;
+  margin-bottom: -3px;
+}
+
 .NewWindowIcon.is-large {
   font-size: 1.5em;
 }

--- a/packages/jaeger-ui/src/components/common/UiFindInput.test.js
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.test.js
@@ -14,8 +14,8 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Icon, Input } from 'antd';
-import { CloseOutlined } from '@ant-design/icons';
+import { Input } from 'antd';
+import { IoClose } from 'react-icons/io5';
 import debounceMock from 'lodash/debounce';
 import queryString from 'query-string';
 
@@ -144,25 +144,25 @@ describe('UiFind', () => {
     });
 
     it('renders clear icon iff clear is enabled and value is a string with at least one character', () => {
-      expect(findIcon().find(CloseOutlined)).toHaveLength(0);
+      expect(findIcon().find(IoClose)).toHaveLength(0);
 
       wrapper.setProps({ uiFind: '' });
-      expect(findIcon().find(CloseOutlined)).toHaveLength(0);
+      expect(findIcon().find(IoClose)).toHaveLength(0);
 
       wrapper.setProps({ uiFind });
-      expect(findIcon().find(CloseOutlined)).toHaveLength(1);
+      expect(findIcon().find(IoClose)).toHaveLength(1);
 
       wrapper.setProps({ allowClear: false });
-      expect(findIcon().find(CloseOutlined)).toHaveLength(0);
+      expect(findIcon().find(IoClose)).toHaveLength(0);
 
       wrapper.setProps({ allowClear: true });
       wrapper.setState({ ownInputValue: '' });
-      expect(findIcon().find(CloseOutlined)).toHaveLength(0);
+      expect(findIcon().find(IoClose)).toHaveLength(0);
     });
 
     it('clears value immediately when clicked', () => {
       wrapper.setProps({ uiFind });
-      findIcon().find(CloseOutlined).simulate('click');
+      findIcon().find(IoClose).simulate('click');
 
       expect(updateUiFindSpy).toHaveBeenLastCalledWith({
         history: props.history,

--- a/packages/jaeger-ui/src/components/common/UiFindInput.tsx
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import { Input, InputRef } from 'antd';
-import { CloseOutlined } from '@ant-design/icons';
+import { IoClose } from 'react-icons/io5';
 import { History as RouterHistory, Location } from 'history';
 import _debounce from 'lodash/debounce';
 import _isString from 'lodash/isString';
@@ -90,7 +90,7 @@ export class UnconnectedUiFindInput extends React.PureComponent<TProps, StateTyp
     const inputValue = _isString(this.state.ownInputValue) ? this.state.ownInputValue : this.props.uiFind;
     const suffix = (
       <>
-        {allowClear && inputValue && inputValue.length && <CloseOutlined onClick={this.clearUiFind} />}
+        {allowClear && inputValue && inputValue.length && <IoClose onClick={this.clearUiFind} />}
         {inputProps.suffix}
       </>
     );

--- a/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
@@ -39,7 +39,7 @@ exports[`<NameSelector> clear renders with clear icon when not required and with
     <IoChevronDown
       className="NameSelector--chevron"
     />
-    <ForwardRef(CloseOutlined)
+    <IoClose
       className="NameSelector--clearIcon"
       onClick={[Function]}
     />


### PR DESCRIPTION
Signed-off-by: Priyanshu Sharma [priyanshushrama709@gmail.com](mailto:priyanshushrama709@gmail.com)
## Which problem is this PR solving?
- Resolves #1723 

## Description of the changes
- In this pull request, I have replaced all uncontroversial icons from various icon sets with the io5 icon set, enhancing the visual consistency and user experience across the platform.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
