### PR TITLE
[deps]: upgrade antd and @ant-design/compatible to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,20 +56,21 @@
       }
     },
     "node_modules/@ant-design/colors": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.1.0.tgz",
-      "integrity": "sha512-MMoDGWn1y9LdQJQSHiCC20x3uZ3CwQnv9QMz6pCmJOrqdgM9YxsoVVY0wtrdXbmfSgnV0KNk6zi09NAhMR2jvg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.0.tgz",
+      "integrity": "sha512-bjTObSnZ9C/O8MB/B4OUtd/q9COomuJAR2SYfhxLyHvCKn4EKwCN3e+fWGMo7H5InAyV0wL17jdE9ALrdOW/6A==",
       "license": "MIT",
       "dependencies": {
-        "@ctrl/tinycolor": "^3.6.1"
+        "@ant-design/fast-color": "^2.0.6"
       }
     },
     "node_modules/@ant-design/compatible": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/compatible/-/compatible-5.1.3.tgz",
-      "integrity": "sha512-uLvjwENnpY/1gxYb5m8L2k+WmBpBHqH45fO76+4J+WUDKTUKpmwbEW3OG/in2mSO2HI6h3Mcp57+tAMr18ZkgQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@ant-design/compatible/-/compatible-5.1.4.tgz",
+      "integrity": "sha512-sykrus7W8SDtDE2BefzMlQpug18O4haIqZW/zrhTSSYUKO77yIOqL5BFMgs5QSvgghSzjMRNNKzn4dX43I0TQg==",
       "license": "MIT",
       "dependencies": {
+        "@ctrl/tinycolor": "^3.6.1",
         "classnames": "^2.2.6",
         "dayjs": "^1.11.4",
         "lodash.camelcase": "^4.3.0",
@@ -91,9 +92,9 @@
       "license": "MIT"
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.1.tgz",
-      "integrity": "sha512-tyWnlK+XH7Bumd0byfbCiZNK43HEubMoCcu9VxwsAwiHdHTgWa+tMN0/yvxa+e8EzuFP1WdUNNPclRpVtD33lg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.23.0.tgz",
+      "integrity": "sha512-7GAg9bD/iC9ikWatU9ym+P9ugJhi/WbsTWzcKN6T4gU0aehsprtke1UAaaSxxkjjmkJb3llet/rbUSLPgwlY4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -102,7 +103,7 @@
         "classnames": "^2.3.1",
         "csstype": "^3.1.3",
         "rc-util": "^5.35.0",
-        "stylis": "^4.3.3"
+        "stylis": "^4.3.4"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
@@ -110,9 +111,9 @@
       }
     },
     "node_modules/@ant-design/cssinjs-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.0.tgz",
-      "integrity": "sha512-E9nOWObXx7Dy7hdyuYlOFaer/LtPO7oyZVxZphh0CYEslr5EmhJPM3WI0Q2RBHRtYg6dSNqeSK73kvZjPN3IMQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
+      "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
@@ -137,9 +138,9 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.1.tgz",
-      "integrity": "sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.0.tgz",
+      "integrity": "sha512-Mb6QkQmPLZsmIHJ6oBsoyKrrT8/kAUdQ6+8q38e2bQSclROi69SiDlI4zZroaIPseae1w110RJH0zGrphAvlSQ==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
@@ -2133,9 +2134,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -3802,9 +3803,9 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.3.tgz",
-      "integrity": "sha512-X1oFIpKoXAMXNDYCviOmTfuNuYxE4h5laBsyCqVAVMjNHxoF3/uiyA7XdegK1XbCvBbCZ6P6byWrEoDRpKL8+A==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.6.tgz",
+      "integrity": "sha512-/9zuTnWwhQ3S3WT1T8BubuFTT46kvnXgaERR9f4BTKyn61/wpf/BvbImzYBubzJibU707FxwbKszLlHjcLiv1Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
@@ -3812,7 +3813,7 @@
         "classnames": "^2.3.2",
         "rc-motion": "^2.0.0",
         "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.38.0"
