### PR TITLE
Fixed a flaky test in virtualizedTraceView

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js
@@ -111,7 +111,7 @@ describe('<VirtualizedTraceViewImpl>', () => {
   });
 
   it('renders when a trace is not set', () => {
-    wrapper.setProps({ trace: null });
+    wrapper.setProps({ trace: [] });
     expect(wrapper).toBeDefined();
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1875

## Description of the changes
- If trace is set to null code path will not goes through the generateRowStates function 
https://github.com/jaegertracing/jaeger-ui/blob/cd6b28461d8a45d45d465099177638ac6a81f211/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx#L150
- so trace is set to an empty array
https://github.com/jaegertracing/jaeger-ui/blob/cd6b28461d8a45d45d465099177638ac6a81f211/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.js#L114-L115