### PR TITLE
replace match.params with useParams hook

### DIFF
--- a/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
@@ -65,93 +65,58 @@ exports[`JaegerUIApp does not explode 1`] = `
       <Connect(WithRouteProps)>
         <Switch>
           <Route
-            component={
-              Object {
-                "$$typeof": Symbol(react.memo),
-                "WrappedComponent": [Function],
-                "compare": null,
-                "type": [Function],
-              }
-            }
             path="/search"
-          />
+          >
+            <Connect(SearchTracePageImpl) />
+          </Route>
           <Route
-            component={
-              Object {
-                "$$typeof": Symbol(react.memo),
-                "WrappedComponent": [Function],
-                "compare": null,
-                "type": [Function],
-              }
-            }
             path="/trace/:a?\\\\.\\\\.\\\\.:b?"
-          />
+          >
+            <WithRouteProps />
+          </Route>
           <Route
-            component={
-              Object {
-                "$$typeof": Symbol(react.memo),
-                "WrappedComponent": [Function],
-                "compare": null,
-                "type": [Function],
-              }
-            }
             path="/trace/:id"
-          />
+          >
+            <WithRouteProps />
+          </Route>
           <Route
-            component={
-              Object {
-                "$$typeof": Symbol(react.memo),
-                "WrappedComponent": [Function],
-                "compare": null,
-                "type": [Function],
-              }
-            }
             path="/dependencies"
-          />
+          >
+            <Connect(DependencyGraphPageImpl) />
+          </Route>
           <Route
-            component={
-              Object {
-                "$$typeof": Symbol(react.memo),
-                "WrappedComponent": [Function],
-                "compare": null,
-                "type": [Function],
-              }
-            }
             path="/deep-dependencies"
-          />
+          >
+            <Connect(DeepDependencyGraphPageImpl) />
+          </Route>
           <Route
-            component={
-              Object {
-                "$$typeof": Symbol(react.memo),
-                "WrappedComponent": [Function],
-                "compare": null,
-                "type": [Function],
-              }
-            }
             path="/quality-metrics"
-          />
+          >
+            <Connect(UnconnectedQualityMetrics) />
+          </Route>
           <Route
-            component={[Function]}
             path="/monitor"
-          />
-          <Redirect
+          >
+            <MonitorATMPage />
+          </Route>
+          <Route
             exact={true}
             path="/"
-            to="/search"
+            render={[Function]}
           />
-          <Redirect
+          <Route
             exact={true}
             path=""
-            to="/search"
-          />
-          <Redirect
-            exact={true}
-            path="/"
-            to="/search"
+            render={[Function]}
           />
           <Route
-            component={[Function]}
+            exact={true}
+            path="/"
+            render={[Function]}
           />
+          <Route>
+            <NotFound />
+          </Route>
         </Switch>
       </Connect(WithRouteProps)>
     </Router>

--- a/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
@@ -82,17 +82,17 @@ exports[`JaegerUIApp does not explode 1`] = `
           <Route
             path="/dependencies"
           >
-            <Connect(DependencyGraphPageImpl) />
+            <WithRouteProps />
           </Route>
           <Route
             path="/deep-dependencies"
           >
-            <Connect(DeepDependencyGraphPageImpl) />
+            <WithRouteProps />
           </Route>
           <Route
             path="/quality-metrics"
           >
-            <Connect(UnconnectedQualityMetrics) />
+            <WithRouteProps />
           </Route>
           <Route
             path="/monitor"

--- a/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/App/__snapshots__/index.test.js.snap
@@ -67,7 +67,7 @@ exports[`JaegerUIApp does not explode 1`] = `
           <Route
             path="/search"
           >
-            <Connect(SearchTracePageImpl) />
+            <WithRouteProps />
           </Route>
           <Route
             path="/trace/:a?\\\\.\\\\.\\\\.:b?"
@@ -102,18 +102,27 @@ exports[`JaegerUIApp does not explode 1`] = `
           <Route
             exact={true}
             path="/"
-            render={[Function]}
-          />
+          >
+            <Redirect
+              to="/search"
+            />
+          </Route>
           <Route
             exact={true}
             path=""
-            render={[Function]}
-          />
+          >
+            <Redirect
+              to="/search"
+            />
+          </Route>
           <Route
             exact={true}
             path="/"
-            render={[Function]}
-          />
+          >
+            <Redirect
+              to="/search"
+            />
+          </Route>
           <Route>
             <NotFound />
           </Route>

