### PR TITLE
Fix linting warnings for no-unused-vars, no-var-requires

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,7 +83,7 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'warn',
     '@typescript-eslint/no-empty-function': 0,
     '@typescript-eslint/ban-types': 'warn',
-    '@typescript-eslint/ban-ts-comment': 0,
+    '@typescript-eslint/ban-ts-comment': 'warn',
 
     /* jsx */
     'jsx-a11y/anchor-is-valid': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,7 +83,7 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'warn',
     '@typescript-eslint/no-empty-function': 0,
     '@typescript-eslint/ban-types': 'warn',
-    '@typescript-eslint/ban-ts-comment': 'warn',
+    '@typescript-eslint/ban-ts-comment': 0,
 
     /* jsx */
     'jsx-a11y/anchor-is-valid': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,7 +82,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'warn',
     '@typescript-eslint/no-var-requires': 'warn',
     '@typescript-eslint/no-empty-function': 0,
-    '@typescript-eslint/ban-types': 0,
+    '@typescript-eslint/ban-types': 'warn',
     '@typescript-eslint/ban-ts-comment': 0,
 
     /* jsx */

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,7 +78,7 @@ module.exports = {
     'prefer-destructuring': 0,
 
     /* tsx */
-    '@typescript-eslint/no-explicit-any': 0,
+    '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-vars': 'warn',
     '@typescript-eslint/no-var-requires': 'warn',
     '@typescript-eslint/no-empty-function': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,11 +78,11 @@ module.exports = {
     'prefer-destructuring': 0,
 
     /* tsx */
-    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/no-unused-vars': 'warn',
     '@typescript-eslint/no-var-requires': 'warn',
     '@typescript-eslint/no-empty-function': 0,
-    '@typescript-eslint/ban-types': 'warn',
+    '@typescript-eslint/ban-types': 0,
     '@typescript-eslint/ban-ts-comment': 0,
 
     /* jsx */

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
@@ -322,7 +322,7 @@ describe('<MonitorATMServicesView>', () => {
 });
 
 describe('<MonitorATMServicesView> on page switch', () => {
-  // eslint-disable-next-line no-unused-vars
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   let wrapper;
   const stateOnPageSwitch = {
     services: {

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.test.js
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.test.js
@@ -31,6 +31,8 @@ describe('QualityMetrics', () => {
       service: 'test-service',
       services: ['foo', 'bar', 'baz'],
     };
+
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     const { service: _s, ...propsWithoutService } = props;
     let fetchQualityMetricsSpy;
     let promise;

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
@@ -26,7 +26,9 @@ export default function FileLoader(props: FileLoaderProps) {
   return (
     <Dragger
       accept=".json"
-      beforeUpload={(file, fileList) => fileList.forEach(file => props.loadJsonTraces({ file }))}
+      beforeUpload={(file, fileList) =>
+        fileList.forEach(fileFromList => props.loadJsonTraces({ file: fileFromList }))
+      }
       multiple
     >
       <p className="ant-upload-drag-icon">

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
@@ -206,15 +206,8 @@ describe('mapStateToProps()', () => {
       },
     };
 
-    const {
-      maxTraceDuration,
-      traceResults,
-      traceResultsToDownload,
-      diffCohort,
-      numberOfTraceResults,
-      location,
-      ...rest
-    } = mapStateToProps(state);
+    const { maxTraceDuration, traceResults, traceResultsToDownload, diffCohort, ...rest } =
+      mapStateToProps(state);
     expect(traceResults).toHaveLength(stateTrace.search.results.length);
     expect(traceResults[0].traceID).toBe(trace.traceID);
     expect(traceResultsToDownload[0].traceID).toBe(trace.traceID);

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
@@ -242,9 +242,9 @@ describe('SearchTracePage/url', () => {
       expect(isSameQuery(baseQuery)).toBe(false);
     });
 
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     it('returns `false` if a considered key is changed or omitted', () => {
       queryKeys.forEach(key => {
-        // eslint-disable-next-line camelcase
         const { [key]: _omitted, ...rest } = baseQuery;
         expect(isSameQuery(baseQuery, rest)).toBe(false);
         expect(isSameQuery(baseQuery, { ...rest, [key]: 'changed' })).toBe(false);

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.test.js
@@ -130,6 +130,7 @@ describe('TraceDiffGraph', () => {
   it('renders an empty div when a or b lack data', () => {
     expect(wrapper.children().length).not.toBe(0);
 
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     const { data: unusedAData, ...aWithoutData } = props.a;
     wrapper.setProps({ a: aWithoutData });
     expect(wrapper.children().length).toBe(0);

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/index.tsx
@@ -98,6 +98,7 @@ function criticalPathForTrace(trace: Trace) {
       const sanitizedSpanMap = sanitizeOverFlowingChildren(refinedSpanMap);
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
+      /* eslint-disable no-console */
       console.log('error while computing critical path for a trace', error);
     }
   }

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test3.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test3.js
@@ -27,7 +27,7 @@ Span B will be dropped.                           |
 span A is on critical path(+++++)                 |
 */
 
-const trace = require('../../TraceStatistics/tableValuesTestTrace/traceWithSingleChildSpanLongerThanParent.json');
+import trace from '../../TraceStatistics/tableValuesTestTrace/traceWithSingleChildSpanLongerThanParent.json';
 
 const transformedTrace = transformTraceData(trace);
 const traceStart = 1679437737490189;

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.js
@@ -18,7 +18,7 @@ import { convertJaegerTraceToProfile } from '@pyroscope/flamegraph';
 
 import TraceFlamegraph from './index';
 
-const testTrace = require('./testTrace.json');
+import testTrace from './testTrace.json';
 
 const profile = convertJaegerTraceToProfile(testTrace.data);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.js
@@ -20,7 +20,7 @@ import calculateTraceDagEV from './calculateTraceDagEV';
 import TraceGraph, { setOnEdgePath } from './TraceGraph';
 import { MODE_SERVICE, MODE_TIME, MODE_SELFTIME } from './OpNode';
 
-const testTrace = require('./testTrace.json');
+import testTrace from './testTrace.json';
 
 const transformedTrace = transformTraceData(testTrace);
 const ev = calculateTraceDagEV(transformedTrace);

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.test.js
@@ -15,7 +15,7 @@
 import transformTraceData from '../../../model/transform-trace-data';
 import calculateTraceDagEV from './calculateTraceDagEV';
 
-const testTrace = require('./testTrace.json');
+import testTrace from './testTrace.json';
 
 const transformedTrace = transformTraceData(testTrace);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.js
@@ -17,7 +17,7 @@ import { mount, shallow } from 'enzyme';
 import TraceSpanView from './index';
 import transformTraceData from '../../../model/transform-trace-data';
 
-const testTrace = require('../TraceStatistics/tableValuesTestTrace/testTrace.json');
+import testTrace from '../TraceStatistics/tableValuesTestTrace/testTrace.json';
 
 const transformedTrace = transformTraceData(testTrace);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
@@ -16,7 +16,7 @@ import generateColor from './generateColor';
 import transformTraceData from '../../../model/transform-trace-data';
 import { getColumnValuesSecondDropdown, getColumnValues } from './tableValues';
 
-const testTrace = require('./tableValuesTestTrace/testTrace.json');
+import testTrace from './tableValuesTestTrace/testTrace.json';
 
 const transformedTrace = transformTraceData(testTrace);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.js
@@ -16,7 +16,7 @@ import { generateDropdownValue, generateSecondDropdownValue } from './generateDr
 import transformTraceData from '../../../model/transform-trace-data';
 import { getColumnValues } from './tableValues';
 
-const testTrace = require('./tableValuesTestTrace/testTrace.json');
+import testTrace from './tableValuesTestTrace/testTrace.json';
 
 const transformedTrace = transformTraceData(testTrace);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
@@ -20,7 +20,7 @@ import PopupSql from './PopupSql';
 import transformTraceData from '../../../model/transform-trace-data';
 import { getColumnValues, getColumnValuesSecondDropdown } from './tableValues';
 
-const testTrace = require('./tableValuesTestTrace/testTrace.json');
+import testTrace from './tableValuesTestTrace/testTrace.json';
 
 const transformedTrace = transformTraceData(testTrace);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
@@ -15,17 +15,17 @@
 import transformTraceData from '../../../model/transform-trace-data';
 import { getColumnValues, getColumnValuesSecondDropdown } from './tableValues';
 
-const testTraceNormal = require('./tableValuesTestTrace/testTraceNormal.json');
-const traceSpanAmongEachOther = require('./tableValuesTestTrace/spansAmongEachOther.json');
-const traceSpanAmongEachOtherGrouped = require('./tableValuesTestTrace/spansAmongEachOtherGrouped.json');
-const traceSpanAmongEachOtherGroupedAndSpans = require('./tableValuesTestTrace/spanAmongEachOtherGroupedAndSpans.json');
-const traceSpanLongerAsParent = require('./tableValuesTestTrace/spanLongerAsParent.json');
-const traceWithOverlappingChildrenLongerThanParent = require('./tableValuesTestTrace/traceWithOverlappingChildrenLongerThanParent.json');
-const traceWithTwoNonOverlappingChildren = require('./tableValuesTestTrace/traceWithTwoNonOverlappingChildren.json');
-const traceWithOverlappingChildren = require('./tableValuesTestTrace/traceWithOverlappingChildren.json');
-const traceWithSingleChildSpanLongerThanParent = require('./tableValuesTestTrace/traceWithSingleChildSpanLongerThanParent.json');
-const traceWithThreeShortChildren = require('./tableValuesTestTrace/traceWithThreeShortChildren.json');
-const traceWithTwoChildrenStartedAtTraceStart = require('./tableValuesTestTrace/traceWithTwoChildrenStartedAtTraceStart.json');
+import testTraceNormal from './tableValuesTestTrace/testTraceNormal.json';
+import traceSpanAmongEachOther from './tableValuesTestTrace/spansAmongEachOther.json';
+import traceSpanAmongEachOtherGrouped from './tableValuesTestTrace/spansAmongEachOtherGrouped.json';
+import traceSpanAmongEachOtherGroupedAndSpans from './tableValuesTestTrace/spanAmongEachOtherGroupedAndSpans.json';
+import traceSpanLongerAsParent from './tableValuesTestTrace/spanLongerAsParent.json';
+import traceWithOverlappingChildrenLongerThanParent from './tableValuesTestTrace/traceWithOverlappingChildrenLongerThanParent.json';
+import traceWithTwoNonOverlappingChildren from './tableValuesTestTrace/traceWithTwoNonOverlappingChildren.json';
+import traceWithOverlappingChildren from './tableValuesTestTrace/traceWithOverlappingChildren.json';
+import traceWithSingleChildSpanLongerThanParent from './tableValuesTestTrace/traceWithSingleChildSpanLongerThanParent.json';
+import traceWithThreeShortChildren from './tableValuesTestTrace/traceWithThreeShortChildren.json';
+import traceWithTwoChildrenStartedAtTraceStart from './tableValuesTestTrace/traceWithTwoChildrenStartedAtTraceStart.json';
 
 const transformedTrace = transformTraceData(testTraceNormal);
 const transformedTraceSpanAmongEachOthe = transformTraceData(traceSpanAmongEachOther);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
@@ -140,13 +140,14 @@ function SpanBar(props: TCommonProps) {
         />
       )}
       {criticalPath &&
-        criticalPath.map(each => {
+        criticalPath.map((each, index) => {
           const critcalPathViewBounds = getViewedBounds(each.section_start, each.section_end);
           const criticalPathViewStart = critcalPathViewBounds.start;
           const criticalPathViewEnd = critcalPathViewBounds.end;
+          const key = `${each.spanId}-${index}`;
           return (
             <div
-              key={each.spanId}
+              key={key}
               data-testid="SpanBar--criticalPath"
               className="SpanBar--criticalPath"
               style={{

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
@@ -140,13 +140,13 @@ function SpanBar(props: TCommonProps) {
         />
       )}
       {criticalPath &&
-        criticalPath.map((each, index) => {
+        criticalPath.map(each => {
           const critcalPathViewBounds = getViewedBounds(each.section_start, each.section_end);
           const criticalPathViewStart = critcalPathViewBounds.start;
           const criticalPathViewEnd = critcalPathViewBounds.end;
           return (
             <div
-              key={index}
+              key={each.spanId}
               data-testid="SpanBar--criticalPath"
               className="SpanBar--criticalPath"
               style={{

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Input, InputRef } from 'antd';
+import { InputRef } from 'antd';
 import { Location, History as RouterHistory } from 'history';
 import _clamp from 'lodash/clamp';
 import _get from 'lodash/get';

--- a/packages/jaeger-ui/src/components/common/UiFindInput.test.js
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.test.js
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Icon, Input } from 'antd';
+import { Input } from 'antd';
 import { CloseOutlined } from '@ant-design/icons';
 import debounceMock from 'lodash/debounce';
 import queryString from 'query-string';

--- a/packages/jaeger-ui/src/reducers/ddg.test.js
+++ b/packages/jaeger-ui/src/reducers/ddg.test.js
@@ -241,6 +241,8 @@ describe('deepDependencyGraph reducers', () => {
           state: fetchedState.DONE,
           viewModifiers: new Map(),
         };
+
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         const { operation: _op, ...emphasizedPayloadWithoutOp } = emphasizedPayload;
         const newState = addViewModifier(operationlessDoneState, emphasizedPayloadWithoutOp);
         const expected = _cloneDeep(operationlessDoneState);

--- a/packages/jaeger-ui/src/utils/TreeNode.tsx
+++ b/packages/jaeger-ui/src/utils/TreeNode.tsx
@@ -10,13 +10,13 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
+// limitations under the License
 
 export default class TreeNode<TValue> {
   value: TValue;
   children: Array<TreeNode<TValue>>;
 
-  static iterFunction<TValue>(fn: Function, depth = 0) {
+  static iterFunction<TValue>(fn: (value: TValue, node: TreeNode<TValue>, depth: number) => any, depth = 0) {
     return (node: TreeNode<TValue>) => fn(node.value, node, depth);
   }
 
@@ -89,7 +89,7 @@ export default class TreeNode<TValue> {
     return findPath(this, []);
   }
 
-  walk(fn: Function, startDepth = 0) {
+  walk(fn: (spanID: TValue, node: TreeNode<TValue>, depth: number) => void, startDepth = 0) {
     type StackEntry = {
       node: TreeNode<TValue>;
       depth: number;
@@ -111,7 +111,7 @@ export default class TreeNode<TValue> {
     }
   }
 
-  paths(fn: Function) {
+  paths(fn: (pathIds: TValue[]) => void) {
     type StackEntry = {
       node: TreeNode<TValue>;
       childIndex: number;

--- a/scripts/generateDepcheckrcJaegerUI.js
+++ b/scripts/generateDepcheckrcJaegerUI.js
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 /* eslint-disable import/no-extraneous-dependencies */
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+
+/* eslint-disable @typescript-eslint/no-var-requires */
 const { babelConfiguration } = require('../packages/jaeger-ui/test/babel-transform');
 
 const packageNames = [

--- a/scripts/generateDepcheckrcJaegerUI.js
+++ b/scripts/generateDepcheckrcJaegerUI.js
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 /* eslint-disable import/no-extraneous-dependencies */
-import fs from 'fs';
-import path from 'path';
-
 /* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
+const path = require('path');
 const { babelConfiguration } = require('../packages/jaeger-ui/test/babel-transform');
 
 const packageNames = [

--- a/scripts/generateDepcheckrcPlexus.js
+++ b/scripts/generateDepcheckrcPlexus.js
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 /* eslint-disable import/no-extraneous-dependencies */
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+
+/* eslint-disable @typescript-eslint/no-var-requires */
 const getBabelConfig = require('../packages/plexus/babel.config');
 
 const babelConfiguration = getBabelConfig({

--- a/scripts/generateDepcheckrcPlexus.js
+++ b/scripts/generateDepcheckrcPlexus.js
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 /* eslint-disable import/no-extraneous-dependencies */
-import fs from 'fs';
-import path from 'path';
-
 /* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
+const path = require('path');
 const getBabelConfig = require('../packages/plexus/babel.config');
 
 const babelConfiguration = getBabelConfig({

--- a/scripts/get-changelog.js
+++ b/scripts/get-changelog.js
@@ -16,6 +16,7 @@
 
 // This code will generate changelog entries
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const { readFile } = require('fs').promises;
 // eslint-disable-next-line import/no-extraneous-dependencies
 const jsdom = require('jsdom');

--- a/scripts/get-tracking-version.js
+++ b/scripts/get-tracking-version.js
@@ -16,6 +16,7 @@
 
 // See the comment on `getVersion(..)` for details on what this script does.
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const spawnSync = require('child_process').spawnSync;
 
 const version = require('../package.json').version;


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves: https://github.com/jaegertracing/jaeger-ui/issues/1608

## Description of the changes
-  I fixed eslint warnings in our codebase, which we are got after running yarn lint. This improves code quality, consistency, and reduces technical debt.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
