### PR TITLE
Fix CopyIcon to receive ReactNode instead of string

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
@@ -25,7 +25,7 @@ exports[`drawNode diffNode renders as expected when props.a and props.b are the 
             <CopyIcon
               className="DiffNode--copyIcon"
               copyText="serviceName operationName"
-              icon="copy"
+              icon={<ForwardRef(CopyOutlined) />}
               placement="top"
               tooltipTitle="Copy label"
             />
@@ -66,7 +66,7 @@ exports[`drawNode diffNode renders as expected when props.a and props.b are the 
           <CopyIcon
             className="DiffNode--copyIcon"
             copyText="serviceName operationName"
-            icon="copy"
+            icon={<ForwardRef(CopyOutlined) />}
             placement="top"
             tooltipTitle="Copy label"
           />
@@ -114,7 +114,7 @@ exports[`drawNode diffNode renders as expected when props.a is 0 1`] = `
             <CopyIcon
               className="DiffNode--copyIcon"
               copyText="serviceName operationName"
-              icon="copy"
+              icon={<ForwardRef(CopyOutlined) />}
               placement="top"
               tooltipTitle="Copy label"
             />
@@ -175,7 +175,7 @@ exports[`drawNode diffNode renders as expected when props.a is 0 1`] = `
           <CopyIcon
             className="DiffNode--copyIcon"
             copyText="serviceName operationName"
-            icon="copy"
+            icon={<ForwardRef(CopyOutlined) />}
             placement="top"
             tooltipTitle="Copy label"
           />
@@ -238,7 +238,7 @@ exports[`drawNode diffNode renders as expected when props.a is less than props.b
             <CopyIcon
               className="DiffNode--copyIcon"
               copyText="serviceName operationName"
-              icon="copy"
+              icon={<ForwardRef(CopyOutlined) />}
               placement="top"
               tooltipTitle="Copy label"
             />
@@ -299,7 +299,7 @@ exports[`drawNode diffNode renders as expected when props.a is less than props.b
           <CopyIcon
             className="DiffNode--copyIcon"
             copyText="serviceName operationName"
-            icon="copy"
+            icon={<ForwardRef(CopyOutlined) />}
             placement="top"
             tooltipTitle="Copy label"
           />
@@ -362,7 +362,7 @@ exports[`drawNode diffNode renders as expected when props.a is more than props.b
             <CopyIcon
               className="DiffNode--copyIcon"
               copyText="serviceName operationName"
-              icon="copy"
+              icon={<ForwardRef(CopyOutlined) />}
               placement="top"
               tooltipTitle="Copy label"
             />
@@ -423,7 +423,7 @@ exports[`drawNode diffNode renders as expected when props.a is more than props.b
           <CopyIcon
             className="DiffNode--copyIcon"
             copyText="serviceName operationName"
-            icon="copy"
+            icon={<ForwardRef(CopyOutlined) />}
             placement="top"
             tooltipTitle="Copy label"
           />
@@ -486,7 +486,7 @@ exports[`drawNode diffNode renders as expected when props.b is 0 1`] = `
             <CopyIcon
               className="DiffNode--copyIcon"
               copyText="serviceName operationName"
-              icon="copy"
+              icon={<ForwardRef(CopyOutlined) />}
               placement="top"
               tooltipTitle="Copy label"
             />
@@ -547,7 +547,7 @@ exports[`drawNode diffNode renders as expected when props.b is 0 1`] = `
           <CopyIcon
             className="DiffNode--copyIcon"
             copyText="serviceName operationName"
-            icon="copy"
+            icon={<ForwardRef(CopyOutlined) />}
             placement="top"
             tooltipTitle="Copy label"
           />
@@ -605,7 +605,7 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
             <CopyIcon
               className="DiffNode--copyIcon"
               copyText="serviceName operationName"
-              icon="copy"
+              icon={<ForwardRef(CopyOutlined) />}
               placement="top"
               tooltipTitle="Copy label"
             />
@@ -646,7 +646,7 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
           <CopyIcon
             className="DiffNode--copyIcon"
             copyText="serviceName operationName"
-            icon="copy"
+            icon={<ForwardRef(CopyOutlined) />}
             placement="top"
             tooltipTitle="Copy label"
           />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -15,7 +15,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import * as React from 'react';
 import { Dropdown, Menu } from 'antd';
-import { ExportOutlined, ProfileOutlined } from '@ant-design/icons';
+import { ExportOutlined, ProfileOutlined, SnippetsOutlined } from '@ant-design/icons';
 import { JsonView, allExpanded, collapseAllNested, defaultStyles } from 'react-json-view-lite';
 
 import CopyIcon from '../../../common/CopyIcon';
@@ -172,7 +172,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                   />
                   <CopyIcon
                     className="KeyValueTable--copyIcon"
-                    icon="snippets"
+                    icon={<SnippetsOutlined />}
                     copyText={JSON.stringify(row, null, 2)}
                     tooltipTitle="Copy JSON"
                     buttonText="JSON"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -15,6 +15,7 @@
 import React from 'react';
 import { Divider } from 'antd';
 
+import { LinkOutlined } from '@ant-design/icons';
 import AccordianKeyValues from './AccordianKeyValues';
 import AccordianLogs from './AccordianLogs';
 import AccordianReferences from './AccordianReferences';
@@ -145,7 +146,7 @@ export default function SpanDetail(props: SpanDetailProps) {
           <span className="SpanDetail--debugLabel" data-label="SpanID:" /> {spanID}
           <CopyIcon
             copyText={deepLinkCopyText}
-            icon="link"
+            icon={<LinkOutlined />}
             placement="topRight"
             tooltipTitle="Copy deep link to this span"
           />

--- a/packages/jaeger-ui/src/components/common/CopyIcon.tsx
+++ b/packages/jaeger-ui/src/components/common/CopyIcon.tsx
@@ -20,11 +20,12 @@ import cx from 'classnames';
 import copy from 'copy-to-clipboard';
 
 import './CopyIcon.css';
+import { CopyOutlined } from '@ant-design/icons';
 
 type PropsType = {
   className?: string;
   copyText: string;
-  icon?: string;
+  icon?: React.ReactNode;
   placement?: TooltipPlacement;
   tooltipTitle: string;
   buttonText: string;
@@ -37,7 +38,7 @@ type StateType = {
 export default class CopyIcon extends React.PureComponent<PropsType, StateType> {
   static defaultProps: Partial<PropsType> = {
     className: undefined,
-    icon: 'copy',
+    icon: <CopyOutlined />,
     placement: 'top',
   };
 

--- a/packages/jaeger-ui/src/components/common/__snapshots__/CopyIcon.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/CopyIcon.test.js.snap
@@ -11,7 +11,7 @@ exports[`<CopyIcon /> renders as expected 1`] = `
   <Button
     className="classNameValue CopyIcon"
     htmlType="button"
-    icon="copy"
+    icon={<ForwardRef(CopyOutlined) />}
     onClick={[Function]}
   />
 </Tooltip>


### PR DESCRIPTION
## Which problem is this PR solving?
- fixes #1790 

## Description of the changes
- Since ant-design v4 doesn't support Icon Names passed to the Button Prop as a string. Instead, it needs a React Node to be passed.

## How was this change tested?
- yarn test

## New Behavior:
![image](https://github.com/jaegertracing/jaeger-ui/assets/94157520/3066f538-f65f-47bc-8f2f-42e7e1c2720e)
![image](https://github.com/jaegertracing/jaeger-ui/assets/94157520/b5a298ef-dca2-4b7e-93f9-c97be734ede4)

## Previous Behavior:
![image](https://github.com/jaegertracing/jaeger-ui/assets/94157520/fa5f530e-c4ac-40ac-83ae-5e6ded1b8d90)


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
