### PR TITLE
Change dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     labels: [ "changelog:dependencies" ]
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
     # we have too many dependency PRs today to rebase automatically
     rebase-strategy: "disabled"
     groups:
@@ -38,5 +39,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
     labels: [ "changelog:dependencies" ]


### PR DESCRIPTION
## Which problem is this PR solving?
- Daily frequency in unnecessary and occasionally picks multiple patch releases in a single Jaeger cycle, which is just unnecessary overhead on maintainers

## Description of the changes
- Change run frequency to weekly

## How was this change tested?
- CI
