### PR TITLE
[AccordianKeyValues]: replace defaultProps with destructuring

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.js
@@ -91,7 +91,7 @@ describe('<AccordianKeyValues>', () => {
   it('does not apply high contrast styles by default', () => {
     expect(wrapper.find('.AccordianKeyValues--header').hasClass('is-high-contrast')).toBe(false);
   });
-  
+
   it('applies high contrast styles when highContrast is true', () => {
     wrapper.setProps({ highContrast: true });
     expect(wrapper.find('.AccordianKeyValues--header').hasClass('is-high-contrast')).toBe(true);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.js
@@ -55,6 +55,7 @@ describe('<KeyValuesSummary>', () => {
 
 describe('<AccordianKeyValues>', () => {
   let wrapper;
+  const mockToggle = jest.fn();
 
   const props = {
     compact: false,
@@ -62,7 +63,7 @@ describe('<AccordianKeyValues>', () => {
     highContrast: false,
     isOpen: false,
     label: 'le-label',
-    onToggle: jest.fn(),
+    onToggle: mockToggle,
   };
 
   beforeEach(() => {
@@ -72,6 +73,28 @@ describe('<AccordianKeyValues>', () => {
   it('renders without exploding', () => {
     expect(wrapper).toBeDefined();
     expect(wrapper.exists()).toBe(true);
+  });
+
+  it('calls onToggle when clicked', () => {
+    wrapper.find('.AccordianKeyValues--header').simulate('click');
+    expect(mockToggle).toHaveBeenCalled();
+  });
+
+  it('does not call onToggle if interactive is false', () => {
+    mockToggle.mockClear();
+    wrapper.setProps({ interactive: false });
+    wrapper.update();
+    wrapper.find('.AccordianKeyValues--header').simulate('click');
+    expect(mockToggle).not.toHaveBeenCalled();
+  });
+
+  it('does not apply high contrast styles by default', () => {
+    expect(wrapper.find('.AccordianKeyValues--header').hasClass('is-high-contrast')).toBe(false);
+  });
+  
+  it('applies high contrast styles when highContrast is true', () => {
+    wrapper.setProps({ highContrast: true });
+    expect(wrapper.find('.AccordianKeyValues--header').hasClass('is-high-contrast')).toBe(true);
   });
 
   it('renders the label', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
@@ -23,20 +23,9 @@ import { KeyValuePair, Link } from '../../../../types/trace';
 
 import './AccordianKeyValues.css';
 
-type AccordianKeyValuesProps = {
-  className?: string | TNil;
-  data: KeyValuePair[];
-  highContrast?: boolean;
-  interactive?: boolean;
-  isOpen: boolean;
-  label: string;
-  linksGetter: ((pairs: KeyValuePair[], index: number) => Link[]) | TNil;
-  onToggle?: null | (() => void);
-};
-
 // export for tests
 export function KeyValuesSummary(props: { data?: KeyValuePair[] }) {
-  const { data } = props;
+  const { data } = props || null;
   if (!Array.isArray(data) || !data.length) {
     return null;
   }
@@ -55,12 +44,25 @@ export function KeyValuesSummary(props: { data?: KeyValuePair[] }) {
   );
 }
 
-KeyValuesSummary.defaultProps = {
-  data: null,
-};
-
-export default function AccordianKeyValues(props: AccordianKeyValuesProps) {
-  const { className, data, highContrast, interactive, isOpen, label, linksGetter, onToggle } = props;
+export default function AccordianKeyValues({
+  className = null,
+  data,
+  highContrast = false,
+  interactive = true,
+  isOpen,
+  label,
+  linksGetter,
+  onToggle = null,
+}: {
+  className?: string | TNil;
+  data: KeyValuePair[];
+  highContrast?: boolean;
+  interactive?: boolean;
+  isOpen: boolean;
+  label: string;
+  linksGetter: ((pairs: KeyValuePair[], index: number) => Link[]) | TNil;
+  onToggle?: null | (() => void);
+}) {
   const isEmpty = !Array.isArray(data) || !data.length;
   const iconCls = cx('u-align-icon', { 'AccordianKeyValues--emptyIcon': isEmpty });
   let arrow: React.ReactNode | null = null;
@@ -94,10 +96,3 @@ export default function AccordianKeyValues(props: AccordianKeyValuesProps) {
     </div>
   );
 }
-
-AccordianKeyValues.defaultProps = {
-  className: null,
-  highContrast: false,
-  interactive: true,
-  onToggle: null,
-};

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
@@ -24,8 +24,7 @@ import { KeyValuePair, Link } from '../../../../types/trace';
 import './AccordianKeyValues.css';
 
 // export for tests
-export function KeyValuesSummary(props: { data?: KeyValuePair[] }) {
-  const { data } = props || null;
+export function KeyValuesSummary({ data }: { data: KeyValuePair[] }) {
   if (!Array.isArray(data) || !data.length) {
     return null;
   }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -117,14 +117,10 @@ function formatValue(key: string, value: any) {
 }
 
 export const LinkValue = (props: { href: string; title?: string; children: React.ReactNode }) => (
-  <a href={props.href} title={props.title} target="_blank" rel="noopener noreferrer">
+  <a href={props.href} title={props.title || ''} target="_blank" rel="noopener noreferrer">
     {props.children} <IoOpenOutline className="KeyValueTable--linkIcon" />
   </a>
 );
-
-LinkValue.defaultProps = {
-  title: '',
-};
 
 const linkValueList = (links: Link[]) => {
   const dropdownItems = links.map(({ text, url }, index) => ({


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #2596


## Description of the changes
- removed defaultProps from AccordianKeyValues

## How was this change tested?
- npm ci
- npm test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
