### PR TITLE
Updated react-icons and antd version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "eslint-plugin-react": "7.37.1",
         "husky": "9.1.0",
-        "jsdom": "25.0.1",
+        "jsdom": "^26.0.0",
         "npm-run-all2": "7.0.1",
         "prettier": "3.4.2",
         "rxjs-compat": "6.6.7",
@@ -60,7 +60,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.1.0.tgz",
       "integrity": "sha512-MMoDGWn1y9LdQJQSHiCC20x3uZ3CwQnv9QMz6pCmJOrqdgM9YxsoVVY0wtrdXbmfSgnV0KNk6zi09NAhMR2jvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ctrl/tinycolor": "^3.6.1"
       }
@@ -96,7 +95,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.1.tgz",
       "integrity": "sha512-tyWnlK+XH7Bumd0byfbCiZNK43HEubMoCcu9VxwsAwiHdHTgWa+tMN0/yvxa+e8EzuFP1WdUNNPclRpVtD33lg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -116,7 +114,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.0.tgz",
       "integrity": "sha512-E9nOWObXx7Dy7hdyuYlOFaer/LtPO7oyZVxZphh0CYEslr5EmhJPM3WI0Q2RBHRtYg6dSNqeSK73kvZjPN3IMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
         "@babel/runtime": "^7.23.2",
@@ -144,7 +141,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.1.tgz",
       "integrity": "sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
         "@ant-design/icons-svg": "^4.4.0",
@@ -181,6 +177,27 @@
       "peerDependencies": {
         "react": ">=16.9.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-2.8.3.tgz",
+      "integrity": "sha512-GIc76d9UI1hCvOATjZPyHFmE5qhRccp3/zGfMPapK3jBi+yocEzp6BBB0UnfRYP9NP4FANqUZYb0hnfs3TM3hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.1",
+        "@csstools/css-color-parser": "^3.0.7",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/cli": {
       "version": "7.26.4",
@@ -2203,12 +2220,126 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.1.tgz",
+      "integrity": "sha512-MKtmkA0BX87PKaO1NFRTFH+UnkgnmySQOvNxJubsadusqPEC2aJ9MOQiMceZJJ6oitUl/i0L6u0M1IrmAOmgBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.1.tgz",
+      "integrity": "sha512-rL7kaUnTkL9K+Cvo2pnCieqNpTKgQzy5f+N+5Iuko9HAoasP+xgprVh7KN/MaJVvVL1l0EzQq2MoqBHKSrDrag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.7.tgz",
+      "integrity": "sha512-nkMp2mTICw32uE5NN+EsJ4f5N+IGFeCFu4bGpiKgb2Pq/7J/MpyLBeQ5ry4KKtRFZaYs6sTmcMYrSRIyj5DFKA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.1",
+        "@csstools/css-calc": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@ctrl/tinycolor": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
       "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5559,14 +5690,11 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
@@ -5713,7 +5841,6 @@
       "resolved": "https://registry.npmjs.org/antd/-/antd-5.21.3.tgz",
       "integrity": "sha512-Yby3gU6jfuvhNFRPsrHB4Yc/G3LHLNHHy0kShwNmmZf1QTCiW5TmqP3DT5m/NHbJsTgEwJpwo3AaOWo+KQyEjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^7.1.0",
         "@ant-design/cssinjs": "^1.21.1",
@@ -5867,8 +5994,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
       "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -7356,13 +7482,14 @@
       "license": "MIT"
     },
     "node_modules/cssstyle": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
-      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.2.1.tgz",
+      "integrity": "sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "rrweb-cssom": "^0.7.1"
+        "@asamuzakjp/css-color": "^2.8.2",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
         "node": ">=18"
@@ -10776,13 +10903,13 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -13271,23 +13398,23 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
-      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.0.0.tgz",
+      "integrity": "sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.1.0",
+        "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
         "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.1",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.12",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^5.0.0",
@@ -13295,7 +13422,7 @@
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
+        "whatwg-url": "^14.1.0",
         "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
@@ -13303,7 +13430,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -14387,9 +14514,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.13",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
-      "integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==",
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
+      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -14768,13 +14895,13 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -15601,7 +15728,6 @@
       "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.28.1.tgz",
       "integrity": "sha512-9+8oHIMWVLHxuaapDiqFNmD9KSyKN/P4bo9x/MBuDbyTqP8f2/POmmZxdXWBO3yq/uE3pKyQCXYNUxrNfHRv2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
