### PR TITLE
Add link to FAQ explaining why service map is empty

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
@@ -82,7 +82,19 @@ export class DependencyGraphPageImpl extends Component {
     }
 
     if (!nodes || !links) {
-      return <div className="u-simple-card ub-m3">No service dependencies found.</div>;
+      return (
+        <div className="u-simple-card ub-m3">
+          No service dependencies found.{' '}
+          <a
+            href="https://www.jaegertracing.io/docs/latest/faq/#why-is-the-dependencies-page-empty"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            See FAQ
+          </a>
+          .
+        </div>
+      );
     }
 
     const GRAPH_TYPE_OPTIONS = [GRAPH_TYPES.FORCE_DIRECTED];


### PR DESCRIPTION
## Which problem is this PR solving?
- Still getting questions like https://github.com/jaegertracing/jaeger/issues/4939

## Description of the changes
- Add a link to FAQ that explains why service map can be empty.

## How was this change tested?
<img width="671" alt="image" src="https://github.com/jaegertracing/jaeger-ui/assets/3523016/5fba809e-a888-4dd4-a0ee-46e067e31c65">
