### PR TITLE
Fix HTML code for apostrophe

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
@@ -339,7 +339,7 @@ export class SearchFormImpl extends React.PureComponent {
                   <ul key="info" className="SearchForm--tagsHintInfo">
                     <li>Use space for AND conjunctions</li>
                     <li>
-                      Values containing whitespace or equal-sign &apos=&apos should be enclosed in quotes
+                      Values containing whitespace or equal-sign &apos;=&apos; should be enclosed in quotes
                     </li>
                     <li>
                       Elasticsearch/OpenSearch storage supports regexp query, therefore{' '}


### PR DESCRIPTION
missing semicolon resulted in bad tooltip: `Values containing whitespace or equal-sign &apos=&apos should be enclosed in quotes`