### PR TITLE
[fix]: Remove redux-form dependency from Monitor page

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
@@ -14,19 +14,13 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
         >
           Service
         </h2>
-        <Field
-          component={[Function]}
-          name="service"
+        <SearchableSelect
+          className="select-a-service-input"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Service"
-          props={
-            Object {
-              "className": "select-a-service-input",
-              "disabled": null,
-              "loading": null,
-              "value": "s1",
-            }
-          }
+          value="s1"
         >
           <Option
             key="s1"
@@ -40,7 +34,7 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
           >
             s2
           </Option>
-        </Field>
+        </SearchableSelect>
       </Col>
       <Col
         span={6}
@@ -50,20 +44,13 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
         >
           Span Kind
         </h2>
-        <Field
-          component={[Function]}
-          name="spanKind"
+        <SearchableSelect
+          className="span-kind-selector"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Span Kind"
-          props={
-            Object {
-              "className": "span-kind-selector",
-              "defaultValue": "server",
-              "disabled": null,
-              "loading": null,
-              "value": "server",
-            }
-          }
+          value="server"
         >
           <Option
             key="client"
@@ -95,7 +82,7 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
           >
             Consumer
           </Option>
-        </Field>
+        </SearchableSelect>
       </Col>
     </Row>
     <Row
@@ -124,23 +111,13 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
         className="timeframe-selector"
         span={8}
       >
-        <Field
-          component={[Function]}
-          name="timeframe"
+        <SearchableSelect
+          className="select-a-timeframe-input"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Timeframe"
-          props={
-            Object {
-              "className": "select-a-timeframe-input",
-              "defaultValue": Object {
-                "label": "Last Hour",
-                "value": 3600000,
-              },
-              "disabled": null,
-              "loading": null,
-              "value": 3600000,
-            }
-          }
+          value={3600000}
         >
           <Option
             key="300000"
@@ -196,7 +173,7 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
           >
             Last 2 days
           </Option>
-        </Field>
+        </SearchableSelect>
       </Col>
     </Row>
     <Row>
@@ -486,19 +463,13 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
         >
           Service
         </h2>
-        <Field
-          component={[Function]}
-          name="service"
+        <SearchableSelect
+          className="select-a-service-input"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Service"
-          props={
-            Object {
-              "className": "select-a-service-input",
-              "disabled": null,
-              "loading": null,
-              "value": "s1",
-            }
-          }
+          value="s1"
         />
       </Col>
       <Col
@@ -509,20 +480,13 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
         >
           Span Kind
         </h2>
-        <Field
-          component={[Function]}
-          name="spanKind"
+        <SearchableSelect
+          className="span-kind-selector"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Span Kind"
-          props={
-            Object {
-              "className": "span-kind-selector",
-              "defaultValue": "server",
-              "disabled": null,
-              "loading": null,
-              "value": "server",
-            }
-          }
+          value="server"
         >
           <Option
             key="client"
@@ -554,7 +518,7 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
           >
             Consumer
           </Option>
-        </Field>
+        </SearchableSelect>
       </Col>
     </Row>
     <Row
@@ -583,23 +547,13 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
         className="timeframe-selector"
         span={8}
       >
-        <Field
-          component={[Function]}
-          name="timeframe"
+        <SearchableSelect
+          className="select-a-timeframe-input"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Timeframe"
-          props={
-            Object {
-              "className": "select-a-timeframe-input",
-              "defaultValue": Object {
-                "label": "Last Hour",
-                "value": 3600000,
-              },
-              "disabled": null,
-              "loading": null,
-              "value": 3600000,
-            }
-          }
+          value={3600000}
         >
           <Option
             key="300000"
@@ -655,7 +609,7 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
           >
             Last 2 days
           </Option>
-        </Field>
+        </SearchableSelect>
       </Col>
     </Row>
     <Row>
@@ -864,19 +818,13 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
         >
           Service
         </h2>
-        <Field
-          component={[Function]}
-          name="service"
+        <SearchableSelect
+          className="select-a-service-input"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Service"
-          props={
-            Object {
-              "className": "select-a-service-input",
-              "disabled": null,
-              "loading": null,
-              "value": "s1",
-            }
-          }
+          value="s1"
         />
       </Col>
       <Col
