### PR TITLE
Prepare release v1.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Run `make changelog` to generate content.
 
 </details>
 
+## v1.64.0 (2024-12-06)
+
+#### 🐞 Bug fixes, Minor Improvements
+
+* Add new formatting function "add" ([@drewcorlin1](https://github.com/drewcorlin1) in [#2507](https://github.com/jaegertracing/jaeger-ui/pull/2507))
+* Add pad_start link formatting function #2505 ([@drewcorlin1](https://github.com/drewcorlin1) in [#2504](https://github.com/jaegertracing/jaeger-ui/pull/2504))
+* Allow formatting link parameter values as iso date #2487 ([@drewcorlin1](https://github.com/drewcorlin1) in [#2501](https://github.com/jaegertracing/jaeger-ui/pull/2501))
+
 ## v1.63.0 (2024-11-10)
 
 #### 🐞 Bug fixes, Minor Improvements

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,8 @@
 # Cutting a Jaeger UI release
 
 1. Create and merge, per approval, a PR which preps the release ([example](https://github.com/jaegertracing/jaeger-ui/pull/1767)).
-   1. The PR title should match the format "Prepare release vX.Y.Z".
+   1. The PR title should match the format "Prepare release vX.Y.Z"
+      - Apply the label `changelog:skip`
    2. CHANGELOG.md
       - Change the version of the current release from "Next (unreleased)" to "vX.Y.Z (Month D, YYYY)",
         where "vX.Y.Z" is the [semver](https://semver.org) for this release.

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "jaeger-ui",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "main": "src/index.tsx",
   "license": "Apache-2.0",
   "homepage": ".",


### PR DESCRIPTION
Prepares release v1.64.0 per https://github.com/jaegertracing/jaeger-ui/blob/main/RELEASE.md