### PR TITLE
[KeyValuesTable]: replace defaultProps with destructuring 

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -117,14 +117,10 @@ function formatValue(key: string, value: any) {
 }
 
 export const LinkValue = (props: { href: string; title?: string; children: React.ReactNode }) => (
-  <a href={props.href} title={props.title} target="_blank" rel="noopener noreferrer">
+  <a href={props.href} title={props.title || ''} target="_blank" rel="noopener noreferrer">
     {props.children} <IoOpenOutline className="KeyValueTable--linkIcon" />
   </a>
 );
-
-LinkValue.defaultProps = {
-  title: '',
-};
 
 const linkValueList = (links: Link[]) => {
   const dropdownItems = links.map(({ text, url }, index) => ({


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #2596

## Description of the changes
- Removed defaultprops from KeyValuesTable

## How was this change tested?
- npm ci 
- npm test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
