### PR TITLE
fix: upgrade react-json-view-lite

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -76,7 +76,7 @@ function formatValue(key: string, value: any) {
     content = (
       <JsonView
         data={parsed}
-        shouldInitiallyExpand={shouldJsonTreeExpand ? allExpanded : collapseAllNested}
+        shouldExpandNode ={shouldJsonTreeExpand ? allExpanded : collapseAllNested}
         style={{
           ...defaultStyles,
           container: 'json-markup',

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/__snapshots__/KeyValuesTable.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/__snapshots__/KeyValuesTable.test.js.snap
@@ -25,7 +25,7 @@ exports[`<KeyValuesTable> renders the expected text for each span value 1`] = `
         "xss_link": "https://example.com with \\"quotes\\"",
       }
     }
-    shouldInitiallyExpand={[Function]}
+    shouldExpandNode ={[Function]}
     style={
       Object {
         "basicChildStyle": "json-markup-child",


### PR DESCRIPTION
fix the failing because of breaking changes in 1.0, needs a fix.Property shouldInitiallyExpand has different name shouldExpandNode change the name.
#1797