### PR TITLE
"Fix Cache-Control header and update package-lock.json"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21792,7 +21792,7 @@
       }
     },
     "packages/jaeger-ui": {
-      "version": "1.62.0",
+      "version": "1.63.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ant-design/compatible": "^5.1.3",
@@ -21827,7 +21827,7 @@
         "react-json-view-lite": "1.5.0",
         "react-redux": "^8.1.2",
         "react-router-dom": "5.3.4",
-        "react-router-dom-v5-compat": "^6.28.0",
+        "react-router-dom-v5-compat": "^6.24.0",
         "react-vis": "1.11.12",
         "react-vis-force": "^0.3.1",
         "react-window": "^1.8.10",


### PR DESCRIPTION
Which problem is this PR solving?
Query Service - Cache-Control header for static assets #616
Resolves issues with improper Cache-Control headers for static assets in the Jaeger query UI.
Description of the changes
Updated the Cache-Control header to ensure static assets are cached for a long time (max-age of 1 year).
Updated dependencies in go.mod, go.sum, and package-lock.json to address compatibility and security issues.
How was this change tested?
Built and ran the Jaeger UI locally to verify that the static assets are served with the correct Cache-Control header.
Ran the test suite for both jaeger and jaeger-ui to ensure all tests passed after the dependency updates.
Checklist
 I have read [CONTRIBUTING_GUIDELINES.md](https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md)
 I have signed all commits
 I have added unit tests for the new functionality (if applicable)
 I have run lint and test steps successfully
for jaeger: make lint test
for jaeger-ui: yarn lint and yarn test