@@ -887,20 +835,13 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
         >
           Span Kind
         </h2>
-        <Field
-          component={[Function]}
-          name="spanKind"
+        <SearchableSelect
+          className="span-kind-selector"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Span Kind"
-          props={
-            Object {
-              "className": "span-kind-selector",
-              "defaultValue": "server",
-              "disabled": null,
-              "loading": null,
-              "value": "server",
-            }
-          }
+          value="server"
         >
           <Option
             key="client"
@@ -932,7 +873,7 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
           >
             Consumer
           </Option>
-        </Field>
+        </SearchableSelect>
       </Col>
     </Row>
     <Row
@@ -961,23 +902,13 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
         className="timeframe-selector"
         span={8}
       >
-        <Field
-          component={[Function]}
-          name="timeframe"
+        <SearchableSelect
+          className="select-a-timeframe-input"
+          disabled={null}
+          loading={null}
           onChange={[Function]}
           placeholder="Select A Timeframe"
-          props={
-            Object {
-              "className": "select-a-timeframe-input",
-              "defaultValue": Object {
-                "label": "Last Hour",
-                "value": 3600000,
-              },
-              "disabled": null,
-              "loading": null,
-              "value": 3600000,
-            }
-          }
+          value={3600000}
         >
           <Option
             key="300000"
@@ -1033,7 +964,7 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
           >
             Last 2 days
           </Option>
-        </Field>
+        </SearchableSelect>
       </Col>
     </Row>
     <Row>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/__snapshots__/index.test.js.snap
@@ -16,8 +16,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
         </h2>
         <SearchableSelect
           className="select-a-service-input"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Service"
           value="s1"
@@ -46,8 +44,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
         </h2>
         <SearchableSelect
           className="span-kind-selector"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Span Kind"
           value="server"
@@ -113,8 +109,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
       >
         <SearchableSelect
           className="select-a-timeframe-input"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Timeframe"
           value={3600000}
@@ -420,7 +414,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test 1`] = `
             "opsLatencies": null,
           }
         }
-        loading={null}
         lookback={3600000}
         serviceName="s1"
       />
@@ -465,8 +458,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
         </h2>
         <SearchableSelect
           className="select-a-service-input"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Service"
           value="s1"
@@ -482,8 +473,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
         </h2>
         <SearchableSelect
           className="span-kind-selector"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Span Kind"
           value="server"
@@ -549,8 +538,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
       >
         <SearchableSelect
           className="select-a-timeframe-input"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Timeframe"
           value={3600000}
@@ -775,7 +762,6 @@ exports[`<MonitorATMServicesView> ATM snapshot test with no metrics 1`] = `
             "opsLatencies": null,
           }
         }
-        loading={null}
         lookback={3600000}
         serviceName="s1"
       />
@@ -820,8 +806,6 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
         </h2>
         <SearchableSelect
           className="select-a-service-input"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Service"
           value="s1"
@@ -837,8 +821,6 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
         </h2>
         <SearchableSelect
           className="span-kind-selector"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Span Kind"
           value="server"
@@ -904,8 +886,6 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
       >
         <SearchableSelect
           className="select-a-timeframe-input"
-          disabled={null}
-          loading={null}
           onChange={[Function]}
           placeholder="Select A Timeframe"
           value={3600000}
@@ -1131,7 +1111,6 @@ exports[`<MonitorATMServicesView> render one service latency 1`] = `
             "opsLatencies": null,
           }
         }
