### PR TITLE
Remove unused matrix from codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,8 +27,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language: ["javascript"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Which problem is this PR solving?
- We only used Javascript, matrix was unnecessary

