### PR TITLE
Replace deprecated usage of ant-design Tabs component from SearchTracePage

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
@@ -108,13 +108,7 @@ export class SearchTracePageImpl extends Component {
       tabItems.push({
         label: 'Upload',
         key: 'fileLoader',
-        children: (
-          <FileLoader
-            loadJsonTraces={fileList => {
-              loadJsonTraces(fileList);
-            }}
-          />
-        ),
+        children: <FileLoader loadJsonTraces={loadJsonTraces} />,
       });
     }
     return (

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
@@ -40,8 +40,6 @@ import './index.css';
 import JaegerLogo from '../../img/jaeger-logo.svg';
 import withRouteProps from '../../utils/withRouteProps';
 
-const TabPane = Tabs.TabPane;
-
 // export for tests
 export class SearchTracePageImpl extends Component {
   componentDidMount() {
@@ -100,25 +98,31 @@ export class SearchTracePageImpl extends Component {
     const hasTraceResults = traceResults && traceResults.length > 0;
     const showErrors = errors && !loadingTraces;
     const showLogo = isHomepage && !hasTraceResults && !loadingTraces && !errors;
+    const tabItems = [];
+    if (!loadingServices && services) {
+      tabItems.push({ label: 'Search', key: 'searchForm', children: <SearchForm services={services} /> });
+    } else {
+      tabItems.push({ label: 'Search', key: 'searchForm', children: <LoadingIndicator /> });
+    }
+    if (!disableFileUploadControl) {
+      tabItems.push({
+        label: 'Upload',
+        key: 'fileLoader',
+        children: (
+          <FileLoader
+            loadJsonTraces={fileList => {
+              loadJsonTraces(fileList);
+            }}
+          />
+        ),
+      });
+    }
     return (
       <Row className="SearchTracePage--row">
         {!embedded && (
           <Col span={6} className="SearchTracePage--column">
             <div className="SearchTracePage--find">
-              <Tabs size="large">
-                <TabPane tab="Search" key="searchForm">
-                  {!loadingServices && services ? <SearchForm services={services} /> : <LoadingIndicator />}
-                </TabPane>
-                {!disableFileUploadControl && (
-                  <TabPane tab="Upload" key="fileLoader">
-                    <FileLoader
-                      loadJsonTraces={fileList => {
-                        loadJsonTraces(fileList);
-                      }}
-                    />
-                  </TabPane>
-                )}
-              </Tabs>
+              <Tabs size="large" items={tabItems} />
             </div>
           </Col>
         )}

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { MemoryRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 
 jest.mock('redux-form', () => {
   function reduxForm() {
@@ -29,17 +29,26 @@ jest.mock('store');
 
 /* eslint-disable import/first */
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import store from 'store';
 
+import { Provider } from 'react-redux';
 import { SearchTracePageImpl as SearchTracePage, mapStateToProps } from './index';
-import FileLoader from './FileLoader';
 import SearchForm from './SearchForm';
 import LoadingIndicator from '../common/LoadingIndicator';
 import { fetchedState } from '../../constants';
 import traceGenerator from '../../demo/trace-generators';
 import { MOST_RECENT } from '../../model/order-by';
 import transformTraceData from '../../model/transform-trace-data';
+import { store as globalStore } from '../../utils/configure-store';
+
+const AllProvider = ({ children }) => (
+  <BrowserRouter>
+    <Provider store={globalStore}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </Provider>
+  </BrowserRouter>
+);
 
 describe('<SearchTracePage>', () => {
   const queryOfResults = {};
@@ -76,7 +85,7 @@ describe('<SearchTracePage>', () => {
       fetchServices: jest.fn(),
       searchTraces: jest.fn(),
     };
-    wrapper = shallow(<SearchTracePage {...props} />);
+    wrapper = mount(<SearchTracePage {...props} />, { wrappingComponent: AllProvider });
   });
 
   it('searches for traces if `service` or `traceID` are in the query string', () => {
@@ -166,12 +175,12 @@ describe('<SearchTracePage>', () => {
   });
 
   it('shows Upload tab by default', () => {
-    expect(wrapper.find(FileLoader).length).toBe(1);
+    expect(wrapper.find({ 'data-node-key': 'fileLoader' }).length).toBe(1);
   });
 
   it('hides Upload tab if it is disabled via config', () => {
     wrapper.setProps({ disableFileUploadControl: true });
-    expect(wrapper.find(FileLoader).length).toBe(0);
+    expect(wrapper.find({ 'data-node-key': 'fileLoader' }).length).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Which problem is this PR solving?
- part of: https://github.com/jaegertracing/jaeger-ui/issues/1703

## Description of the changes
- replace deprecated usage of Tabs component from SearchTracePage
- The ant-design v4 introduces a new API `items` which increases the performance by deferring the In-Active components for the first load.
- This is the reason we cannot test for the actual `FileLoader` component to be present, rather, we can [test for the Tab Key to be present](https://github.com/jaegertracing/jaeger-ui/pull/1857/files#diff-aed5cd35151c3219d94e8071c5fe875b963075a0c89df5f070c9b4c34dadf646R178).

## How was this change tested?
- manually, and automated tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