+        "rc-util": "^5.44.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -5696,58 +5697,58 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.21.3",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.21.3.tgz",
-      "integrity": "sha512-Yby3gU6jfuvhNFRPsrHB4Yc/G3LHLNHHy0kShwNmmZf1QTCiW5TmqP3DT5m/NHbJsTgEwJpwo3AaOWo+KQyEjw==",
+      "version": "5.23.3",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.23.3.tgz",
+      "integrity": "sha512-xDvwl7C43/NZ9rTOS1bkbuKoSxqZKf6FlaSW/BRsV8QST3Ce2jGx7dJzYahKIZwe3WNSgvEXAlTrckBHMKHcgQ==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^7.1.0",
-        "@ant-design/cssinjs": "^1.21.1",
-        "@ant-design/cssinjs-utils": "^1.1.0",
-        "@ant-design/icons": "^5.5.1",
+        "@ant-design/colors": "^7.2.0",
+        "@ant-design/cssinjs": "^1.23.0",
+        "@ant-design/cssinjs-utils": "^1.1.3",
+        "@ant-design/fast-color": "^2.0.6",
+        "@ant-design/icons": "^5.6.0",
         "@ant-design/react-slick": "~1.1.2",
-        "@babel/runtime": "^7.25.6",
-        "@ctrl/tinycolor": "^3.6.1",
+        "@babel/runtime": "^7.26.0",
         "@rc-component/color-picker": "~2.0.1",
         "@rc-component/mutate-observer": "^1.1.0",
         "@rc-component/qrcode": "~1.0.0",
         "@rc-component/tour": "~1.15.1",
-        "@rc-component/trigger": "^2.2.3",
+        "@rc-component/trigger": "^2.2.6",
         "classnames": "^2.5.1",
         "copy-to-clipboard": "^3.3.3",
         "dayjs": "^1.11.11",
-        "rc-cascader": "~3.28.1",
-        "rc-checkbox": "~3.3.0",
-        "rc-collapse": "~3.8.0",
+        "rc-cascader": "~3.33.0",
+        "rc-checkbox": "~3.5.0",
+        "rc-collapse": "~3.9.0",
         "rc-dialog": "~9.6.0",
         "rc-drawer": "~7.2.0",
-        "rc-dropdown": "~4.2.0",
-        "rc-field-form": "~2.4.0",
+        "rc-dropdown": "~4.2.1",
+        "rc-field-form": "~2.7.0",
         "rc-image": "~7.11.0",
-        "rc-input": "~1.6.3",
-        "rc-input-number": "~9.2.0",
-        "rc-mentions": "~2.16.1",
-        "rc-menu": "~9.15.1",
-        "rc-motion": "^2.9.3",
+        "rc-input": "~1.7.2",
+        "rc-input-number": "~9.4.0",
+        "rc-mentions": "~2.19.1",
+        "rc-menu": "~9.16.0",
+        "rc-motion": "^2.9.5",
         "rc-notification": "~5.6.2",
-        "rc-pagination": "~4.3.0",
-        "rc-picker": "~4.6.15",
+        "rc-pagination": "~5.0.0",
+        "rc-picker": "~4.9.2",
         "rc-progress": "~4.0.0",
         "rc-rate": "~2.13.0",
-        "rc-resize-observer": "^1.4.0",
-        "rc-segmented": "~2.5.0",
-        "rc-select": "~14.15.2",
-        "rc-slider": "~11.1.7",
+        "rc-resize-observer": "^1.4.3",
+        "rc-segmented": "~2.7.0",
+        "rc-select": "~14.16.6",
+        "rc-slider": "~11.1.8",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.47.5",
-        "rc-tabs": "~15.3.0",
-        "rc-textarea": "~1.8.2",
-        "rc-tooltip": "~6.2.1",
-        "rc-tree": "~5.9.0",
-        "rc-tree-select": "~5.23.0",
+        "rc-table": "~7.50.2",
+        "rc-tabs": "~15.5.0",
+        "rc-textarea": "~1.9.0",
+        "rc-tooltip": "~6.3.2",
+        "rc-tree": "~5.13.0",
+        "rc-tree-select": "~5.27.0",
         "rc-upload": "~4.8.1",
