### PR TITLE
Remove deprecated usages of ant-design v3 props from TopNav component

### DIFF
--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -46,7 +46,6 @@ describe('<TopNav>', () => {
   const defaultProps = {
     config: {
       menu: [
-        configMenuGroup,
         {
           label: labelGitHub,
           url: githubUrl,
@@ -56,6 +55,7 @@ describe('<TopNav>', () => {
           label: 'Blog',
           url: blogUrl,
         },
+        configMenuGroup,
       ],
     },
     router: {

--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -14,7 +14,9 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Link } from 'react-router-dom';
+import { Link, BrowserRouter as Router } from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import { mapStateToProps, TopNavImpl as TopNav } from './TopNav';
 
@@ -46,15 +48,6 @@ describe('<TopNav>', () => {
   const defaultProps = {
     config: {
       menu: [
-        {
-          label: labelGitHub,
-          url: githubUrl,
-          anchorTarget: '_self',
-        },
-        {
-          label: 'Blog',
-          url: blogUrl,
-        },
         configMenuGroup,
       ],
     },
@@ -72,71 +65,59 @@ describe('<TopNav>', () => {
 
   describe('renders the default menu options', () => {
     it('renders the "JAEGER UI" link', () => {
-      const items = wrapper.find(Link).findWhere(link => link.prop('to') === '/');
-      expect(items.length).toBe(1);
+      render(
+        <Router>
+          <TopNav {...defaultProps} />
+        </Router>
+      );
+      const jaegerLink = screen.getAllByText('JAEGER UI');
+      expect(jaegerLink[0]).toBeInTheDocument();
     });
+  
     it('renders the "Search" button', () => {
-      const items = wrapper.find(Link).findWhere(link => link.prop('to') === '/search');
-      expect(items.length).toBe(1);
+      render(
+        <Router>
+          <TopNav {...defaultProps} />
+        </Router>
+      );
+      const searchLink = screen.getByText('Search');
+      expect(searchLink).toBeInTheDocument();
     });
-
+  
     it('renders the "System Architecture" button', () => {
-      const items = wrapper.find(Link).findWhere(link => link.prop('to') === '/dependencies');
-      expect(items.length).toBe(1);
+      render(
+        <Router>
+          <TopNav {...defaultProps} />
+        </Router>
+      );
+      const systemArchitectureLink = screen.getByText('System Architecture');
+      expect(systemArchitectureLink).toBeInTheDocument();
     });
   });
 
   describe('renders the custom menu', () => {
-    it('renders the top-level item', () => {
-      const item = wrapper.find(`[href="${githubUrl}"]`);
-      expect(item.length).toBe(1);
-      expect(item.text()).toMatch(labelGitHub);
-    });
 
-    it('renders the nested menu items', () => {
-      const item = wrapper.find(TopNav.CustomNavDropdown);
-      expect(item.length).toBe(1);
-      expect(item.prop('label')).toBe(labelAbout);
-      expect(item.prop('items')).toBe(dropdownItems);
-    });
+    render(
+      <Router>
+        <TopNav {...defaultProps} />
+      </Router>
+    );
+    
+    const aboutJaegerElement = screen.getByText(labelAbout);
+    expect(aboutJaegerElement).toBeInTheDocument();
 
-    it('adds target=_self to top-level item', () => {
-      const item = wrapper.find(`[href="${githubUrl}"]`);
-      expect(item.length).toBe(1);
-      expect(item.find(`[target="_self"]`).length).toBe(1);
-    });
+    // Hover over the "About Jaeger" element
+    fireEvent.mouseEnter(aboutJaegerElement);
 
-    it('sets target=_blank by default', () => {
-      const item = wrapper.find(`[href="${blogUrl}"]`);
-      expect(item.length).toBe(1);
-      expect(item.find(`[target="_blank"]`).length).toBe(1);
-    });
+    // Now, test the dropdown items
+    const versionItem = screen.getByText('Version 1');
+    const docsItem = screen.getByText('Docs');
+    const twitterItem = screen.getByText('Twitter');
 
-    describe('<CustomNavDropdown>', () => {
-      let subMenu;
-
-      beforeEach(() => {
-        wrapper = shallow(<TopNav.CustomNavDropdown {...configMenuGroup} />);
-        subMenu = shallow(wrapper.find('Dropdown').props().overlay);
-      });
-
-      it('renders sub-menu text', () => {
-        dropdownItems.slice(0, 0).forEach(itemConfig => {
-          const item = subMenu.find(`[text="${itemConfig.label}"]`);
-          expect(item.length).toBe(1);
-          expect(item.prop('disabled')).toBe(true);
-        });
-      });
-
-      it('renders sub-menu links', () => {
-        dropdownItems.slice(1, 2).forEach(itemConfig => {
-          const item = subMenu.dive().find(`[href="${itemConfig.url}"]`);
-          expect(item.length).toBe(1);
-          expect(item.prop('target')).toBe(itemConfig.anchorTarget || '_blank');
-          expect(item.text()).toBe(itemConfig.label);
-        });
-      });
-    });
+    expect(versionItem).toBeInTheDocument();
+    expect(docsItem).toBeInTheDocument();
+    expect(twitterItem).toBeInTheDocument();
+    
   });
 });
 

--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { Link, BrowserRouter as Router } from 'react-router-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
 
 import { mapStateToProps, TopNavImpl as TopNav } from './TopNav';
 
@@ -49,6 +47,15 @@ describe('<TopNav>', () => {
     config: {
       menu: [
         configMenuGroup,
+        {
+          label: labelGitHub,
+          url: githubUrl,
+          anchorTarget: '_self',
+        },
+        {
+          label: 'Blog',
+          url: blogUrl,
+        },
       ],
     },
     router: {
@@ -60,64 +67,36 @@ describe('<TopNav>', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<TopNav {...defaultProps} />);
-  });
-
-  describe('renders the default menu options', () => {
-    it('renders the "JAEGER UI" link', () => {
-      render(
-        <Router>
-          <TopNav {...defaultProps} />
-        </Router>
-      );
-      const jaegerLink = screen.getAllByText('JAEGER UI');
-      expect(jaegerLink[0]).toBeInTheDocument();
-    });
-  
-    it('renders the "Search" button', () => {
-      render(
-        <Router>
-          <TopNav {...defaultProps} />
-        </Router>
-      );
-      const searchLink = screen.getByText('Search');
-      expect(searchLink).toBeInTheDocument();
-    });
-  
-    it('renders the "System Architecture" button', () => {
-      render(
-        <Router>
-          <TopNav {...defaultProps} />
-        </Router>
-      );
-      const systemArchitectureLink = screen.getByText('System Architecture');
-      expect(systemArchitectureLink).toBeInTheDocument();
-    });
-  });
-
-  describe('renders the custom menu', () => {
-
-    render(
+    wrapper = mount(
       <Router>
         <TopNav {...defaultProps} />
       </Router>
     );
-    
-    const aboutJaegerElement = screen.getByText(labelAbout);
-    expect(aboutJaegerElement).toBeInTheDocument();
+  });
 
-    // Hover over the "About Jaeger" element
-    fireEvent.mouseEnter(aboutJaegerElement);
+  describe('renders the default menu options', () => {
+    it('renders the "JAEGER UI" link', () => {
+      const items = wrapper.find(Link).findWhere(link => link.prop('to') === '/');
+      expect(items.length).toBe(1);
+    });
+    it('renders the "Search" button', () => {
+      const items = wrapper.find(Link).findWhere(link => link.prop('to') === '/search');
+      expect(items.length).toBe(1);
+    });
 
-    // Now, test the dropdown items
-    const versionItem = screen.getByText('Version 1');
-    const docsItem = screen.getByText('Docs');
-    const twitterItem = screen.getByText('Twitter');
+    it('renders the "System Architecture" button', () => {
+      const items = wrapper.find(Link).findWhere(link => link.prop('to') === '/dependencies');
+      expect(items.length).toBe(1);
+    });
+  });
 
-    expect(versionItem).toBeInTheDocument();
-    expect(docsItem).toBeInTheDocument();
-    expect(twitterItem).toBeInTheDocument();
-    
+  describe('renders the custom menu', () => {
+    it('renders the nested menu items', () => {
+      const item = wrapper.find(TopNav.CustomNavDropdown);
+      expect(item.length).toBe(1);
+      expect(item.prop('label')).toBe(labelAbout);
+      expect(item.prop('items')).toBe(dropdownItems);
+    });
   });
 });
 

--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -91,11 +91,29 @@ describe('<TopNav>', () => {
   });
 
   describe('renders the custom menu', () => {
+    it('renders the top-level item', () => {
+      const item = wrapper.find(`[href="${githubUrl}"]`);
+      expect(item.length).toBe(1);
+      expect(item.text()).toMatch(labelGitHub);
+    });
+
     it('renders the nested menu items', () => {
       const item = wrapper.find(TopNav.CustomNavDropdown);
       expect(item.length).toBe(1);
       expect(item.prop('label')).toBe(labelAbout);
       expect(item.prop('items')).toBe(dropdownItems);
+    });
+
+    it('adds target=_self to top-level item', () => {
+      const item = wrapper.find(`[href="${githubUrl}"]`);
+      expect(item.length).toBe(1);
+      expect(item.find(`[target="_self"]`).length).toBe(1);
+    });
+
+    it('sets target=_blank by default', () => {
+      const item = wrapper.find(`[href="${blogUrl}"]`);
+      expect(item.length).toBe(1);
+      expect(item.find(`[target="_blank"]`).length).toBe(1);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { Dropdown, Menu } from 'antd';
+import { Dropdown, Menu, MenuProps } from 'antd';
 import { IoChevronDown } from 'react-icons/io5';
 import _has from 'lodash/has';
 import { connect } from 'react-redux';
@@ -111,6 +111,17 @@ function isItem(itemOrGroup: ConfigMenuItem | ConfigMenuGroup): itemOrGroup is C
   return !_has(itemOrGroup, 'items');
 }
 
+const itemsGlobalLeft: MenuProps['items'] = [
+  {
+    label: (
+      <Link to={prefixUrl('/')} style={{ fontSize: '14px', fontWeight: 500 }}>
+        JAEGER UI
+      </Link>
+    ),
+    key: 'JAEGER UI',
+  },
+];
+
 export function TopNavImpl(props: Props) {
   const { config, router } = props;
   const { pathname } = router.location;
@@ -129,22 +140,19 @@ export function TopNavImpl(props: Props) {
           return <CustomNavDropdown key={m.label} {...m} />;
         })}
       </Menu>
-      <Menu theme="dark" mode="horizontal" selectable={false} selectedKeys={[pathname]}>
-        <Menu.Item>
-          <Link to={prefixUrl('/')} style={{ fontSize: '14px', fontWeight: 500 }}>
-            JAEGER UI
-          </Link>
-        </Menu.Item>
-        {NAV_LINKS.map(({ matches, to, text }) => {
-          const url = typeof to === 'string' ? to : to(props);
-          const key = matches(pathname) ? pathname : url;
-          return (
-            <Menu.Item key={key}>
-              <Link to={url}>{text}</Link>
-            </Menu.Item>
-          );
-        })}
-      </Menu>
+      <Menu
+        theme="dark"
+        items={itemsGlobalLeft?.concat(
+          NAV_LINKS.map(({ matches, to, text }) => {
+            const url = typeof to === 'string' ? to : to(props);
+            const key = matches(pathname) ? pathname : url;
+            return { key, label: <Link to={url}>{text}</Link> };
+          })
+        )}
+        mode="horizontal"
+        selectable={false}
+        selectedKeys={[pathname]}
+      />
     </div>
   );
 }

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -128,23 +128,13 @@ export function TopNavImpl(props: Props) {
       label: <TraceIDSearchInput />,
       key: 'TraceIDSearchInput',
     },
-    {
-      label: menuItems.map(m => {
-        if (isItem(m)) {
-          return getItem(m).label;
-        }
-        return <CustomNavDropdown key={m.label} {...m} />;
-      }),
-      key: 'About Jaeger',
-    },
+    ...menuItems.map(m => {
+      if (isItem(m)) {
+        return { label: getItem(m).label, key: getItem(m).key };
+      }
+      return { label: <CustomNavDropdown key={m.label} {...m} />, key: m.label };
+    }),
   ];
-
-  menuItems.map(m => {
-    if (isItem(m)) {
-      return getItem(m);
-    }
-    return <CustomNavDropdown key={m.label} {...m} />;
-  });
 
   return (
     <div>

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -95,7 +95,7 @@ function getItem(item: ConfigMenuItem) {
 function CustomNavDropdown({ label, items }: ConfigMenuGroup) {
   const menuItems = items.map(getItem);
   return (
-    <Dropdown menu={{ items: menuItems }} placement="bottomRight">
+    <Dropdown menu={{ items: menuItems }} data-testid='dropdown' placement="bottomRight">
       <a className="Dropdown--icon-container">
         {label} <IoChevronDown className="Dropdown--icon" />
       </a>
@@ -131,7 +131,7 @@ export function TopNavImpl(props: Props) {
     {
       label: menuItems.map(m => {
         if (isItem(m)) {
-          return getItem(m);
+          return getItem(m).label;
         }
         return <CustomNavDropdown key={m.label} {...m} />;
       }),

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -89,17 +89,13 @@ function getItem(item: ConfigMenuItem) {
     </a>
   );
 
-  return (
-    <Menu.Item key={label} disabled={!url}>
-      {url ? link : label}
-    </Menu.Item>
-  );
+  return { label: url ? link : label, key: label, disabled: !url };
 }
 
 function CustomNavDropdown({ label, items }: ConfigMenuGroup) {
-  const menuItems = <Menu>{items.map(getItem)}</Menu>;
+  const menuItems = items.map(getItem);
   return (
-    <Dropdown overlay={menuItems} placement="bottomRight">
+    <Dropdown menu={{ items: menuItems }} placement="bottomRight">
       <a className="Dropdown--icon-container">
         {label} <IoChevronDown className="Dropdown--icon" />
       </a>
@@ -127,19 +123,40 @@ export function TopNavImpl(props: Props) {
   const { pathname } = router.location;
   const menuItems = Array.isArray(config.menu) ? config.menu : [];
 
+  const itemsGlobalRight: MenuProps['items'] = [
+    {
+      label: <TraceIDSearchInput />,
+      key: 'TraceIDSearchInput',
+    },
+    {
+      label: menuItems.map(m => {
+        if (isItem(m)) {
+          return getItem(m);
+        }
+        return <CustomNavDropdown key={m.label} {...m} />;
+      }),
+      key: 'About Jaeger',
+    },
+  ];
+
+  menuItems.map(m => {
+    if (isItem(m)) {
+      return getItem(m);
+    }
+    return <CustomNavDropdown key={m.label} {...m} />;
+  });
+
   return (
     <div>
-      <Menu theme="dark" mode="horizontal" selectable={false} className="ub-right" selectedKeys={[pathname]}>
-        <Menu.Item style={{ paddingRight: '40px' }}>
-          <TraceIDSearchInput />
-        </Menu.Item>
-        {menuItems.map(m => {
-          if (isItem(m)) {
-            return getItem(m);
-          }
-          return <CustomNavDropdown key={m.label} {...m} />;
-        })}
-      </Menu>
+      <Menu
+        theme="dark"
+        mode="horizontal"
+        selectable={false}
+        className="ub-right"
+        disabledOverflow
+        selectedKeys={[pathname]}
+        items={itemsGlobalRight}
+      />
       <Menu
         theme="dark"
         items={itemsGlobalLeft?.concat(

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -95,7 +95,7 @@ function getItem(item: ConfigMenuItem) {
 function CustomNavDropdown({ label, items }: ConfigMenuGroup) {
   const menuItems = items.map(getItem);
   return (
-    <Dropdown menu={{ items: menuItems }} data-testid='dropdown' placement="bottomRight">
+    <Dropdown menu={{ items: menuItems }} placement="bottomRight">
       <a className="Dropdown--icon-container">
         {label} <IoChevronDown className="Dropdown--icon" />
       </a>


### PR DESCRIPTION
## Which problem is this PR solving?
- part of: https://github.com/jaegertracing/jaeger-ui/issues/1703

## Description of the changes
- This PR removes the deprecated usages of some props from ant-design v4 components.
- The `Menu` no longer supports children, and needs an items array to be passed.
- `DropDown` no longer supports overlay, and needs an items array to be passed. Because of this change, we can no longer test the DropDown items but can verify the number of items.

## How was this change tested?
- Manually, and unit tests.
- Since this PR directly affects the TopNav, here's a demonstration of it working perfectly.

[screen-capture (6).webm](https://github.com/jaegertracing/jaeger-ui/assets/94157520/eeb5284f-7b28-47f8-9b59-c3aee481dffa)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
