### PR TITLE
Bump react-json-view-lite library to v1.0.0 and resolve all breaking changes

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -83,7 +83,7 @@
     "react-helmet": "^6.1.0",
     "react-icons": "^4.10.1",
     "react-is": "^18.2.0",
-    "react-json-view-lite": "^0.9.8",
+    "react-json-view-lite": "1.0.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "4.3.1",
     "react-router-redux": "5.0.0-alpha.8",

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -76,17 +76,19 @@ function formatValue(key: string, value: any) {
     content = (
       <JsonView
         data={parsed}
-        shouldInitiallyExpand={shouldJsonTreeExpand ? allExpanded : collapseAllNested}
+        shouldExpandNode={shouldJsonTreeExpand ? allExpanded : collapseAllNested}
         style={{
           ...defaultStyles,
           container: 'json-markup',
           label: 'json-markup-key',
           stringValue: 'json-markup-string',
+          collapseIcon: 'json-markup-icon-collapse',
+          collapsedContent: 'json-markup-collapse-content',
+          expandIcon: 'json-markup-icon-expand',
           numberValue: 'json-markup-number',
           booleanValue: 'json-markup-bool',
           nullValue: 'json-markup-null',
           undefinedValue: 'json-markup-undefined',
-          expander: 'json-markup-expander',
           basicChildStyle: 'json-markup-child',
           punctuation: 'json-markup-puncuation',
           otherValue: 'json-markup-other',

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/__snapshots__/KeyValuesTable.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/__snapshots__/KeyValuesTable.test.js.snap
@@ -25,18 +25,19 @@ exports[`<KeyValuesTable> renders the expected text for each span value 1`] = `
         "xss_link": "https://example.com with \\"quotes\\"",
       }
     }
-    shouldInitiallyExpand={[Function]}
+    shouldExpandNode={[Function]}
     style={
       Object {
         "basicChildStyle": "json-markup-child",
         "booleanValue": "json-markup-bool",
+        "collapseIcon": "json-markup-icon-collapse",
+        "collapsedContent": "json-markup-collapse-content",
         "container": "json-markup",
-        "expander": "json-markup-expander",
+        "expandIcon": "json-markup-icon-expand",
         "label": "json-markup-key",
         "nullValue": "json-markup-null",
         "numberValue": "json-markup-number",
         "otherValue": "json-markup-other",
-        "pointer": "_1MFti",
         "punctuation": "json-markup-puncuation",
         "stringValue": "json-markup-string",
         "undefinedValue": "json-markup-undefined",

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -55,10 +55,31 @@ limitations under the License.
   color: lightgrey;
 }
 
-.json-markup-expander {
-  font-size: 1.2em;
-  margin-right: 5px;
-  user-select: none;
+.json-markup-icon-expand {
+  margin-right: 4px;
+}
+
+.json-markup-icon-expand::after {
+  content: '\25B6';
+  color: black;
+  font-size: 12px;
+}
+
+.json-markup-icon-collapse {
+  margin-right: 4px;
+}
+
+.json-markup-icon-collapse::after {
+  content: '\25BC';
+  color: black;
+  font-size: 12px;
+}
+
+.json-markup-collapse-content::after {
+  content: '\2026';
+  color: black;
+  font-size: 18px;
+  margin-right: 4px;
 }
 
 .json-markup-child {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,12 +2604,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@16.9.18", "@types/react-dom@18.2.5", "@types/react-dom@^18.0.0":
-  version "16.9.18"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.18.tgz#1fda8b84370b1339d639a797a84c16d5a195b419"
-  integrity sha512-lmNARUX3+rNF/nmoAFqasG0jAA7q6MeGZK/fdeLwY3kAA4NPgHHrG5bNQe2B5xmD4B+x6Z6h0rEJQ7MEEgQxsw==
+"@types/react-dom@18.2.5":
+  version "18.2.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.5.tgz#5c5f13548bda23cd98f50ca4a59107238bfe18f3"
+  integrity sha512-sRQsOS/sCLnpQhR4DSKGTtWFE3FZjpQa86KPVbhUqdYMRZ9FEFcfAytKhR/vUG2rH1oFbOOej6cuD7MFSobDRQ==
   dependencies:
-    "@types/react" "^16"
+    "@types/react" "*"
+
+"@types/react-dom@^18.0.0":
+  version "18.2.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
+  integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-helmet@^6.1.5":
   version "6.1.5"
@@ -2647,7 +2654,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.14.35", "@types/react@16.8.7", "@types/react@^16":
+"@types/react@*", "@types/react@16.14.35":
   version "16.14.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.35.tgz#9d3cf047d85aca8006c4776693124a5be90ee429"
   integrity sha512-NUEiwmSS1XXtmBcsm1NyRRPYjoZF2YTE89/5QiLt5mlGffYK9FQqOKuOLuXNrjPQV04oQgaZG+Yq02ZfHoFyyg==
@@ -2655,6 +2662,14 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/react@16.8.7":
+  version "16.8.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.7.tgz#7b1c0223dd5494f9b4501ad2a69aa6acb350a29b"
+  integrity sha512-0xbkIyrDNKUn4IJVf8JaCn+ucao/cq6ZB8O6kSzhrJub1cVSqgTArtG0qCfdERWKMEIvUbrwLXeQMqWEsyr9dA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/redux-actions@2.2.1":
   version "2.2.1"
@@ -4514,6 +4529,11 @@ cssstyle@^3.0.0:
   integrity sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==
   dependencies:
     rrweb-cssom "^0.6.0"
+
+csstype@^2.2.0:
+  version "2.6.21"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
+  integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
 
 csstype@^3.0.2:
   version "3.1.2"
@@ -8334,7 +8354,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.21, lodash@^4.16.5, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.16.5, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10493,10 +10513,10 @@ react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-json-view-lite@^0.9.8:
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/react-json-view-lite/-/react-json-view-lite-0.9.8.tgz#d3d91bc16d62ef774a7b5c4ad95ccaaa623362d6"
-  integrity sha512-4D0UgQ5SjanNi2KzgEsEKOb9kj0L9HQz/3IshwIZN5reZsSU62t6sp8c+vskV42lXjGQCi7qGfoXIpNRsON7LA==
+react-json-view-lite@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-json-view-lite/-/react-json-view-lite-1.0.0.tgz#4fc00b2532ba983e323f7a1e215753eb14a32544"
+  integrity sha512-2Ozbq9uoUw7CY+SR/efvoCRBOimh8X8Uv8ERJas7tKQcNtBqJaREC0+4nppCmOGnAhKrdobmEgT2JU1V+wu6/g==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolve: https://github.com/jaegertracing/jaeger-ui/issues/1797

## Description of the changes
- This pull request upgrades the React-Json-View-Lite library to version 1.0.0 and fix important breaking changes.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
