### PR TITLE
Add missing integrity checks to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21846,6 +21846,8 @@
     },
     "packages/jaeger-ui/node_modules/react-is": {
       "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "packages/plexus": {
@@ -21899,6 +21901,8 @@
     },
     "packages/plexus/node_modules/@babel/core": {
       "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21928,6 +21932,8 @@
     },
     "packages/plexus/node_modules/@babel/preset-env": {
       "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
+      "integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22024,6 +22030,8 @@
     },
     "packages/plexus/node_modules/glob": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -22046,6 +22054,8 @@
     },
     "packages/plexus/node_modules/minimatch": {
       "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -22060,6 +22070,8 @@
     },
     "packages/plexus/node_modules/rimraf": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Which problem is this PR solving?
- Add missing integrity checks to package-lock.json

## Description of the changes
- I noticed some lockfile entries didn't have the `resolved` and `integrity` field set. This PR fixed that.
- I think it's related to this npm issue: https://github.com/npm/cli/issues/4263

## How was this change tested?
- no functional change

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
