### PR TITLE
Prevent KeyValueTable copy column from wrapping

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -26,11 +26,11 @@ limitations under the License.
   vertical-align: baseline;
 }
 
-.KeyValueTable--row>td {
+.KeyValueTable--row > td {
   padding: 0.25rem 0.5rem;
 }
 
-.KeyValueTable--row:nth-child(2n)>td {
+.KeyValueTable--row:nth-child(2n) > td {
   background: #f5f5f5;
 }
 
@@ -45,11 +45,11 @@ limitations under the License.
   text-align: right;
 }
 
-.KeyValueTable--row:not(:hover)>.KeyValueTable--copyColumn>.KeyValueTable--copyIcon {
+.KeyValueTable--row:not(:hover) > .KeyValueTable--copyColumn > .KeyValueTable--copyIcon {
   visibility: hidden;
 }
 
-.KeyValueTable--row>td {
+.KeyValueTable--row > td {
   padding: 0.25rem 0.5rem;
   vertical-align: top;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -26,11 +26,11 @@ limitations under the License.
   vertical-align: baseline;
 }
 
-.KeyValueTable--row > td {
+.KeyValueTable--row>td {
   padding: 0.25rem 0.5rem;
 }
 
-.KeyValueTable--row:nth-child(2n) > td {
+.KeyValueTable--row:nth-child(2n)>td {
   background: #f5f5f5;
 }
 
@@ -41,14 +41,15 @@ limitations under the License.
 }
 
 .KeyValueTable--copyColumn {
+  white-space: nowrap;
   text-align: right;
 }
 
-.KeyValueTable--row:not(:hover) > .KeyValueTable--copyColumn > .KeyValueTable--copyIcon {
+.KeyValueTable--row:not(:hover)>.KeyValueTable--copyColumn>.KeyValueTable--copyIcon {
   visibility: hidden;
 }
 
-.KeyValueTable--row > td {
+.KeyValueTable--row>td {
   padding: 0.25rem 0.5rem;
   vertical-align: top;
 }


### PR DESCRIPTION
Before:

<img width="1624" alt="image" src="https://github.com/jaegertracing/jaeger-ui/assets/89186/a8f40b54-4045-4768-9490-19be70a692a0">

After:

<img width="1624" alt="image" src="https://github.com/jaegertracing/jaeger-ui/assets/89186/ac4ea3dc-d743-4f3f-a9aa-3bad25c72f9c">

## How was this change tested?

- Manually tested with my eyeballs

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`