### PR TITLE
refac: migrate `ChevronDown` from enzyme to RTL

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/ChevronDown.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/ChevronDown.test.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { IoChevronDown } from 'react-icons/io5';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import ChevronDown from './ChevronDown';
 
@@ -24,14 +24,14 @@ describe('ChevronDown', () => {
     const style = {
       border: 'black solid 1px',
     };
-    const wrapper = shallow(<ChevronDown className={className} style={style} />);
+    const { container } = render(<ChevronDown className={className} style={style} />);
 
-    expect(wrapper.hasClass(className)).toBe(true);
-    expect(wrapper.find(IoChevronDown).prop('style')).toBe(style);
+    expect(container.firstChild).toHaveClass(className);
+    expect(container.firstChild).toHaveStyle(style);
   });
 
   it('does not add `undefined` as a className when not given a className', () => {
-    const wrapper = shallow(<ChevronDown />);
-    expect(wrapper.hasClass('undefined')).toBe(false);
+    const { container } = render(<ChevronDown />);
+    expect(container.firstChild).not.toHaveClass('undefined');
   });
 });


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
Fixes part of #1668 

## Description of the changes
Migrates the test for `ChevronDown.tsx` to RTL

## How was this change tested?
Ran the test suite locally

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
