### PR TITLE
Changed UI of buttons in sidebar

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
@@ -57,19 +57,26 @@ limitations under the License.
   padding-bottom: 0.3rem;
 }
 
-.TraceGraph--menu button {
-  padding-bottom: 0.3rem; 
+.TraceGraph--menu > li button {
+  padding: 0.3rem; 
   cursor: pointer;
-  font-size: 1rem; 
-  width: 100%; 
+  font-size: 1rem;
+  width: 100%;
+  background-color: transparent;
+  border: 1px solid #ddd; 
+  border-radius: 4px;
+  display: block; 
 }
 
-.TraceGraph--menu button.active {
+.TraceGraph--menu > li button.active {
   background-color: #007bff; 
   color: white; 
-  font-weight: bold; 
+  font-weight: bold;
   border: none; 
-  border-radius: 4px; 
+}
+
+.TraceGraph--menu > li button:hover {
+  background-color: #f0f0f0; /* Change background on hover */
 }
 
 .TraceGraph--sidebar {

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
@@ -57,6 +57,21 @@ limitations under the License.
   padding-bottom: 0.3rem;
 }
 
+.TraceGraph--menu button {
+  padding-bottom: 0.3rem; 
+  cursor: pointer;
+  font-size: 1rem; 
+  width: 100%; 
+}
+
+.TraceGraph--menu button.active {
+  background-color: #007bff; 
+  color: white; 
+  font-weight: bold; 
+  border: none; 
+  border-radius: 4px; 
+}
+
 .TraceGraph--sidebar {
   cursor: default;
   box-shadow: -1px 0 rgba(0, 0, 0, 0.2);

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -218,7 +218,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
             <li>
               <Tooltip placement="left" title="Service">
                 <Button
-                  className="TraceGraph--btn-service"
+                  className={`TraceGraph--btn-service ${mode === MODE_SERVICE ? 'active' : ''}`}
                   htmlType="button"
                   shape="circle"
                   size="small"
@@ -231,7 +231,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
             <li>
               <Tooltip placement="left" title="Time">
                 <Button
-                  className="TraceGraph--btn-time"
+                  className={`TraceGraph--btn-time ${mode === MODE_TIME ? 'active' : ''}`}
                   htmlType="button"
                   shape="circle"
                   size="small"
@@ -244,7 +244,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
             <li>
               <Tooltip placement="left" title="Selftime">
                 <Button
-                  className="TraceGraph--btn-selftime"
+                  className={`TraceGraph--btn-time ${mode === MODE_TIME ? 'active' : ''}`}
                   htmlType="button"
                   shape="circle"
                   size="small"


### PR DESCRIPTION
Solves https://github.com/jaegertracing/jaeger-ui/issues/2572 issue
[Feature]: TraceGraph should indicate which mode is selected

To provide better visual aid when users view the TraceGraph page. The state changes to solid colour when a mode is active, hovering effect is also added

## How was this change tested?
Tested on localhost

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
