### PR TITLE
Speed up CI unit-test workflow by 28%

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,9 @@ concurrency:
 
 jobs:
   unit-tests:
+    strategy:
+      matrix:
+        workers: [8] # Adjust the number of workers as needed
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: "Unit Tests"
 
 on:
   push:
-    branches: [jest-boost]
+    branches: [main]
 
   pull_request:
     branches: [main]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,9 +13,6 @@ concurrency:
 
 jobs:
   unit-tests:
-    strategy:
-      matrix:
-        workers: [8] # Adjust the number of workers as needed
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: "Unit Tests"
 
 on:
   push:
-    branches: [main]
+    branches: [jest-boost]
 
   pull_request:
     branches: [main]

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -107,7 +107,7 @@
     "start:ga-debug": "REACT_APP_GA_DEBUG=1 REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) vite",
     "start": "vite",
     "test": "jest",
-    "test-ci": "CI=1 jest --silent --color"
+    "test-ci": "CI=1 jest --silent --color --maxWorkers=8"
   },
   "jest": {
     "globalSetup": "./test/jest.global-setup.js",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -107,7 +107,7 @@
     "start:ga-debug": "REACT_APP_GA_DEBUG=1 REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) vite",
     "start": "vite",
     "test": "jest",
-    "test-ci": "CI=1 jest --silent --color"
+    "test-ci": "CI=1 jest --silent --color --maxWorkers=4"
   },
   "jest": {
     "globalSetup": "./test/jest.global-setup.js",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -107,7 +107,7 @@
     "start:ga-debug": "REACT_APP_GA_DEBUG=1 REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) vite",
     "start": "vite",
     "test": "jest",
-    "test-ci": "CI=1 jest --silent --color --maxWorkers=4"
+    "test-ci": "CI=1 jest --silent --color"
   },
   "jest": {
     "globalSetup": "./test/jest.global-setup.js",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -107,7 +107,7 @@
     "start:ga-debug": "REACT_APP_GA_DEBUG=1 REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) vite",
     "start": "vite",
     "test": "jest",
-    "test-ci": "CI=1 jest --silent --color --maxWorkers=8"
+    "test-ci": "CI=1 jest --silent --color --maxWorkers=4"
   },
   "jest": {
     "globalSetup": "./test/jest.global-setup.js",


### PR DESCRIPTION
## Which problem is this PR solving?
- I recently benchmarked against some `jest` settings to speed up the total test execution time.
- The best setting according to GitHub Actions so far, according to internet and manual testing is using `--maxWorkers=4`

## How was this change tested?
- Executed in 5m 25 s with this setting: https://github.com/anshgoyalevil/jaeger-ui/actions/runs/6224545765/job/16892986157
- Executed in 8m without this setting: https://github.com/jaegertracing/jaeger-ui/actions/runs/6222381378/job/16886209310

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
