### PR TITLE
Workaround for root spans with alien `FOLLOWS_FROM` references

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/index.tsx
@@ -46,38 +46,40 @@ const computeCriticalPath = (
 ): criticalPathSection[] => {
   const currentSpan: Span = spanMap.get(spanId)!;
 
-  const lastFinishingChildSpan = findLastFinishingChildSpan(spanMap, currentSpan, returningChildStartTime);
-  let spanCriticalSection: criticalPathSection;
+  if (currentSpan) {
+    const lastFinishingChildSpan = findLastFinishingChildSpan(spanMap, currentSpan, returningChildStartTime);
+    let spanCriticalSection: criticalPathSection;
 
-  if (lastFinishingChildSpan) {
-    spanCriticalSection = {
-      spanId: currentSpan.spanID,
-      section_start: lastFinishingChildSpan.startTime + lastFinishingChildSpan.duration,
-      section_end: returningChildStartTime || currentSpan.startTime + currentSpan.duration,
-    };
-    if (spanCriticalSection.section_start !== spanCriticalSection.section_end) {
-      criticalPath.push(spanCriticalSection);
-    }
-    // Now focus shifts to the lastFinishingChildSpan of cuurent span
-    computeCriticalPath(spanMap, lastFinishingChildSpan.spanID, criticalPath);
-  } else {
-    // If there is no last finishing child then total section upto startTime of span is on critical path
-    spanCriticalSection = {
-      spanId: currentSpan.spanID,
-      section_start: currentSpan.startTime,
-      section_end: returningChildStartTime || currentSpan.startTime + currentSpan.duration,
-    };
-    if (spanCriticalSection.section_start !== spanCriticalSection.section_end) {
-      criticalPath.push(spanCriticalSection);
-    }
-    // Now as there are no lfc's focus shifts to parent span from startTime of span
-    // return from recursion and walk backwards to one level depth to parent span
-    // provide span's startTime as returningChildStartTime
-    if (currentSpan.references.length) {
-      const parentSpanId: string = currentSpan.references.filter(
-        reference => reference.refType === 'CHILD_OF'
-      )[0].spanID;
-      computeCriticalPath(spanMap, parentSpanId, criticalPath, currentSpan.startTime);
+    if (lastFinishingChildSpan) {
+      spanCriticalSection = {
+        spanId: currentSpan.spanID,
+        section_start: lastFinishingChildSpan.startTime + lastFinishingChildSpan.duration,
+        section_end: returningChildStartTime || currentSpan.startTime + currentSpan.duration,
+      };
+      if (spanCriticalSection.section_start !== spanCriticalSection.section_end) {
+        criticalPath.push(spanCriticalSection);
+      }
+      // Now focus shifts to the lastFinishingChildSpan of cuurent span
+      computeCriticalPath(spanMap, lastFinishingChildSpan.spanID, criticalPath);
+    } else {
+      // If there is no last finishing child then total section upto startTime of span is on critical path
+      spanCriticalSection = {
+        spanId: currentSpan.spanID,
+        section_start: currentSpan.startTime,
+        section_end: returningChildStartTime || currentSpan.startTime + currentSpan.duration,
+      };
+      if (spanCriticalSection.section_start !== spanCriticalSection.section_end) {
+        criticalPath.push(spanCriticalSection);
+      }
+      // Now as there are no lfc's focus shifts to parent span from startTime of span
+      // return from recursion and walk backwards to one level depth to parent span
+      // provide span's startTime as returningChildStartTime
+      if (currentSpan.references.length) {
+        const parentSpanId: string = currentSpan.references.filter(
+          reference => reference.refType === 'CHILD_OF'
+        )[0].spanID;
+        computeCriticalPath(spanMap, parentSpanId, criticalPath, currentSpan.startTime);
+      }
     }
   }
   return criticalPath;

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/utils/getChildOfSpans.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/utils/getChildOfSpans.tsx
@@ -24,7 +24,7 @@ const getChildOfSpans = (spanMap: Map<string, Span>): Map<string, Span> => {
 
   // First find all FOLLOWS_FROM refType spans
   spanMap.forEach(each => {
-    if (each.references[0]?.refType === 'FOLLOWS_FROM') {
+    if (each.references[0]?.refType === 'FOLLOWS_FROM' && each.references[0]?.traceID === each.traceID) {
       followFromSpanIds.push(each.spanID);
       // Remove the spanId from childSpanIds array of its parentSpan
       const parentSpan = spanMap.get(each.references[0].spanID)!;


### PR DESCRIPTION
## Which problem is this PR solving?
- Workaround/solution for #2427

## Description of the changes

These were the changes I had to make locally (in the Chrome debug tools) to prevent the page from crashing when the root span had a `FOLLOWS_FROM` reference from a different trace.

## How was this change tested?

Only by making these changes directly in the minified sources in Chrome/Edge's "Local Overrides". It stopped things failing, but I'm not sure whether the actual critical path algorithm still works afterwards.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
