### PR TITLE
Add Custom withRouteProps HOC for react-router-dom v6 migration

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -48,7 +48,7 @@
     "@types/lodash": "^4.14.123",
     "@types/object-hash": "^3.0.2",
     "@types/react-helmet": "^6.1.5",
-    "@types/react-router-dom": "^4.3.1",
+    "@types/react-router-dom": "^5.1.0",
     "@types/redux-actions": "2.2.1",
     "antd": "4.24.13",
     "chance": "^1.0.10",

--- a/packages/jaeger-ui/src/components/App/Page.tsx
+++ b/packages/jaeger-ui/src/components/App/Page.tsx
@@ -17,7 +17,6 @@ import { Layout } from 'antd';
 import cx from 'classnames';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import TopNav from './TopNav';
 import { ReduxState } from '../../types';
@@ -25,8 +24,9 @@ import { EmbeddedState } from '../../types/embedded';
 import { trackPageView } from '../../utils/tracking';
 
 import './Page.css';
+import withRouteProps from '../../utils/withRouteProps';
 
-type TProps = RouteComponentProps<any> & {
+type TProps = {
   children: React.ReactNode;
   embedded: EmbeddedState;
   pathname: string;
@@ -76,4 +76,4 @@ export function mapStateToProps(state: ReduxState) {
   return { embedded, pathname, search };
 }
 
-export default withRouter(connect(mapStateToProps)(PageImpl));
+export default connect(mapStateToProps)(withRouteProps(PageImpl));

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -17,7 +17,7 @@ import { Dropdown, Menu } from 'antd';
 import { IoChevronDown } from 'react-icons/io5';
 import _has from 'lodash/has';
 import { connect } from 'react-redux';
-import { RouteComponentProps, Link, withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import TraceIDSearchInput from './TraceIDSearchInput';
 import * as dependencyGraph from '../DependencyGraph/url';
@@ -32,8 +32,9 @@ import { getConfigValue } from '../../utils/config/get-config';
 import prefixUrl from '../../utils/prefix-url';
 
 import './TopNav.css';
+import withRouteProps from '../../utils/withRouteProps';
 
-type Props = RouteComponentProps<any> & ReduxState;
+type Props = ReduxState;
 
 const NAV_LINKS = [
   {
@@ -155,4 +156,4 @@ export function mapStateToProps(state: ReduxState) {
   return state;
 }
 
-export default withRouter(connect(mapStateToProps)(TopNavImpl));
+export default connect(mapStateToProps)(withRouteProps(TopNavImpl));

--- a/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.js
+++ b/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.js
@@ -16,10 +16,11 @@
 
 import React from 'react';
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { Router } from 'react-router-dom';
 import TraceIDSearchInput from './TraceIDSearchInput';
+import { HistoryProvider } from '../../utils/useHistory';
 
 describe('<TraceIDSearchInput />', () => {
   let history;
@@ -27,9 +28,11 @@ describe('<TraceIDSearchInput />', () => {
   beforeEach(() => {
     history = createMemoryHistory();
     render(
-      <Router history={history}>
-        <TraceIDSearchInput />
-      </Router>
+      <HistoryProvider history={history}>
+        <Router history={history}>
+          <TraceIDSearchInput />
+        </Router>
+      </HistoryProvider>
     );
   });
 

--- a/packages/jaeger-ui/src/components/App/TraceIDSearchInput.tsx
+++ b/packages/jaeger-ui/src/components/App/TraceIDSearchInput.tsx
@@ -18,14 +18,15 @@ import { Form } from '@ant-design/compatible';
 import '@ant-design/compatible/assets/index.css';
 import { Input } from 'antd';
 import { IoSearch } from 'react-icons/io5';
-import { RouteComponentProps, Router as RouterHistory, withRouter } from 'react-router-dom';
 
+import { History } from 'history';
 import { getUrl } from '../TracePage/url';
 
 import './TraceIDSearchInput.css';
+import withRouteProps from '../../utils/withRouteProps';
 
-type Props = RouteComponentProps<any> & {
-  history: RouterHistory;
+type Props = {
+  history: History;
 };
 
 class TraceIDSearchInput extends React.PureComponent<Props> {
@@ -57,4 +58,4 @@ class TraceIDSearchInput extends React.PureComponent<Props> {
   }
 }
 
-export default withRouter(TraceIDSearchInput);
+export default withRouteProps(TraceIDSearchInput);

--- a/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
@@ -12,7 +12,7 @@ exports[`JaegerUIApp does not explode 1`] = `
     }
   }
 >
-  <Router
+  <HistoryProvider
     history={
       Object {
         "action": "POP",
@@ -37,98 +37,124 @@ exports[`JaegerUIApp does not explode 1`] = `
       }
     }
   >
-    <withRouter(Connect(PageImpl))>
-      <Switch>
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "type": [Function],
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "back": [Function],
+          "block": [Function],
+          "createHref": [Function],
+          "forward": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "length": 1,
+          "listen": [Function],
+          "listenObject": false,
+          "location": Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+    >
+      <Connect(WithRouteProps)>
+        <Switch>
+          <Route
+            component={
+              Object {
+                "$$typeof": Symbol(react.memo),
+                "WrappedComponent": [Function],
+                "compare": null,
+                "type": [Function],
+              }
             }
-          }
-          path="/search"
-        />
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "type": [Function],
+            path="/search"
+          />
+          <Route
+            component={
+              Object {
+                "$$typeof": Symbol(react.memo),
+                "WrappedComponent": [Function],
+                "compare": null,
+                "type": [Function],
+              }
             }
-          }
-          path="/trace/:a?\\\\.\\\\.\\\\.:b?"
-        />
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "type": [Function],
+            path="/trace/:a?\\\\.\\\\.\\\\.:b?"
+          />
+          <Route
+            component={
+              Object {
+                "$$typeof": Symbol(react.memo),
+                "WrappedComponent": [Function],
+                "compare": null,
+                "type": [Function],
+              }
             }
-          }
-          path="/trace/:id"
-        />
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "type": [Function],
+            path="/trace/:id"
+          />
+          <Route
+            component={
+              Object {
+                "$$typeof": Symbol(react.memo),
+                "WrappedComponent": [Function],
+                "compare": null,
+                "type": [Function],
+              }
             }
-          }
-          path="/dependencies"
-        />
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "type": [Function],
+            path="/dependencies"
+          />
+          <Route
+            component={
+              Object {
+                "$$typeof": Symbol(react.memo),
+                "WrappedComponent": [Function],
+                "compare": null,
+                "type": [Function],
+              }
             }
-          }
-          path="/deep-dependencies"
-        />
-        <Route
-          component={
-            Object {
-              "$$typeof": Symbol(react.memo),
-              "WrappedComponent": [Function],
-              "compare": null,
-              "type": [Function],
+            path="/deep-dependencies"
+          />
+          <Route
+            component={
+              Object {
+                "$$typeof": Symbol(react.memo),
+                "WrappedComponent": [Function],
+                "compare": null,
+                "type": [Function],
+              }
             }
-          }
-          path="/quality-metrics"
-        />
-        <Route
-          component={[Function]}
-          path="/monitor"
-        />
-        <Redirect
-          exact={true}
-          path="/"
-          to="/search"
-        />
-        <Redirect
-          exact={true}
-          path=""
-          to="/search"
-        />
-        <Redirect
-          exact={true}
-          path="/"
-          to="/search"
-        />
-        <Route
-          component={[Function]}
-        />
-      </Switch>
-    </withRouter(Connect(PageImpl))>
-  </Router>
+            path="/quality-metrics"
+          />
+          <Route
+            component={[Function]}
+            path="/monitor"
+          />
+          <Redirect
+            exact={true}
+            path="/"
+            to="/search"
+          />
+          <Redirect
+            exact={true}
+            path=""
+            to="/search"
+          />
+          <Redirect
+            exact={true}
+            path="/"
+            to="/search"
+          />
+          <Route
+            component={[Function]}
+          />
+        </Switch>
+      </Connect(WithRouteProps)>
+    </Router>
+  </HistoryProvider>
 </Provider>
 `;

--- a/packages/jaeger-ui/src/components/App/index.jsx
+++ b/packages/jaeger-ui/src/components/App/index.jsx
@@ -40,6 +40,7 @@ import '../common/vars.css';
 import '../common/utils.css';
 import './index.css';
 import { history, store } from '../../utils/configure-store';
+import { HistoryProvider } from '../../utils/useHistory';
 
 export default class JaegerUIApp extends Component {
   constructor(props) {
@@ -51,25 +52,27 @@ export default class JaegerUIApp extends Component {
   render() {
     return (
       <Provider store={store}>
-        <Router history={history}>
-          <Page>
-            <Switch>
-              <Route path={searchPath} component={SearchTracePage} />
-              <Route path={traceDiffPath} component={TraceDiff} />
-              <Route path={tracePath} component={TracePage} />
-              <Route path={dependenciesPath} component={DependencyGraph} />
-              <Route path={deepDependenciesPath} component={DeepDependencies} />
-              <Route path={qualityMetricsPath} component={QualityMetrics} />
-              <Route path={monitorATMPath} component={MonitorATMPage} />
+        <HistoryProvider history={history}>
+          <Router history={history}>
+            <Page>
+              <Switch>
+                <Route path={searchPath} component={SearchTracePage} />
+                <Route path={traceDiffPath} component={TraceDiff} />
+                <Route path={tracePath} component={TracePage} />
+                <Route path={dependenciesPath} component={DependencyGraph} />
+                <Route path={deepDependenciesPath} component={DeepDependencies} />
+                <Route path={qualityMetricsPath} component={QualityMetrics} />
+                <Route path={monitorATMPath} component={MonitorATMPage} />
 
-              <Redirect exact path="/" to={searchPath} />
-              <Redirect exact path={prefixUrl()} to={searchPath} />
-              <Redirect exact path={prefixUrl('/')} to={searchPath} />
+                <Redirect exact path="/" to={searchPath} />
+                <Redirect exact path={prefixUrl()} to={searchPath} />
+                <Redirect exact path={prefixUrl('/')} to={searchPath} />
 
-              <Route component={NotFound} />
-            </Switch>
-          </Page>
-        </Router>
+                <Route component={NotFound} />
+              </Switch>
+            </Page>
+          </Router>
+        </HistoryProvider>
       </Provider>
     );
   }

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/__snapshots__/index.test.js.snap
@@ -36,7 +36,7 @@ exports[`<Header> renders the hops selector if distanceToPathElems is provided 1
         <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
-        <withRouter(Connect(UnconnectedUiFindInput))
+        <Connect(WithRouteProps)
           allowClear={true}
           forwardedRef={
             Object {
@@ -102,7 +102,7 @@ exports[`<Header> renders the operation selector iff a service is selected 1`] =
         <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
-        <withRouter(Connect(UnconnectedUiFindInput))
+        <Connect(WithRouteProps)
           allowClear={true}
           forwardedRef={
             Object {
@@ -172,7 +172,7 @@ exports[`<Header> renders the operation selector iff a service is selected 2`] =
         <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
-        <withRouter(Connect(UnconnectedUiFindInput))
+        <Connect(WithRouteProps)
           allowClear={true}
           forwardedRef={
             Object {
@@ -226,7 +226,7 @@ exports[`<Header> renders with minimal props 1`] = `
         <IoSearch
           className="DdgHeader--uiFindSearchIcon"
         />
-        <withRouter(Connect(UnconnectedUiFindInput))
+        <Connect(WithRouteProps)
           allowClear={true}
           forwardedRef={
             Object {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { Select } from 'antd';
 import { History as RouterHistory, Location } from 'history';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Field, formValueSelector, reduxForm } from 'redux-form';
 import queryString from 'query-string';
 
@@ -44,6 +44,7 @@ import { KeyValuePair, Trace, TraceData } from '../../../types/trace';
 
 import './index.css';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
+import withRouteProps from '../../../utils/withRouteProps';
 
 type SearchResultsProps = {
   cohortAddTrace: (traceId: string) => void;
@@ -98,7 +99,7 @@ export function createBlob(rawTraces: TraceData[]) {
   return new Blob([`{"data":${JSON.stringify(rawTraces)}}`], { type: 'application/json' });
 }
 
-export class UnconnectedSearchResults extends React.PureComponent<SearchResultsProps & RouteComponentProps> {
+export class UnconnectedSearchResults extends React.PureComponent<SearchResultsProps> {
   static defaultProps = { skipMessage: false, spanLinks: undefined, queryOfResults: undefined };
 
   toggleComparison = (traceID: string, remove?: boolean) => {
@@ -245,4 +246,4 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
   }
 }
 
-export default withRouter(UnconnectedSearchResults);
+export default withRouteProps(UnconnectedSearchResults);

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/TraceDiffGraph.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/TraceDiffGraph.test.js.snap
@@ -70,7 +70,7 @@ exports[`TraceDiffGraph renders a DiGraph when it has data 1`] = `
     vertices={Array []}
     zoom={true}
   />
-  <withRouter(Connect(UnconnectedUiFindInput))
+  <Connect(WithRouteProps)
     inputProps={
       Object {
         "className": "TraceDiffGraph--uiFind",

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -16,12 +16,12 @@ import * as React from 'react';
 import cx from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
-import { withRouter, RouteComponentProps } from 'react-router-dom';
 import _isEqual from 'lodash/isEqual';
 
 // import { History as RouterHistory, Location } from 'history';
 
 import memoizeOne from 'memoize-one';
+import { Location, History } from 'history';
 import { actions } from './duck';
 import ListView from './ListView';
 import SpanBarRow from './SpanBarRow';
@@ -47,6 +47,7 @@ import TTraceTimeline from '../../../types/TTraceTimeline';
 import './VirtualizedTraceView.css';
 import updateUiFind from '../../../utils/update-ui-find';
 import { PEER_SERVICE } from '../../../constants/tag-keys';
+import withRouteProps from '../../../utils/withRouteProps';
 
 type RowState = {
   isDetail: boolean;
@@ -78,11 +79,16 @@ type TDispatchProps = {
   focusUiFindMatches: (trace: Trace, uiFind: string | TNil, allowHide?: boolean) => void;
 };
 
+type RouteProps = {
+  location: Location;
+  history: History;
+};
+
 type VirtualizedTraceViewProps = TVirtualizedTraceViewOwnProps &
   TDispatchProps &
   TExtractUiFindFromStateReturn &
   TTraceTimeline &
-  RouteComponentProps;
+  RouteProps;
 
 // export for tests
 export const DEFAULT_HEIGHTS = {
@@ -496,14 +502,12 @@ function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
   return bindActionCreators(actions, dispatch) as any as TDispatchProps;
 }
 
-export default withRouter(
-  connect<
-    TTraceTimeline & TExtractUiFindFromStateReturn,
-    TDispatchProps,
-    TVirtualizedTraceViewOwnProps,
-    ReduxState
-  >(
-    mapStateToProps,
-    mapDispatchToProps
-  )(VirtualizedTraceViewImpl)
-);
+export default connect<
+  TTraceTimeline & TExtractUiFindFromStateReturn,
+  TDispatchProps,
+  TVirtualizedTraceViewOwnProps,
+  ReduxState
+>(
+  mapStateToProps,
+  mapDispatchToProps
+)(withRouteProps(VirtualizedTraceViewImpl));

--- a/packages/jaeger-ui/src/components/common/UiFindInput.tsx
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.tsx
@@ -19,13 +19,13 @@ import { History as RouterHistory, Location } from 'history';
 import _debounce from 'lodash/debounce';
 import _isString from 'lodash/isString';
 import { connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import updateUiFind from '../../utils/update-ui-find';
 import { TNil, ReduxState } from '../../types/index';
 import parseQuery from '../../utils/parseQuery';
+import withRouteProps from '../../utils/withRouteProps';
 
-type TOwnProps = RouteComponentProps<any> & {
+type TOwnProps = {
   allowClear?: boolean;
   forwardedRef?: React.Ref<InputRef>;
   inputProps: Record<string, any>;
@@ -115,4 +115,4 @@ export function extractUiFindFromState(state: ReduxState): TExtractUiFindFromSta
   return { uiFind };
 }
 
-export default withRouter<TOwnProps>(connect(extractUiFindFromState)(UnconnectedUiFindInput) as any);
+export default connect(extractUiFindFromState)(withRouteProps(UnconnectedUiFindInput)) as any;

--- a/packages/jaeger-ui/src/utils/useHistory.test.js
+++ b/packages/jaeger-ui/src/utils/useHistory.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/utils/useHistory.test.js
+++ b/packages/jaeger-ui/src/utils/useHistory.test.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useHistory, HistoryProvider } from './useHistory';
+
+describe('useHistory', () => {
+  it('should return the history object from the context', () => {
+    const history = { push: jest.fn() };
+    const TestComponent = () => {
+      const historyFromContext = useHistory();
+      expect(historyFromContext).toEqual(history);
+      return null;
+    };
+    render(
+      <HistoryProvider history={history}>
+        <TestComponent />
+      </HistoryProvider>
+    );
+  });
+});

--- a/packages/jaeger-ui/src/utils/useHistory.tsx
+++ b/packages/jaeger-ui/src/utils/useHistory.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { createContext, useContext } from 'react';
+
+const HistoryContext = createContext(undefined);
+
+export const useHistory = () => {
+  return useContext(HistoryContext);
+};
+
+export const HistoryProvider = ({ children, history }: any) => {
+  return <HistoryContext.Provider value={history}>{children}</HistoryContext.Provider>;
+};

--- a/packages/jaeger-ui/src/utils/useHistory.tsx
+++ b/packages/jaeger-ui/src/utils/useHistory.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { createContext, useContext } from 'react';
+import React, { ReactNode, createContext, useContext, FC } from 'react';
+import { History } from 'history';
 
-const HistoryContext = createContext(undefined);
+const HistoryContext = createContext<History | undefined>(undefined);
+interface IHistoryProviderProps {
+  children: ReactNode;
+  history: History;
+}
 
-export const useHistory = () => {
+export const useHistory = (): History | undefined => {
   return useContext(HistoryContext);
 };
 
-export const HistoryProvider = ({ children, history }: any) => {
+export const HistoryProvider: FC<IHistoryProviderProps> = ({ children, history }) => {
   return <HistoryContext.Provider value={history}>{children}</HistoryContext.Provider>;
 };

--- a/packages/jaeger-ui/src/utils/withRouteProps.test.js
+++ b/packages/jaeger-ui/src/utils/withRouteProps.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/utils/withRouteProps.test.js
+++ b/packages/jaeger-ui/src/utils/withRouteProps.test.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import withRouteProps from './withRouteProps';
+import { useHistory, HistoryProvider } from './useHistory';
+
+jest.mock('./useHistory', () => ({
+  useHistory: jest.fn(),
+  HistoryProvider: ({ children }) => <div>{children}</div>,
+}));
+
+describe('withRouteProps', () => {
+  test('passes route props to WrappedComponent', () => {
+    const mockHistory = {
+      push: jest.fn(),
+      replace: jest.fn(),
+      location: { pathname: '/test', search: '?param=value' },
+    };
+
+    useHistory.mockReturnValue(mockHistory);
+
+    const WrappedComponent = jest.fn(() => null);
+    const ComponentWithRouteProps = withRouteProps(WrappedComponent);
+    render(
+      <HistoryProvider history={mockHistory}>
+        <MemoryRouter initialEntries={['/test?param=value']}>
+          <Route path="/test">
+            <ComponentWithRouteProps />
+          </Route>
+        </MemoryRouter>
+      </HistoryProvider>
+    );
+
+    expect(WrappedComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: expect.objectContaining({
+          pathname: '/test',
+          search: '?param=value',
+        }),
+        pathname: '/test',
+        search: '?param=value',
+        params: {},
+        history: mockHistory,
+      }),
+      {}
+    );
+  });
+});

--- a/packages/jaeger-ui/src/utils/withRouteProps.tsx
+++ b/packages/jaeger-ui/src/utils/withRouteProps.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { useHistory } from './useHistory';
+
+export default function withRouteProps(WrappedComponent: any) {
+  return function WithRouteProps(props: any) {
+    const location = useLocation();
+    const params = useParams();
+    const { pathname, search } = location;
+    const history = useHistory();
+
+    return (
+      <WrappedComponent
+        {...props}
+        location={location}
+        pathname={pathname}
+        search={search}
+        params={params}
+        history={history}
+      />
+    );
+  };
+}

--- a/packages/jaeger-ui/src/utils/withRouteProps.tsx
+++ b/packages/jaeger-ui/src/utils/withRouteProps.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jaeger-ui/src/utils/withRouteProps.tsx
+++ b/packages/jaeger-ui/src/utils/withRouteProps.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2023 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
+import { Location, History } from 'history';
 import { useHistory } from './useHistory';
 
-export default function withRouteProps(WrappedComponent: any) {
-  return function WithRouteProps(props: any) {
+interface IWithRouteProps {
+  children?: (props: {
+    location: Location;
+    pathname: string;
+    search: string;
+    params: object;
+    history: History;
+  }) => ReactNode;
+}
+
+interface IRouteProps {
+  location: Location;
+  pathname: string;
+  search: string;
+  params: object;
+  history: History | undefined;
+}
+
+export default function withRouteProps(WrappedComponent: React.ComponentType<IWithRouteProps>) {
+  return function WithRouteProps(props: IWithRouteProps) {
     const location = useLocation();
     const params = useParams();
     const { pathname, search } = location;
     const history = useHistory();
 
-    return (
-      <WrappedComponent
-        {...props}
-        location={location}
-        pathname={pathname}
-        search={search}
-        params={params}
-        history={history}
-      />
-    );
+    const routeProps: IRouteProps = {
+      location,
+      pathname,
+      search,
+      params,
+      history,
+    };
+
+    return <WrappedComponent {...props} {...routeProps} />;
   };
 }

--- a/packages/jaeger-ui/src/utils/withRouteProps.tsx
+++ b/packages/jaeger-ui/src/utils/withRouteProps.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,44 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { Location, History } from 'history';
+import { History, Location } from 'history';
 import { useHistory } from './useHistory';
 
-interface IWithRouteProps {
-  children?: (props: {
-    location: Location;
-    pathname: string;
-    search: string;
-    params: object;
-    history: History;
-  }) => ReactNode;
-}
-
-interface IRouteProps {
+export type IWithRouteProps = {
   location: Location;
   pathname: string;
   search: string;
   params: object;
-  history: History | undefined;
-}
+  history: History;
+};
 
-export default function withRouteProps(WrappedComponent: React.ComponentType<IWithRouteProps>) {
-  return function WithRouteProps(props: IWithRouteProps) {
+export default function withRouteProps(WrappedComponent: any) {
+  return function WithRouteProps(props: IWithRouteProps | object) {
     const location = useLocation();
     const params = useParams();
     const { pathname, search } = location;
     const history = useHistory();
 
-    const routeProps: IRouteProps = {
-      location,
-      pathname,
-      search,
-      params,
-      history,
-    };
-
-    return <WrappedComponent {...props} {...routeProps} />;
+    return (
+      <WrappedComponent
+        {...props}
+        location={location}
+        pathname={pathname}
+        search={search}
+        params={params}
+        history={history}
+      />
+    );
   };
 }

--- a/packages/jaeger-ui/src/utils/withRouteProps.tsx
+++ b/packages/jaeger-ui/src/utils/withRouteProps.tsx
@@ -25,7 +25,7 @@ export type IWithRouteProps = {
   history: History;
 };
 
-export default function withRouteProps(WrappedComponent: any) {
+export default function withRouteProps(WrappedComponent: React.ElementType) {
   return function WithRouteProps(props: IWithRouteProps | object) {
     const location = useLocation();
     const params = useParams();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,12 +2616,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@16.9.18", "@types/react-dom@18.2.5", "@types/react-dom@^18.0.0":
-  version "16.9.18"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.18.tgz#1fda8b84370b1339d639a797a84c16d5a195b419"
-  integrity sha512-lmNARUX3+rNF/nmoAFqasG0jAA7q6MeGZK/fdeLwY3kAA4NPgHHrG5bNQe2B5xmD4B+x6Z6h0rEJQ7MEEgQxsw==
+"@types/react-dom@18.2.5":
+  version "18.2.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.5.tgz#5c5f13548bda23cd98f50ca4a59107238bfe18f3"
+  integrity sha512-sRQsOS/sCLnpQhR4DSKGTtWFE3FZjpQa86KPVbhUqdYMRZ9FEFcfAytKhR/vUG2rH1oFbOOej6cuD7MFSobDRQ==
   dependencies:
-    "@types/react" "^16"
+    "@types/react" "*"
+
+"@types/react-dom@^18.0.0":
+  version "18.2.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.8.tgz#338f1b0a646c9f10e0a97208c1d26b9f473dffd6"
+  integrity sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-helmet@^6.1.5":
   version "6.1.5"
@@ -2630,10 +2637,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-router-dom@^4.3.1":
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"
-  integrity sha512-eFajSUASYbPHg2BDM1G8Btx+YqGgvROPIg6sBhl3O4kbDdYXdFdfrgQFf/pcBuQVObjfT9AL/dd15jilR5DIEA==
+"@types/react-router-dom@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.0.tgz#8baa84a7fa8c8e7797fb3650ca51f93038cb4caf"
+  integrity sha512-YCh8r71pL5p8qDwQf59IU13hFy/41fDQG/GeOI3y+xmD4o0w3vEPxE8uBe+dvOgMoDl0W1WUZsWH0pxc1mcZyQ==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"
@@ -2653,7 +2660,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.14.35", "@types/react@16.8.7", "@types/react@^16":
+"@types/react@*", "@types/react@16.14.35":
   version "16.14.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.35.tgz#9d3cf047d85aca8006c4776693124a5be90ee429"
   integrity sha512-NUEiwmSS1XXtmBcsm1NyRRPYjoZF2YTE89/5QiLt5mlGffYK9FQqOKuOLuXNrjPQV04oQgaZG+Yq02ZfHoFyyg==
@@ -2661,6 +2668,14 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/react@16.8.7":
+  version "16.8.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.7.tgz#7b1c0223dd5494f9b4501ad2a69aa6acb350a29b"
+  integrity sha512-0xbkIyrDNKUn4IJVf8JaCn+ucao/cq6ZB8O6kSzhrJub1cVSqgTArtG0qCfdERWKMEIvUbrwLXeQMqWEsyr9dA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/redux-actions@2.2.1":
   version "2.2.1"
@@ -4525,6 +4540,11 @@ cssstyle@^3.0.0:
   integrity sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==
   dependencies:
     rrweb-cssom "^0.6.0"
+
+csstype@^2.2.0:
+  version "2.6.21"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
+  integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
 
 csstype@^3.0.2:
   version "3.1.2"
@@ -8344,7 +8364,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.21, lodash@^4.16.5, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.16.5, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Which problem is this PR solving?
- part of: https://github.com/jaegertracing/jaeger-ui/issues/1825

## Description of the changes
- On our pathway to upgrade rrd to v6.x latest, we have to use custom `withRouteProps` HOC since rrd v6 doesn't support `withRouter`.
- With this change, we won't be able to access the history object anymore, and neither the other Route Props.
- This PR adds the custom `useHistory()` hook and provider to use the `history` object in our custom `withRouterProps` HOC.

## Why this PR is necessary?
- This is a part of the upgrade process for rrd v6.
- Since there are a lot of breaking changes other than `withRouter` removal in rrd v6, this PR ensure that we migrate out codebase at v5 only as recommended by the react-router-dom team in their v5 to v6 migration guide

## How was this change tested?
- Have manually checked every page. Everything is working as of now.

[screen-capture (3).webm](https://github.com/jaegertracing/jaeger-ui/assets/94157520/5ea71aa3-4921-45f4-8ccd-107a5444a564)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
