### PR TITLE
Change deep dependency endpoint

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -80,7 +80,6 @@ function getJSON(url, options = {}) {
 }
 
 export const DEFAULT_API_ROOT = prefixUrl('/api/');
-export const ANALYTICS_ROOT = prefixUrl('/analytics/');
 export const DEFAULT_DEPENDENCY_LOOKBACK = dayjs.duration(1, 'weeks').asMilliseconds();
 
 const JaegerAPI = {
@@ -92,7 +91,7 @@ const JaegerAPI = {
     return getJSON(url);
   },
   fetchDeepDependencyGraph(query) {
-    return getJSON(`${ANALYTICS_ROOT}v1/dependencies`, { query });
+    return getJSON(`${this.apiRoot}deep-dependencies`, { query });
   },
   fetchDependencies(endTs = new Date().getTime(), lookback = DEFAULT_DEPENDENCY_LOOKBACK) {
     return getJSON(`${this.apiRoot}dependencies`, { query: { endTs, lookback } });


### PR DESCRIPTION
## Which problem is this PR solving?
- Related pr to https://github.com/jaegertracing/jaeger/pull/6654

## Description of the changes
-  Changes endpoint for deep-dependencies from /analytics/v1/dependencies

## How was this change tested?
- `npm run lint` and `npm run test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
