### PR TITLE
Converted CircularLoader.tsx to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/MetricCard.test.js.snap
+++ b/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/MetricCard.test.js.snap
@@ -7,7 +7,7 @@ exports[`MetricCard renders as expected when passCount is zero 1`] = `
   <div
     className="MetricCard--CircularProgressbarWrapper"
   >
-    <CircularProgressbar
+    <Memo(CircularProgressbar)
       backgroundHue={0}
       decorationHue={0}
       maxValue={255}
@@ -83,7 +83,7 @@ exports[`MetricCard renders as expected with details 1`] = `
   <div
     className="MetricCard--CircularProgressbarWrapper"
   >
-    <CircularProgressbar
+    <Memo(CircularProgressbar)
       decorationHue={120}
       maxValue={363}
       text="29.7%"
@@ -200,7 +200,7 @@ exports[`MetricCard renders as expected without details 1`] = `
   <div
     className="MetricCard--CircularProgressbarWrapper"
   >
-    <CircularProgressbar
+    <Memo(CircularProgressbar)
       decorationHue={120}
       maxValue={363}
       text="29.7%"
@@ -275,7 +275,7 @@ exports[`MetricCard renders as expected without details 2`] = `
   <div
     className="MetricCard--CircularProgressbarWrapper"
   >
-    <CircularProgressbar
+    <Memo(CircularProgressbar)
       decorationHue={120}
       maxValue={363}
       text="29.7%"

--- a/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/ScoreCard.test.js.snap
+++ b/packages/jaeger-ui/src/components/QualityMetrics/__snapshots__/ScoreCard.test.js.snap
@@ -12,7 +12,7 @@ exports[`ScoreCard renders as expected when score is below max 1`] = `
   <div
     className="ScoreCard--CircularProgressbarWrapper"
   >
-    <CircularProgressbar
+    <Memo([object Object])
       decorationHue={120}
       maxValue={108}
       text="38.9%"
@@ -42,7 +42,7 @@ exports[`ScoreCard renders as expected when score is max 1`] = `
   <div
     className="ScoreCard--CircularProgressbarWrapper"
   >
-    <CircularProgressbar
+    <Memo([object Object])
       decorationHue={120}
       maxValue={108}
       text="100.0%"
@@ -72,7 +72,7 @@ exports[`ScoreCard renders as expected when score is zero 1`] = `
   <div
     className="ScoreCard--CircularProgressbarWrapper"
   >
-    <CircularProgressbar
+    <Memo([object Object])
       backgroundHue={0}
       decorationHue={120}
       maxValue={108}

--- a/packages/jaeger-ui/src/components/common/CircularProgressbar.tsx
+++ b/packages/jaeger-ui/src/components/common/CircularProgressbar.tsx
@@ -26,40 +26,51 @@ type TProps = {
   value: number;
 };
 
-export default class CircularProgressbar extends React.PureComponent<TProps> {
-  render() {
-    const { backgroundHue, decorationHue = 0, maxValue, strokeWidth, text, value } = this.props;
-    const scale = (value / maxValue) ** (1 / 4);
+function CircularProgressbar({
+  backgroundHue,
+  decorationHue = 0,
+  maxValue,
+  strokeWidth,
+  text,
+  value,
+}: TProps) {
+  const { decorationColor, decorationBackgroundColor } = React.useMemo(() => {
+    const scale = Math.pow(value / maxValue, 1 / 4);
     const saturation = 20 + Math.ceil(scale * 80);
     const light = 50 + Math.ceil((1 - scale) * 30);
     const decorationColor = `hsl(${decorationHue}, ${saturation}%, ${light}%)`;
-    const backgroundScale = ((maxValue - value) / maxValue) ** (1 / 4);
+
+    const backgroundScale = Math.pow((maxValue - value) / maxValue, 1 / 4);
     const backgroundSaturation = 20 + Math.ceil(backgroundScale * 80);
     const backgroundLight = 50 + Math.ceil((1 - backgroundScale) * 30);
     const decorationBackgroundColor = `hsl(${backgroundHue}, ${backgroundSaturation}%, ${backgroundLight}%)`;
 
-    return (
-      <div data-testid="circular-progress-bar">
-        <CircularProgressbarImpl
-          styles={{
-            path: {
-              stroke: decorationColor,
-              strokeLinecap: 'butt',
-            },
-            text: {
-              fill: decorationColor,
-            },
-            trail: {
-              stroke: backgroundHue !== undefined ? decorationBackgroundColor : 'transparent',
-              strokeLinecap: 'butt',
-            },
-          }}
-          maxValue={maxValue}
-          strokeWidth={strokeWidth}
-          text={text}
-          value={value}
-        />
-      </div>
-    );
-  }
+    return { decorationColor, decorationBackgroundColor };
+  }, [backgroundHue, decorationHue, maxValue, value]);
+
+  return (
+    <div data-testid="circular-progress-bar">
+      <CircularProgressbarImpl
+        styles={{
+          path: {
+            stroke: decorationColor,
+            strokeLinecap: 'butt',
+          },
+          text: {
+            fill: decorationColor,
+          },
+          trail: {
+            stroke: backgroundHue !== undefined ? decorationBackgroundColor : 'transparent',
+            strokeLinecap: 'butt',
+          },
+        }}
+        maxValue={maxValue}
+        strokeWidth={strokeWidth}
+        text={text}
+        value={value}
+      />
+    </div>
+  );
 }
+
+export default React.memo(CircularProgressbar);

--- a/packages/jaeger-ui/src/model/path-agnostic-decorations/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/model/path-agnostic-decorations/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`extractDecorationFromState prefers operation specific decoration over service decoration 1`] = `
-<CircularProgressbar
+<Memo(CircularProgressbar)
   backgroundHue={120}
   decorationHue={0}
   maxValue={108}
@@ -12,7 +12,7 @@ exports[`extractDecorationFromState prefers operation specific decoration over s
 `;
 
 exports[`extractDecorationFromState returns service decoration 1`] = `
-<CircularProgressbar
+<Memo(CircularProgressbar)
   backgroundHue={120}
   decorationHue={0}
   maxValue={108}


### PR DESCRIPTION

## Which problem is this PR solving?
- Part of #2610 

## Description of the changes
- Since the class was a react pure component, I have added memoization to the functional component instead of directly exporting it as a simple function. 

## How was this change tested?
- npm run lint
- npm run test

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
