### PR TITLE
Refactor: Rewrite search page related components into functional comp…

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as React from 'react';
-import { History as RouterHistory, Location } from 'history';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { Location, History as RouterHistory } from 'history';
 import _get from 'lodash/get';
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
@@ -83,138 +84,126 @@ export type TReduxProps = TExtractUiFindFromStateReturn & {
 export type TOwnProps = {
   baseUrl: string;
   extraUrlArgs?: { [key: string]: unknown };
-  history: RouterHistory;
+  history: RouterHistory,
   location: Location;
   showSvcOpsHeader: boolean;
 };
 
 export type TProps = TDispatchProps & TReduxProps & TOwnProps;
 
-type TState = {
-  selectedVertex?: TDdgVertex;
-};
+export const DeepDependencyGraphPageImpl: React.FC<TProps> = ({
+  addViewModifier,
+  fetchDeepDependencyGraph,
+  fetchServices,
+  fetchServiceServerOps,
+  removeViewModifierFromIndices,
+  graph,
+  graphState,
+  serverOpsForService,
+  services,
+  showOp,
+  urlState,
+  baseUrl = ROUTE_PATH,
+  extraUrlArgs,
+  showSvcOpsHeader = true,
+  uiFind,
+}) => {
+  const navigate = useNavigate();
+  const [selectedVertex, setSelectedVertex] = useState<TDdgVertex | undefined>(undefined);
+  
+  useEffect(() => {
+    fetchModelIfStale();
+    if (!services && fetchServices) {
+      fetchServices();
+    }
+    if (urlState.service && serverOpsForService && !Reflect.has(serverOpsForService, urlState.service) && fetchServiceServerOps) {
+      fetchServiceServerOps(urlState.service);
+    }
+  }, [urlState.service, services, serverOpsForService]);
 
-// export for tests
-export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps, TState> {
-  static defaultProps = {
-    showSvcOpsHeader: true,
-    baseUrl: ROUTE_PATH,
-  };
+  useEffect(() => {
+    fetchModelIfStale();
+  }, [urlState]);
 
-  static fetchModelIfStale(props: TProps) {
-    const { fetchDeepDependencyGraph, graphState = null, urlState } = props;
+  const fetchModelIfStale = () => {
     const { service, operation } = urlState;
     if (!graphState && service && fetchDeepDependencyGraph) {
       fetchDeepDependencyGraph({ service, operation, start: 0, end: 0 });
     }
-  }
-
-  state: TState = {};
-
-  constructor(props: TProps) {
-    super(props);
-    DeepDependencyGraphPageImpl.fetchModelIfStale(props);
-
-    const { fetchServices, fetchServiceServerOps, serverOpsForService, services, urlState } = props;
-    const { service } = urlState;
-
-    if (!services && fetchServices) {
-      fetchServices();
-    }
-    if (
-      service &&
-      serverOpsForService &&
-      !Reflect.has(serverOpsForService, service) &&
-      fetchServiceServerOps
-    ) {
-      fetchServiceServerOps(service);
-    }
-  }
-
-  componentDidUpdate() {
-    DeepDependencyGraphPageImpl.fetchModelIfStale(this.props);
-  }
-
-  clearOperation = () => {
-    trackClearOperation();
-    this.updateUrlState({ operation: undefined });
   };
 
-  focusPathsThroughVertex = (vertexKey: string) => {
-    const elems = this.getVisiblePathElems(vertexKey);
+  const clearOperation = () => {
+    trackClearOperation();
+    updateUrlState({ operation: undefined });
+  };
+
+  const focusPathsThroughVertex = (vertexKey: string) => {
+    const elems = getVisiblePathElems(vertexKey);
     if (!elems) return;
 
     trackFocusPaths();
     const indices = ([] as number[]).concat(
       ...elems.map(({ memberOf }) => memberOf.members.map(({ visibilityIdx }) => visibilityIdx))
     );
-    this.updateUrlState({ visEncoding: encode(indices) });
+    updateUrlState({ visEncoding: encode(indices) });
   };
 
-  getGenerationVisibility = (vertexKey: string, direction: EDirection): ECheckedStatus | null => {
-    const { graph, urlState } = this.props;
+  const getGenerationVisibility = (vertexKey: string, direction: EDirection): ECheckedStatus | null => {
     if (graph) {
       return graph.getGenerationVisibility(vertexKey, direction, urlState.visEncoding);
     }
     return null;
   };
 
-  getVisiblePathElems = (key: string) => {
-    const { graph, urlState } = this.props;
+  const getVisiblePathElems = (key: string) => {
     if (graph) {
       return graph.getVertexVisiblePathElems(key, urlState.visEncoding);
     }
     return undefined;
   };
 
-  hideVertex = (vertexKey: string) => {
-    const { graph, urlState } = this.props;
+  const hideVertex = (vertexKey: string) => {
     if (!graph) return;
 
     const visEncoding = graph.getVisWithoutVertex(vertexKey, urlState.visEncoding);
     if (!visEncoding) return;
 
     trackHide();
-    this.updateUrlState({ visEncoding });
+    updateUrlState({ visEncoding });
   };
 
-  setDecoration = (decoration: string | undefined) => this.updateUrlState({ decoration });
+  const setDecoration = (decoration: string | undefined) => updateUrlState({ decoration });
 
-  setDensity = (density: EDdgDensity) => this.updateUrlState({ density });
+  const setDensity = (density: EDdgDensity) => updateUrlState({ density });
 
-  setDistance = (distance: number, direction: EDirection) => {
-    const { graphState } = this.props;
-    const { visEncoding } = this.props.urlState;
-
+  const setDistance = (distance: number, direction: EDirection) => {
     if (graphState && graphState.state === fetchedState.DONE) {
       const { model: ddgModel } = graphState as IDoneState;
 
-      this.updateUrlState({
+      updateUrlState({
         visEncoding: encodeDistance({
           ddgModel,
           direction,
           distance,
-          prevVisEncoding: visEncoding,
+          prevVisEncoding: urlState.visEncoding,
         }),
       });
     }
   };
 
-  setOperation = (operation: string) => {
-    this.updateUrlState({ operation, visEncoding: undefined });
+  const setOperation = (operation: string) => {
+    updateUrlState({ operation, visEncoding: undefined });
   };
 
-  setService = (service: string) => {
-    const { fetchServiceServerOps, serverOpsForService } = this.props;
+  const setService = (service: string) => {
     if (serverOpsForService && !Reflect.has(serverOpsForService, service) && fetchServiceServerOps) {
       fetchServiceServerOps(service);
     }
-    this.updateUrlState({ operation: undefined, service, visEncoding: undefined });
+    updateUrlState({ operation: undefined, service, visEncoding: undefined });
     trackSetService();
   };
 
-  setViewModifier = (visibilityIndices: number[], viewModifier: EViewModifier, enable: boolean) => {
-    const { addViewModifier, graph, removeViewModifierFromIndices, urlState } = this.props;
+  const setViewModifier = (visibilityIndices: number[], viewModifier: EViewModifier, enable: boolean) => {
     const fn = enable ? addViewModifier : removeViewModifierFromIndices;
     const { service, operation } = urlState;
     if (!fn || !graph || !service) return;
@@ -228,21 +217,18 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps, TSt
     });
   };
 
-  selectVertex = (selectedVertex?: TDdgVertex) => {
-    this.setState({ selectedVertex });
+  const selectVertex = (vertex?: TDdgVertex) => {
+    setSelectedVertex(vertex);
   };
 
-  showVertices = (vertexKeys: string[]) => {
-    const { graph, urlState } = this.props;
-    const { visEncoding } = urlState;
+  const showVertices = (vertexKeys: string[]) => {
     if (!graph) return;
-    this.updateUrlState({ visEncoding: graph.getVisWithVertices(vertexKeys, visEncoding) });
+    updateUrlState({ visEncoding: graph.getVisWithVertices(vertexKeys, urlState.visEncoding) });
   };
 
-  toggleShowOperations = (enable: boolean) => this.updateUrlState({ showOp: enable });
+  const toggleShowOperations = (enable: boolean) => updateUrlState({ showOp: enable });
 
-  updateGenerationVisibility = (vertexKey: string, direction: EDirection) => {
-    const { graph, urlState } = this.props;
+  const updateGenerationVisibility = (vertexKey: string, direction: EDirection) => {
     if (!graph) return;
 
     const result = graph.getVisWithUpdatedGeneration(vertexKey, direction, urlState.visEncoding);
@@ -251,161 +237,145 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps, TSt
     const { visEncoding, update } = result;
     if (update === ECheckedStatus.Empty) trackHide(direction);
     else trackShow(direction);
-    this.updateUrlState({ visEncoding });
+    updateUrlState({ visEncoding });
   };
 
-  updateUrlState = (newValues: Partial<TDdgSparseUrlState>) => {
-    const { baseUrl, extraUrlArgs, graphState, history, uiFind, urlState } = this.props;
+  const updateUrlState = (newValues: Partial<TDdgSparseUrlState>) => {
     const getUrlArg = { uiFind, ...urlState, ...newValues, ...extraUrlArgs };
     const hash = _get(graphState, 'model.hash');
     if (hash) getUrlArg.hash = hash;
-    history.push(getUrl(getUrlArg, baseUrl));
+    navigate(getUrl(getUrlArg, baseUrl), {replace: true});
   };
 
-  render() {
-    const { selectedVertex } = this.state;
-    const {
-      baseUrl,
-      extraUrlArgs,
-      graph,
-      graphState,
-      serverOpsForService,
-      services,
-      showOp,
-      uiFind,
-      urlState,
-      showSvcOpsHeader,
-    } = this.props;
-    const { density, operation, service, visEncoding } = urlState;
-    const distanceToPathElems =
-      graphState && graphState.state === fetchedState.DONE
-        ? (graphState as IDoneState).model.distanceToPathElems
-        : undefined;
-    const uiFindMatches = graph && graph.getVisibleUiFindMatches(uiFind, visEncoding);
-    const hiddenUiFindMatches = graph && graph.getHiddenUiFindMatches(uiFind, visEncoding);
+  const { density, operation, service, visEncoding } = urlState;
+  const distanceToPathElems =
+    graphState && graphState.state === fetchedState.DONE
+      ? (graphState as IDoneState).model.distanceToPathElems
+      : undefined;
+  const uiFindMatches = graph && graph.getVisibleUiFindMatches(uiFind, visEncoding);
+  const hiddenUiFindMatches = graph && graph.getHiddenUiFindMatches(uiFind, visEncoding);
 
-    let content: React.ReactElement | null = null;
-    let wrapperClassName = '';
-    if (!graphState) {
-      content = <h1>Enter query above</h1>;
-    } else if (graphState.state === fetchedState.DONE && graph) {
-      const { edges, vertices } = graph.getVisible(visEncoding);
-      const { viewModifiers } = graphState as IDoneState;
-      const { edges: edgesViewModifiers, vertices: verticesViewModifiers } = graph.getDerivedViewModifiers(
-        visEncoding,
-        viewModifiers
-      );
-      if (vertices.length > 1) {
-        wrapperClassName = 'is-horizontal';
-        // TODO: using `key` here is a hack, debug digraph to fix the underlying issue
-        content = (
-          <>
-            <Graph
-              key={JSON.stringify({ density, showOp, service, operation, visEncoding })}
-              baseUrl={baseUrl}
-              density={density}
-              edges={edges}
-              edgesViewModifiers={edgesViewModifiers}
-              extraUrlArgs={extraUrlArgs}
-              focusPathsThroughVertex={this.focusPathsThroughVertex}
-              getGenerationVisibility={this.getGenerationVisibility}
-              getVisiblePathElems={this.getVisiblePathElems}
-              hideVertex={this.hideVertex}
-              selectVertex={this.selectVertex}
-              setOperation={this.setOperation}
-              setViewModifier={this.setViewModifier}
-              uiFindMatches={uiFindMatches}
-              updateGenerationVisibility={this.updateGenerationVisibility}
-              vertices={vertices}
-              verticesViewModifiers={verticesViewModifiers}
-            />
-            <SidePanel
-              clearSelected={this.selectVertex}
-              selectDecoration={this.setDecoration}
-              selectedDecoration={urlState.decoration}
-              selectedVertex={selectedVertex}
-            />
-          </>
-        );
-      } else if (
-        (graphState as IDoneState).model.distanceToPathElems.has(-1) ||
-        (graphState as IDoneState).model.distanceToPathElems.has(1)
-      ) {
-        content = (
-          <>
-            <h1 className="Ddg--center">There is nothing visible to show</h1>
-            <p className="Ddg--center">Select at least one hop to view</p>
-          </>
-        );
-      } else {
-        const lookback = getConfigValue('search.maxLookback.value');
-        const checkLink = getSearchUrl({
-          lookback,
-          minDuration: '0ms',
-          operation,
-          service,
-          tags: '{"span.kind":"server"}',
-        });
-        content = (
-          <>
-            <h1 className="Ddg--center">There are no dependencies</h1>
-            <p className="Ddg--center">
-              No traces were found that contain {service}
-              {operation && `:${operation}`} and any other service where span.kind is &lsquo;server&rsquo;.
-            </p>
-            <p className="Ddg--center">
-              <a href={checkLink}>Confirm by searching</a>
-            </p>
-          </>
-        );
-      }
-    } else if (graphState.state === fetchedState.LOADING) {
-      content = <LoadingIndicator centered className="u-mt-vast" />;
-    } else if (graphState.state === fetchedState.ERROR) {
+  let content: React.ReactElement | null = null;
+  let wrapperClassName = '';
+  if (!graphState) {
+    content = <h1>Enter query above</h1>;
+  } else if (graphState.state === fetchedState.DONE && graph) {
+    const { edges, vertices } = graph.getVisible(visEncoding);
+    const { viewModifiers } = graphState as IDoneState;
+    const { edges: edgesViewModifiers, vertices: verticesViewModifiers } = graph.getDerivedViewModifiers(
+      visEncoding,
+      viewModifiers
+    );
+    if (vertices.length > 1) {
+      wrapperClassName = 'is-horizontal';
+      // TODO: using `key` here is a hack, debug digraph to fix the underlying issue
       content = (
         <>
-          <ErrorMessage error={(graphState as IErrorState).error} className="ub-m4" />
-          <p className="Ddg--center">If you are using an adblocker, whitelist Jaeger and retry.</p>
+          <Graph
+            key={JSON.stringify({ density, showOp, service, operation, visEncoding })}
+            baseUrl={baseUrl}
+            density={density}
+            edges={edges}
+            edgesViewModifiers={edgesViewModifiers}
+            extraUrlArgs={extraUrlArgs}
+            focusPathsThroughVertex={focusPathsThroughVertex}
+            getGenerationVisibility={getGenerationVisibility}
+            getVisiblePathElems={getVisiblePathElems}
+            hideVertex={hideVertex}
+            selectVertex={selectVertex}
+            setOperation={setOperation}
+            setViewModifier={setViewModifier}
+            uiFindMatches={uiFindMatches}
+            updateGenerationVisibility={updateGenerationVisibility}
+            vertices={vertices}
+            verticesViewModifiers={verticesViewModifiers}
+          />
+          <SidePanel
+            clearSelected={selectVertex}
+            selectDecoration={setDecoration}
+            selectedDecoration={urlState.decoration}
+            selectedVertex={selectedVertex}
+          />
+        </>
+      );
+    } else if (
+      (graphState as IDoneState).model.distanceToPathElems.has(-1) ||
+      (graphState as IDoneState).model.distanceToPathElems.has(1)
+    ) {
+      content = (
+        <>
+          <h1 className="Ddg--center">There is nothing visible to show</h1>
+          <p className="Ddg--center">Select at least one hop to view</p>
         </>
       );
     } else {
+      const lookback = getConfigValue('search.maxLookback.value');
+      const checkLink = getSearchUrl({
+        lookback,
+        minDuration: '0ms',
+        operation,
+        service,
+        tags: '{"span.kind":"server"}',
+      });
       content = (
         <>
-          <h1 className="Ddg--center">Unknown graphState:</h1>
-          <p className="Ddg--center">{JSON.stringify(graphState, null, 2)}</p>
+          <h1 className="Ddg--center">There are no dependencies</h1>
+          <p className="Ddg--center">
+            No traces were found that contain {service}
+            {operation && `:${operation}`} and any other service where span.kind is &lsquo;server&rsquo;.
+          </p>
+          <p className="Ddg--center">
+            <a href={checkLink}>Confirm by searching</a>
+          </p>
         </>
       );
     }
-
-    return (
-      <div className="Ddg">
-        <div>
-          <Header
-            clearOperation={this.clearOperation}
-            density={density}
-            distanceToPathElems={distanceToPathElems}
-            hiddenUiFindMatches={hiddenUiFindMatches}
-            operation={operation}
-            operations={serverOpsForService && serverOpsForService[service || '']}
-            service={service}
-            services={services}
-            setDensity={this.setDensity}
-            setDistance={this.setDistance}
-            setOperation={this.setOperation}
-            setService={this.setService}
-            showOperations={showOp}
-            showParameters={showSvcOpsHeader}
-            showVertices={this.showVertices}
-            toggleShowOperations={this.toggleShowOperations}
-            uiFindCount={uiFind ? uiFindMatches && uiFindMatches.size : undefined}
-            visEncoding={visEncoding}
-          />
-        </div>
-        <div className={`Ddg--graphWrapper ${wrapperClassName}`}>{content}</div>
-      </div>
+  } else if (graphState.state === fetchedState.LOADING) {
+    content = <LoadingIndicator centered className="u-mt-vast" />;
+  } else if (graphState.state === fetchedState.ERROR) {
+    content = (
+      <>
+        <ErrorMessage error={(graphState as IErrorState).error} className="ub-m4" />
+        <p className="Ddg--center">If you are using an adblocker, whitelist Jaeger and retry.</p>
+      </>
+    );
+  } else {
+    content = (
+      <>
+        <h1 className="Ddg--center">Unknown graphState:</h1>
+        <p className="Ddg--center">{JSON.stringify(graphState, null, 2)}</p>
+      </>
     );
   }
-}
+
+  return (
+    <div className="Ddg">
+      <div>
+        <Header
+          clearOperation={clearOperation}
+          density={density}
+          distanceToPathElems={distanceToPathElems}
+          hiddenUiFindMatches={hiddenUiFindMatches}
+          operation={operation}
+          operations={serverOpsForService && serverOpsForService[service || '']}
+          service={service}
+          services={services}
+          setDensity={setDensity}
+          setDistance={setDistance}
+          setOperation={setOperation}
+          setService={setService}
+          showOperations={showOp}
+          showParameters={showSvcOpsHeader}
+          showVertices={showVertices}
+          toggleShowOperations={toggleShowOperations}
+          uiFindCount={uiFind ? uiFindMatches && uiFindMatches.size : undefined}
+          visEncoding={visEncoding}
+        />
+      </div>
+      <div className={`Ddg--graphWrapper ${wrapperClassName}`}>{content}</div>
+    </div>
+  );
+};
 
 // export for tests
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {

--- a/packages/jaeger-ui/src/components/DeepDependencies/traces.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/traces.tsx
@@ -30,13 +30,19 @@ import transformTracesToPaths from '../../model/ddg/transformTracesToPaths';
 
 import { TDdgStateEntry } from '../../types/TDdgState';
 import { ReduxState } from '../../types';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 // Required for proper memoization of subsequent function calls
 const svcOp = memoizeOne((service, operation) => ({ service, operation }));
 
 // export for tests
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
-  const urlState = getUrlState(ownProps.location.search);
+  // ownProps.location.search !== state.router.location.search
+  // Graph displayed only when the state.router.location.search is used, which contains all the params
+  // ownProps.location.search contains only the `?view=dgg` param
+  // const urlState = getUrlState(ownProps.location.search);
+  const urlState = getUrlState(state.router.location.search);
+
   const { density, operation, service, showOp: urlStateShowOp } = urlState;
   const showOp = urlStateShowOp !== undefined ? urlStateShowOp : operation !== undefined;
   let graphState: TDdgStateEntry | undefined;
@@ -65,10 +71,11 @@ type TOwnProps = {
   location: Location;
 };
 
+type TProps = TOwnProps & TReduxProps;
+
 // export for tests
-export class TracesDdgImpl extends React.PureComponent<TOwnProps & TReduxProps> {
-  render(): React.ReactNode {
-    const { location } = this.props;
+export const TracesDdgImpl: React.FC<TProps> = (props) => {
+    const location = useLocation();
     const urlArgs = queryString.parse(location.search);
     const { end, start, limit, lookback, maxDuration, minDuration, view } = urlArgs;
     const extraArgs = { end, start, limit, lookback, maxDuration, minDuration, view };
@@ -77,10 +84,10 @@ export class TracesDdgImpl extends React.PureComponent<TOwnProps & TReduxProps> 
         baseUrl={ROUTE_PATH}
         extraUrlArgs={extraArgs}
         showSvcOpsHeader={false}
-        {...this.props}
+        {...props}
       />
     );
   }
-}
+// }
 
 export default connect(mapStateToProps)(TracesDdgImpl);

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
@@ -14,11 +14,12 @@
 
 /* eslint-disable react/require-default-props */
 
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Col, Row, Tabs } from 'antd';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import store from 'store';
 import memoizeOne from 'memoize-one';
 
@@ -39,26 +40,35 @@ import FileLoader from './FileLoader';
 
 import './index.css';
 import JaegerLogo from '../../img/jaeger-logo.svg';
-import withRouteProps from '../../utils/withRouteProps';
 import { trackSortByChange } from './SearchForm.track';
 
-// export for tests
-export class SearchTracePageImpl extends Component {
-  state = {
-    sortBy: orderBy.MOST_RECENT,
-  };
-
-  componentDidMount() {
-    const {
-      diffCohort,
-      fetchMultipleTraces,
-      fetchServiceOperations,
-      fetchServices,
-      isHomepage,
-      queryOfResults,
-      searchTraces,
-      urlQueryParams,
-    } = this.props;
+const SearchTracePageImpl = ({
+  cohortAddTrace,
+  cohortRemoveTrace,
+  diffCohort,
+  embedded,
+  errors,
+  isHomepage,
+  disableFileUploadControl,
+  loadingServices,
+  loadingTraces,
+  maxTraceDuration,
+  services,
+  traceResultsToDownload,
+  queryOfResults,
+  loadJsonTraces,
+  urlQueryParams,
+  sortedTracesXformer,
+  traces,
+  searchTraces,
+  fetchMultipleTraces,
+  fetchServiceOperations,
+  fetchServices,
+}) => {
+  const [sortBy, setSortBy] = useState(orderBy.MOST_RECENT);
+  const navigate = useNavigate();
+  
+  useEffect(() => {
     if (!isHomepage && urlQueryParams && !isSameQuery(urlQueryParams, queryOfResults)) {
       searchTraces(urlQueryParams);
     }
@@ -74,108 +84,87 @@ export class SearchTracePageImpl extends Component {
     if (service && service !== '-') {
       fetchServiceOperations(service);
     }
-  }
+  }, [urlQueryParams, isHomepage, queryOfResults, diffCohort, searchTraces, fetchMultipleTraces, fetchServiceOperations, fetchServices]);
 
-  handleSortChange = sortBy => {
-    this.setState({ sortBy });
+  const handleSortChange = (sortBy) => {
+    setSortBy(sortBy);
     trackSortByChange(sortBy);
-  };
-
-  goToTrace = traceID => {
-    const { queryOfResults } = this.props;
-    const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
-    this.props.history.push(getTraceLocation(traceID, { fromSearch: searchUrl }));
-  };
-
-  render() {
-    const {
-      cohortAddTrace,
-      cohortRemoveTrace,
-      diffCohort,
-      embedded,
-      errors,
-      isHomepage,
-      disableFileUploadControl,
-      loadingServices,
-      loadingTraces,
-      maxTraceDuration,
-      services,
-      traceResultsToDownload,
-      queryOfResults,
-      loadJsonTraces,
-      urlQueryParams,
-      sortedTracesXformer,
-      traces,
-    } = this.props;
-    const { sortBy } = this.state;
-    const traceResults = sortedTracesXformer(traces, sortBy);
-    const hasTraceResults = traceResults && traceResults.length > 0;
-    const showErrors = errors && !loadingTraces;
-    const showLogo = isHomepage && !hasTraceResults && !loadingTraces && !errors;
-    const tabItems = [];
-    if (!loadingServices && services) {
-      tabItems.push({ label: 'Search', key: 'searchForm', children: <SearchForm services={services} /> });
-    } else {
-      tabItems.push({ label: 'Search', key: 'searchForm', children: <LoadingIndicator /> });
-    }
-    if (!disableFileUploadControl) {
-      tabItems.push({
-        label: 'Upload',
-        key: 'fileLoader',
-        children: <FileLoader loadJsonTraces={loadJsonTraces} />,
-      });
-    }
-    return (
-      <Row className="SearchTracePage--row">
-        {!embedded && (
-          <Col span={6} className="SearchTracePage--column">
-            <div className="SearchTracePage--find">
-              <Tabs size="large" items={tabItems} />
-            </div>
-          </Col>
-        )}
-        <Col span={!embedded ? 18 : 24} className="SearchTracePage--column">
-          {showErrors && (
-            <div className="js-test-error-message">
-              <h2>There was an error querying for traces:</h2>
-              {errors.map(err => (
-                <ErrorMessage key={err.message} error={err} />
-              ))}
-            </div>
-          )}
-          {!showErrors && (
-            <SearchResults
-              cohortAddTrace={cohortAddTrace}
-              cohortRemoveTrace={cohortRemoveTrace}
-              diffCohort={diffCohort}
-              disableComparisons={embedded}
-              goToTrace={this.goToTrace}
-              hideGraph={embedded && embedded.searchHideGraph}
-              loading={loadingTraces}
-              maxTraceDuration={maxTraceDuration}
-              queryOfResults={queryOfResults}
-              showStandaloneLink={Boolean(embedded)}
-              skipMessage={isHomepage}
-              spanLinks={urlQueryParams && urlQueryParams.spanLinks}
-              traces={traceResults}
-              rawTraces={traceResultsToDownload}
-              sortBy={this.state.sortBy}
-              handleSortChange={this.handleSortChange}
-            />
-          )}
-          {showLogo && (
-            <img
-              className="SearchTracePage--logo js-test-logo"
-              alt="presentation"
-              src={JaegerLogo}
-              width="400"
-            />
-          )}
-        </Col>
-      </Row>
-    );
   }
-}
+
+  const goToTrace = (traceID) => {
+    const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
+    navigate(getTraceLocation(traceID, { fromSearch: searchUrl }));
+  }
+
+  const traceResults = sortedTracesXformer(traces, sortBy);
+  const hasTraceResults = traceResults && traceResults.length > 0;
+  const showErrors = errors && !loadingTraces;
+  const showLogo = isHomepage && !hasTraceResults && !loadingTraces && !errors;
+  const tabItems = [];
+  if (!loadingServices && services) {
+    tabItems.push({ label: 'Search', key: 'searchForm', children: <SearchForm services={services} /> });
+  } else {
+    tabItems.push({ label: 'Search', key: 'searchForm', children: <LoadingIndicator /> });
+  }
+  if (!disableFileUploadControl) {
+    tabItems.push({
+      label: 'Upload',
+      key: 'fileLoader',
+      children: <FileLoader loadJsonTraces={loadJsonTraces} />,
+    });
+  }
+
+  return (
+    <Row className="SearchTracePage--row">
+      {!embedded && (
+        <Col span={6} className="SearchTracePage--column">
+          <div className="SearchTracePage--find">
+            <Tabs size="large" items={tabItems} />
+          </div>
+        </Col>
+      )}
+      <Col span={!embedded ? 18 : 24} className="SearchTracePage--column">
+        {showErrors && (
+          <div className="js-test-error-message">
+            <h2>There was an error querying for traces:</h2>
+            {errors.map(err => (
+              <ErrorMessage key={err.message} error={err} />
+            ))}
+          </div>
+        )}
+        {!showErrors && (
+          <SearchResults
+            cohortAddTrace={cohortAddTrace}
+            cohortRemoveTrace={cohortRemoveTrace}
+            diffCohort={diffCohort}
+            disableComparisons={embedded}
+            goToTrace={goToTrace}
+            hideGraph={embedded && embedded.searchHideGraph}
+            loading={loadingTraces}
+            maxTraceDuration={maxTraceDuration}
+            queryOfResults={queryOfResults}
+            showStandaloneLink={Boolean(embedded)}
+            skipMessage={isHomepage}
+            spanLinks={urlQueryParams && urlQueryParams.spanLinks}
+            traces={traceResults}
+            rawTraces={traceResultsToDownload}
+            sortBy={sortBy}
+            handleSortChange={handleSortChange}
+          />
+        )}
+        {showLogo && (
+          <img
+            className="SearchTracePage--logo js-test-logo"
+            alt="presentation"
+            src={JaegerLogo}
+            width="400"
+          />
+        )}
+      </Col>
+    </Row>
+  );
+};
+
 SearchTracePageImpl.propTypes = {
   isHomepage: PropTypes.bool,
   // eslint-disable-next-line react/forbid-prop-types
@@ -206,9 +195,6 @@ SearchTracePageImpl.propTypes = {
     })
   ),
   searchTraces: PropTypes.func,
-  history: PropTypes.shape({
-    push: PropTypes.func,
-  }),
   fetchMultipleTraces: PropTypes.func,
   fetchServiceOperations: PropTypes.func,
   fetchServices: PropTypes.func,
@@ -320,4 +306,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(SearchTracePageImpl));
+export default connect(mapStateToProps, mapDispatchToProps)(SearchTracePageImpl);

--- a/packages/jaeger-ui/src/utils/withRouteProps.tsx
+++ b/packages/jaeger-ui/src/utils/withRouteProps.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import { History, Location } from 'history';
 import { useHistory } from './useHistory';
 


### PR DESCRIPTION

## Which problem is this PR solving?
- Part of #2532 
- Supporting PR/PoC for #2580 

## Description of the changes
- Converted several class-based components into functional ones, to enable the use of useHooks from rrd v6

## How was this change tested?
- `npm run test`
- Currently, many failing tests - will address if this concept works

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
