### PR TITLE
Update @types/react to 18.3.11

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -19,7 +19,7 @@
     "@testing-library/react": "^15.0.7",
     "@types/deep-freeze": "^0.1.1",
     "@types/lodash": "^4.17.0",
-    "@types/react": "^18.3.3",
+    "@types/react": "^18.3.11",
     "@types/react-window": "^1.8.0",
     "@types/redux-form": "^8.3.10",
     "@types/react-helmet": "^6.1.5",

--- a/packages/plexus/package.json
+++ b/packages/plexus/package.json
@@ -22,7 +22,7 @@
     "@babel/preset-react": "7.24.6",
     "@babel/preset-typescript": "7.24.6",
     "@types/d3-zoom": "3.0.8",
-    "@types/react": "^18.3.3",
+    "@types/react": "^18.3.11",
     "@types/react-dom": "18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",

--- a/packages/plexus/src/DirectedGraph/builtins/Node.tsx
+++ b/packages/plexus/src/DirectedGraph/builtins/Node.tsx
@@ -14,12 +14,12 @@
 
 import * as React from 'react';
 
-type TProps = Record<string, any> & {
-  classNamePrefix: string;
+type TProps = {
+  classNamePrefix?: string | null;
   children?: React.ReactNode;
   forwardedRef: any;
   hidden?: boolean;
-  labelFactory: Function;
+  labelFactory: ((vertex: any) => React.ReactNode) | null;
   left?: number;
   top?: number;
   vertex: any;
@@ -44,7 +44,7 @@ class Node extends React.PureComponent<TProps> {
     p.className = `${classNamePrefix}-Node ${p.className || ''}`;
     return (
       <div ref={forwardedRef} {...p}>
-        {labelFactory(vertex)}
+        {labelFactory?.(vertex)}
       </div>
     );
   }
@@ -53,4 +53,6 @@ class Node extends React.PureComponent<TProps> {
 // ghetto fabulous cast because the 16.3 API is not in flow yet
 // https://github.com/facebook/flow/issues/6103
 // eslint-disable-next-line react/no-multi-comp
-export default React.forwardRef<{}, TProps>((props, ref) => <Node {...props} forwardedRef={ref} />);
+export default React.forwardRef<{}, Omit<TProps, 'forwardedRef'>>((props, ref) => (
+  <Node {...props} forwardedRef={ref} />
+));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,10 +2587,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.3.3":
-  version "18.3.3"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
-  integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
+"@types/react@*", "@types/react@^18.3.11":
+  version "18.3.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.11.tgz#9d530601ff843ee0d7030d4227ea4360236bd537"
+  integrity sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"


### PR DESCRIPTION
## Which problem is this PR solving?
- Update dependencies to their latest version

## Description of the changes
- Update @types/react to 18.3.11

## How was this change tested?
- `yarn start` & jaeger all-in-one

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