@@ -15620,7 +15746,6 @@
       "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.3.0.tgz",
       "integrity": "sha512-Ih3ZaAcoAiFKJjifzwsGiT/f/quIkxJoklW4yKGho14Olulwn8gN7hOBve0/WGDg5o/l/5mL0w7ff7/YGvefVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.3.2",
@@ -15636,7 +15761,6 @@
       "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.8.0.tgz",
       "integrity": "sha512-YVBkssrKPBG09TGfcWWGj8zJBYD9G3XuTy89t5iUmSXrIXEAnO1M+qjUxRW6b4Qi0+wNWG6MHJF/+US+nmIlzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -15687,7 +15811,6 @@
       "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.0.tgz",
       "integrity": "sha512-odM8Ove+gSh0zU27DUj5cG1gNKg7mLWBYzB5E4nNLrLwBmYEgYP43vHKDGOVZcJSVElQBI0+jTQgjnq0NfLjng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@rc-component/trigger": "^2.0.0",
@@ -15704,7 +15827,6 @@
       "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.4.0.tgz",
       "integrity": "sha512-XZ/lF9iqf9HXApIHQHqzJK5v2w4mkUMsVqAzOyWVzoiwwXEavY6Tpuw7HavgzIoD+huVff4JghSGcgEfX6eycg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "@rc-component/async-validator": "^5.0.3",
@@ -15780,7 +15902,6 @@
       "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.6.3.tgz",
       "integrity": "sha512-wI4NzuqBS8vvKr8cljsvnTUqItMfG1QbJoxovCgL+DX4eVUcHIjVwharwevIxyy7H/jbLryh+K7ysnJr23aWIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -15796,7 +15917,6 @@
       "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.2.0.tgz",
       "integrity": "sha512-5XZFhBCV5f9UQ62AZ2hFbEY8iZT/dm23Q1kAg0H8EvOgD3UDbYYJAayoVIkM3lQaCqYAW5gV0yV3vjw1XtzWHg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/mini-decimal": "^1.0.1",
@@ -15814,7 +15934,6 @@
       "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.16.1.tgz",
       "integrity": "sha512-GnhSTGP9Mtv6pqFFGQze44LlrtWOjHNrUUAcsdo9DnNAhN4pwVPEWy4z+2jpjkiGlJ3VoXdvMHcNDQdfI9fEaw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@rc-component/trigger": "^2.0.0",
@@ -15834,7 +15953,6 @@
       "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.15.1.tgz",
       "integrity": "sha512-UKporqU6LPfHnpPmtP6hdEK4iO5Q+b7BRv/uRpxdIyDGplZy9jwUjsnpev5bs3PQKB0H0n34WAPDfjAfn3kAPA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^2.0.0",
@@ -15903,7 +16021,6 @@
       "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.3.0.tgz",
       "integrity": "sha512-UubEWA0ShnroQ1tDa291Fzw6kj0iOeF26IsUObxYTpimgj4/qPCWVFl18RLZE+0Up1IZg0IK4pMn6nB3mjvB7g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.3.2",
@@ -15919,7 +16036,6 @@
       "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.6.15.tgz",
       "integrity": "sha512-OWZ1yrMie+KN2uEUfYCfS4b2Vu6RC1FWwNI0s+qypsc3wRt7g+peuZKVIzXCTaJwyyZruo80+akPg2+GmyiJjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7",
         "@rc-component/trigger": "^2.0.0",
@@ -16008,7 +16124,6 @@
       "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.5.0.tgz",
       "integrity": "sha512-B28Fe3J9iUFOhFJET3RoXAPFJ2u47QvLSYcZWC4tFYNGPEjug5LAxEasZlA/PpAxhdOPqGWsGbSj7ftneukJnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -16025,7 +16140,6 @@
       "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.15.2.tgz",
       "integrity": "sha512-oNoXlaFmpqXYcQDzcPVLrEqS2J9c+/+oJuGrlXeVVX/gVgrbHa5YcyiRUXRydFjyuA7GP3elRuLF7Y3Tfwltlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^2.1.1",
