### PR TITLE
Make ScatterPlot y-axis margin wider to fit longer durations

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
@@ -59,7 +59,7 @@ export default function ScatterPlot(props) {
       {containerWidth && (
         <XYPlot
           margin={{
-            left: 50,
+            left: 70,
           }}
           width={containerWidth}
           colorType="literal"


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolve #2180 

## Description of the changes
- Make ScatterPlot margin wider, `50 px` => `70 px`

## How was this change tested?
- manual test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