-        "rc-util": "^5.43.0",
+        "rc-util": "^5.44.3",
         "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.2"
       },
@@ -5848,12 +5849,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==",
-      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -6995,9 +6990,9 @@
       "license": "MIT"
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
-      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -15570,17 +15565,16 @@
       "license": "MIT"
     },
     "node_modules/rc-cascader": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.28.1.tgz",
-      "integrity": "sha512-9+8oHIMWVLHxuaapDiqFNmD9KSyKN/P4bo9x/MBuDbyTqP8f2/POmmZxdXWBO3yq/uE3pKyQCXYNUxrNfHRv2A==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.33.0.tgz",
+      "integrity": "sha512-JvZrMbKBXIbEDmpIORxqvedY/bck6hGbs3hxdWT8eS9wSQ1P7//lGxbyKjOSyQiVBbgzNWriSe6HoMcZO/+0rQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
+        "@babel/runtime": "^7.25.7",
         "classnames": "^2.3.1",
-        "rc-select": "~14.15.0",
-        "rc-tree": "~5.9.0",
-        "rc-util": "^5.37.0"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -15588,9 +15582,9 @@
       }
     },
     "node_modules/rc-checkbox": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.3.0.tgz",
-      "integrity": "sha512-Ih3ZaAcoAiFKJjifzwsGiT/f/quIkxJoklW4yKGho14Olulwn8gN7hOBve0/WGDg5o/l/5mL0w7ff7/YGvefVw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
+      "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -15603,9 +15597,9 @@
       }
     },
     "node_modules/rc-collapse": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.8.0.tgz",
-      "integrity": "sha512-YVBkssrKPBG09TGfcWWGj8zJBYD9G3XuTy89t5iUmSXrIXEAnO1M+qjUxRW6b4Qi0+wNWG6MHJF/+US+nmIlzA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
+      "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -15653,15 +15647,15 @@
       }
     },
     "node_modules/rc-dropdown": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.0.tgz",
-      "integrity": "sha512-odM8Ove+gSh0zU27DUj5cG1gNKg7mLWBYzB5E4nNLrLwBmYEgYP43vHKDGOVZcJSVElQBI0+jTQgjnq0NfLjng==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
+      "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-util": "^5.17.0"
+        "rc-util": "^5.44.1"
       },
       "peerDependencies": {
         "react": ">=16.11.0",
@@ -15669,9 +15663,9 @@
       }
     },
     "node_modules/rc-field-form": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.4.0.tgz",
-      "integrity": "sha512-XZ/lF9iqf9HXApIHQHqzJK5v2w4mkUMsVqAzOyWVzoiwwXEavY6Tpuw7HavgzIoD+huVff4JghSGcgEfX6eycg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.0.tgz",
+      "integrity": "sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -15744,9 +15738,9 @@
       }
     },
     "node_modules/rc-input": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.6.3.tgz",
-      "integrity": "sha512-wI4NzuqBS8vvKr8cljsvnTUqItMfG1QbJoxovCgL+DX4eVUcHIjVwharwevIxyy7H/jbLryh+K7ysnJr23aWIA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.7.2.tgz",
+      "integrity": "sha512-g3nYONnl4edWj2FfVoxsU3Ec4XTE+Hb39Kfh2MFxMZjp/0gGyPUgy/v7ZhS27ZxUFNkuIDYXm9PJsLyJbtg86A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -15759,15 +15753,15 @@
       }
     },
     "node_modules/rc-input-number": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.2.0.tgz",