-        loading={null}
         lookback={3600000}
         serviceName="s1"
       />

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
@@ -207,9 +207,7 @@ describe('<MonitorATMServicesView>', () => {
 
   it('should update state after choosing a new timeframe', () => {
     const firstGraphXDomain = wrapper.state().graphXDomain;
-    wrapper.setProps({
-      selectedTimeFrame: 3600000 * 2,
-    });
+    wrapper.instance().handleTimeFrameChange(3600000 * 2);
 
     expect(wrapper.state().graphXDomain).not.toBe(firstGraphXDomain);
   });
@@ -308,13 +306,13 @@ describe('<MonitorATMServicesView>', () => {
     wrapper.find('Search').simulate('change', { target: { value: newValue } });
     expect(trackSearchOperationSpy).toHaveBeenCalledWith(newValue);
 
-    wrapper.find('Field').first().simulate('change', null, newValue);
+    wrapper.find('SearchableSelect').first().prop('onChange')(newValue);
     expect(trackSelectServiceSpy).toHaveBeenCalledWith(newValue);
 
-    wrapper.find({ name: 'spanKind' }).simulate('change', null, spanKindOption.value);
+    wrapper.find('.span-kind-selector').prop('onChange')(spanKindOption.value);
     expect(trackSelectSpanKindSpy).toHaveBeenCalledWith(spanKindOption.label);
 
-    wrapper.find('Field').last().simulate('change', null, timeFrameOption.value);
+    wrapper.find('SearchableSelect').last().prop('onChange')(timeFrameOption.value);
     expect(trackSelectTimeframeSpy).toHaveBeenCalledWith(timeFrameOption.label);
 
     wrapper.find({ children: 'View all traces' }).simulate('click');
@@ -367,9 +365,6 @@ describe('mapStateToProps()', () => {
     expect(mapStateToProps(state)).toEqual({
       metrics: originInitialState,
       services: [],
-      selectedService: 's1',
-      selectedSpanKind: 'server',
-      selectedTimeFrame: 3600000,
     });
   });
 });

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -29,7 +29,7 @@ import { trackSortOperations, trackViewTraces } from './index.track';
 type TProps = {
   data: ServiceOpsMetrics[] | undefined;
   error: MetricsReduxState['opsError'];
-  loading: boolean | null;
+  loading: boolean | undefined;
   endTime: number;
   lookback: number;
   serviceName: string;

--- a/packages/jaeger-ui/src/reducers/metrics.mock.js
+++ b/packages/jaeger-ui/src/reducers/metrics.mock.js
@@ -721,7 +721,7 @@ const originInitialState = {
   },
   isATMActivated: null,
   loading: false,
-  operationMetricsLoading: null,
+  operationMetricsLoading: undefined,
   serviceMetrics: null,
   serviceOpsMetrics: undefined,
 };

--- a/packages/jaeger-ui/src/reducers/metrics.tsx
+++ b/packages/jaeger-ui/src/reducers/metrics.tsx
@@ -46,7 +46,7 @@ const initialState: MetricsReduxState = {
   },
   isATMActivated: null,
   loading: false,
-  operationMetricsLoading: null,
+  operationMetricsLoading: undefined,
   serviceMetrics: null,
   serviceOpsMetrics: undefined,
 };

--- a/packages/jaeger-ui/src/types/metrics.tsx
+++ b/packages/jaeger-ui/src/types/metrics.tsx
@@ -124,7 +124,7 @@ export type MetricsReduxState = {
   };
   isATMActivated: null | boolean;
   loading: boolean;
-  operationMetricsLoading: null | boolean;
+  operationMetricsLoading: undefined | boolean;
   serviceMetrics: ServiceMetrics | null;
   serviceOpsMetrics: ServiceOpsMetrics[] | undefined;
 };


### PR DESCRIPTION
## Which problem is this PR solving?
- part of #2556 

## Description of the changes
- This PR removes dependency of Monitor page on `redux-form`.
- To keep this PR small and easy to review, I haven't removed other instances of `redux-form` in this same PR. Neither have I removed `redux-form` package as of now.
- `Antd` `SearchableSelect` requires loading type to be `boolean | undefined` so I have changed the related types in other files to fix ts-lint errors.

### Why this change was needed?
- Monitor page has a few selectors that doesn't need any global state sync to other components. `redux-form` is anyway deprecating so in-built react state management is a good choice.
- React uses `state` object for state management, and `props` for injecting props to the component. `redux-form` use to inject those Dropdown Selector values `selectedService`, `selectedSpanKind`, and `selectedTimeFrame` from redux store.
- This PR moves that to in-built react state, so we won't have to inject those from store anymore. 

## How was this change tested?
- `npm run test`
- `npm run start` with monitor page view. everything seems to be working fine.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
