### PR TITLE
[BreakableText]: Replace defaultProps with destructuring

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
@@ -81,7 +81,6 @@ exports[`<DdgNodeContent> omits the operation if it is null 1`] = `
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -96,7 +95,6 @@ exports[`<DdgNodeContent> omits the operation if it is null 1`] = `
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -230,7 +228,6 @@ exports[`<DdgNodeContent> omits the operation if it is null 2`] = `
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -364,7 +361,6 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 1`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -379,7 +375,6 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 1`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -513,7 +508,6 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 2`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -528,7 +522,6 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 2`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -662,7 +655,6 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 1`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -677,7 +669,6 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 1`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -814,7 +805,6 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 2`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -829,7 +819,6 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 2`]
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -963,7 +952,6 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -978,7 +966,6 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -1112,7 +1099,6 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -1127,7 +1113,6 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -1188,7 +1173,6 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -1203,7 +1187,6 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-operation"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />
@@ -1337,7 +1320,6 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
         }
       >
         <BreakableText
-          className="BreakableText"
           text="some-service"
           wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
         />

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/DetailsPanel.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/__snapshots__/DetailsPanel.test.js.snap
@@ -13,9 +13,7 @@ exports[`<SidePanel> render renders 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div
@@ -53,9 +51,7 @@ exports[`<SidePanel> render renders detailLink 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div
@@ -113,9 +109,7 @@ exports[`<SidePanel> render renders details 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div
@@ -158,9 +152,7 @@ exports[`<SidePanel> render renders details error 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div
@@ -203,9 +195,7 @@ exports[`<SidePanel> render renders omitted array of operations 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div
@@ -243,9 +233,7 @@ exports[`<SidePanel> render renders while loading 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div
@@ -290,14 +278,10 @@ exports[`<SidePanel> render renders with operation 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
     <BreakableText
-      className="BreakableText"
       text="::test op"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div
@@ -335,9 +319,7 @@ exports[`<SidePanel> render renders with progressbar 1`] = `
     className="Ddg--DetailsPanel--SvcOpHeader"
   >
     <BreakableText
-      className="BreakableText"
       text="test svc"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
   </div>
   <div

--- a/packages/jaeger-ui/src/components/common/BreakableText.tsx
+++ b/packages/jaeger-ui/src/components/common/BreakableText.tsx
@@ -18,14 +18,15 @@ import './BreakableText.css';
 
 const WORD_RX = /\W*\w+\W*/g;
 
-type Props = {
+export default function BreakableText({
+  className = 'BreakableText',
+  wordRegexp = WORD_RX,
+  text,
+}: {
   text: string;
   className?: string;
   wordRegexp?: RegExp;
-};
-
-export default function BreakableText(props: Props) {
-  const { className, text, wordRegexp = WORD_RX } = props;
+}) {
   if (!text) {
     return typeof text === 'string' ? text : null;
   }
@@ -43,8 +44,3 @@ export default function BreakableText(props: Props) {
   }
   return spans;
 }
-
-BreakableText.defaultProps = {
-  className: 'BreakableText',
-  wordRegexp: WORD_RX,
-};

--- a/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/__snapshots__/NameSelector.test.js.snap
@@ -34,7 +34,6 @@ exports[`<NameSelector> clear renders with clear icon when not required and with
     <BreakableText
       className="NameSelector--value"
       text="foo"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
     <IoChevronDown
       className="NameSelector--chevron"
@@ -75,7 +74,6 @@ exports[`<NameSelector> renders with is-invalid when required and without a valu
     <BreakableText
       className="NameSelector--value"
       text="This is the placeholder"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
     <IoChevronDown
       className="NameSelector--chevron"
@@ -112,7 +110,6 @@ exports[`<NameSelector> renders without exploding 1`] = `
     <BreakableText
       className="NameSelector--value"
       text="This is the placeholder"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
     <IoChevronDown
       className="NameSelector--chevron"
@@ -149,7 +146,6 @@ exports[`<NameSelector> renders without is-invalid when not required and without
     <BreakableText
       className="NameSelector--value"
       text="This is the placeholder"
-      wordRegexp={/\\\\W\\*\\\\w\\+\\\\W\\*/g}
     />
     <IoChevronDown
       className="NameSelector--chevron"


### PR DESCRIPTION
## Which problem is this PR solving?
- Partially Resolves #2596

## Description of the changes
- Removed defaultProps and updated the snapshots for the BreakableText component


## How was this change tested?
- By running `npm run update-snapshots` 

## Checklist
- [x I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
