### PR TITLE
fix TraceDiff graph pan and zoom issue

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.tsx
@@ -121,7 +121,7 @@ export class UnconnectedTraceDiffGraph extends React.PureComponent<Props> {
               layerType: 'html',
             },
           ]}
-          setOnGraph={classNameIsSmall}
+          setOnGraph={[classNameIsSmall, { style: { position: 'static' } }]}
           edges={edges}
           vertices={vertices}
         />

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/TraceDiffGraph.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/TraceDiffGraph.test.js.snap
@@ -66,7 +66,16 @@ exports[`TraceDiffGraph renders a DiGraph when it has data 1`] = `
     measurableNodesKey="nodes"
     minimap={true}
     minimapClassName="u-miniMap"
-    setOnGraph={[Function]}
+    setOnGraph={
+      Array [
+        [Function],
+        Object {
+          "style": Object {
+            "position": "static",
+          },
+        },
+      ]
+    }
     vertices={Array []}
     zoom={true}
   />


### PR DESCRIPTION
## Which problem is this PR solving?
- Fix pan and zoom issue on TraceDiff graph.
## Description of the changes
- This PR fixes the PAN and ZOOM functionality, which was caused by a minor CSS issue on the graph's parent that had relative position carried down the DOM to graph.

## How was this change tested?
- viewed the changes in browser by running jaeger-ui in dev, and jaeger monitor docker compose example.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
