### PR TITLE
Migrate `TraceTimelineLink.test.js` from enzyme to RTL

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceTimelineLink.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceTimelineLink.test.js
@@ -29,7 +29,9 @@ describe('TraceTimelineLink', () => {
   });
 
   it('links to the given trace', () => {
-    expect(screen.getByRole('link').href).toBe(`http://localhost/trace/${traceID}`);
+    const link = screen.getByRole('link');
+    const url = new URL(link.href);
+    expect(url.pathname).toBe(`/trace/${traceID}`);
   });
 
   it('stops event propagation', () => {

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceTimelineLink.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceTimelineLink.test.js
@@ -13,30 +13,31 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
 
 import TraceTimelineLink from './TraceTimelineLink';
-import NewWindowIcon from '../../common/NewWindowIcon';
 
 describe('TraceTimelineLink', () => {
   const traceID = 'test-trace-id';
-  let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(<TraceTimelineLink traceID={traceID} />);
+    render(<TraceTimelineLink traceID={traceID} />);
   });
 
   it('renders the NewWindowIcon', () => {
-    expect(wrapper.find(NewWindowIcon).length).toBe(1);
+    expect(screen.getAllByTestId('NewWindowIcon').length).toBe(1);
   });
 
   it('links to the given trace', () => {
-    expect(wrapper.find('a').prop('href')).toBe(`/trace/${traceID}`);
+    expect(screen.getByRole('link').href).toBe(`http://localhost/trace/${traceID}`);
   });
 
   it('stops event propagation', () => {
-    const stopPropagation = jest.fn();
-    wrapper.find('a').simulate('click', { stopPropagation });
-    expect(stopPropagation).toHaveBeenCalled();
+    // Create an event to capture the click
+    const propogatedEvent = createEvent.click(screen.getByRole('link'));
+    propogatedEvent.stopPropagation = jest.fn();
+
+    fireEvent(screen.getByRole('link'), propogatedEvent);
+    expect(propogatedEvent.stopPropagation).toHaveBeenCalled();
   });
 });

--- a/packages/jaeger-ui/src/components/common/NewWindowIcon.tsx
+++ b/packages/jaeger-ui/src/components/common/NewWindowIcon.tsx
@@ -25,7 +25,7 @@ type Props = {
 export default function NewWindowIcon(props: Props) {
   const { isLarge, ...rest } = props;
   const cls = cx('NewWindowIcon', { 'is-large': isLarge });
-  return <IoOpenOutline className={cls} {...rest} />;
+  return <IoOpenOutline className={cls} {...rest} data-testid="NewWindowIcon" />;
 }
 
 NewWindowIcon.defaultProps = {


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
Fixes part of #1668 

## Description of the changes
Migrated the `TraceTimelineLink.test.js` to `RTL` using the idiomatic RTL practices

## How was this change tested?
Ran the test suite to ensure all changes passed.

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
