### PR TITLE
Migrate EmpasizedNode from class based to function based component

### DIFF
--- a/packages/jaeger-ui/src/components/common/EmphasizedNode.tsx
+++ b/packages/jaeger-ui/src/components/common/EmphasizedNode.tsx
@@ -16,31 +16,30 @@ import * as React from 'react';
 
 import './EmphasizedNode.css';
 
-type Props = {
+type EmphasizedNodeProps = {
   height: number;
   width: number;
 };
 
-export default class EmphasizedNode extends React.PureComponent<Props> {
-  render() {
-    const { height, width } = this.props;
-    return (
-      <svg>
-        <rect
-          className="EmphasizedNode--contrast is-non-scaling"
-          vectorEffect="non-scaling-stroke"
-          width={width}
-          height={height}
-        />
-        <rect className="EmphasizedNode--contrast is-scaling" width={width} height={height} />
-        <rect
-          className="EmphasizedNode is-non-scaling"
-          vectorEffect="non-scaling-stroke"
-          width={width}
-          height={height}
-        />
-        <rect className="EmphasizedNode is-scaling" width={width} height={height} />
-      </svg>
-    );
-  }
+function EmphasizedNode({ height, width }: EmphasizedNodeProps) {
+  return (
+    <svg>
+      <rect
+        className="EmphasizedNode--contrast is-non-scaling"
+        vectorEffect="non-scaling-stroke"
+        width={width}
+        height={height}
+      />
+      <rect className="EmphasizedNode--contrast is-scaling" width={width} height={height} />
+      <rect
+        className="EmphasizedNoe is-non-scaling"
+        vectorEffect="non-scaling-stroke"
+        width={width}
+        height={height}
+      />
+      <rect className="EmphasizedNode is-scaling" width={width} height={height} />
+    </svg>
+  );
 }
+
+export default EmphasizedNode;

--- a/packages/jaeger-ui/src/components/common/EmphasizedNode.tsx
+++ b/packages/jaeger-ui/src/components/common/EmphasizedNode.tsx
@@ -32,7 +32,7 @@ function EmphasizedNode({ height, width }: EmphasizedNodeProps) {
       />
       <rect className="EmphasizedNode--contrast is-scaling" width={width} height={height} />
       <rect
-        className="EmphasizedNoe is-non-scaling"
+        className="EmphasizedNode is-non-scaling"
         vectorEffect="non-scaling-stroke"
         width={width}
         height={height}


### PR DESCRIPTION
## Which problem is this PR solving?
Converted EmphasizedNode in #2610 

## Description of the changes
- Refactored class components to functional components for EmphasizedNode.tsx for Issue #2610.
- Renamed the Props to EmphasizedNodeProps

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