-      "integrity": "sha512-5XZFhBCV5f9UQ62AZ2hFbEY8iZT/dm23Q1kAg0H8EvOgD3UDbYYJAayoVIkM3lQaCqYAW5gV0yV3vjw1XtzWHg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.4.0.tgz",
+      "integrity": "sha512-Tiy4DcXcFXAf9wDhN8aUAyMeCLHJUHA/VA/t7Hj8ZEx5ETvxG7MArDOSE6psbiSCo+vJPm4E3fGN710ITVn6GA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
-        "rc-input": "~1.6.0",
+        "rc-input": "~1.7.1",
         "rc-util": "^5.40.1"
       },
       "peerDependencies": {
@@ -15776,17 +15770,17 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.16.1.tgz",
-      "integrity": "sha512-GnhSTGP9Mtv6pqFFGQze44LlrtWOjHNrUUAcsdo9DnNAhN4pwVPEWy4z+2jpjkiGlJ3VoXdvMHcNDQdfI9fEaw==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.19.1.tgz",
+      "integrity": "sha512-KK3bAc/bPFI993J3necmaMXD2reZTzytZdlTvkeBbp50IGH1BDPDvxLdHDUrpQx2b2TGaVJsn+86BvYa03kGqA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
-        "rc-input": "~1.6.0",
-        "rc-menu": "~9.15.1",
-        "rc-textarea": "~1.8.0",
+        "rc-input": "~1.7.1",
+        "rc-menu": "~9.16.0",
+        "rc-textarea": "~1.9.0",
         "rc-util": "^5.34.1"
       },
       "peerDependencies": {
@@ -15795,9 +15789,9 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.15.1.tgz",
-      "integrity": "sha512-UKporqU6LPfHnpPmtP6hdEK4iO5Q+b7BRv/uRpxdIyDGplZy9jwUjsnpev5bs3PQKB0H0n34WAPDfjAfn3kAPA==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.0.tgz",
+      "integrity": "sha512-vAL0yqPkmXWk3+YKRkmIR8TYj3RVdEt3ptG2jCJXWNAvQbT0VJJdRyHZ7kG/l1JsZlB+VJq/VcYOo69VR4oD+w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -15813,14 +15807,14 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.3.tgz",
-      "integrity": "sha512-rkW47ABVkic7WEB0EKJqzySpvDqwl60/tdkY7hWP7dYnh5pm0SzJpo54oW3TDUGXV5wfxXFmMkxrzRRbotQ0+w==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
+      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
-        "rc-util": "^5.43.0"
+        "rc-util": "^5.44.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -15847,9 +15841,9 @@
       }
     },
     "node_modules/rc-overflow": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.3.2.tgz",
-      "integrity": "sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.4.1.tgz",
+      "integrity": "sha512-3MoPQQPV1uKyOMVNd6SZfONi+f3st0r8PksexIdBTeIYbMX0Jr+k7pHEDvsXtR4BpCv90/Pv2MovVNhktKrwvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -15863,9 +15857,9 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.3.0.tgz",
-      "integrity": "sha512-UubEWA0ShnroQ1tDa291Fzw6kj0iOeF26IsUObxYTpimgj4/qPCWVFl18RLZE+0Up1IZg0IK4pMn6nB3mjvB7g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.0.0.tgz",
+      "integrity": "sha512-QjrPvbAQwps93iluvFM62AEYglGYhWW2q/nliQqmvkTi4PXP4HHoh00iC1Sa5LLVmtWQHmG73fBi2x6H6vFHRg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -15878,9 +15872,9 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "4.6.15",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.6.15.tgz",
-      "integrity": "sha512-OWZ1yrMie+KN2uEUfYCfS4b2Vu6RC1FWwNI0s+qypsc3wRt7g+peuZKVIzXCTaJwyyZruo80+akPg2+GmyiJjw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.9.2.tgz",
+      "integrity": "sha512-SLW4PRudODOomipKI0dvykxW4P8LOqtMr17MOaLU6NQJhkh9SZeh44a/8BMxwv5T6e3kiIeYc9k5jFg2Mv35Pg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -15950,14 +15944,14 @@
       }
     },
     "node_modules/rc-resize-observer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.0.tgz",