@@ -16048,7 +16162,6 @@
       "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.7.tgz",
       "integrity": "sha512-ytYbZei81TX7otdC0QvoYD72XSlxvTihNth5OeZ6PMXyEDq/vHdWFulQmfDGyXK1NwKwSlKgpvINOa88uT5g2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -16100,7 +16213,6 @@
       "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.47.5.tgz",
       "integrity": "sha512-fzq+V9j/atbPIcvs3emuclaEoXulwQpIiJA6/7ey52j8+9cJ4P8DGmp4YzfUVDrb3qhgedcVeD6eRgUrokwVEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/context": "^1.4.0",
@@ -16122,7 +16234,6 @@
       "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.3.0.tgz",
       "integrity": "sha512-lzE18r+zppT/jZWOAWS6ntdkDUKHOLJzqMi5UAij1LeKwOaQaupupAoI9Srn73GRzVpmGznkECMRrzkRusC40A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
@@ -16145,7 +16256,6 @@
       "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.8.2.tgz",
       "integrity": "sha512-UFAezAqltyR00a8Lf0IPAyTd29Jj9ee8wt8DqXyDMal7r/Cg/nDt3e1OOv3Th4W6mKaZijjgwuPXhAfVNTN8sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
@@ -16163,7 +16273,6 @@
       "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.1.tgz",
       "integrity": "sha512-rws0duD/3sHHsD905Nex7FvoUGy2UBQRhTkKxeEvr2FB+r21HsOxcDJI0TzyO8NHhnAA8ILr8pfbSBg5Jj5KBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/trigger": "^2.0.0",
@@ -16179,7 +16288,6 @@
       "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.9.0.tgz",
       "integrity": "sha512-CPrgOvm9d/9E+izTONKSngNzQdIEjMox2PBufWjS1wf7vxtvmCWzK1SlpHbRY6IaBfJIeZ+88RkcIevf729cRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -16200,7 +16308,6 @@
       "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.23.0.tgz",
       "integrity": "sha512-aQGi2tFSRw1WbXv0UVXPzHm09E0cSvUVZMLxQtMv3rnZZpNmdRXWrnd9QkLNlVH31F+X5rgghmdSFF3yZW0N9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -17390,9 +17497,9 @@
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -19754,9 +19861,9 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
-      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.0.tgz",
+      "integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20103,7 +20210,7 @@
         "@ant-design/compatible": "^5.1.3",
         "@jaegertracing/plexus": "0.2.0",
         "@pyroscope/flamegraph": "0.21.4",
-        "@sentry/browser": "^8.48.0",
+        "@sentry/browser": "^8.18.0",
         "antd": "^5.21.3",
         "chance": "^1.0.10",
         "classnames": "^2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
         "packages/plexus",
         "packages/jaeger-ui"
       ],
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.1.0",
+        "antd": "^5.23.1",
+        "react-icons": "^5.4.0"
+      },
       "devDependencies": {
         "@babel/eslint-parser": "^7.24.6",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
@@ -56,12 +61,12 @@
       }
     },
     "node_modules/@ant-design/colors": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.1.0.tgz",
-      "integrity": "sha512-MMoDGWn1y9LdQJQSHiCC20x3uZ3CwQnv9QMz6pCmJOrqdgM9YxsoVVY0wtrdXbmfSgnV0KNk6zi09NAhMR2jvg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.0.tgz",
+      "integrity": "sha512-bjTObSnZ9C/O8MB/B4OUtd/q9COomuJAR2SYfhxLyHvCKn4EKwCN3e+fWGMo7H5InAyV0wL17jdE9ALrdOW/6A==",
       "license": "MIT",
       "dependencies": {
-        "@ctrl/tinycolor": "^3.6.1"
+        "@ant-design/fast-color": "^2.0.6"
       }
     },
     "node_modules/@ant-design/compatible": {
@@ -91,9 +96,9 @@
       "license": "MIT"
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.1.tgz",
-      "integrity": "sha512-tyWnlK+XH7Bumd0byfbCiZNK43HEubMoCcu9VxwsAwiHdHTgWa+tMN0/yvxa+e8EzuFP1WdUNNPclRpVtD33lg==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.22.1.tgz",
+      "integrity": "sha512-SLuXM4wiEE1blOx94iXrkOgseMZHzdr4ngdFu3VVDq6AOWh7rlwqTkMAtJho3EsBF6x/eUGOtK53VZXGQG7+sQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -102,7 +107,7 @@
         "classnames": "^2.3.1",
         "csstype": "^3.1.3",
         "rc-util": "^5.35.0",
-        "stylis": "^4.3.3"
+        "stylis": "^4.3.4"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
@@ -110,9 +115,9 @@
       }
     },
     "node_modules/@ant-design/cssinjs-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.0.tgz",
