### PR TITLE
Replace label name operation with span_name #2352

### DIFF
--- a/packages/jaeger-ui/src/reducers/metrics.mock.js
+++ b/packages/jaeger-ui/src/reducers/metrics.mock.js
@@ -221,7 +221,7 @@ const serviceOpsLatencies = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -258,7 +258,7 @@ const serviceOpsLatenciesWithNull = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -284,7 +284,7 @@ const serviceOpsLatenciesWithNull = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -320,7 +320,7 @@ const serviceOpsLatenciesZeroDivision = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -346,7 +346,7 @@ const serviceOpsLatenciesZeroDivision = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -382,7 +382,7 @@ const serviceOpsErrors = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -418,7 +418,7 @@ const serviceOpsErrorsWithNull = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -444,7 +444,7 @@ const serviceOpsErrorsWithNull = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -480,7 +480,7 @@ const serviceOpsErrorsZeroDivision = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -506,7 +506,7 @@ const serviceOpsErrorsZeroDivision = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -542,7 +542,7 @@ const serviceOpsCalls = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -578,7 +578,7 @@ const serviceOpsCallsWithNull = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -605,7 +605,7 @@ const serviceOpsCallsWithNull = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -642,7 +642,7 @@ const serviceOpsCallsZeroDivision = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -669,7 +669,7 @@ const serviceOpsCallsZeroDivision = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -1175,7 +1175,7 @@ const serviceOpsLatenciesNoMetrics = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -1188,7 +1188,7 @@ const serviceOpsLatenciesNoMetrics = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -1250,7 +1250,7 @@ const serviceOpsCallsNoMetrics = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -1263,7 +1263,7 @@ const serviceOpsCallsNoMetrics = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {
@@ -1286,7 +1286,7 @@ const serviceOpsErrorsNoMetrics = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/PlaceOrder',
           },
           {
@@ -1299,7 +1299,7 @@ const serviceOpsErrorsNoMetrics = {
       {
         labels: [
           {
-            name: 'operation',
+            name: 'span_name',
             value: '/Checkout',
           },
           {

--- a/packages/jaeger-ui/src/reducers/metrics.tsx
+++ b/packages/jaeger-ui/src/reducers/metrics.tsx
@@ -192,7 +192,7 @@ function fetchOpsMetricsDone(
             service_operation_error_rate: 0,
           };
           metricDetails.labels.forEach((label: { name: string; value: string }) => {
-            if (label.name === 'operation') {
+            if (label.name === 'span_name') {
               opsName = label.value;
             }
           });


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves jaegertracing/jaeger#5672

## Description of the changes
- Replace label name operation with span_name

## How was this change tested?
- Tested with v1.58.0 backend and `yarn start`

<img width="1903" alt="testing" src="https://github.com/jaegertracing/jaeger-ui/assets/1564148/aa7ee4e5-bade-4680-9008-06f780e504d8">

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