-      "integrity": "sha512-PnMVyRid9JLxFavTjeDXEXo65HCRqbmLBw9xX9gfC4BZiSzbLXKzW3jPz+J0P71pLbD5tBMTT+mkstV5gD0c9Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "classnames": "^2.2.1",
-        "rc-util": "^5.38.0",
+        "rc-util": "^5.44.1",
         "resize-observer-polyfill": "^1.5.1"
       },
       "peerDependencies": {
@@ -15966,9 +15960,9 @@
       }
     },
     "node_modules/rc-segmented": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.5.0.tgz",
-      "integrity": "sha512-B28Fe3J9iUFOhFJET3RoXAPFJ2u47QvLSYcZWC4tFYNGPEjug5LAxEasZlA/PpAxhdOPqGWsGbSj7ftneukJnw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.0.tgz",
+      "integrity": "sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -15982,9 +15976,9 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.15.2",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.15.2.tgz",
-      "integrity": "sha512-oNoXlaFmpqXYcQDzcPVLrEqS2J9c+/+oJuGrlXeVVX/gVgrbHa5YcyiRUXRydFjyuA7GP3elRuLF7Y3Tfwltlw==",
+      "version": "14.16.6",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.6.tgz",
+      "integrity": "sha512-YPMtRPqfZWOm2XGTbx5/YVr1HT0vn//8QS77At0Gjb3Lv+Lbut0IORJPKLWu1hQ3u4GsA0SrDzs7nI8JG7Zmyg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16004,9 +15998,9 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.7.tgz",
-      "integrity": "sha512-ytYbZei81TX7otdC0QvoYD72XSlxvTihNth5OeZ6PMXyEDq/vHdWFulQmfDGyXK1NwKwSlKgpvINOa88uT5g2A==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.8.tgz",
+      "integrity": "sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16055,16 +16049,16 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.47.5",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.47.5.tgz",
-      "integrity": "sha512-fzq+V9j/atbPIcvs3emuclaEoXulwQpIiJA6/7ey52j8+9cJ4P8DGmp4YzfUVDrb3qhgedcVeD6eRgUrokwVEQ==",
+      "version": "7.50.2",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.50.2.tgz",
+      "integrity": "sha512-+nJbzxzstBriLb5sr9U7Vjs7+4dO8cWlouQbMwBVYghk2vr508bBdkHJeP/z9HVjAIKmAgMQKxmtbgDd3gc5wA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.41.0",
+        "rc-util": "^5.44.3",
         "rc-virtual-list": "^3.14.2"
       },
       "engines": {
@@ -16076,15 +16070,15 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.3.0.tgz",
-      "integrity": "sha512-lzE18r+zppT/jZWOAWS6ntdkDUKHOLJzqMi5UAij1LeKwOaQaupupAoI9Srn73GRzVpmGznkECMRrzkRusC40A==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.5.0.tgz",
+      "integrity": "sha512-NrDcTaUJLh9UuDdMBkjKTn97U9iXG44s9D03V5NHkhEDWO5/nC6PwC3RhkCWFMKB9hh+ryqgZ+TIr1b9Jd/hnQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
         "rc-dropdown": "~4.2.0",
-        "rc-menu": "~9.15.1",
+        "rc-menu": "~9.16.0",
         "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.34.1"
@@ -16098,14 +16092,14 @@
       }
     },
     "node_modules/rc-textarea": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.8.2.tgz",
-      "integrity": "sha512-UFAezAqltyR00a8Lf0IPAyTd29Jj9ee8wt8DqXyDMal7r/Cg/nDt3e1OOv3Th4W6mKaZijjgwuPXhAfVNTN8sw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.9.0.tgz",
+      "integrity": "sha512-dQW/Bc/MriPBTugj2Kx9PMS5eXCCGn2cxoIaichjbNvOiARlaHdI99j4DTxLl/V8+PIfW06uFy7kjfUIDDKyxQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
-        "rc-input": "~1.6.0",
+        "rc-input": "~1.7.1",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.27.0"
       },