-      "integrity": "sha512-E9nOWObXx7Dy7hdyuYlOFaer/LtPO7oyZVxZphh0CYEslr5EmhJPM3WI0Q2RBHRtYg6dSNqeSK73kvZjPN3IMQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
+      "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
@@ -137,9 +142,9 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.1.tgz",
-      "integrity": "sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.2.tgz",
+      "integrity": "sha512-xc53rjVBl9v2BqFxUjZGti/RfdDeA8/6KYglmInM2PNqSXc/WfuGDTifJI/ZsokJK0aeKvOIbXc9y2g8ILAhEA==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
@@ -2154,9 +2159,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -2336,12 +2341,12 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
-      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.0.tgz",
+      "integrity": "sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -3938,9 +3943,9 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.3.tgz",
-      "integrity": "sha512-X1oFIpKoXAMXNDYCviOmTfuNuYxE4h5laBsyCqVAVMjNHxoF3/uiyA7XdegK1XbCvBbCZ6P6byWrEoDRpKL8+A==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.6.tgz",
+      "integrity": "sha512-/9zuTnWwhQ3S3WT1T8BubuFTT46kvnXgaERR9f4BTKyn61/wpf/BvbImzYBubzJibU707FxwbKszLlHjcLiv1Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
@@ -3948,7 +3953,7 @@
         "classnames": "^2.3.2",
         "rc-motion": "^2.0.0",
         "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.38.0"
+        "rc-util": "^5.44.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -5837,58 +5842,58 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.21.3",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.21.3.tgz",
-      "integrity": "sha512-Yby3gU6jfuvhNFRPsrHB4Yc/G3LHLNHHy0kShwNmmZf1QTCiW5TmqP3DT5m/NHbJsTgEwJpwo3AaOWo+KQyEjw==",
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.23.1.tgz",
+      "integrity": "sha512-rg5xd5LotHw0IRyo/nsiUN/EEV3e+xU4V4UmIb/62hMN9+3APyz1Ohjf17a+fN13jC8sNY1hP1K252SU2Th0xA==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^7.1.0",
-        "@ant-design/cssinjs": "^1.21.1",
-        "@ant-design/cssinjs-utils": "^1.1.0",
-        "@ant-design/icons": "^5.5.1",
+        "@ant-design/colors": "^7.2.0",
+        "@ant-design/cssinjs": "^1.22.0",
+        "@ant-design/cssinjs-utils": "^1.1.3",
+        "@ant-design/fast-color": "^2.0.6",
+        "@ant-design/icons": "^5.5.2",
         "@ant-design/react-slick": "~1.1.2",
-        "@babel/runtime": "^7.25.6",
-        "@ctrl/tinycolor": "^3.6.1",
+        "@babel/runtime": "^7.26.0",
         "@rc-component/color-picker": "~2.0.1",
         "@rc-component/mutate-observer": "^1.1.0",
         "@rc-component/qrcode": "~1.0.0",
         "@rc-component/tour": "~1.15.1",
-        "@rc-component/trigger": "^2.2.3",
+        "@rc-component/trigger": "^2.2.6",
         "classnames": "^2.5.1",
         "copy-to-clipboard": "^3.3.3",
         "dayjs": "^1.11.11",
-        "rc-cascader": "~3.28.1",
-        "rc-checkbox": "~3.3.0",
-        "rc-collapse": "~3.8.0",
+        "rc-cascader": "~3.33.0",
+        "rc-checkbox": "~3.5.0",
+        "rc-collapse": "~3.9.0",
         "rc-dialog": "~9.6.0",
         "rc-drawer": "~7.2.0",
-        "rc-dropdown": "~4.2.0",
-        "rc-field-form": "~2.4.0",
+        "rc-dropdown": "~4.2.1",
+        "rc-field-form": "~2.7.0",
         "rc-image": "~7.11.0",
-        "rc-input": "~1.6.3",
-        "rc-input-number": "~9.2.0",
-        "rc-mentions": "~2.16.1",
-        "rc-menu": "~9.15.1",
-        "rc-motion": "^2.9.3",
+        "rc-input": "~1.7.2",
+        "rc-input-number": "~9.4.0",
+        "rc-mentions": "~2.19.1",
+        "rc-menu": "~9.16.0",
+        "rc-motion": "^2.9.5",
         "rc-notification": "~5.6.2",
