### PR TITLE
Gracefully handle spans without logs field

### DIFF
--- a/packages/jaeger-ui/src/utils/filter-spans.test.js
+++ b/packages/jaeger-ui/src/utils/filter-spans.test.js
@@ -118,6 +118,16 @@ describe('filterSpans', () => {
       },
     ],
   };
+
+  // span3 contain empty logs
+  const spanID3 = 'span-id-3';
+  const span3 = {
+    spanID: spanID3,
+    operationName: 'operationName3',
+    process: {
+      serviceName: 'serviceName3',
+    },
+  };
   const spans = [span0, span2];
 
   it('should return `null` if spans is falsy', () => {
@@ -240,6 +250,10 @@ describe('filterSpans', () => {
     expect(filterSpans('processTagValue1 -processTagKey2', spans)).toEqual(new Set([spanID0]));
     expect(filterSpans('processTagValue1 -processTagKey1', spans)).toEqual(new Set([spanID2]));
     expect(filterSpans('"processTag Value3" -processTagKey3', spans)).toEqual(new Set());
+  });
+
+  it("span without log shouldn't break filtering", () => {
+    expect(filterSpans('operationName2', [span2, span3])).toEqual(new Set([spanID2]));
   });
 
   // This test may false positive if other tests are failing

--- a/packages/jaeger-ui/src/utils/filter-spans.tsx
+++ b/packages/jaeger-ui/src/utils/filter-spans.tsx
@@ -60,7 +60,7 @@ export default function filterSpans(textFilter: string, spans: Span[] | TNil) {
     isTextInFilters(includeFilters, span.operationName) ||
     isTextInFilters(includeFilters, span.process.serviceName) ||
     isTextInKeyValues(span.tags) ||
-    (span.logs !== null && span.logs.some(log => isTextInKeyValues(log.fields))) ||
+    (Array.isArray(span.logs) && span.logs.some(log => isTextInKeyValues(log.fields))) ||
     isTextInKeyValues(span.process.tags) ||
     includeFilters.some(filter => filter.replace(/^0*/, '') === span.spanID.replace(/^0*/, ''));
 


### PR DESCRIPTION
Searching of spans throws "Cannot read properties of undefined (reading 'some')" exceptions and breaks UI

To reproduce:
1. Open the attached file via _Search|Upload_: [opentelemetry (8).json](https://github.com/jaegertracing/jaeger-ui/files/14449091/opentelemetry.8.json)
2. Type `bootstrap` in search 

The following exception will be thrown and UI will crash completely:
```
chunk-JFYQRAKV.js?v=ef5bea20:9145 Uncaught TypeError: Cannot read properties of undefined (reading 'some')
    at isSpanAMatch (filter-spans.tsx:63:38)
    at Array.filter (<anonymous>)
    at TracePageImpl.filterSpans (filter-spans.tsx:68:41)
    at TracePageImpl.memoized [as _filterSpans] (chunk-X3V25DTT.js?v=ef5bea20:22:27)
    at TracePageImpl.render (index.tsx:358:32)
    at finishClassComponent (chunk-JFYQRAKV.js?v=ef5bea20:14694:39)
    at updateClassComponent (chunk-JFYQRAKV.js?v=ef5bea20:14659:32)
    at beginWork (chunk-JFYQRAKV.js?v=ef5bea20:15918:22)
    at beginWork$1 (chunk-JFYQRAKV.js?v=ef5bea20:19749:22)
    at performUnitOfWork (chunk-JFYQRAKV.js?v=ef5bea20:19194:20)
```