@@ -16115,9 +16109,9 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.1.tgz",
-      "integrity": "sha512-rws0duD/3sHHsD905Nex7FvoUGy2UBQRhTkKxeEvr2FB+r21HsOxcDJI0TzyO8NHhnAA8ILr8pfbSBg5Jj5KBg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.3.2.tgz",
+      "integrity": "sha512-oA4HZIiZJbUQ5ojigM0y4XtWxaH/aQlJSzknjICRWNpqyemy1sL3X3iEQV2eSPBWEq+bqU3+aSs81z+28j9luA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -16130,9 +16124,9 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.9.0.tgz",
-      "integrity": "sha512-CPrgOvm9d/9E+izTONKSngNzQdIEjMox2PBufWjS1wf7vxtvmCWzK1SlpHbRY6IaBfJIeZ+88RkcIevf729cRg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.0.tgz",
+      "integrity": "sha512-2+lFvoVRnvHQ1trlpXMOWtF8BUgF+3TiipG72uOfhpL5CUdXCk931kvDdUkTL/IZVtNEDQKwEEmJbAYJSA5NnA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -16150,16 +16144,16 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.23.0.tgz",
-      "integrity": "sha512-aQGi2tFSRw1WbXv0UVXPzHm09E0cSvUVZMLxQtMv3rnZZpNmdRXWrnd9QkLNlVH31F+X5rgghmdSFF3yZW0N9A==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
+      "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.25.7",
         "classnames": "2.x",