-        "rc-pagination": "~4.3.0",
-        "rc-picker": "~4.6.15",
+        "rc-pagination": "~5.0.0",
+        "rc-picker": "~4.9.2",
         "rc-progress": "~4.0.0",
         "rc-rate": "~2.13.0",
-        "rc-resize-observer": "^1.4.0",
-        "rc-segmented": "~2.5.0",
-        "rc-select": "~14.15.2",
-        "rc-slider": "~11.1.7",
+        "rc-resize-observer": "^1.4.3",
+        "rc-segmented": "~2.7.0",
+        "rc-select": "~14.16.5",
+        "rc-slider": "~11.1.8",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.47.5",
-        "rc-tabs": "~15.3.0",
-        "rc-textarea": "~1.8.2",
-        "rc-tooltip": "~6.2.1",
-        "rc-tree": "~5.9.0",
-        "rc-tree-select": "~5.23.0",
+        "rc-table": "~7.50.2",
+        "rc-tabs": "~15.5.0",
+        "rc-textarea": "~1.9.0",
+        "rc-tooltip": "~6.3.2",
+        "rc-tree": "~5.13.0",
+        "rc-tree-select": "~5.27.0",
         "rc-upload": "~4.8.1",
-        "rc-util": "^5.43.0",
+        "rc-util": "^5.44.3",
         "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.2"
       },
@@ -5989,12 +5994,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==",
-      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -15724,17 +15723,16 @@
       "license": "MIT"
     },
     "node_modules/rc-cascader": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.28.1.tgz",
-      "integrity": "sha512-9+8oHIMWVLHxuaapDiqFNmD9KSyKN/P4bo9x/MBuDbyTqP8f2/POmmZxdXWBO3yq/uE3pKyQCXYNUxrNfHRv2A==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.33.0.tgz",
+      "integrity": "sha512-JvZrMbKBXIbEDmpIORxqvedY/bck6hGbs3hxdWT8eS9wSQ1P7//lGxbyKjOSyQiVBbgzNWriSe6HoMcZO/+0rQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
+        "@babel/runtime": "^7.25.7",
         "classnames": "^2.3.1",
-        "rc-select": "~14.15.0",
-        "rc-tree": "~5.9.0",
-        "rc-util": "^5.37.0"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -15742,9 +15740,9 @@
       }
     },
     "node_modules/rc-checkbox": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.3.0.tgz",
-      "integrity": "sha512-Ih3ZaAcoAiFKJjifzwsGiT/f/quIkxJoklW4yKGho14Olulwn8gN7hOBve0/WGDg5o/l/5mL0w7ff7/YGvefVw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
+      "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -15757,9 +15755,9 @@
       }
     },
     "node_modules/rc-collapse": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.8.0.tgz",
-      "integrity": "sha512-YVBkssrKPBG09TGfcWWGj8zJBYD9G3XuTy89t5iUmSXrIXEAnO1M+qjUxRW6b4Qi0+wNWG6MHJF/+US+nmIlzA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
+      "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -15807,15 +15805,15 @@
       }
     },
     "node_modules/rc-dropdown": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.0.tgz",
-      "integrity": "sha512-odM8Ove+gSh0zU27DUj5cG1gNKg7mLWBYzB5E4nNLrLwBmYEgYP43vHKDGOVZcJSVElQBI0+jTQgjnq0NfLjng==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
+      "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-util": "^5.17.0"
+        "rc-util": "^5.44.1"
       },
       "peerDependencies": {
         "react": ">=16.11.0",
@@ -15823,9 +15821,9 @@
       }
     },
     "node_modules/rc-field-form": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.4.0.tgz",
-      "integrity": "sha512-XZ/lF9iqf9HXApIHQHqzJK5v2w4mkUMsVqAzOyWVzoiwwXEavY6Tpuw7HavgzIoD+huVff4JghSGcgEfX6eycg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.0.tgz",
+      "integrity": "sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -15898,9 +15896,9 @@
       }
     },
     "node_modules/rc-input": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.6.3.tgz",
-      "integrity": "sha512-wI4NzuqBS8vvKr8cljsvnTUqItMfG1QbJoxovCgL+DX4eVUcHIjVwharwevIxyy7H/jbLryh+K7ysnJr23aWIA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.7.2.tgz",
+      "integrity": "sha512-g3nYONnl4edWj2FfVoxsU3Ec4XTE+Hb39Kfh2MFxMZjp/0gGyPUgy/v7ZhS27ZxUFNkuIDYXm9PJsLyJbtg86A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -15913,15 +15911,15 @@
       }
     },
     "node_modules/rc-input-number": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.2.0.tgz",