--- a/packages/jaeger-ui/src/components/App/index.jsx
+++ b/packages/jaeger-ui/src/components/App/index.jsx
@@ -56,19 +56,35 @@ export default class JaegerUIApp extends Component {
           <Router history={history}>
             <Page>
               <Switch>
-                <Route path={searchPath} component={SearchTracePage} />
-                <Route path={traceDiffPath} component={TraceDiff} />
-                <Route path={tracePath} component={TracePage} />
-                <Route path={dependenciesPath} component={DependencyGraph} />
-                <Route path={deepDependenciesPath} component={DeepDependencies} />
-                <Route path={qualityMetricsPath} component={QualityMetrics} />
-                <Route path={monitorATMPath} component={MonitorATMPage} />
+                <Route path={searchPath}>
+                  <SearchTracePage />
+                </Route>
+                <Route path={traceDiffPath}>
+                  <TraceDiff />
+                </Route>
+                <Route path={tracePath}>
+                  <TracePage />
+                </Route>
+                <Route path={dependenciesPath}>
+                  <DependencyGraph />
+                </Route>
+                <Route path={deepDependenciesPath}>
+                  <DeepDependencies />
+                </Route>
+                <Route path={qualityMetricsPath}>
+                  <QualityMetrics />
+                </Route>
+                <Route path={monitorATMPath}>
+                  <MonitorATMPage />
+                </Route>
 
-                <Redirect exact path="/" to={searchPath} />
-                <Redirect exact path={prefixUrl()} to={searchPath} />
-                <Redirect exact path={prefixUrl('/')} to={searchPath} />
+                <Route exact path="/" render={() => <Redirect to={searchPath} />} />
+                <Route exact path={prefixUrl()} render={() => <Redirect to={searchPath} />} />
+                <Route exact path={prefixUrl('/')} render={() => <Redirect to={searchPath} />} />
 
-                <Route component={NotFound} />
+                <Route>
+                  <NotFound />
+                </Route>
               </Switch>
             </Page>
           </Router>

--- a/packages/jaeger-ui/src/components/App/index.jsx
+++ b/packages/jaeger-ui/src/components/App/index.jsx
@@ -78,9 +78,15 @@ export default class JaegerUIApp extends Component {
                   <MonitorATMPage />
                 </Route>
 
-                <Route exact path="/" render={() => <Redirect to={searchPath} />} />
-                <Route exact path={prefixUrl()} render={() => <Redirect to={searchPath} />} />
-                <Route exact path={prefixUrl('/')} render={() => <Redirect to={searchPath} />} />
+                <Route exact path="/">
+                  <Redirect to={searchPath} />
+                </Route>
+                <Route exact path={prefixUrl()}>
+                  <Redirect to={searchPath} />
+                </Route>
+                <Route exact path={prefixUrl('/')}>
+                  <Redirect to={searchPath} />
+                </Route>
 
                 <Route>
                   <NotFound />

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -49,6 +49,7 @@ import { TDdgStateEntry } from '../../types/TDdgState';
 
 import './index.css';
 import { ApiError } from '../../types/api-error';
+import withRouteProps from '../../utils/withRouteProps';
 
 interface IDoneState {
   state: typeof fetchedState.DONE;
@@ -449,4 +450,4 @@ export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchPro
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DeepDependencyGraphPageImpl);
+export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(DeepDependencyGraphPageImpl));

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
@@ -29,6 +29,7 @@ import { formatDependenciesAsNodesAndLinks } from '../../selectors/dependencies'
 import { getConfigValue } from '../../utils/config/get-config';
 
 import './index.css';
+import withRouteProps from '../../utils/withRouteProps';
 
 const TabPane = Tabs.TabPane;
 
@@ -131,4 +132,4 @@ export function mapDispatchToProps(dispatch) {
   return { fetchDependencies };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DependencyGraphPageImpl);
+export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(DependencyGraphPageImpl));

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -49,6 +49,7 @@ import {
   trackSelectTimeframe,
   trackViewAllTraces,
 } from './index.track';
