### PR TITLE
FIxed unstable test in jaeger-ui/src/api/jaeger.test.js

### DIFF
--- a/packages/jaeger-ui/src/demo/trace-generators.js
+++ b/packages/jaeger-ui/src/demo/trace-generators.js
@@ -136,7 +136,7 @@ export default chance.mixin({
   }) {
     const startTime = chance.integer({
       min: traceStartTime,
-      max: traceEndTime,
+      max: traceEndTime - 1,
     });
 
     return {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1846 

## Description of the changes
-  In chance.integer({min: ,max: }) min and max are inclusive. 

`Previously`
https://github.com/jaegertracing/jaeger-ui/blob/87e6e6f16451b3e9395cbf251a00cf8be00f9340/packages/jaeger-ui/src/demo/trace-generators.js#L137-L140
- Sometimes code randomly takes startTime = max (=traceEndTime) which resultants `max = 0` in 
https://github.com/jaegertracing/jaeger-ui/blob/87e6e6f16451b3e9395cbf251a00cf8be00f9340/packages/jaeger-ui/src/demo/trace-generators.js#L150
 Which throws an error (As max < min)
 
 `Code Changes FIxes`
https://github.com/jaegertracing/jaeger-ui/blob/c703726d8e03d290c58138304a830b6df7e8b2f2/packages/jaeger-ui/src/demo/trace-generators.js#L137-L140
 - Now startTIme max value is traceEndTime-1 
 Which ensures max value will not fall behind min value in 
 https://github.com/jaegertracing/jaeger-ui/blob/87e6e6f16451b3e9395cbf251a00cf8be00f9340/packages/jaeger-ui/src/demo/trace-generators.js#L150
 (Here minimum of max is 1, So always min <= max) 
 
 @yurishkuro 