-      "integrity": "sha512-5XZFhBCV5f9UQ62AZ2hFbEY8iZT/dm23Q1kAg0H8EvOgD3UDbYYJAayoVIkM3lQaCqYAW5gV0yV3vjw1XtzWHg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.4.0.tgz",
+      "integrity": "sha512-Tiy4DcXcFXAf9wDhN8aUAyMeCLHJUHA/VA/t7Hj8ZEx5ETvxG7MArDOSE6psbiSCo+vJPm4E3fGN710ITVn6GA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
-        "rc-input": "~1.6.0",
+        "rc-input": "~1.7.1",
         "rc-util": "^5.40.1"
       },
       "peerDependencies": {
@@ -15930,17 +15928,17 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.16.1.tgz",
-      "integrity": "sha512-GnhSTGP9Mtv6pqFFGQze44LlrtWOjHNrUUAcsdo9DnNAhN4pwVPEWy4z+2jpjkiGlJ3VoXdvMHcNDQdfI9fEaw==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.19.1.tgz",
+      "integrity": "sha512-KK3bAc/bPFI993J3necmaMXD2reZTzytZdlTvkeBbp50IGH1BDPDvxLdHDUrpQx2b2TGaVJsn+86BvYa03kGqA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-input": "~1.6.0",
-        "rc-menu": "~9.15.1",
-        "rc-textarea": "~1.8.0",
+        "rc-input": "~1.7.1",
+        "rc-menu": "~9.16.0",
+        "rc-textarea": "~1.9.0",
         "rc-util": "^5.34.1"
       },
       "peerDependencies": {
@@ -15949,9 +15947,9 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.15.1.tgz",
-      "integrity": "sha512-UKporqU6LPfHnpPmtP6hdEK4iO5Q+b7BRv/uRpxdIyDGplZy9jwUjsnpev5bs3PQKB0H0n34WAPDfjAfn3kAPA==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.0.tgz",
+      "integrity": "sha512-vAL0yqPkmXWk3+YKRkmIR8TYj3RVdEt3ptG2jCJXWNAvQbT0VJJdRyHZ7kG/l1JsZlB+VJq/VcYOo69VR4oD+w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -15967,14 +15965,14 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.3.tgz",
-      "integrity": "sha512-rkW47ABVkic7WEB0EKJqzySpvDqwl60/tdkY7hWP7dYnh5pm0SzJpo54oW3TDUGXV5wfxXFmMkxrzRRbotQ0+w==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
+      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
-        "rc-util": "^5.43.0"
+        "rc-util": "^5.44.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -16001,9 +15999,9 @@
       }
     },
     "node_modules/rc-overflow": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.3.2.tgz",
-      "integrity": "sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.4.1.tgz",
+      "integrity": "sha512-3MoPQQPV1uKyOMVNd6SZfONi+f3st0r8PksexIdBTeIYbMX0Jr+k7pHEDvsXtR4BpCv90/Pv2MovVNhktKrwvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -16017,9 +16015,9 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.3.0.tgz",
-      "integrity": "sha512-UubEWA0ShnroQ1tDa291Fzw6kj0iOeF26IsUObxYTpimgj4/qPCWVFl18RLZE+0Up1IZg0IK4pMn6nB3mjvB7g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.0.0.tgz",
+      "integrity": "sha512-QjrPvbAQwps93iluvFM62AEYglGYhWW2q/nliQqmvkTi4PXP4HHoh00iC1Sa5LLVmtWQHmG73fBi2x6H6vFHRg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16032,9 +16030,9 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "4.6.15",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.6.15.tgz",
-      "integrity": "sha512-OWZ1yrMie+KN2uEUfYCfS4b2Vu6RC1FWwNI0s+qypsc3wRt7g+peuZKVIzXCTaJwyyZruo80+akPg2+GmyiJjw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.9.2.tgz",
+      "integrity": "sha512-SLW4PRudODOomipKI0dvykxW4P8LOqtMr17MOaLU6NQJhkh9SZeh44a/8BMxwv5T6e3kiIeYc9k5jFg2Mv35Pg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -16104,14 +16102,14 @@
       }
     },
     "node_modules/rc-resize-observer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.0.tgz",
