### PR TITLE
Treat exception key in log as error

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -29,9 +29,10 @@ import ResultItemTitle from './ResultItemTitle';
 import colorGenerator from '../../../utils/color-generator';
 import { formatRelativeDate } from '../../../utils/date';
 
-import { KeyValuePair, Trace } from '../../../types/trace';
+import { Trace } from '../../../types/trace';
 
 import './ResultItem.css';
+import { isErrorSpan } from '../../TracePage/TraceTimelineViewer/utils';
 
 dayjs.extend(relativeTime);
 
@@ -52,8 +53,6 @@ type State = {
   fromNow: string | boolean;
 };
 
-const isErrorTag = ({ key, value }: KeyValuePair<boolean | string>) =>
-  key === 'error' && (value === true || value === 'true');
 const trackTraceConversions = () => trackConversions(EAltViewActions.Traces);
 
 export default class ResultItem extends React.PureComponent<Props, State> {
@@ -66,7 +65,7 @@ export default class ResultItem extends React.PureComponent<Props, State> {
     const erroredServices: Set<string> = new Set<string>();
 
     const numErredSpans = spans.filter(sp => {
-      const hasError = sp.tags.some(isErrorTag);
+      const hasError = isErrorSpan(sp);
       if (hasError) {
         erroredServices.add(sp.process.serviceName);
       }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -40,12 +40,13 @@ import reduxFormFieldAdapter from '../../../utils/redux-form-field-adapter';
 
 import { FetchedTrace } from '../../../types';
 import { SearchQuery } from '../../../types/search';
-import { KeyValuePair, Trace, TraceData } from '../../../types/trace';
+import { Trace, TraceData } from '../../../types/trace';
 
 import './index.css';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 import withRouteProps from '../../../utils/withRouteProps';
 import SearchableSelect from '../../common/SearchableSelect';
+import { isErrorSpan } from '../../TracePage/TraceTimelineViewer/utils';
 
 type SearchResultsProps = {
   cohortAddTrace: (traceId: string) => void;
@@ -179,8 +180,6 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
     }
     const cohortIds = new Set(diffCohort.map(datum => datum.id));
     const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
-    const isErrorTag = ({ key, value }: KeyValuePair<string | boolean>) =>
-      key === 'error' && (value === true || value === 'true');
     return (
       <div className="SearchResults">
         <div className="SearchResults--header">
@@ -193,7 +192,7 @@ export class UnconnectedSearchResults extends React.PureComponent<SearchResultsP
                   traceID: t.traceID,
                   size: t.spans.length,
                   name: t.traceName,
-                  color: t.spans.some(sp => sp.tags.some(isErrorTag)) ? 'red' : '#12939A',
+                  color: t.spans.some(isErrorSpan) ? 'red' : '#12939A',
                 }))}
                 onValueClick={(t: Trace) => {
                   goToTrace(t.traceID);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
@@ -69,12 +69,26 @@ export function spanHasTag(key: string, value: string | boolean, span: Span) {
   return span.tags.some(tag => tag.key === key && tag.value === value);
 }
 
+/**
+ * Returns `true` if the `span` has a log matching `key` = `value`.
+ *
+ * @param   {string}  key   The log key to match on.
+ * @param   {any}     value The log value to match.
+ * @param   {Span}    span  The span object.
+ *
+ * @returns {boolean}       True if a match was found.
+ */
+export function spanHasLog(key: string, value: string, span: Span) {
+  return span.logs.some(log => log.fields.some(field => field.key === key && field.value === value));
+}
+
 export const isClientSpan = spanHasTag.bind(null, 'span.kind', 'client');
 export const isServerSpan = spanHasTag.bind(null, 'span.kind', 'server');
 
 const isErrorBool = spanHasTag.bind(null, 'error', true);
 const isErrorStr = spanHasTag.bind(null, 'error', 'true');
-export const isErrorSpan = (span: Span) => isErrorBool(span) || isErrorStr(span);
+const isExceptionEvent = spanHasLog.bind(null, 'event', 'exception');
+export const isErrorSpan = (span: Span) => isErrorBool(span) || isErrorStr(span) || isExceptionEvent(span);
 
 /**
  * Returns `true` if at least one of the descendants of the `parentSpanIndex`


### PR DESCRIPTION
## Which problem is this PR solving?

This is how OpenTelemetry distringuishes errors:

* https://opentelemetry.io/docs/specs/otel/trace/exceptions/

I also unified computation of the condition into `isErrorSpan`.

With this change:

<img width="1552" alt="image" src="https://github.com/jaegertracing/jaeger-ui/assets/89186/2f76c2fb-bf73-4a13-bbf0-758abdac615c">

<img width="1552" alt="image" src="https://github.com/jaegertracing/jaeger-ui/assets/89186/024e0d78-f5a0-41a7-a443-25e910c6641c">

## How was this change tested?

Manually tested. Happy to add tests if this makes sense.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
