### PR TITLE
Add fake DCO check for merge queue events

### DIFF
--- a/.github/workflows/dco_merge_group.yml
+++ b/.github/workflows/dco_merge_group.yml
@@ -1,0 +1,12 @@
+# Fake "DCO check" workkflow inspired by https://github.com/onnx/onnx/pull/5398/files.
+# The regular DCO check is required, but it does not from a merge queue and there is
+# no way to configure it to run.
+name: dco
+on:
+  merge_group:
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Fake DCO check to avoid blocking the merge queue"


### PR DESCRIPTION
## Which problem is this PR solving?
The DCO check does not get triggered from the merge queue.
<img width="919" alt="image" src="https://github.com/user-attachments/assets/d9309590-1483-41d8-806f-f738d5f4fab7" />


## Description of the changes
- Create a fake DCO check workflow that only runs on merge queue