-      "integrity": "sha512-PnMVyRid9JLxFavTjeDXEXo65HCRqbmLBw9xX9gfC4BZiSzbLXKzW3jPz+J0P71pLbD5tBMTT+mkstV5gD0c9Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "classnames": "^2.2.1",
-        "rc-util": "^5.38.0",
+        "rc-util": "^5.44.1",
         "resize-observer-polyfill": "^1.5.1"
       },
       "peerDependencies": {
@@ -16120,9 +16118,9 @@
       }
     },
     "node_modules/rc-segmented": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.5.0.tgz",
-      "integrity": "sha512-B28Fe3J9iUFOhFJET3RoXAPFJ2u47QvLSYcZWC4tFYNGPEjug5LAxEasZlA/PpAxhdOPqGWsGbSj7ftneukJnw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.0.tgz",
+      "integrity": "sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -16136,9 +16134,9 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.15.2",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.15.2.tgz",
-      "integrity": "sha512-oNoXlaFmpqXYcQDzcPVLrEqS2J9c+/+oJuGrlXeVVX/gVgrbHa5YcyiRUXRydFjyuA7GP3elRuLF7Y3Tfwltlw==",
+      "version": "14.16.6",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.6.tgz",
+      "integrity": "sha512-YPMtRPqfZWOm2XGTbx5/YVr1HT0vn//8QS77At0Gjb3Lv+Lbut0IORJPKLWu1hQ3u4GsA0SrDzs7nI8JG7Zmyg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16158,9 +16156,9 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.7.tgz",
-      "integrity": "sha512-ytYbZei81TX7otdC0QvoYD72XSlxvTihNth5OeZ6PMXyEDq/vHdWFulQmfDGyXK1NwKwSlKgpvINOa88uT5g2A==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.8.tgz",
+      "integrity": "sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16209,16 +16207,16 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.47.5",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.47.5.tgz",
-      "integrity": "sha512-fzq+V9j/atbPIcvs3emuclaEoXulwQpIiJA6/7ey52j8+9cJ4P8DGmp4YzfUVDrb3qhgedcVeD6eRgUrokwVEQ==",
+      "version": "7.50.2",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.50.2.tgz",
+      "integrity": "sha512-+nJbzxzstBriLb5sr9U7Vjs7+4dO8cWlouQbMwBVYghk2vr508bBdkHJeP/z9HVjAIKmAgMQKxmtbgDd3gc5wA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.41.0",
+        "rc-util": "^5.44.3",
         "rc-virtual-list": "^3.14.2"
       },
       "engines": {
@@ -16230,15 +16228,15 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.3.0.tgz",
-      "integrity": "sha512-lzE18r+zppT/jZWOAWS6ntdkDUKHOLJzqMi5UAij1LeKwOaQaupupAoI9Srn73GRzVpmGznkECMRrzkRusC40A==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.5.0.tgz",
+      "integrity": "sha512-NrDcTaUJLh9UuDdMBkjKTn97U9iXG44s9D03V5NHkhEDWO5/nC6PwC3RhkCWFMKB9hh+ryqgZ+TIr1b9Jd/hnQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
         "rc-dropdown": "~4.2.0",
-        "rc-menu": "~9.15.1",
+        "rc-menu": "~9.16.0",
         "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.34.1"
@@ -16252,14 +16250,14 @@
       }
     },
     "node_modules/rc-textarea": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.8.2.tgz",
-      "integrity": "sha512-UFAezAqltyR00a8Lf0IPAyTd29Jj9ee8wt8DqXyDMal7r/Cg/nDt3e1OOv3Th4W6mKaZijjgwuPXhAfVNTN8sw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.9.0.tgz",
+      "integrity": "sha512-dQW/Bc/MriPBTugj2Kx9PMS5eXCCGn2cxoIaichjbNvOiARlaHdI99j4DTxLl/V8+PIfW06uFy7kjfUIDDKyxQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
-        "rc-input": "~1.6.0",
+        "rc-input": "~1.7.1",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.27.0"
       },