-        "rc-select": "~14.15.0",
-        "rc-tree": "~5.9.0",
-        "rc-util": "^5.16.1"
+        "rc-select": "~14.16.2",
+        "rc-tree": "~5.13.0",
+        "rc-util": "^5.43.0"
       },
       "peerDependencies": {
         "react": "*",
@@ -16182,9 +16176,9 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.43.0.tgz",
-      "integrity": "sha512-AzC7KKOXFqAdIBqdGWepL9Xn7cm3vnAmjlHqUnoQaTMZYhM4VlXGLkkHHxj/BZ7Td0+SOPKB4RGPboBVKT9htw==",
+      "version": "5.44.3",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.3.tgz",
+      "integrity": "sha512-q6KCcOFk3rv/zD3MckhJteZxb0VjAIFuf622B7ElK4vfrZdAzs16XR5p3VTdy3+U5jfJU5ACz4QnhLSuAGe5dA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -16196,9 +16190,9 @@
       }
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.14.8",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.14.8.tgz",
-      "integrity": "sha512-8D0KfzpRYi6YZvlOWIxiOm9BGt4Wf2hQyEaM6RXlDDiY2NhLheuYI+RA+7ZaZj1lq+XQqy3KHlaeeXQfzI5fGg==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.18.1.tgz",
+      "integrity": "sha512-ARSsD/dey/I4yNQHFYYUaKLUkD1wnD4lRZIvb3rCLMbTMmoFQJRVrWuSfbNt5P5MzMNooEBDvqrUPM4QN7BMNA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
@@ -18306,9 +18300,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.4.tgz",
-      "integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.5.tgz",
+      "integrity": "sha512-K7npNOKGRYuhAFFzkzMGfxFDpN6gDwf8hcMiE+uveTVbBgm93HrNP3ZDUpKqzZ4pG7TP6fmb+EMAQPjq9FqqvA==",
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -19991,14 +19985,14 @@
       }
     },
     "packages/jaeger-ui": {
-      "version": "1.65.0",
+      "version": "1.66.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ant-design/compatible": "^5.1.3",
+        "@ant-design/compatible": "^5.1.4",
         "@jaegertracing/plexus": "0.2.0",
         "@pyroscope/flamegraph": "0.21.4",
         "@sentry/browser": "8.51.0",
-        "antd": "^5.21.3",
+        "antd": "^5.23.3",
         "chance": "^1.0.10",
         "classnames": "^2.5.1",
         "combokeys": "^3.0.0",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -45,11 +45,11 @@
     "vite-plugin-imp": "^2.4.0"
   },
   "dependencies": {
-    "@ant-design/compatible": "^5.1.3",
+    "@ant-design/compatible": "^5.1.4",
     "@jaegertracing/plexus": "0.2.0",
     "@pyroscope/flamegraph": "0.21.4",
     "@sentry/browser": "8.51.0",
-    "antd": "^5.21.3",
+    "antd": "^5.23.3",
     "chance": "^1.0.10",
     "classnames": "^2.5.1",
     "combokeys": "^3.0.0",

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
@@ -108,22 +108,22 @@ exports[`<OperationTableDetails> Table rendered successfully 1`] = `
 
 exports[`<OperationTableDetails> render No data table 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table ant-table-empty css-dev-only-do-not-override-vryruh"
+          className="ant-table ant-table-empty css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -639,11 +639,12 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                       style={Object {}}
                     >
                       <div
-                        className="css-dev-only-do-not-override-vryruh ant-empty ant-empty-normal"
+                        className="css-dev-only-do-not-override-cdzvx5 ant-empty ant-empty-normal"
                         style={Object {}}
                       >
                         <div
                           className="ant-empty-image"
+                          style={Object {}}
                         >
                           <svg
                             height="41"
@@ -652,7 +653,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <title>
-                              Simple Empty
+                              No data
                             </title>
                             <g
                               fill="none"
@@ -683,6 +684,7 @@ exports[`<OperationTableDetails> render No data table 1`] = `
                         </div>
                         <div
                           className="ant-empty-description"
+                          style={Object {}}
                         >
                           No data
                         </div>
@@ -702,22 +704,22 @@ exports[`<OperationTableDetails> render No data table 1`] = `
 
 exports[`<OperationTableDetails> render P95 latency with more than 2 decimal places value 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -1498,7 +1500,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={100}
-                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -1547,7 +1549,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -1642,7 +1644,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1656,7 +1658,9 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -1670,6 +1674,7 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -1687,14 +1692,14 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]
@@ -1743,22 +1748,22 @@ exports[`<OperationTableDetails> render P95 latency with more than 2 decimal pla
 
 exports[`<OperationTableDetails> render error rate with more than 2 decimal places value 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -2539,7 +2544,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={100}
-                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -2588,7 +2593,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -2683,7 +2688,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -2697,7 +2702,9 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -2711,6 +2718,7 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -2728,14 +2736,14 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]
@@ -2784,22 +2792,22 @@ exports[`<OperationTableDetails> render error rate with more than 2 decimal plac
 
 exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -3580,7 +3588,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={100}
-                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -3629,7 +3637,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -3724,7 +3732,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -3738,7 +3746,9 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -3752,6 +3762,7 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -3769,14 +3780,14 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]
@@ -3825,22 +3836,22 @@ exports[`<OperationTableDetails> render lower than 0.1 P95 latency 1`] = `
 
 exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -4621,7 +4632,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={100}
-                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -4670,7 +4681,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -4765,7 +4776,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -4779,7 +4790,9 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -4793,6 +4806,7 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -4810,14 +4824,14 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]
@@ -4866,22 +4880,22 @@ exports[`<OperationTableDetails> render lower than 0.1 error rate 1`] = `
 
 exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -5662,7 +5676,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={100}
-                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -5711,7 +5725,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -5806,7 +5820,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -5820,7 +5834,9 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -5834,6 +5850,7 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -5851,14 +5868,14 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]
@@ -5907,22 +5924,22 @@ exports[`<OperationTableDetails> render lower than 0.1 request rate value 1`] = 
 
 exports[`<OperationTableDetails> render request rate number with more than 2 decimal places value 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -6703,7 +6720,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={100}
-                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -6752,7 +6769,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -6847,7 +6864,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -6861,7 +6878,9 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -6875,6 +6894,7 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -6892,14 +6912,14 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]
@@ -6948,22 +6968,22 @@ exports[`<OperationTableDetails> render request rate number with more than 2 dec
 
 exports[`<OperationTableDetails> render some values in the table 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -7744,7 +7764,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={100}
-                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -7793,7 +7813,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -7888,7 +7908,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -7902,7 +7922,9 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -7916,6 +7938,7 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -7933,14 +7956,14 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]
@@ -7989,22 +8012,22 @@ exports[`<OperationTableDetails> render some values in the table 1`] = `
 
 exports[`<OperationTableDetails> test column render function 1`] = `
 <div
-  className="ant-col ant-col-24 css-dev-only-do-not-override-vryruh"
+  className="ant-col ant-col-24 css-dev-only-do-not-override-cdzvx5"
   style={Object {}}
 >
   <div
-    className="ant-table-wrapper css-dev-only-do-not-override-vryruh"
+    className="ant-table-wrapper css-dev-only-do-not-override-cdzvx5"
     style={Object {}}
   >
     <div
-      className="ant-spin-nested-loading css-dev-only-do-not-override-vryruh"
+      className="ant-spin-nested-loading css-dev-only-do-not-override-cdzvx5"
     >
       <div
         className="ant-spin-container"
         key="container"
       >
         <div
-          className="ant-table css-dev-only-do-not-override-vryruh"
+          className="ant-table css-dev-only-do-not-override-cdzvx5"
         >
           <div
             className="ant-table-container"
@@ -8596,7 +8619,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                           aria-valuemax={100}
                           aria-valuemin={0}
                           aria-valuenow={NaN}
-                          className="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-vryruh"
+                          className="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-default impact css-dev-only-do-not-override-cdzvx5"
                           role="progressbar"
                           style={Object {}}
                         >
@@ -8645,7 +8668,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
           </div>
         </div>
         <ul
-          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-vryruh"
+          className="ant-pagination ant-table-pagination ant-table-pagination-right css-dev-only-do-not-override-cdzvx5"
           style={Object {}}
         >
           <li
@@ -8740,7 +8763,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
           >
             <div
               aria-label="Page Size"
-              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-vryruh ant-select-single ant-select-show-arrow ant-select-show-search"
+              className="ant-select ant-select-outlined ant-pagination-options-size-changer css-dev-only-do-not-override-cdzvx5 ant-select-single ant-select-show-arrow ant-select-show-search"
               onBlur={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -8754,7 +8777,9 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                   onClick={[Function]}
                   onMouseDown={[Function]}
                 >
-                  Array [
+                  <span
+                    className="ant-select-selection-wrap"
+                  >
                     <span
                       className="ant-select-selection-search"
                     >
@@ -8768,6 +8793,7 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                         autoComplete="off"
                         className="ant-select-selection-search-input"
                         disabled={false}
+                        onBlur={[Function]}
                         onChange={[Function]}
                         onCompositionEnd={[Function]}
                         onCompositionStart={[Function]}
@@ -8785,14 +8811,14 @@ exports[`<OperationTableDetails> test column render function 1`] = `
                         unselectable={null}
                         value=""
                       />
-                    </span>,
+                    </span>
                     <span
                       className="ant-select-selection-item"
                       title="20 / page"
                     >
                       20 / page
-                    </span>,
-                  ]
+                    </span>
+                  </span>
                 </div>,
                 "",
               ]


### PR DESCRIPTION
## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger-ui/issues/2576

## Description of the changes
- This PR upgrades the antd and @ant-design/compatible to latest version which wold unblock the jsdom PR by renovate bot since ant-design have introduced some changes to the selectors internally in the `rc-*` packages.

## How was this change tested?
- npm run test
- ui changes using npm run start

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
