### PR TITLE
Fix: Deep clone trace data for consistency

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
@@ -13,12 +13,14 @@
 // limitations under the License.
 import React from 'react';
 import { FlamegraphRenderer, convertJaegerTraceToProfile } from '@pyroscope/flamegraph';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import '@pyroscope/flamegraph/dist/index.css';
 import './index.css';
 
 const TraceFlamegraph = ({ trace }: any) => {
-  const convertedProfile = trace && trace.data ? convertJaegerTraceToProfile(trace.data) : null;
+  // Cloned b/c convertJaegerTraceToProfile or FlamegraphRenderer can possibly mutate the trace
+  const convertedProfile = trace && trace.data ? convertJaegerTraceToProfile(_cloneDeep(trace.data)) : null;
 
   return (
     <div className="Flamegraph-wrapper">

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
@@ -20,6 +20,7 @@ import './index.css';
 
 const TraceFlamegraph = ({ trace }: any) => {
   // Cloned b/c convertJaegerTraceToProfile or FlamegraphRenderer can possibly mutate the trace
+  // https://github.com/jaegertracing/jaeger-ui/issues/2483
   const convertedProfile = trace && trace.data ? convertJaegerTraceToProfile(_cloneDeep(trace.data)) : null;
 
   return (


### PR DESCRIPTION
Resolves #2483 

## Description of the changes
- deep cloned the trace data before passing it to @pyroscope/flamegraph

## How was this change tested?
- npm run test
- visual comparison with this traces data [trace.zip](https://github.com/user-attachments/files/18364826/trace.zip):

Timeline view: 

![timeline](https://github.com/user-attachments/assets/52f3e039-0ef9-40e9-9461-69e3c3867995)

Flamegraph view:

![flamegraph](https://github.com/user-attachments/assets/e68110e1-e26a-4a09-99b3-beb99ebc5275)

Navigating back and forth between flamegraph and timeline views no longer show inconsistent data

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
