### PR TITLE
Update history package and fix failing test cases 

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -59,7 +59,7 @@
     "deep-freeze": "^0.0.1",
     "drange": "^2.0.0",
     "global": "^4.3.2",
-    "history": "^4.6.3",
+    "history": "^5.3.0",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.19",
     "logfmt": "^1.4.0",

--- a/packages/jaeger-ui/src/utils/configure-store.test.js
+++ b/packages/jaeger-ui/src/utils/configure-store.test.js
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import createMemoryHistory from 'history/createMemoryHistory';
+// import createMemoryHistory from 'history/createMemoryHistory';
+import { createMemoryHistory } from 'history';
 
 import configureStore from './configure-store';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5830,7 +5830,7 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
 
-history@^4.6.3, history@^4.9.0:
+history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==


### PR DESCRIPTION
## Which problem is this PR solving?

Updating the `history` package 

## Description of the changes
1. Updated yarn.lock
2. Updated package.json
3. And configure-store.test.js 

## How was this change tested?

By running the command `yarn test` previously 3 tests were failing due to updation of package while inspecting the failures 1 got fixed by changing import statement but the rest two were falling due to deprecated `history.length` 

Below is the ss of failing tests 

![image](https://github.com/jaegertracing/jaeger-ui/assets/124715224/0af36715-7d68-43a1-91e9-f57bf382a120)

Upon checking open issues in core repo. got these: 

https://github.com/remix-run/history/issues/811
https://github.com/remix-run/history/issues/960


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
