### PR TITLE
CI: Add the label-check workflow to verify changelog labels on each PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     open-pull-requests-limit: 50
+    labels: [ "changelog:dependencies" ]
     directory: "/"
     schedule:
       interval: "daily"
@@ -38,3 +39,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels: [ "changelog:dependencies" ]

--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -1,0 +1,30 @@
+name: Verify PR Label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR author
+        id: check_author
+        run: echo "::set-output name=is_dependabot::$(echo ${{ github.event.pull_request.user.login }} | grep -o 'dependabot')"
+
+      - name: Check PR label
+        if: steps.check_author.outputs.is_dependabot != 'dependabot'
+        run: |
+          LABEL_NAME="changelog:"
+          if [[ $(curl -s "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" | jq -r '.labels[].name' | grep -c "^$LABEL_NAME") -eq 0 ]]; then
+            echo "Error: Pull request is missing a required label of the form '${LABEL_NAME}***'."
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Which problem is this PR solving?
- resolves https://github.com/jaegertracing/jaeger/issues/4799

## Description of the changes
- [x] Add a GitHub Action that will verify that a PR has a specific categorization label before it can be merged. We already have a bunch of those labels changelog:*** labels
- [x] Configure dependabot to use `changelog:dependencies` label
- Since we already use the release script from `jaeger` repo, everything else is setup 🚀 
- One task is left, that is to create changelog labels inside this `jaeger-ui` repository. //cc: @yurishkuro 

https://github.com/jaegertracing/jaeger-ui/blob/1909398b498b8f4536c6a58809c2fe1eb88b062a/Makefile#L2-L5

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
