### PR TITLE
Color log markers by user-specified log fields

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -23,6 +23,7 @@ import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import AltViewOptions from './AltViewOptions';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
+import TracePageSettings from './TracePageSettings';
 import SpanGraph from './SpanGraph';
 import TracePageSearchBar from './TracePageSearchBar';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from '../types';
@@ -58,6 +59,9 @@ type TracePageHeaderEmbedProps = {
   showViewOptions: boolean;
   slimView: boolean;
   textFilter: string | TNil;
+  availableTagKeys: string[];
+  selectedMarkerColorKey: string[];
+  setMarkerColorKey: (tagKey: string[]) => void;
   toSearch: string | null;
   trace: Trace;
   viewType: ETraceViewType;
@@ -127,6 +131,9 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
     disableJsonView,
     slimView,
     textFilter,
+    availableTagKeys,
+    selectedMarkerColorKey,
+    setMarkerColorKey,
     toSearch,
     trace,
     viewType,
@@ -189,6 +196,12 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
           resultCount={resultCount}
           textFilter={textFilter}
           navigable={viewType === ETraceViewType.TraceTimelineViewer}
+        />
+        <TracePageSettings
+          className="ub-m2"
+          availableTagKeys={availableTagKeys}
+          selectedMarkerColorKey={selectedMarkerColorKey}
+          onMarkerColorKeyChange={setMarkerColorKey}
         />
         {showShortcutsHelp && <KeyboardShortcutsHelp className="ub-m2" />}
         {showViewOptions && (

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSettings.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSettings.css
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2024 The Jaeger Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.TracePageSettings--cta {
+  font-size: 1.2rem;
+  margin: -3px -7px;
+}
+
+.TracePageSettings-emptyColorKey,
+.TracePageSettings--noColorKey {
+  font-style: italic;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSettings.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { Button, Dropdown, Form, Modal, Space, Tag } from 'antd';
+import { IoAdd, IoCheckmark, IoChevronDown, IoClose, IoSettings } from 'react-icons/io5';
+
+import keyboardMappings from '../keyboard-mappings';
+import track from './KeyboardShortcutsHelp.track';
+
+import './KeyboardShortcutsHelp.css';
+
+type Props = {
+  availableTagKeys: string[];
+  selectedMarkerColorKey: string[];
+  onMarkerColorKeyChange: (tagKey: string[]) => void;
+  className: string;
+};
+
+type State = {
+  visible: boolean;
+};
+
+type DataRecord = {
+  key: string;
+  kbds: React.JSX.Element;
+  description: string;
+};
+
+function renderTagKey(tag: string) {
+  if (tag === '') {
+    return <span className="TracePageSettings-emptyMarkerColorKey">(Empty string)</span>;
+  }
+
+  return <span>{tag}</span>;
+}
+
+function getMarkerColorKeyFormItem(props: Props) {
+  const items = [];
+  const callbacks: { [key: string]: boolean } = {}; // whether the key should be added or removed
+
+  for (const key of props.selectedMarkerColorKey) {
+    callbacks[key] = false;
+    items.push({
+      key: key,
+      label: (
+        <span>
+          {renderTagKey(key)}
+          <IoCheckmark />
+        </span>
+      ),
+    });
+  }
+
+  for (const key of props.availableTagKeys) {
+    if (callbacks.hasOwnProperty(key)) {
+      continue;
+    }
+
+    callbacks[key] = true;
+    items.push({
+      key: key,
+      label: renderTagKey(key),
+    });
+  }
+
+  const toggle = key => {
+    console.log(callbacks);
+    console.log(key, callbacks[key]);
+    let newList: string[];
+    if (callbacks[key]) {
+      newList = props.selectedMarkerColorKey.concat([key]);
+      newList.sort();
+    } else {
+      newList = props.selectedMarkerColorKey.filter(item => item != key);
+    }
+    console.log(newList);
+    props.onMarkerColorKeyChange(newList);
+  };
+
+  return (
+    <Form.Item label="Color log ticks by log field:">
+      <>
+        {props.selectedMarkerColorKey.map(key => (
+          <Tag
+            closeIcon={<IoClose />}
+            onClose={e => {
+              e.preventDefault();
+              toggle(key);
+            }}
+          >
+            {renderTagKey(key)}
+          </Tag>
+        ))}
+      </>
+      <Dropdown menu={{ items, onClick: ({ key }) => toggle(key) }}>
+        <Tag>
+          <IoAdd />
+        </Tag>
+      </Dropdown>
+    </Form.Item>
+  );
+}
+
+export default class TracePageSettings extends React.PureComponent<Props, State> {
+  state = {
+    visible: false,
+  };
+
+  onCtaClicked = () => {
+    track();
+    this.setState({ visible: true });
+  };
+
+  onCloserClicked = () => this.setState({ visible: false });
+
+  render() {
+    const { className } = this.props;
+    return (
+      <React.Fragment>
+        <Button className={className} htmlType="button" onClick={this.onCtaClicked}>
+          <span className="TracePageSettings--cta">
+            <IoSettings />
+          </span>
+        </Button>
+        <Modal
+          title="Page settings"
+          open={this.state.visible}
+          onOk={this.onCloserClicked}
+          onCancel={this.onCloserClicked}
+          cancelButtonProps={{ style: { display: 'none' } }}
+          bodyStyle={{ padding: 0 }}
+        >
+          <Form>{getMarkerColorKeyFormItem(this.props)}</Form>
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.css
@@ -101,7 +101,6 @@ limitations under the License.
 }
 
 .SpanBar--logMarker {
-  background-color: rgba(0, 0, 0, 0.5);
   cursor: pointer;
   height: 60%;
   min-width: 1px;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -22,6 +22,7 @@ import SpanBar from './SpanBar';
 import Ticks from './Ticks';
 
 import { TNil } from '../../../types';
+import { ColorGenerator } from '../../../utils/color-generator';
 import { criticalPathSection, Span } from '../../../types/trace';
 
 import './SpanBarRow.css';
@@ -55,6 +56,8 @@ type SpanBarRowProps = {
   showErrorIcon: boolean;
   getViewedBounds: ViewedBoundsFunctionType;
   traceStartTime: number;
+  colorGenerator: ColorGenerator;
+  markerColorKey: string[];
   span: Span;
   focusSpan: (spanID: string) => void;
 };
@@ -98,6 +101,8 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
       traceStartTime,
       span,
       focusSpan,
+      colorGenerator,
+      markerColorKey,
     } = this.props;
     const {
       duration,
@@ -211,6 +216,8 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
             hintSide={hintSide}
             traceStartTime={traceStartTime}
             span={span}
+            colorGenerator={colorGenerator}
+            markerColorKey={markerColorKey}
           />
         </TimelineRow.Cell>
       </TimelineRow>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -62,6 +62,7 @@ type TVirtualizedTraceViewOwnProps = {
   registerAccessors: (accesors: Accessors) => void;
   trace: Trace;
   criticalPath: criticalPathSection[];
+  markerColorKey: string[];
 };
 
 type TDispatchProps = {
@@ -386,6 +387,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       spanNameColumnWidth,
       trace,
       criticalPath,
+      markerColorKey,
     } = this.props;
     // to avert flow error
     if (!trace) {
@@ -445,6 +447,8 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           traceStartTime={trace.startTime}
           span={span}
           focusSpan={this.focusSpan}
+          colorGenerator={colorGenerator}
+          markerColorKey={markerColorKey}
         />
       </div>
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -45,6 +45,7 @@ type TProps = TDispatchProps & {
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRange: IViewRange;
+  markerColorKey: string[];
 };
 
 const NUM_TICKS = 5;

--- a/packages/jaeger-ui/src/utils/color-generator.tsx
+++ b/packages/jaeger-ui/src/utils/color-generator.tsx
@@ -36,7 +36,7 @@ const COLORS_HEX = [
 ];
 
 // TS needs the precise return type
-function strToRgb(s: string): [number, number, number] {
+function strToRgb(s: string): Rgb {
   if (s.length !== 7) {
     return [0, 0, 0];
   }
@@ -46,9 +46,13 @@ function strToRgb(s: string): [number, number, number] {
   return [parseInt(r, 16), parseInt(g, 16), parseInt(b, 16)];
 }
 
+function rgbToStr(rgb: Rgb): string {
+  return `rgb(${rgb.map(c => c.toString()).join(', ')})`;
+}
+
 export class ColorGenerator {
   colorsHex: string[];
-  colorsRgb: [number, number, number][];
+  colorsRgb: Rgb[];
   cache: Map<string, number>;
   currentIdx: number;
 
@@ -84,7 +88,7 @@ export class ColorGenerator {
    * it with a color if the key is not recognized.
    * @return {number[]} An array of three ints [0, 255] representing a color.
    */
-  getRgbColorByKey(key: string): [number, number, number] {
+  getRgbColorByKey(key: string): Rgb {
     const i = this._getColorIndex(key);
     return this.colorsRgb[i];
   }
@@ -92,6 +96,33 @@ export class ColorGenerator {
   clear() {
     this.cache.clear();
     this.currentIdx = 0;
+  }
+}
+
+export type Rgb = [number, number, number];
+export type RgbMapper = (Rgb) => Rgb;
+
+/**
+ * An alternative view of a ColorGenerator with mapped colors.
+ * Shares the same underlying cache.
+ */
+export class ColorGeneratorView {
+  base: ColorGenerator;
+  mapper: RgbMapper;
+
+  constructor(base: ColorGenerator, mapRgb: RgbMapper) {
+    this.base = base;
+    this.mapper = mapRgb;
+  }
+
+  getRgbColorByKey(key: string): Rgb {
+    const rgb = this.base.getRgbColorByKey(key);
+    return this.mapper(rgb);
+  }
+
+  getColorByKey(key: string): string {
+    const rgb = this.getRgbColorByKey(key);
+    return rgbToStr(rgb);
   }
 }
 


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->
- Resolves #2361

## Description of the changes
- Add a settings dialog to TracePage
- Add an option to select log marker color keys
- Change log marker colors from black to colorgenerator-based (same color generator as span bars, but with only 2/3 brightness to avoid producing identical colors)

<img width="958" alt="image" src="https://github.com/jaegertracing/jaeger-ui/assets/19623715/3aa73638-8e1c-45c9-8b2f-815967289034">

## How was this change tested?
- 

(This is my first time working with a reactjs project, would appreciate pointers to what tests I need to write)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
