### PR TITLE
Fix time calculation in Trace Graph view

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.test.js
@@ -35,6 +35,7 @@ describe('<OpNode>', () => {
       selfTime: 180000,
       service: 'service1',
       time: 200000,
+      totalTime: 200000,
     };
     wrapper = shallow(<OpNode {...props} mode={mode} />);
   });

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
@@ -66,7 +66,8 @@ export function round2(percent: number) {
 
 export default class OpNode extends React.PureComponent<Props> {
   render() {
-    const { count, errors, time, percent, selfTime, percentSelfTime, operation, service, mode } = this.props;
+    const { count, errors, time, totalTime, percent, selfTime, percentSelfTime, operation, service, mode } =
+      this.props;
 
     // Spans over 20 % time are full red - we have probably to reconsider better approach
     let backgroundColor;
@@ -99,7 +100,7 @@ export default class OpNode extends React.PureComponent<Props> {
                 tooltipTitle="Copy label"
               />
             </td>
-            <td className="OpNode--metricCell OpNode--avg">{round2(time / 1000 / count)} ms</td>
+            <td className="OpNode--metricCell OpNode--avg">{round2(totalTime / 1000 / count)} ms</td>
           </tr>
           <tr>
             <td className="OpNode--metricCell OpNode--time">

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.test.js
@@ -19,7 +19,7 @@ import testTrace from './testTrace.json';
 
 const transformedTrace = transformTraceData(testTrace);
 
-function assertData(nodes, service, operation, count, errors, time, percent, selfTime) {
+function assertData(nodes, service, operation, count, errors, time, totalTime, percent, selfTime) {
   const d = nodes.find(({ data: n }) => n.service === service && n.operation === operation).data;
   expect(d).toBeDefined();
   expect(d.count).toBe(count);
@@ -34,18 +34,18 @@ describe('calculateTraceDagEV', () => {
     const traceDag = calculateTraceDagEV(transformedTrace);
     const { vertices: nodes } = traceDag;
     expect(nodes.length).toBe(9);
-    assertData(nodes, 'service1', 'op1', 1, 0, 390, 39, 224);
+    assertData(nodes, 'service1', 'op1', 1, 0, 390, 390, 39, 224);
     // accumulate data (count,times)
-    assertData(nodes, 'service1', 'op2', 2, 1, 70, 7, 70);
+    assertData(nodes, 'service1', 'op2', 2, 1, 70, 70, 7, 70);
     // self-time is substracted from child
-    assertData(nodes, 'service1', 'op3', 1, 0, 66, 6.6, 46);
-    assertData(nodes, 'service2', 'op1', 1, 0, 20, 2, 2);
-    assertData(nodes, 'service2', 'op2', 1, 0, 18, 1.8, 18);
+    assertData(nodes, 'service1', 'op3', 1, 0, 66, 66, 6.6, 46);
+    assertData(nodes, 'service2', 'op1', 1, 0, 20, 20, 2, 2);
+    assertData(nodes, 'service2', 'op2', 1, 0, 18, 18, 1.8, 18);
     // follows_from relation will not influence self-time
-    assertData(nodes, 'service1', 'op4', 1, 0, 20, 2, 20);
-    assertData(nodes, 'service2', 'op3', 1, 0, 200, 20, 200);
+    assertData(nodes, 'service1', 'op4', 1, 0, 20, 20, 2, 20);
+    assertData(nodes, 'service2', 'op3', 1, 0, 200, 200, 20, 200);
     // fork-join self-times are calculated correctly (self-time drange)
-    assertData(nodes, 'service1', 'op6', 1, 0, 10, 1, 1);
-    assertData(nodes, 'service1', 'op7', 2, 0, 17, 1.7, 17);
+    assertData(nodes, 'service1', 'op6', 1, 0, 10, 10, 1, 1);
+    assertData(nodes, 'service1', 'op7', 2, 0, 9, 17, 0.9, 9);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.tsx
@@ -81,7 +81,12 @@ export function calculateTraceDag(trace: Trace): TraceDag<TSumSpan & TDenseSpanM
   const dag = new TraceDag<TSumSpan & TDenseSpanMembers>();
 
   baseDag.nodesMap.forEach(node => {
-    const ntime = node.members.reduce((p, m) => p + m.span.duration, 0);
+    const ntime = node.members.reduce(
+      (mdr, m) =>
+        mdr.add(m.span.startTime, m.span.startTime + (m.span.duration <= 0 ? 0 : m.span.duration - 1)),
+      new DRange()
+    ).length;
+    const totalTime = node.members.reduce((p, m) => p + m.span.duration, 0);
     const numErrors = node.members.reduce((p, m) => (p + isError(m.span.tags) ? 1 : 0), 0);
     const childDurationsDRange = node.members.reduce((p, m) => {
       // Using DRange to handle overlapping spans (fork-join)
@@ -96,6 +101,7 @@ export function calculateTraceDag(trace: Trace): TraceDag<TSumSpan & TDenseSpanM
       count: node.members.length,
       errors: numErrors,
       time: ntime,
+      totalTime: totalTime,
       percent: (100 / trace.duration) * ntime,
       selfTime: stime,
       percentSelfTime: (100 / ntime) * stime,

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/types.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/types.tsx
@@ -24,6 +24,7 @@ export type TSumSpan = {
   percentSelfTime: number;
   selfTime: number;
   time: number;
+  totalTime: number;
 };
 
 export type TEv = {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1918

## Description of the changes
- Now the total duration is calculating as the duration of the union of spans.

## How was this change tested?
- Modified existing tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