+import withRouteProps from '../../../utils/withRouteProps';
 
 type StateType = {
   graphWidth: number;
@@ -451,11 +452,13 @@ export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchPro
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(
-  reduxForm<{}, TProps>({
-    form: 'serviceForm',
-  })(MonitorATMServicesViewImpl)
+export default withRouteProps(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(
+    reduxForm<{}, TProps>({
+      form: 'serviceForm',
+    })(MonitorATMServicesViewImpl)
+  )
 );

--- a/packages/jaeger-ui/src/components/Monitor/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/__snapshots__/index.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MonitorATMPage> Component is displayed 1`] = `<Connect(ReduxForm) />`;
+exports[`<MonitorATMPage> Component is displayed 1`] = `<WithRouteProps />`;

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.tsx
@@ -32,6 +32,7 @@ import { ReduxState } from '../../types';
 import { TQualityMetrics } from './types';
 
 import './index.css';
+import withRouteProps from '../../utils/withRouteProps';
 
 type TOwnProps = {
   history: RouterHistory;
@@ -212,4 +213,4 @@ export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchPro
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(UnconnectedQualityMetrics);
+export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(UnconnectedQualityMetrics));

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
@@ -38,6 +38,7 @@ import FileLoader from './FileLoader';
 
 import './index.css';
 import JaegerLogo from '../../img/jaeger-logo.svg';
+import withRouteProps from '../../utils/withRouteProps';
 
 const TabPane = Tabs.TabPane;
 
@@ -309,4 +310,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchTracePageImpl);
+export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(SearchTracePageImpl));

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.js
@@ -225,11 +225,9 @@ describe('TraceDiff', () => {
 
   describe('mapStateToProps', () => {
     const getOwnProps = ({ a = defaultA, b = defaultB } = {}) => ({
-      match: {
-        params: {
-          a,
-          b,
-        },
+      params: {
+        a,
+        b,
       },
     });
     const makeTestReduxState = ({ cohortIds = defaultCohortIds } = {}) => ({

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
@@ -15,7 +15,6 @@
 import * as React from 'react';
 import { History as RouterHistory } from 'history';
 import { connect } from 'react-redux';
-import { match } from 'react-router-dom';
 import { bindActionCreators, Dispatch } from 'redux';
 
 import { actions as diffActions } from './duck';
@@ -30,6 +29,7 @@ import pluckTruthy from '../../utils/ts/pluckTruthy';
 
 import './TraceDiff.css';
 import parseQuery from '../../utils/parseQuery';
+import withRouteProps from '../../utils/withRouteProps';
 
 type TStateProps = {
   a: string | undefined;
@@ -46,7 +46,7 @@ type TDispatchProps = {
 
 type TOwnProps = {
   history: RouterHistory;
-  match: match<TDiffRouteParams>;
+  params: TDiffRouteParams;
 };
 
 type TState = {
@@ -163,8 +163,8 @@ export class TraceDiffImpl extends React.PureComponent<TStateProps & TDispatchPr
 }
 
 // TODO(joe): simplify but do not invalidate the URL
-export function mapStateToProps(state: ReduxState, ownProps: { match: match<TDiffRouteParams> }) {
-  const { a, b } = ownProps.match.params;
+export function mapStateToProps(state: ReduxState, ownProps: TOwnProps) {
+  const { a, b } = ownProps.params;
   const { cohort: origCohort = [] } = parseQuery(state.router.location.search);
   const fullCohortSet: Set<string> = new Set(pluckTruthy([a, b].concat(origCohort)));
   const cohort: string[] = Array.from(fullCohortSet);
@@ -187,7 +187,9 @@ export function mapDispatchToProps(dispatch: Dispatch<any>) {
   return { fetchMultipleTraces, forceState };
 }
 
-export default connect<TStateProps, TDispatchProps, TOwnProps, ReduxState>(
-  mapStateToProps,
-  mapDispatchToProps
-)(TraceDiffImpl);
+export default withRouteProps(
+  connect<TStateProps, TDispatchProps, TOwnProps, ReduxState>(
+    mapStateToProps,
+    mapDispatchToProps
+  )(TraceDiffImpl)
+);

--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -726,9 +726,7 @@ describe('mapStateToProps()', () => {
   const trace = {};
   const embedded = 'a-faux-embedded-config';
   const ownProps = {
-    match: {
-      params: { id: traceID },
-    },
+    params: { id: traceID },
   };
   let state;
   beforeEach(() => {
@@ -764,10 +762,8 @@ describe('mapStateToProps()', () => {
 
   it('handles falsy ownProps.match.params.id', () => {
     const props = mapStateToProps(state, {
-      match: {
-        params: {
-          id: '',
-        },
+      params: {
+        id: '',
       },
     });
     expect(props).toEqual(

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -20,7 +20,6 @@ import _get from 'lodash/get';
 import _mapValues from 'lodash/mapValues';
 import _memoize from 'lodash/memoize';
 import { connect } from 'react-redux';
-import { match as Match } from 'react-router-dom';
 import { bindActionCreators, Dispatch } from 'redux';
 
 import ArchiveNotifier from './ArchiveNotifier';
@@ -62,6 +61,7 @@ import { TraceGraphConfig } from '../../types/config';
 
 import './index.css';
 import memoizedTraceCriticalPath from './CriticalPath/index';
+import withRouteProps from '../../utils/withRouteProps';
 
 type TDispatchProps = {
   acknowledgeArchive: (id: string) => void;
@@ -73,7 +73,7 @@ type TDispatchProps = {
 type TOwnProps = {
   history: RouterHistory;
   location: Location;
-  match: Match<{ id: string }>;
+  params: { id: string };
 };
 
 type TReduxProps = {
@@ -439,7 +439,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
 
 // export for tests
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
-  const { id } = ownProps.match.params;
+  const { id } = ownProps.params;
   const { archive, config, embedded, router } = state;
   const { traces } = state.trace;
   const trace = id ? traces[id] : null;
@@ -472,4 +472,4 @@ export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchPro
   return { acknowledgeArchive, archiveTrace, fetchTrace, focusUiFindMatches };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TracePageImpl);
+export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(TracePageImpl));

--- a/packages/jaeger-ui/src/utils/withRouteProps.tsx
+++ b/packages/jaeger-ui/src/utils/withRouteProps.tsx
@@ -17,6 +17,15 @@ import { useLocation, useParams } from 'react-router-dom';
 import { History, Location } from 'history';
 import { useHistory } from './useHistory';
 
+/**
+ * Interface representing route-related props passed to the enhanced component.
+ * @interface
+ * @property {Location} location - The current location object containing information about the URL.
+ * @property {string} pathname - The current URL pathname.
+ * @property {string} search - The current URL search string.
+ * @property {object} params - The URL parameters.
+ * @property {History} history - The history object for navigation.
+ */
 export type IWithRouteProps = {
   location: Location;
   pathname: string;
@@ -25,13 +34,53 @@ export type IWithRouteProps = {
   history: History;
 };
 
+/**
+ * Enhances a React component with route-related props. Works similar to withRouter export from react-router-dom v5 below.
+ * @function
+ * @param {React.ElementType} WrappedComponent - The component to be enhanced.
+ * @returns {React.Component} A higher-order component with route-related props.
+ */
 export default function withRouteProps(WrappedComponent: React.ElementType) {
+  /**
+   * @function
+   * @param {IWithRouteProps|object} props - The props passed to the enhanced component.
+   * @returns {React.Component} The enhanced component with additional route-related props.
+   */
   return function WithRouteProps(props: IWithRouteProps | object) {
+    /**
+     * The current location object containing information about the URL.
+     * @type {Location}
+     */
     const location = useLocation();
+
+    /**
+     * The URL parameters extracted from the route.
+     * @type {object}
+     */
     const params = useParams();
-    const { pathname, search } = location;
+
+    /**
+     * The current URL pathname.
+     * @type {string}
+     */
+    const { pathname } = location;
+
+    /**
+     * The current URL search string.
+     * @type {string}
+     */
+    const { search } = location;
+
+    /**
+     * The history object for navigation.
+     * @type {History}
+     */
     const history = useHistory();
 
+    /**
+     * Renders the enhanced component with route-related props.
+     * @returns {React.Component} The enhanced component with additional route-related props.
+     */
     return (
       <WrappedComponent
         {...props}


### PR DESCRIPTION
## Which problem is this PR solving?
- part of: #1825 

## Description of the changes
- In rrd v6, we can no longer use `match` prop. Since the introduction of hooks, we need to use `useParams()` hook for accessing that.
- rrd v5 to v5.1 guide recommends using `<Route children ..` instead of `<Route component ..> since it would be deprecated in v6.
- This is the last PR for the v6 preparation. The next PR would finally upgrade rrd to v6.

## How was this change tested?
- Manually, by visiting each page.

[screen-capture (4).webm](https://github.com/jaegertracing/jaeger-ui/assets/94157520/42ead7db-26bd-47c9-a16d-a4500b76cd3f)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
