### PR TITLE
Don't run codeql from merge queue

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   codeql-analyze:
+    # Run only on pull requests, see https://github.com/github/codeql-action/issues/1537
+    if: ${{ github.event_name == 'pull_request' }}
     permissions:
       actions: read  # for github/codeql-action/init to get workflow details
       contents: read  # for actions/checkout to fetch code


### PR DESCRIPTION
## Which problem is this PR solving?
<img width="779" alt="image" src="https://github.com/user-attachments/assets/e90f041b-70d3-4c8a-a68a-7246f91b00f0" />

## Changes
* Don't run this workflow on merge queue
* Workaround from https://github.com/orgs/community/discussions/46757#discussioncomment-5365379
