### PR TITLE
Add new formatting function "add"

### DIFF
--- a/packages/jaeger-ui/src/utils/link-formatting.test.js
+++ b/packages/jaeger-ui/src/utils/link-formatting.test.js
@@ -56,6 +56,29 @@ describe('getParameterAndFormatter()', () => {
     });
   });
 
+  describe('add', () => {
+    test.each([1000, -1000])('offset: %s', offset => {
+      const result = getParameterAndFormatter(`startTime | add ${offset}`);
+      expect(result).toEqual({
+        parameterName: 'startTime',
+        formatFunction: expect.any(Function),
+      });
+      const startTime = new Date('2020-01-01').getTime() * 1000;
+      expect(result.formatFunction(startTime)).toEqual(startTime + offset);
+    });
+
+    test('Invalid value', () => {
+      const result = getParameterAndFormatter(`startTime | add 1000`);
+      expect(result.formatFunction('invalid')).toEqual('invalid');
+    });
+
+    test('Invalid offset', () => {
+      const result = getParameterAndFormatter('startTime | add invalid');
+      const startTime = new Date('2020-01-01').getTime() * 1000;
+      expect(result.formatFunction(startTime)).toEqual(startTime);
+    });
+  });
+
   test('No function', () => {
     const result = getParameterAndFormatter('startTime');
     expect(result).toEqual({

--- a/packages/jaeger-ui/src/utils/link-formatting.test.js
+++ b/packages/jaeger-ui/src/utils/link-formatting.test.js
@@ -79,6 +79,40 @@ describe('getParameterAndFormatter()', () => {
     });
   });
 
+  describe('Chaining formatting functions', () => {
+    test.each(['', ' ', '  ', '                          '])(
+      'add and epoch_micros_to_date_iso - delimeter: %p',
+      spaceChars => {
+        const expression = ['startTime', 'add 60000000', 'epoch_micros_to_date_iso'].join(
+          `${spaceChars}|${spaceChars}`
+        );
+        const result = getParameterAndFormatter(expression);
+        expect(result).toEqual({
+          parameterName: 'startTime',
+          formatFunction: expect.any(Function),
+        });
+
+        const startTime = new Date('2020-01-01').getTime() * 1000; // Convert to microseconds
+        const expectedDate = new Date('2020-01-01T00:01:00.000Z').toISOString();
+        expect(result.formatFunction(startTime)).toEqual(expectedDate);
+      }
+    );
+
+    test.each([' ', '  ', '                          '])(
+      'add and epoch_micros_to_date_iso with extra spaces between functions and arguments - delimeter: %',
+      spaceChars => {
+        const expression = [`startTime | add${spaceChars}60000000 | epoch_micros_to_date_iso`].join(
+          `${spaceChars}|${spaceChars}`
+        );
+        const result = getParameterAndFormatter(expression);
+
+        const startTime = new Date('2020-01-01').getTime() * 1000; // Convert to microseconds
+        const expectedDate = new Date('2020-01-01T00:01:00.000Z').toISOString();
+        expect(result.formatFunction(startTime)).toEqual(expectedDate);
+      }
+    );
+  });
+
   test('No function', () => {
     const result = getParameterAndFormatter('startTime');
     expect(result).toEqual({

--- a/packages/jaeger-ui/src/utils/link-formatting.tsx
+++ b/packages/jaeger-ui/src/utils/link-formatting.tsx
@@ -16,7 +16,7 @@ import { Trace } from '../types/trace';
 
 function getFormatFunctions<T = Trace[keyof Trace]>(): Record<
   string,
-  (value: T, ...args: string[]) => string | T
+  (value: T, ...args: string[]) => T | string | number
 > {
   return {
     epoch_micros_to_date_iso: microsSinceEpoch => {
@@ -49,6 +49,27 @@ function getFormatFunctions<T = Trace[keyof Trace]>(): Record<
 
       return value.padStart(desiredLength, padCharacter);
     },
+
+    add: (value, offsetString: string) => {
+      if (typeof value !== 'number') {
+        console.error('add can only operate on numbers, ignoring formatting', {
+          value,
+          offsetString,
+        });
+        return value;
+      }
+
+      const offset = parseInt(offsetString, 10);
+      if (Number.isNaN(offset)) {
+        console.error('add needs a valid offset in microseconds as second argument, ignoring formatting', {
+          value,
+          offsetString,
+        });
+        return value;
+      }
+
+      return value + offset;
+    },
   };
 }
 
@@ -56,7 +77,7 @@ export function getParameterAndFormatter<T = Trace[keyof Trace]>(
   parameter: string
 ): {
   parameterName: string;
-  formatFunction: ((value: T) => T | string) | null;
+  formatFunction: ((value: T) => T | string | number) | null;
 } {
   const parts = parameter.split('|').map(part => part.trim());
   const parameterName = parts[0];


### PR DESCRIPTION
## Which problem is this PR solving?
In addition to #2501 and #2504, allowing any numbers (in my immediate case a date in microseconds since epoch) to be offset by a number is useful to allow users to see logs before/after their span/trace timestamps by a configurable offset. 

## Description of the changes
This adds a `add` function and gives the ability to chain formatting functions together (eg `#{endTime | add 60000000 | epoch_micros_to_date_iso}`)

## How was this change tested?
Unit tests and with the following UI config
```
const DEFAULT_CONFIG = {
  "linkPatterns": [
    {
      "type": "traces",
      "url": "https://myKibana/_dashboards/app/discover#/?_g=(time:(from:'#{startTime | shift_epoch_micros -60000000 | epoch_micros_to_date_iso}',to:'#{endTime | shift_epoch_micros 60000000 | epoch_micros_to_date_iso}'))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:filebeat-all,key:json.traceId,negate:!f,params:(query:'42c7668cd8d887da'),type:phrase),query:(match_phrase:(json.traceId:'42c7668cd8d887da')))),index:filebeat-all)",
      "text": "Logs"
    }
  ]
};
```

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger-ui`: `yarn lint` and `yarn test`
