### PR TITLE
feat: remove `is-promise` library

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -60,7 +60,6 @@
     "drange": "^2.0.0",
     "global": "^4.3.2",
     "history": "^4.6.3",
-    "is-promise": "^4.0.0",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.19",
     "logfmt": "^1.4.0",

--- a/packages/jaeger-ui/src/actions/jaeger-api.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.js
@@ -21,18 +21,6 @@ const metricType = {
   errors: 'errors',
 };
 
-// export for tests
-// TODO use native `allSetteled` once #818 is done
-export function allSettled(promises) {
-  const wrappedPromises = promises.map(p =>
-    Promise.resolve(p).then(
-      val => ({ status: 'fulfilled', value: val }),
-      err => ({ status: 'rejected', reason: err })
-    )
-  );
-  return Promise.all(wrappedPromises);
-}
-
 export const fetchTrace = createAction(
   '@JAEGER_API/FETCH_TRACE',
   id => JaegerAPI.fetchTrace(id),
@@ -84,7 +72,7 @@ export const fetchDependencies = createAction('@JAEGER_API/FETCH_DEPENDENCIES', 
 export const fetchAllServiceMetrics = createAction(
   '@JAEGER_API/FETCH_ALL_SERVICE_METRICS',
   (serviceName, query) => {
-    return allSettled([
+    return Promise.allSettled([
       JaegerAPI.fetchMetrics(metricType.latencies, [serviceName], { ...query, quantile: 0.5 }),
       JaegerAPI.fetchMetrics(metricType.latencies, [serviceName], { ...query, quantile: 0.75 }),
       JaegerAPI.fetchMetrics(metricType.latencies, [serviceName], query),
@@ -98,7 +86,7 @@ export const fetchAggregatedServiceMetrics = createAction(
   '@JAEGER_API/FETCH_AGGREGATED_SERVICE_METRICS',
   (serviceName, queryParams) => {
     const query = { ...queryParams, groupByOperation: true };
-    return allSettled([
+    return Promise.allSettled([
       JaegerAPI.fetchMetrics(metricType.latencies, [serviceName], query),
       JaegerAPI.fetchMetrics(metricType.calls, [serviceName], query),
       JaegerAPI.fetchMetrics(metricType.errors, [serviceName], query),

--- a/packages/jaeger-ui/src/actions/jaeger-api.test.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.test.js
@@ -23,8 +23,11 @@ jest.mock(
     })
 );
 
-import sinon from 'sinon';
+function isPromise(p) {
+  return p !== null && typeof p === 'object' && typeof p.then === 'function' && typeof p.catch === 'function';
+}
 
+import sinon from 'sinon';
 import * as jaegerApiActions from './jaeger-api';
 import JaegerAPI from '../api/jaeger';
 
@@ -48,6 +51,11 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
+  it('@JAEGER_API/FETCH_TRACE should return the promise', () => {
+    const { payload } = jaegerApiActions.fetchTrace(id);
+    expect(isPromise(payload)).toBeTruthy();
+  });
+
   it('@JAEGER_API/FETCH_TRACE should attach the id as meta', () => {
     const { meta } = jaegerApiActions.fetchTrace(id);
     expect(meta.id).toBe(id);
@@ -57,6 +65,11 @@ describe('actions/jaeger-api', () => {
     mock.expects('searchTraces').withExactArgs(sinon.match.has('traceID', ids));
     jaegerApiActions.fetchMultipleTraces(ids);
     expect(() => mock.verify()).not.toThrow();
+  });
+
+  it('@JAEGER_API/FETCH_MULTIPLE_TRACES should return the promise', () => {
+    const { payload } = jaegerApiActions.fetchMultipleTraces(ids);
+    expect(isPromise(payload)).toBeTruthy();
   });
 
   it('@JAEGER_API/FETCH_MULTIPLE_TRACES should attach the ids as meta', () => {
@@ -70,6 +83,11 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
+  it('@JAEGER_API/ARCHIVE_TRACE should return the promise', () => {
+    const { payload } = jaegerApiActions.archiveTrace(id);
+    expect(isPromise(payload)).toBeTruthy();
+  });
+
   it('@JAEGER_API/ARCHIVE_TRACE should attach the id as meta', () => {
     const { meta } = jaegerApiActions.archiveTrace(id);
     expect(meta.id).toBe(id);
@@ -81,9 +99,19 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
+  it('@JAEGER_API/SEARCH_TRACES should return the promise', () => {
+    const { payload } = jaegerApiActions.searchTraces(query);
+    expect(isPromise(payload)).toBeTruthy();
+  });
+
   it('@JAEGER_API/SEARCH_TRACES should attach the query as meta', () => {
     const { meta } = jaegerApiActions.searchTraces(query);
     expect(meta.query).toEqual(query);
+  });
+
+  it('@JAEGER_API/FETCH_SERVICES should return a promise', () => {
+    const { payload } = jaegerApiActions.fetchServices();
+    expect(isPromise(payload)).toBeTruthy();
   });
 
   it('@JAEGER_API/FETCH_SERVICE_OPERATIONS should call the JaegerAPI', () => {
@@ -104,6 +132,11 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
+  it('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should return the promise', () => {
+    const { payload } = jaegerApiActions.fetchDeepDependencyGraph(query);
+    expect(isPromise(payload)).toBeTruthy();
+  });
+
   it('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should attach the query as meta', () => {
     const { meta } = jaegerApiActions.fetchDeepDependencyGraph(query);
     expect(meta.query).toEqual(query);
@@ -115,6 +148,11 @@ describe('actions/jaeger-api', () => {
     expect(called.verify()).toBeTruthy();
   });
 
+  it('@JAEGER_API/FETCH_ALL_SERVICE_METRICS should return the promise', () => {
+    const { payload } = jaegerApiActions.fetchAllServiceMetrics('serviceName', query);
+    expect(isPromise(payload)).toBeTruthy();
+  });
+
   it('@JAEGER_API/FETCH_ALL_SERVICE_METRICS should fetch service metrics by name', () => {
     mock.expects('fetchMetrics');
     mock.expects('fetchMetrics');
@@ -123,6 +161,11 @@ describe('actions/jaeger-api', () => {
     mock.expects('fetchMetrics');
     jaegerApiActions.fetchAllServiceMetrics('serviceName', query);
     expect(() => mock.verify()).not.toThrow();
+  });
+
+  it('@JAEGER_API/FETCH_AGGREGATED_SERVICE_METRICS should return the promise', () => {
+    const { payload } = jaegerApiActions.fetchAggregatedServiceMetrics('serviceName', query);
+    expect(isPromise(payload)).toBeTruthy();
   });
 
   it('@JAEGER_API/FETCH_AGGREGATED_SERVICE_METRICS should fetch service metrics by name', () => {

--- a/packages/jaeger-ui/src/actions/jaeger-api.test.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.test.js
@@ -24,7 +24,6 @@ jest.mock(
 );
 
 import sinon from 'sinon';
-import isPromise from 'is-promise';
 
 import * as jaegerApiActions from './jaeger-api';
 import JaegerAPI from '../api/jaeger';
@@ -49,11 +48,6 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
-  it('@JAEGER_API/FETCH_TRACE should return the promise', () => {
-    const { payload } = jaegerApiActions.fetchTrace(id);
-    expect(isPromise(payload)).toBeTruthy();
-  });
-
   it('@JAEGER_API/FETCH_TRACE should attach the id as meta', () => {
     const { meta } = jaegerApiActions.fetchTrace(id);
     expect(meta.id).toBe(id);
@@ -63,11 +57,6 @@ describe('actions/jaeger-api', () => {
     mock.expects('searchTraces').withExactArgs(sinon.match.has('traceID', ids));
     jaegerApiActions.fetchMultipleTraces(ids);
     expect(() => mock.verify()).not.toThrow();
-  });
-
-  it('@JAEGER_API/FETCH_MULTIPLE_TRACES should return the promise', () => {
-    const { payload } = jaegerApiActions.fetchMultipleTraces(ids);
-    expect(isPromise(payload)).toBeTruthy();
   });
 
   it('@JAEGER_API/FETCH_MULTIPLE_TRACES should attach the ids as meta', () => {
@@ -81,11 +70,6 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
-  it('@JAEGER_API/ARCHIVE_TRACE should return the promise', () => {
-    const { payload } = jaegerApiActions.archiveTrace(id);
-    expect(isPromise(payload)).toBeTruthy();
-  });
-
   it('@JAEGER_API/ARCHIVE_TRACE should attach the id as meta', () => {
     const { meta } = jaegerApiActions.archiveTrace(id);
     expect(meta.id).toBe(id);
@@ -97,19 +81,9 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
-  it('@JAEGER_API/SEARCH_TRACES should return the promise', () => {
-    const { payload } = jaegerApiActions.searchTraces(query);
-    expect(isPromise(payload)).toBeTruthy();
-  });
-
   it('@JAEGER_API/SEARCH_TRACES should attach the query as meta', () => {
     const { meta } = jaegerApiActions.searchTraces(query);
     expect(meta.query).toEqual(query);
-  });
-
-  it('@JAEGER_API/FETCH_SERVICES should return a promise', () => {
-    const { payload } = jaegerApiActions.fetchServices();
-    expect(isPromise(payload)).toBeTruthy();
   });
 
   it('@JAEGER_API/FETCH_SERVICE_OPERATIONS should call the JaegerAPI', () => {
@@ -130,11 +104,6 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
-  it('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should return the promise', () => {
-    const { payload } = jaegerApiActions.fetchDeepDependencyGraph(query);
-    expect(isPromise(payload)).toBeTruthy();
-  });
-
   it('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should attach the query as meta', () => {
     const { meta } = jaegerApiActions.fetchDeepDependencyGraph(query);
     expect(meta.query).toEqual(query);
@@ -144,11 +113,6 @@ describe('actions/jaeger-api', () => {
     const called = mock.expects('fetchDependencies').once();
     jaegerApiActions.fetchDependencies();
     expect(called.verify()).toBeTruthy();
-  });
-
-  it('@JAEGER_API/FETCH_ALL_SERVICE_METRICS should return the promise', () => {
-    const { payload } = jaegerApiActions.fetchAllServiceMetrics('serviceName', query);
-    expect(isPromise(payload)).toBeTruthy();
   });
 
   it('@JAEGER_API/FETCH_ALL_SERVICE_METRICS should fetch service metrics by name', () => {
@@ -161,33 +125,11 @@ describe('actions/jaeger-api', () => {
     expect(() => mock.verify()).not.toThrow();
   });
 
-  it('@JAEGER_API/FETCH_AGGREGATED_SERVICE_METRICS should return the promise', () => {
-    const { payload } = jaegerApiActions.fetchAggregatedServiceMetrics('serviceName', query);
-    expect(isPromise(payload)).toBeTruthy();
-  });
-
   it('@JAEGER_API/FETCH_AGGREGATED_SERVICE_METRICS should fetch service metrics by name', () => {
     mock.expects('fetchMetrics');
     mock.expects('fetchMetrics');
     mock.expects('fetchMetrics');
     jaegerApiActions.fetchAggregatedServiceMetrics('serviceName', query);
     expect(() => mock.verify()).not.toThrow();
-  });
-});
-
-describe('allSettled', () => {
-  it('validate responses', async () => {
-    const res = await jaegerApiActions.allSettled([
-      Promise.resolve(1),
-      // eslint-disable-next-line prefer-promise-reject-errors
-      Promise.reject(2),
-      Promise.resolve(3),
-    ]);
-
-    expect(res).toEqual([
-      { status: 'fulfilled', value: 1 },
-      { status: 'rejected', reason: 2 },
-      { status: 'fulfilled', value: 3 },
-    ]);
   });
 });

--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -224,6 +224,7 @@ describe('formatRelativeDate', () => {
     const output = input.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
+      year: 'numeric',
     });
     expect(formatRelativeDate(input)).toBe(output);
   });

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -12,18 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import isPromise from 'is-promise';
-
 import readJsonFile from './readJsonFile';
 
 describe('fileReader.readJsonFile', () => {
-  it('returns a promise', () => {
-    const promise = readJsonFile({ rando: true });
-    // prevent the unhandled rejection warning
-    promise.catch(() => {});
-    expect(isPromise(promise)).toBeTruthy();
-  });
-
   it('rejects when given an invalid file', () => {
     const p = readJsonFile({ rando: true });
     return expect(p).rejects.toMatchObject(expect.any(Error));

--- a/packages/jaeger-ui/src/utils/readJsonFile.tsx
+++ b/packages/jaeger-ui/src/utils/readJsonFile.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export default function readJsonFile(fileList: { file: File }) {
+export default function readJsonFile(fileList: { file: File }): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {
@@ -22,24 +22,21 @@ export default function readJsonFile(fileList: { file: File }) {
       }
       try {
         resolve(JSON.parse(reader.result));
-        /* eslint-disable @typescript-eslint/no-explicit-any */
-      } catch (error: any) {
-        reject(new Error(`Error parsing JSON: ${error.message}`));
+      } catch (error: unknown) {
+        reject(new Error(`Error parsing JSON: ${(error as Error).message}`));
       }
     };
     reader.onerror = () => {
-      // eslint-disable-next-line no-console
       const errMessage = reader.error ? `: ${String(reader.error)}` : '';
       reject(new Error(`Error reading the JSON file${errMessage}`));
     };
     reader.onabort = () => {
-      // eslint-disable-next-line no-console
       reject(new Error(`Reading the JSON file has been aborted`));
     };
     try {
       reader.readAsText(fileList.file);
-    } catch (error: any) {
-      reject(new Error(`Error reading the JSON file: ${error.message}`));
+    } catch (error: unknown) {
+      reject(new Error(`Error reading the JSON file: ${(error as Error).message}`));
     }
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6110,11 +6110,6 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
-is-promise@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
-  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
-
 is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #2074 

## Description of the changes
- Removed the `is-promise` library
- Added the type assertions wherever necessary
- Removed the redundant tests
- Made use of the native `Promise.allSettled` function (as described in a comment)

There seems to be an unrelated test in `date.test.js` that fails after these changes. I have fixed the test with what I think the intended testing was supposed to do. Would appreciate a review on the same!

## How was this change tested?
- Running the test suite locally

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
