### PR TITLE
Remove deprecated usages from antd DropDown, Tooltip, and Tab components

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
@@ -31,8 +31,6 @@ import { getConfigValue } from '../../utils/config/get-config';
 import './index.css';
 import withRouteProps from '../../utils/withRouteProps';
 
-const TabPane = Tabs.TabPane;
-
 // export for tests
 export const GRAPH_TYPES = {
   FORCE_DIRECTED: { type: 'FORCE_DIRECTED', name: 'Force Directed Graph' },
@@ -92,6 +90,19 @@ export class DependencyGraphPageImpl extends Component {
     if (dependencies.length <= dagMaxNumServices) {
       GRAPH_TYPE_OPTIONS.push(GRAPH_TYPES.DAG);
     }
+    const tabItems = [];
+    GRAPH_TYPE_OPTIONS.forEach(opt => {
+      tabItems.push({
+        label: opt.name,
+        key: opt.type,
+        children: (
+          <div className="DependencyGraph--graphWrapper">
+            {opt.type === 'FORCE_DIRECTED' && <DependencyForceGraph nodes={nodes} links={links} />}
+            {opt.type === 'DAG' && <DAG serviceCalls={dependencies} />}
+          </div>
+        ),
+      });
+    });
 
     return (
       <Tabs
@@ -99,16 +110,8 @@ export class DependencyGraphPageImpl extends Component {
         activeKey={graphType}
         type="card"
         tabBarStyle={{ background: '#f5f5f5', padding: '1rem 1rem 0 1rem' }}
-      >
-        {GRAPH_TYPE_OPTIONS.map(opt => (
-          <TabPane className="ub-relelative" tab={opt.name} key={opt.type}>
-            <div className="DependencyGraph--graphWrapper">
-              {opt.type === 'FORCE_DIRECTED' && <DependencyForceGraph nodes={nodes} links={links} />}
-              {opt.type === 'DAG' && <DAG serviceCalls={dependencies} />}
-            </div>
-          </TabPane>
-        ))}
-      </Tabs>
+        items={tabItems}
+      />
     );
   }
 }

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
@@ -84,14 +84,12 @@ describe('<DependencyGraph>', () => {
       wrapper.simulate('change', GRAPH_TYPES.FORCE_DIRECTED.type);
       expect(wrapper.state('graphType')).toBe(GRAPH_TYPES.FORCE_DIRECTED.type);
       expect(wrapper.props().activeKey).toBe(GRAPH_TYPES.FORCE_DIRECTED.type);
-      expect(wrapper.props().activeKey).not.toBe(GRAPH_TYPES.DAG.type);
     });
 
     it('renders a DAG graph when DAG is the selected type', () => {
       wrapper.simulate('change', GRAPH_TYPES.DAG.type);
       expect(wrapper.state('graphType')).toBe(GRAPH_TYPES.DAG.type);
       expect(wrapper.props().activeKey).toBe(GRAPH_TYPES.DAG.type);
-      expect(wrapper.props().activeKey).not.toBe(GRAPH_TYPES.FORCE_DIRECTED.type);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 import React from 'react';
-import { Tabs } from 'antd';
 import { shallow } from 'enzyme';
 
-import DAG from './DAG';
-import DependencyForceGraph from './DependencyForceGraph';
 import {
   DependencyGraphPageImpl as DependencyGraph,
   GRAPH_TYPES,
@@ -78,21 +75,23 @@ describe('<DependencyGraph>', () => {
 
   describe('graph types', () => {
     it('renders a menu with options for the graph types', () => {
-      expect(wrapper.find(Tabs.TabPane).length).toBe(Object.keys(GRAPH_TYPES).length);
-      expect(wrapper.find({ tab: GRAPH_TYPES.FORCE_DIRECTED.name }).length).toBe(1);
-      expect(wrapper.find({ tab: GRAPH_TYPES.DAG.name }).length).toBe(1);
+      expect(wrapper.props().items.length).toBe(Object.keys(GRAPH_TYPES).length);
+      expect(wrapper.props().items[0].name).toBe(Object.keys(GRAPH_TYPES)[0].name);
+      expect(wrapper.props().items[1].name).toBe(Object.keys(GRAPH_TYPES)[1].name);
     });
 
     it('renders a force graph when FORCE_GRAPH is the selected type', () => {
       wrapper.simulate('change', GRAPH_TYPES.FORCE_DIRECTED.type);
       expect(wrapper.state('graphType')).toBe(GRAPH_TYPES.FORCE_DIRECTED.type);
-      expect(wrapper.find(DependencyForceGraph).length).toBe(1);
+      expect(wrapper.props().activeKey).toBe(GRAPH_TYPES.FORCE_DIRECTED.type);
+      expect(wrapper.props().activeKey).not.toBe(GRAPH_TYPES.DAG.type);
     });
 
     it('renders a DAG graph when DAG is the selected type', () => {
       wrapper.simulate('change', GRAPH_TYPES.DAG.type);
       expect(wrapper.state('graphType')).toBe(GRAPH_TYPES.DAG.type);
-      expect(wrapper.find(DAG).length).toBe(1);
+      expect(wrapper.props().activeKey).toBe(GRAPH_TYPES.DAG.type);
+      expect(wrapper.props().activeKey).not.toBe(GRAPH_TYPES.FORCE_DIRECTED.type);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.js
@@ -30,16 +30,10 @@ describe('AltViewOptions', () => {
 
   let wrapper;
   const getLink = text => {
-    const menu = shallow(wrapper.find(Dropdown).prop('overlay')).dive();
-    const links = menu.find(Link);
+    const links = wrapper.find(Dropdown).prop('menu').items;
     for (let i = 0; i < links.length; i++) {
-      const link = links.at(i);
-      if (link.children().text() === text) return link;
-    }
-    const links2 = menu.find('a');
-    for (let i = 0; i < links2.length; i++) {
-      const link = links2.at(i);
-      if (link.children().text() === text) return link;
+      const link = links[i];
+      if (link.label.props.children === text) return link.label.props;
     }
     throw new Error(`Could not find "${text}"`);
   };
@@ -77,11 +71,11 @@ describe('AltViewOptions', () => {
 
   it('tracks viewing JSONs', () => {
     expect(trackJsonView).not.toHaveBeenCalled();
-    getLink('Trace JSON').simulate('click');
+    getLink('Trace JSON').onClick();
     expect(trackJsonView).toHaveBeenCalledTimes(1);
 
     expect(trackRawJsonView).not.toHaveBeenCalled();
-    getLink('Trace JSON (unadjusted)').simulate('click');
+    getLink('Trace JSON (unadjusted)').onClick();
     expect(trackRawJsonView).toHaveBeenCalledTimes(1);
 
     expect(trackJsonView).toHaveBeenCalledTimes(1);
@@ -126,7 +120,7 @@ describe('AltViewOptions', () => {
       expect(props.onTraceViewChange).toHaveBeenCalledTimes(i);
       expect(trackFn).not.toHaveBeenCalled();
 
-      getLink(link).simulate('click');
+      getLink(link).onClick();
       expect(props.onTraceViewChange).toHaveBeenCalledTimes(i + 1);
       viewInteractions.forEach(({ trackFn: fn }, j) => {
         expect(fn).toHaveBeenCalledTimes(j <= i ? 1 : 0);

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Dropdown, Menu, Button } from 'antd';
+import { Dropdown, Button } from 'antd';
 import { IoChevronDown } from 'react-icons/io5';
 import { Link } from 'react-router-dom';
 import './AltViewOptions.css';
@@ -76,17 +76,20 @@ export default function AltViewOptions(props: Props) {
     onTraceViewChange(item);
   };
 
-  const menu = (
-    <Menu>
-      {MENU_ITEMS.filter(item => item.viewType !== viewType).map(item => (
-        <Menu.Item key={item.viewType}>
-          <a onClick={() => handleSelectView(item.viewType)} role="button">
-            {item.label}
-          </a>
-        </Menu.Item>
-      ))}
-      {!disableJsonView && (
-        <Menu.Item>
+  const dropdownItems = [
+    ...MENU_ITEMS.filter(item => item.viewType !== viewType).map(item => ({
+      label: (
+        <a onClick={() => handleSelectView(item.viewType)} role="button">
+          {item.label}
+        </a>
+      ),
+      key: item.viewType as ETraceViewType | string,
+    })),
+  ];
+  if (!disableJsonView) {
+    dropdownItems.push(
+      {
+        label: (
           <Link
             to={prefixUrl(`/api/traces/${traceID}?prettyPrint=true`)}
             rel="noopener noreferrer"
@@ -95,10 +98,11 @@ export default function AltViewOptions(props: Props) {
           >
             Trace JSON
           </Link>
-        </Menu.Item>
-      )}
-      {!disableJsonView && (
-        <Menu.Item>
+        ),
+        key: 'trace-json',
+      },
+      {
+        label: (
           <Link
             to={prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`)}
             rel="noopener noreferrer"
@@ -107,15 +111,16 @@ export default function AltViewOptions(props: Props) {
           >
             Trace JSON (unadjusted)
           </Link>
-        </Menu.Item>
-      )}
-    </Menu>
-  );
+        ),
+        key: 'trace-json-unadjusted',
+      }
+    );
+  }
 
   const currentItem = MENU_ITEMS.find(item => item.viewType === viewType);
   const dropdownText = currentItem ? currentItem.label : 'Alternate Views';
   return (
-    <Dropdown overlay={menu}>
+    <Dropdown menu={{ items: dropdownItems }}>
       <Button className="AltViewOptions">
         {`${dropdownText} `}
         <IoChevronDown />

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -78,17 +78,18 @@ export default function AltViewOptions(props: Props) {
 
   const dropdownItems = [
     ...MENU_ITEMS.filter(item => item.viewType !== viewType).map(item => ({
+      key: item.viewType as ETraceViewType | string,
       label: (
         <a onClick={() => handleSelectView(item.viewType)} role="button">
           {item.label}
         </a>
       ),
-      key: item.viewType as ETraceViewType | string,
     })),
   ];
   if (!disableJsonView) {
     dropdownItems.push(
       {
+        key: 'trace-json',
         label: (
           <Link
             to={prefixUrl(`/api/traces/${traceID}?prettyPrint=true`)}
@@ -99,9 +100,9 @@ export default function AltViewOptions(props: Props) {
             Trace JSON
           </Link>
         ),
-        key: 'trace-json',
       },
       {
+        key: 'trace-json-unadjusted',
         label: (
           <Link
             to={prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`)}
@@ -112,7 +113,6 @@ export default function AltViewOptions(props: Props) {
             Trace JSON (unadjusted)
           </Link>
         ),
-        key: 'trace-json-unadjusted',
       }
     );
   }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/__snapshots__/AltViewOptions.test.js.snap
@@ -2,61 +2,69 @@
 
 exports[`AltViewOptions renders correctly 1`] = `
 <Dropdown
-  overlay={
-    <Menu>
-      <MenuItem>
-        <a
-          onClick={[Function]}
-          role="button"
-        >
-          Trace Graph
-        </a>
-      </MenuItem>
-      <MenuItem>
-        <a
-          onClick={[Function]}
-          role="button"
-        >
-          Trace Statistics
-        </a>
-      </MenuItem>
-      <MenuItem>
-        <a
-          onClick={[Function]}
-          role="button"
-        >
-          Trace Spans Table
-        </a>
-      </MenuItem>
-      <MenuItem>
-        <a
-          onClick={[Function]}
-          role="button"
-        >
-          Trace Flamegraph
-        </a>
-      </MenuItem>
-      <MenuItem>
-        <Link
-          onClick={[MockFunction]}
-          rel="noopener noreferrer"
-          target="_blank"
-          to="/api/traces/test trace ID?prettyPrint=true"
-        >
-          Trace JSON
-        </Link>
-      </MenuItem>
-      <MenuItem>
-        <Link
-          onClick={[MockFunction]}
-          rel="noopener noreferrer"
-          target="_blank"
-          to="/api/traces/test trace ID?raw=true&prettyPrint=true"
-        >
-          Trace JSON (unadjusted)
-        </Link>
-      </MenuItem>
-    </Menu>
+  menu={
+    Object {
+      "items": Array [
+        Object {
+          "key": "TraceGraph",
+          "label": <a
+            onClick={[Function]}
+            role="button"
+          >
+            Trace Graph
+          </a>,
+        },
+        Object {
+          "key": "TraceStatistics",
+          "label": <a
+            onClick={[Function]}
+            role="button"
+          >
+            Trace Statistics
+          </a>,
+        },
+        Object {
+          "key": "TraceSpansView",
+          "label": <a
+            onClick={[Function]}
+            role="button"
+          >
+            Trace Spans Table
+          </a>,
+        },
+        Object {
+          "key": "TraceFlamegraph",
+          "label": <a
+            onClick={[Function]}
+            role="button"
+          >
+            Trace Flamegraph
+          </a>,
+        },
+        Object {
+          "key": "trace-json",
+          "label": <Link
+            onClick={[MockFunction]}
+            rel="noopener noreferrer"
+            target="_blank"
+            to="/api/traces/test trace ID?prettyPrint=true"
+          >
+            Trace JSON
+          </Link>,
+        },
+        Object {
+          "key": "trace-json-unadjusted",
+          "label": <Link
+            onClick={[MockFunction]}
+            rel="noopener noreferrer"
+            target="_blank"
+            to="/api/traces/test trace ID?raw=true&prettyPrint=true"
+          >
+            Trace JSON (unadjusted)
+          </Link>,
+        },
+      ],
+    }
   }
 >
   <Button

--- a/packages/jaeger-ui/src/components/common/ExternalLinks.test.js
+++ b/packages/jaeger-ui/src/components/common/ExternalLinks.test.js
@@ -30,7 +30,7 @@ describe('<ExternalLinks>', () => {
       const wrapper = shallow(<ExternalLinks links={links} />);
       const dropdown = wrapper.find(Dropdown);
       expect(dropdown.length).toBe(1);
-      const submenuItems = wrapper.props().menu.items[0].label.props.items;
+      const submenuItems = wrapper.props().menu.items;
       expect(submenuItems.length).toBe(links.length);
       submenuItems.forEach((subMenu, i) => {
         expect(subMenu.label.props.href).toBe(links[i].url);

--- a/packages/jaeger-ui/src/components/common/ExternalLinks.test.js
+++ b/packages/jaeger-ui/src/components/common/ExternalLinks.test.js
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Menu, Dropdown } from 'antd';
+import { Dropdown } from 'antd';
 
 import ExternalLinks from './ExternalLinks';
 
@@ -30,13 +30,11 @@ describe('<ExternalLinks>', () => {
       const wrapper = shallow(<ExternalLinks links={links} />);
       const dropdown = wrapper.find(Dropdown);
       expect(dropdown.length).toBe(1);
-      const linkValues = shallow(dropdown.first().props().overlay).dive();
-      const submenuItems = linkValues.find(Menu.Item);
+      const submenuItems = wrapper.props().menu.items[0].label.props.items;
       expect(submenuItems.length).toBe(links.length);
       submenuItems.forEach((subMenu, i) => {
-        const linkValue = subMenu.find('LinkValue');
-        expect(linkValue.props().href).toBe(links[i].url);
-        expect(linkValue.props().children).toBe(links[i].text);
+        expect(subMenu.label.props.href).toBe(links[i].url);
+        expect(subMenu.label.props.children).toBe(links[i].text);
       });
     });
 

--- a/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
+++ b/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
@@ -40,12 +40,12 @@ const LinkValue = (props: {
 
 // export for testing
 export const linkValueList = (links: Link[]) => {
-  const menuItems: MenuProps['items'] = links.map(({ text, url }, index) => ({
+  const dropdownItems = links.map(({ text, url }, index) => ({
     label: <LinkValue href={url}>{text}</LinkValue>,
     key: `${url}-${index}`,
   }));
 
-  return [{ label: <Menu items={menuItems} />, key: 'external-links' }];
+  return dropdownItems;
 };
 
 export default function ExternalLinks(props: ExternalLinksProps) {

--- a/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
+++ b/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Dropdown, Menu, MenuProps } from 'antd';
+import { Dropdown } from 'antd';
 import * as React from 'react';
 import { Link } from '../../types/trace';
 import NewWindowIcon from './NewWindowIcon';

--- a/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
+++ b/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Dropdown, Menu } from 'antd';
+import { Dropdown, Menu, MenuProps } from 'antd';
 import * as React from 'react';
 import { Link } from '../../types/trace';
 import NewWindowIcon from './NewWindowIcon';
@@ -39,17 +39,14 @@ const LinkValue = (props: {
 );
 
 // export for testing
-export const linkValueList = (links: Link[]) => (
-  <Menu>
-    {links.map(({ text, url }, index) => (
-      // `index` is necessary in the key because url can repeat
-      // eslint-disable-next-line react/no-array-index-key
-      <Menu.Item key={`${url}-${index}`}>
-        <LinkValue href={url}>{text}</LinkValue>
-      </Menu.Item>
-    ))}
-  </Menu>
-);
+export const linkValueList = (links: Link[]) => {
+  const menuItems: MenuProps['items'] = links.map(({ text, url }, index) => ({
+    label: <LinkValue href={url}>{text}</LinkValue>,
+    key: `${url}-${index}`,
+  }));
+
+  return [{ label: <Menu items={menuItems} />, key: 'external-links' }];
+};
 
 export default function ExternalLinks(props: ExternalLinksProps) {
   const { links } = props;
@@ -57,7 +54,7 @@ export default function ExternalLinks(props: ExternalLinksProps) {
     return <LinkValue href={links[0].url} title={links[0].text} className="TracePageHeader--back" />;
   }
   return (
-    <Dropdown overlay={linkValueList(links)} placement="bottomRight" trigger={['click']}>
+    <Dropdown menu={{ items: linkValueList(links) }} placement="bottomRight" trigger={['click']}>
       <a className="TracePageHeader--back">
         <NewWindowIcon isLarge />
       </a>

--- a/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
+++ b/packages/jaeger-ui/src/components/common/ExternalLinks.tsx
@@ -48,6 +48,8 @@ export const linkValueList = (links: Link[]) => {
   return dropdownItems;
 };
 
+// ExternalLinks are displayed as a menu at the trace level.
+// Example: https://github.com/jaegertracing/jaeger-ui/assets/94157520/7f0d84bc-c2fb-488c-9e50-1ec9484ea1e6
 export default function ExternalLinks(props: ExternalLinksProps) {
   const { links } = props;
   if (links.length === 1) {

--- a/packages/jaeger-ui/src/components/common/NameSelector.test.js
+++ b/packages/jaeger-ui/src/components/common/NameSelector.test.js
@@ -116,7 +116,7 @@ describe('<NameSelector>', () => {
   it('controls the visibility of the popover', () => {
     expect(wrapper.state('popoverVisible')).toBe(false);
     const popover = wrapper.find(Popover);
-    popover.prop('onVisibleChange')(true);
+    popover.prop('onOpenChange')(true);
     expect(wrapper.state('popoverVisible')).toBe(true);
   });
 

--- a/packages/jaeger-ui/src/components/common/NameSelector.tsx
+++ b/packages/jaeger-ui/src/components/common/NameSelector.tsx
@@ -113,7 +113,7 @@ export default class NameSelector extends React.PureComponent<TProps, TState> {
     return (
       <Popover
         overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
-        onVisibleChange={this.onPopoverVisibleChanged}
+        onOpenChange={this.onPopoverVisibleChanged}
         placement="bottomLeft"
         content={
           <FilteredList
@@ -125,7 +125,7 @@ export default class NameSelector extends React.PureComponent<TProps, TState> {
           />
         }
         trigger="click"
-        visible={popoverVisible}
+        open={popoverVisible}
       >
         <h2 className={rootCls}>
           {useLabel && <span className="NameSelector--label">{label}:</span>}

--- a/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
@@ -16,11 +16,11 @@ exports[`<NameSelector> clear renders with clear icon when not required and with
       value="foo"
     />
   }
-  onVisibleChange={[Function]}
+  onOpenChange={[Function]}
+  open={false}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
   placement="bottomLeft"
   trigger="click"
-  visible={false}
 >
   <h2
     className="NameSelector"
@@ -63,11 +63,11 @@ exports[`<NameSelector> renders with is-invalid when required and without a valu
       value={null}
     />
   }
-  onVisibleChange={[Function]}
+  onOpenChange={[Function]}
+  open={false}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
   placement="bottomLeft"
   trigger="click"
-  visible={false}
 >
   <h2
     className="NameSelector is-invalid"
@@ -100,11 +100,11 @@ exports[`<NameSelector> renders without exploding 1`] = `
       value={null}
     />
   }
-  onVisibleChange={[Function]}
+  onOpenChange={[Function]}
+  open={false}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
   placement="bottomLeft"
   trigger="click"
-  visible={false}
 >
   <h2
     className="NameSelector is-invalid"
@@ -137,11 +137,11 @@ exports[`<NameSelector> renders without is-invalid when not required and without
       value={null}
     />
   }
-  onVisibleChange={[Function]}
+  onOpenChange={[Function]}
+  open={false}
   overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
   placement="bottomLeft"
   trigger="click"
-  visible={false}
 >
   <h2
     className="NameSelector"


### PR DESCRIPTION
## Which problem is this PR solving?
- part of: https://github.com/jaegertracing/jaeger-ui/issues/1703

## Description of the changes
- This PR removes the deprecated usages from ant-design DropDown, Tooltip, and Tab components
- The tab now needs an item array. Same with DropDown.
- The `visible` is changed to `open` without any change in the internal working.

## How was this change tested?
- manually, and unit tests

## What next?
- There are still a few components left with deprecated usages. Those will covered in the upcoming PRs, to keep the code changes per PR small.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
