### PR TITLE
Don't run label check in merge queue

### DIFF
--- a/.github/workflows/ci-label-check.yml
+++ b/.github/workflows/ci-label-check.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   check-label:
+    # Auto-succeed when triggered by merge_group event.
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check PR label


### PR DESCRIPTION
## Which problem is this PR solving?
<img width="669" alt="image" src="https://github.com/user-attachments/assets/d84d7586-f9f8-4639-8090-9a745c980954" />

## Description of the changes
- Only run on PR 