### PR TITLE
Remove defaultProps from ErrorMessage & NewWindowIcon

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
@@ -155,9 +155,7 @@ exports[`<DdgNodeContent> omits the operation if it is null 1`] = `
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -291,9 +289,7 @@ exports[`<DdgNodeContent> omits the operation if it is null 2`] = `
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -442,9 +438,7 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 1`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -593,9 +587,7 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 2`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -744,9 +736,7 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 1`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -898,9 +888,7 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 2`]
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -1049,9 +1037,7 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -1159,9 +1145,7 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -1278,9 +1262,7 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"
@@ -1446,9 +1428,7 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
       <span
         className="DdgNodeContent--actionsItemIconWrapper"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </span>
       <span
         className="DdgNodeContent--actionsItemText"

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/DetailsPanel.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/DetailsPanel.test.js.snap
@@ -74,9 +74,7 @@ exports[`<SidePanel> render renders detailLink 1`] = `
         rel="noreferrer noopener"
         target="_blank"
       >
-        <NewWindowIcon
-          isLarge={false}
-        />
+        <NewWindowIcon />
       </a>
     </Tooltip>
   </div>

--- a/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/MetricCard.test.js.snap
+++ b/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/MetricCard.test.js.snap
@@ -32,9 +32,7 @@ exports[`MetricCard renders as expected when passCount is zero 1`] = `
           rel="noreferrer noopener"
           target="_blank"
         >
-          <NewWindowIcon
-            isLarge={false}
-          />
+          <NewWindowIcon />
         </a>
       </Tooltip>
     </span>
@@ -109,9 +107,7 @@ exports[`MetricCard renders as expected with details 1`] = `
           rel="noreferrer noopener"
           target="_blank"
         >
-          <NewWindowIcon
-            isLarge={false}
-          />
+          <NewWindowIcon />
         </a>
       </Tooltip>
     </span>
@@ -228,9 +224,7 @@ exports[`MetricCard renders as expected without details 1`] = `
           rel="noreferrer noopener"
           target="_blank"
         >
-          <NewWindowIcon
-            isLarge={false}
-          />
+          <NewWindowIcon />
         </a>
       </Tooltip>
     </span>
@@ -305,9 +299,7 @@ exports[`MetricCard renders as expected without details 2`] = `
           rel="noreferrer noopener"
           target="_blank"
         >
-          <NewWindowIcon
-            isLarge={false}
-          />
+          <NewWindowIcon />
         </a>
       </Tooltip>
     </span>

--- a/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/ScoreCard.test.js.snap
+++ b/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/ScoreCard.test.js.snap
@@ -25,9 +25,7 @@ exports[`ScoreCard renders as expected when score is below max 1`] = `
     target="_blank"
   >
     How to improve 
-    <NewWindowIcon
-      isLarge={false}
-    />
+    <NewWindowIcon />
   </a>
 </div>
 `;
@@ -57,9 +55,7 @@ exports[`ScoreCard renders as expected when score is max 1`] = `
     target="_blank"
   >
     Great! What does this mean 
-    <NewWindowIcon
-      isLarge={false}
-    />
+    <NewWindowIcon />
   </a>
 </div>
 `;
@@ -90,9 +86,7 @@ exports[`ScoreCard renders as expected when score is zero 1`] = `
     target="_blank"
   >
     How to improve 
-    <NewWindowIcon
-      isLarge={false}
-    />
+    <NewWindowIcon />
   </a>
 </div>
 `;

--- a/packages/jaeger-ui/src/components/common/ErrorMessage.tsx
+++ b/packages/jaeger-ui/src/components/common/ErrorMessage.tsx
@@ -48,8 +48,7 @@ function ErrorAttr({ name, value }: ErrorAttrProps) {
   );
 }
 
-export function Message(props: SubPartProps) {
-  const { className, error, wrap, wrapperClassName } = props;
+export function Message({ className, error, wrap = false, wrapperClassName }: SubPartProps) {
   const cssClass = `ErrorMessage--msg ${className || ''}`;
 
   const msg =
@@ -66,15 +65,7 @@ export function Message(props: SubPartProps) {
   return msg;
 }
 
-Message.defaultProps = {
-  className: undefined,
-  wrap: false,
-  wrapperClassName: undefined,
-};
-
-export function Details(props: SubPartProps) {
-  const { className, error, wrap, wrapperClassName } = props;
-
+export function Details({ className, error, wrap = false, wrapperClassName }: SubPartProps) {
   if (typeof error === 'string') {
     return null;
   }
@@ -113,12 +104,6 @@ export function Details(props: SubPartProps) {
   return details;
 }
 
-Details.defaultProps = {
-  className: undefined,
-  wrap: false,
-  wrapperClassName: undefined,
-};
-
 export default function ErrorMessage({
   className,
   detailClassName,
@@ -140,9 +125,3 @@ export default function ErrorMessage({
     </div>
   );
 }
-
-ErrorMessage.defaultProps = {
-  className: undefined,
-  detailClassName: undefined,
-  messageClassName: undefined,
-};

--- a/packages/jaeger-ui/src/components/common/NewWindowIcon.tsx
+++ b/packages/jaeger-ui/src/components/common/NewWindowIcon.tsx
@@ -22,12 +22,7 @@ type Props = {
   isLarge?: boolean;
 };
 
-export default function NewWindowIcon(props: Props) {
-  const { isLarge, ...rest } = props;
+export default function NewWindowIcon({ isLarge = false, ...rest }: Props) {
   const cls = cx('NewWindowIcon', { 'is-large': isLarge });
   return <IoOpenOutline className={cls} {...rest} data-testid="NewWindowIcon" />;
 }
-
-NewWindowIcon.defaultProps = {
-  isLarge: false,
-};


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #2596 

## Description of the changes
- Wherever the default value was undefined, I have not added a default value for it since it is automatically undefined.

## How was this change tested?
- npm run lint test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
