### PR TITLE
Fix linting warnings for Function, Boolean and String types

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -112,9 +112,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
               error={error.opsLatencies}
             />
             <div className="table-graph-avg">
-              {row.dataPoints.service_operation_latencies.length > 0
-                ? formatTimeValue(value * 1000)
-                : ''}
+              {row.dataPoints.service_operation_latencies.length > 0 ? formatTimeValue(value * 1000) : ''}
             </div>
           </div>
         ),
@@ -133,9 +131,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
               error={error.opsCalls}
             />
             <div className="table-graph-avg">
-              {typeof value === 'number' && row.dataPoints.service_operation_call_rate.length > 0
-                ? `${formatValue(value)} req/s`
-                : ''}
+              {row.dataPoints.service_operation_call_rate.length > 0 ? `${formatValue(value)} req/s` : ''}
             </div>
           </div>
         ),
@@ -155,9 +151,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
               error={error.opsErrors}
             />
             <div className="table-graph-avg">
-              {typeof value === 'number' && row.dataPoints.service_operation_error_rate.length > 0
-                ? `${formatValue(value * 100)}%`
-                : ''}
+              {row.dataPoints.service_operation_error_rate.length > 0 ? `${formatValue(value * 100)}%` : ''}
             </div>
           </div>
         ),

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -112,7 +112,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
               error={error.opsLatencies}
             />
             <div className="table-graph-avg">
-              {typeof value === 'number' && row.dataPoints.service_operation_latencies.length > 0
+              {row.dataPoints.service_operation_latencies.length > 0
                 ? formatTimeValue(value * 1000)
                 : ''}
             </div>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
@@ -117,10 +117,10 @@ export function findServerChildSpan(spans: Span[]) {
   return null;
 }
 
-export const isKindClient = (span: Span): Boolean =>
+export const isKindClient = (span: Span): boolean =>
   span.tags.some(({ key, value }) => key === 'span.kind' && value === 'client');
 
-export const isKindProducer = (span: Span): Boolean =>
+export const isKindProducer = (span: Span): boolean =>
   span.tags.some(({ key, value }) => key === 'span.kind' && value === 'producer');
 
 export { formatDuration } from '../../../utils/date';

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.tsx
@@ -27,7 +27,7 @@ function transformTracesToPaths(
   focalService: string,
   focalOperation?: string
 ): TDdgPayload {
-  const dependenciesMap = new Map<String, TDdgPayloadPath>();
+  const dependenciesMap = new Map<string, TDdgPayloadPath>();
   Object.values(traces).forEach(({ data }) => {
     if (data) {
       const spanMap: Map<string, Span> = new Map();

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -58,7 +58,7 @@ export type MonitorEmptyStateConfig = {
   description?: string;
   button?: {
     text?: string;
-    onClick?: Function;
+    onClick?: () => void;
   };
   info?: string;
   alert?: {

--- a/packages/jaeger-ui/src/utils/TreeNode.tsx
+++ b/packages/jaeger-ui/src/utils/TreeNode.tsx
@@ -49,7 +49,7 @@ export default class TreeNode<TValue> {
     return this;
   }
 
-  find(search: Function): TreeNode<TValue> | null {
+  find(search: (node: TreeNode<TValue>) => boolean): TreeNode<TValue> | null {
     const searchFn = TreeNode.iterFunction(TreeNode.searchFunction(search));
     if (searchFn(this)) {
       return this;
@@ -63,7 +63,7 @@ export default class TreeNode<TValue> {
     return null;
   }
 
-  getPath(search: Function) {
+  getPath(search: (node: TreeNode<TValue>) => boolean) {
     const searchFn = TreeNode.iterFunction(TreeNode.searchFunction(search));
 
     const findPath = (


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves part of no-unused-vars warnings for #1608 

## Description of the changes
-  Fixed ESlint warnings for Function, Boolean and String types

## How was this change tested?
- By running "yarn lint" command

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