@@ -16269,9 +16267,9 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.1.tgz",
-      "integrity": "sha512-rws0duD/3sHHsD905Nex7FvoUGy2UBQRhTkKxeEvr2FB+r21HsOxcDJI0TzyO8NHhnAA8ILr8pfbSBg5Jj5KBg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.3.2.tgz",
+      "integrity": "sha512-oA4HZIiZJbUQ5ojigM0y4XtWxaH/aQlJSzknjICRWNpqyemy1sL3X3iEQV2eSPBWEq+bqU3+aSs81z+28j9luA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -16284,9 +16282,9 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.9.0.tgz",
-      "integrity": "sha512-CPrgOvm9d/9E+izTONKSngNzQdIEjMox2PBufWjS1wf7vxtvmCWzK1SlpHbRY6IaBfJIeZ+88RkcIevf729cRg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.0.tgz",
+      "integrity": "sha512-2+lFvoVRnvHQ1trlpXMOWtF8BUgF+3TiipG72uOfhpL5CUdXCk931kvDdUkTL/IZVtNEDQKwEEmJbAYJSA5NnA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16304,16 +16302,16 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.23.0.tgz",
-      "integrity": "sha512-aQGi2tFSRw1WbXv0UVXPzHm09E0cSvUVZMLxQtMv3rnZZpNmdRXWrnd9QkLNlVH31F+X5rgghmdSFF3yZW0N9A==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
+      "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.25.7",
         "classnames": "2.x",
-        "rc-select": "~14.15.0",
-        "rc-tree": "~5.9.0",
-        "rc-util": "^5.16.1"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": "*",
@@ -16336,9 +16334,9 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.43.0.tgz",
-      "integrity": "sha512-AzC7KKOXFqAdIBqdGWepL9Xn7cm3vnAmjlHqUnoQaTMZYhM4VlXGLkkHHxj/BZ7Td0+SOPKB4RGPboBVKT9htw==",
+      "version": "5.44.3",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.3.tgz",
+      "integrity": "sha512-q6KCcOFk3rv/zD3MckhJteZxb0VjAIFuf622B7ElK4vfrZdAzs16XR5p3VTdy3+U5jfJU5ACz4QnhLSuAGe5dA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -16350,9 +16348,9 @@
       }
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.14.8",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.14.8.tgz",
-      "integrity": "sha512-8D0KfzpRYi6YZvlOWIxiOm9BGt4Wf2hQyEaM6RXlDDiY2NhLheuYI+RA+7ZaZj1lq+XQqy3KHlaeeXQfzI5fGg==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.17.1.tgz",
+      "integrity": "sha512-n9rKy6BB/Hi/LsOJr9ILpeFxDJfAIYzFYX1famZb0KLQrlsdxNBDsBjBY9lblJ35MTRJwi06ohv5ma9uTUeLog==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
@@ -16424,9 +16422,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
-      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
@@ -18519,9 +18517,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.4.tgz",
-      "integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.5.tgz",
+      "integrity": "sha512-K7npNOKGRYuhAFFzkzMGfxFDpN6gDwf8hcMiE+uveTVbBgm93HrNP3ZDUpKqzZ4pG7TP6fmb+EMAQPjq9FqqvA==",
       "license": "MIT"
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
     "hooks": {
       "pre-commit": "npm-run-all -ln --parallel lint test"
     }
+  },
+  "dependencies": {
+    "@ctrl/tinycolor": "^4.1.0",
+    "antd": "^5.23.1",
+    "react-icons": "^5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "7.37.1",
     "husky": "9.1.0",
-    "jsdom": "25.0.1",
+    "jsdom": "^26.0.0",
     "npm-run-all2": "7.0.1",
     "prettier": "3.4.2",
     "rxjs-compat": "6.6.7",

--- a/packages/jaeger-ui/src/components/common/LoadingIndicator.tsx
+++ b/packages/jaeger-ui/src/components/common/LoadingIndicator.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { LuLoader2 } from 'react-icons/lu';
+import { LuLoader } from 'react-icons/lu';
 
 import './LoadingIndicator.css';
 
@@ -34,7 +34,7 @@ export default function LoadingIndicator(props: LoadingIndicatorProps) {
     ${small ? 'is-small' : ''}
     ${className || ''}
   `;
-  return <LuLoader2 className={cls} {...rest} />;
+  return <LuLoader className={cls} {...rest} />;
 }
 
 LoadingIndicator.defaultProps = {


### PR DESCRIPTION


## Which problem is this PR solving?
- #2576 
## Description of the changes
- updated dependency of react-icons to v5.4.0
- updated dependency of antd to v5.23.1

## How was this change tested?
- npm run test
- npm run start 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
