### PR TITLE
Improve tooltip for tag search

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
@@ -339,7 +339,9 @@ export class SearchFormImpl extends React.PureComponent {
                   </h3>,
                   <ul key="info" className="SearchForm--tagsHintInfo">
                     <li>Use space for AND conjunctions</li>
-                    <li>Values containing whitespace or equal-sign &apos=&apos should be enclosed in quotes</li>
+                    <li>
+                      Values containing whitespace or equal-sign &apos=&apos should be enclosed in quotes
+                    </li>
                   </ul>,
                 ]}
                 content={

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
@@ -339,7 +339,7 @@ export class SearchFormImpl extends React.PureComponent {
                   </h3>,
                   <ul key="info" className="SearchForm--tagsHintInfo">
                     <li>Use space for AND conjunctions</li>
-                    <li>Values containing whitespace or '=' should be enclosed in quotes</li>
+                    <li>Values containing whitespace or equal-sign &apos=&apos should be enclosed in quotes</li>
                   </ul>,
                 ]}
                 content={

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
@@ -338,8 +338,8 @@ export class SearchFormImpl extends React.PureComponent {
                     format.
                   </h3>,
                   <ul key="info" className="SearchForm--tagsHintInfo">
-                    <li>Use space for conjunctions</li>
-                    <li>Values containing whitespace should be enclosed in quotes</li>
+                    <li>Use space for AND conjunctions</li>
+                    <li>Values containing whitespace or '=' should be enclosed in quotes</li>
                   </ul>,
                 ]}
                 content={


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1733
- Closes #1740

## Description of the changes
- Clarify that tag values with '=' sign must also be in quotes
