### PR TITLE
Use import from /dist/ instead of symlink

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
@@ -20,7 +20,7 @@ import { XYPlot, XAxis, YAxis, MarkSeries, Hint } from 'react-vis';
 import { FALLBACK_TRACE_NAME } from '../../../constants';
 import { ONE_MILLISECOND, formatDuration } from '../../../utils/date';
 
-import './react-vis.css';
+import 'react-vis/dist/style.css';
 import './ScatterPlot.css';
 
 export default function ScatterPlot(props) {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/react-vis.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/react-vis.css
@@ -1,1 +1,0 @@
-../../../../../../node_modules/react-vis/dist/style.css


### PR DESCRIPTION
## Which problem is this PR solving?
This is an insignificant issue, so I didn't open an issue ticket beforehand. There's a symlink here to a file in node_modules. It's small problem, but the symlink is unnecessary. I came across this because I have this repo as a submodule in another project, and back up those changes (and a lot of other repos) with `rsync`, the sync checks output to see if there are errors. I would guess this also causes problems on Windows without WSL.

## Description of the changes
Change the import. This Just Works™ in Vite.

## How was this change tested?
`yarn lint && yarn test && yarn start`, and `yarn build`, and grepping `react-vis` clases in the assets.

<img width="733" alt="Screenshot 2024-01-26 at 11 10 46" src="https://github.com/jaegertracing/jaeger-ui/assets/12520493/7336fbea-29fe-4982-abd2-4ff75726b56f">

<img width="733" alt="Screenshot 2024-01-26 at 11 10 37" src="https://github.com/jaegertracing/jaeger-ui/assets/12520493/d12b23f9-272b-4ab2-9f80-92f18ced9414">

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`