### PR TITLE
Fix babel dependencies in plexus repo

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,6 +25,7 @@ jobs:
           cache: npm
           node-version: '20'
       - run: npm ci
+      - run: npm ls --all
       - run: npm run coverage
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -20303,10 +20303,10 @@
       },
       "devDependencies": {
         "@babel/cli": "7.25.6",
-        "@babel/core": "7.26.0",
+        "@babel/core": "^7.25.2",
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/plugin-syntax-dynamic-import": "7.8.3",
-        "@babel/preset-env": "7.26.0",
+        "@babel/preset-env": "^7.25.4",
         "@babel/preset-react": "7.25.7",
         "@babel/preset-typescript": "7.26.0",
         "@types/d3-zoom": "3.0.8",

--- a/packages/plexus/package.json
+++ b/packages/plexus/package.json
@@ -15,10 +15,10 @@
   },
   "devDependencies": {
     "@babel/cli": "7.25.6",
-    "@babel/core": "7.26.0",
+    "@babel/core": "^7.25.2",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
-    "@babel/preset-env": "7.26.0",
+    "@babel/preset-env": "^7.25.4",
     "@babel/preset-react": "7.25.7",
     "@babel/preset-typescript": "7.26.0",
     "@types/d3-zoom": "3.0.8",


### PR DESCRIPTION
## Which problem is this PR solving?
Fix babel dependencies in plexus repo

## Description of the changes
PR #2485 produced an invalid dependency configuration:
The `package.json` file specifies version `7.26.0`:
https://github.com/jaegertracing/jaeger-ui/blob/ef0bb277e0854be44792961f3218ef16fe783285/packages/plexus/package.json#L18
however, the locked version is `7.25.2`:
https://github.com/jaegertracing/jaeger-ui/blob/ef0bb277e0854be44792961f3218ef16fe783285/package-lock.json#L21849-L21850

Same for the `@babel/preset-env` dependency.

The error is visible with:
```
$ npm ls --all
...
npm error code ELSPROBLEMS
npm error invalid: @babel/core@7.25.2 /home/agerstmayr/redhat/dev/jaeger-ui/packages/plexus/node_modules/@babel/core
npm error invalid: @babel/preset-env@7.25.4 /home/agerstmayr/redhat/dev/jaeger-ui/packages/plexus/node_modules/@babel/preset-env
```

To prevent this error in the future, I added a check for this situation to the GitHub action.

## How was this change tested?
- locally

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
