### PR TITLE
Upgrade query-string to v8.1.0

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -75,7 +75,7 @@
     "moment": "^2.18.1",
     "object-hash": "^3.0.0",
     "prop-types": "^15.5.10",
-    "query-string": "^6.3.0",
+    "query-string": "^8.1.0",
     "raven-js": "^3.22.1",
     "react": "^18.2.0",
     "react-circular-progressbar": "^2.1.0",

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.tsx
@@ -42,13 +42,13 @@ export function getUrl(args?: { [key: string]: unknown; showOp?: boolean }, base
   return baseUrl;
 }
 
-function firstParam(arg: string | string[]): string {
+function firstParam(arg: string | (string | null)[] | null): string {
   if (Array.isArray(arg)) {
     const returnVal = arg[0];
     console.warn(`Found multiple query parameters: "${arg}", using "${returnVal}"`); // eslint-disable-line no-console
-    return returnVal;
+    return returnVal as string;
   }
-  return arg;
+  return arg as string;
 }
 
 export const getUrlState = memoizeOne(function getUrlState(search: string): TDdgSparseUrlState {

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.tsx
@@ -33,8 +33,8 @@ export function matches(path: string) {
   return Boolean(matchPath(path, ROUTE_MATCHER));
 }
 
-type TUrlState = Record<string, string | string[] | undefined | Record<string, string>> & {
-  traceID?: string | string[];
+type TUrlState = Record<string, string | (string | null)[] | null | undefined | Record<string, string>> & {
+  traceID?: string | (string | null)[];
   spanLinks?: Record<string, string>;
 };
 
@@ -45,7 +45,7 @@ export function getUrl(query?: TUrlState) {
   const { traceID, spanLinks, ...rest } = query;
   let ids = traceID;
   if (spanLinks && traceID) {
-    ids = (Array.isArray(traceID) ? traceID : [traceID]).filter((id: string) => !spanLinks[id]);
+    ids = (Array.isArray(traceID) ? traceID : [traceID]).filter((id: string | null) => !spanLinks[id!]);
   }
   const stringifyArg = {
     ...rest,
@@ -75,7 +75,7 @@ export const getUrlState: (search: string) => TUrlState = memoizeOne(function ge
   const spanLinks: Record<string, string> = {};
   if (span && span.length) {
     (Array.isArray(span) ? span : [span]).forEach(s => {
-      const [spansStr, trace] = s.split('@');
+      const [spansStr, trace] = s!.split('@');
       traceIDs.add(trace);
       if (spansStr) {
         if (spanLinks[trace]) spanLinks[trace] = spanLinks[trace].concat(' ', spansStr);

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
@@ -166,7 +166,7 @@ export class TraceDiffImpl extends React.PureComponent<TStateProps & TDispatchPr
 export function mapStateToProps(state: ReduxState, ownProps: { match: match<TDiffRouteParams> }) {
   const { a, b } = ownProps.match.params;
   const { cohort: origCohort = [] } = queryString.parse(state.router.location.search);
-  const fullCohortSet: Set<string> = new Set(pluckTruthy([a, b].concat(origCohort)));
+  const fullCohortSet: Set<string> = new Set(pluckTruthy([a, b].concat(origCohort as string | string[])));
   const cohort: string[] = Array.from(fullCohortSet);
   const { traces } = state.trace;
   const kvPairs = cohort.map<[string, FetchedTrace]>(id => [id, traces[id] || { id, state: null }]);

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.tsx
@@ -81,7 +81,7 @@ export class UnconnectedTraceDiffGraph extends React.PureComponent<Props> {
     const dagClassName = cx('TraceDiffGraph--dag', { 'is-uiFind-mode': uiFind });
     const inputProps: Record<string, any> = {
       className: 'TraceDiffGraph--uiFind',
-      suffix: uiFind.length ? String(keys.size) : undefined,
+      suffix: uiFind?.length ? String(keys.size) : undefined,
     };
 
     return (

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/traceDiffGraphUtils.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/traceDiffGraphUtils.tsx
@@ -25,7 +25,7 @@ import { Trace } from '../../../types/trace';
 import filterSpans from '../../../utils/filter-spans';
 
 function getUiFindVertexKeysFn(
-  uiFind: string,
+  uiFind: string | null,
   vertices: TDagPlexusVertex<TDenseSpanMembers>[]
 ): Set<TVertexKey> {
   if (!uiFind) return new Set<TVertexKey>();

--- a/packages/jaeger-ui/src/components/common/UiFindInput.tsx
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.tsx
@@ -36,7 +36,7 @@ type TOwnProps = RouteComponentProps<any> & {
 };
 
 export type TExtractUiFindFromStateReturn = {
-  uiFind: string | undefined;
+  uiFind: string | null | undefined;
 };
 
 type TProps = TOwnProps & TExtractUiFindFromStateReturn;
@@ -103,7 +103,7 @@ export class UnconnectedUiFindInput extends React.PureComponent<TProps, StateTyp
         onChange={this.handleInputChange}
         ref={forwardedRef}
         suffix={suffix}
-        value={inputValue}
+        value={inputValue!}
       />
     );
   }

--- a/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
+++ b/packages/jaeger-ui/src/model/ddg/GraphModel/index.tsx
@@ -234,7 +234,7 @@ export default class GraphModel {
     return keySet;
   }
 
-  public getHiddenUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<string> = memoize(10)(
+  public getHiddenUiFindMatches: (uiFind?: string | null, visEncoding?: string) => Set<string> = memoize(10)(
     (uiFind?: string, visEncoding?: string): Set<string> => {
       const visible = new Set(this.getVisible(visEncoding).vertices);
       const hidden: TDdgVertex[] = Array.from(this.vertices.values()).filter(
@@ -264,7 +264,7 @@ export default class GraphModel {
     }
   );
 
-  public getVisibleUiFindMatches: (uiFind?: string, visEncoding?: string) => Set<string> = memoize(10)(
+  public getVisibleUiFindMatches: (uiFind?: string | null, visEncoding?: string) => Set<string> = memoize(10)(
     (uiFind?: string, visEncoding?: string): Set<string> => {
       const { vertices } = this.getVisible(visEncoding);
       return GraphModel.getUiFindMatches(vertices, uiFind);

--- a/packages/jaeger-ui/src/utils/tracking/ga.tsx
+++ b/packages/jaeger-ui/src/utils/tracking/ga.tsx
@@ -24,7 +24,7 @@ import { IWebAnalyticsFunc } from '../../types/tracking';
 import { logTrackingCalls } from './utils';
 import { getAppEnvironment, shouldDebugGoogleAnalytics } from '../constants';
 
-const isTruish = (value?: string | string[]) => {
+const isTruish = (value?: string | (string | null)[] | null) => {
   return Boolean(value) && value !== '0' && value !== 'false';
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,12 +2582,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@16.9.18", "@types/react-dom@18.2.5", "@types/react-dom@^18.0.0":
-  version "16.9.18"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.18.tgz#1fda8b84370b1339d639a797a84c16d5a195b419"
-  integrity sha512-lmNARUX3+rNF/nmoAFqasG0jAA7q6MeGZK/fdeLwY3kAA4NPgHHrG5bNQe2B5xmD4B+x6Z6h0rEJQ7MEEgQxsw==
+"@types/react-dom@18.2.5":
+  version "18.2.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.5.tgz#5c5f13548bda23cd98f50ca4a59107238bfe18f3"
+  integrity sha512-sRQsOS/sCLnpQhR4DSKGTtWFE3FZjpQa86KPVbhUqdYMRZ9FEFcfAytKhR/vUG2rH1oFbOOej6cuD7MFSobDRQ==
   dependencies:
-    "@types/react" "^16"
+    "@types/react" "*"
+
+"@types/react-dom@^18.0.0":
+  version "18.2.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
+  integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-helmet@^6.1.5":
   version "6.1.5"
@@ -2625,7 +2632,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.14.35", "@types/react@16.8.7", "@types/react@^16":
+"@types/react@*", "@types/react@16.14.35":
   version "16.14.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.35.tgz#9d3cf047d85aca8006c4776693124a5be90ee429"
   integrity sha512-NUEiwmSS1XXtmBcsm1NyRRPYjoZF2YTE89/5QiLt5mlGffYK9FQqOKuOLuXNrjPQV04oQgaZG+Yq02ZfHoFyyg==
@@ -2633,6 +2640,14 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/react@16.8.7":
+  version "16.8.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.7.tgz#7b1c0223dd5494f9b4501ad2a69aa6acb350a29b"
+  integrity sha512-0xbkIyrDNKUn4IJVf8JaCn+ucao/cq6ZB8O6kSzhrJub1cVSqgTArtG0qCfdERWKMEIvUbrwLXeQMqWEsyr9dA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/redux-actions@2.2.1":
   version "2.2.1"
@@ -4493,6 +4508,11 @@ cssstyle@^3.0.0:
   dependencies:
     rrweb-cssom "^0.6.0"
 
+csstype@^2.2.0:
+  version "2.6.21"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
+  integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
+
 csstype@^3.0.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
@@ -4772,10 +4792,10 @@ decimal.js@^10.4.2, decimal.js@^10.4.3:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
-decode-uri-component@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
-  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+decode-uri-component@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
 
 dedent@0.7.0:
   version "0.7.0"
@@ -5969,6 +5989,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-obj@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 finalhandler@1.2.0:
   version "1.2.0"
@@ -8307,7 +8332,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.21, lodash@^4.16.5, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.16.5, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9907,12 +9932,14 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
-query-string@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.3.0.tgz#41ae8a61e1213c80b182d5db6cf129e05af89fc5"
+query-string@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-8.1.0.tgz#e7f95367737219544cd360a11a4f4ca03836e115"
+  integrity sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==
   dependencies:
-    decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
+    decode-uri-component "^0.4.1"
+    filter-obj "^5.1.0"
+    split-on-first "^3.0.0"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -11463,6 +11490,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
+
 split2@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
@@ -11532,10 +11564,6 @@ stop-iteration-iterator@^1.0.0:
 store@^2.0.12:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/store/-/store-2.0.12.tgz#8c534e2a0b831f72b75fc5f1119857c44ef5d593"
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-convert@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
## Which problem is this PR solving?
- This PR upgrades the query-string dep from v6.3.0 to v8.1.0
- part of: https://github.com/jaegertracing/jaeger-ui/issues/998

## Description of the changes
- In query-string v6.4.0, `null` type was introduced. https://github.com/sindresorhus/query-string/commit/49d2203965f911940fb1b43c8263c8aaea5f95fd#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8R36
- Further, in later versions, `string[]` type is changed to `(string | null)[]`

## How was this change tested?
- locally

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
