### PR TITLE
Run s390x build on push to main only

### DIFF
--- a/.github/workflows/s390x-build.yaml
+++ b/.github/workflows/s390x-build.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
 
-  pull_request:
-    branches: [main]
-
 concurrency:
   group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2468
- Resolves #2399

## Description of the changes
- Run s390x build on push to main only due to the long duration of this test. See #2468 for more details.

## How was this change tested?
- 

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
