### PR TITLE
Pin @sentry/browser from ^8.18.0 to 8.50.0

### DIFF
--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -48,7 +48,7 @@
     "@ant-design/compatible": "^5.1.3",
     "@jaegertracing/plexus": "0.2.0",
     "@pyroscope/flamegraph": "0.21.4",
-    "@sentry/browser": "^8.18.0",
+    "@sentry/browser": "8.50.0",
     "antd": "^5.21.3",
     "chance": "^1.0.10",
     "classnames": "^2.5.1",


### PR DESCRIPTION
## Which problem is this PR solving?
- Other PRs keep downgrading this dependency
<img width="616" alt="image" src="https://github.com/user-attachments/assets/e2afd338-110c-42cb-a559-230bb7d1a0a1" />

## Description of the changes
- Pin the version in package.json instead of using `^` range.

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
