### PR TITLE
Replace react-vis with recharts in ScatterPlot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4554,21 +4554,46 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
       }
     },
     "node_modules/@types/d3-selection": {
@@ -4576,6 +4601,27 @@
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-zoom": {
@@ -6985,6 +7031,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7854,6 +7909,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-uri-component": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
@@ -8304,6 +8365,16 @@
       "license": "MIT",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-scroll-into-view": {
@@ -9553,7 +9624,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -9706,6 +9776,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -11158,6 +11237,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/interpret": {
@@ -16594,6 +16682,21 @@
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-test-renderer": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
@@ -16607,6 +16710,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/react-vis": {
@@ -16766,6 +16885,38 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+      "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/rechoir": {
@@ -19364,6 +19515,89 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -20127,7 +20361,7 @@
         "@jaegertracing/plexus": "0.2.0",
         "@pyroscope/flamegraph": "0.21.4",
         "@sentry/browser": "9.0.0",
-        "antd": "^5.24.0",
+        "antd": "^5.23.3",
         "chance": "^1.0.10",
         "classnames": "^2.5.1",
         "combokeys": "^3.0.0",
@@ -20159,6 +20393,7 @@
         "react-vis": "1.11.12",
         "react-vis-force": "^0.3.1",
         "react-window": "^1.8.10",
+        "recharts": "^2.15.1",
         "redux": "^5.0.1",
         "redux-actions": "2.6.5",
         "redux-first-history": "^5.2.0",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -81,6 +81,7 @@
     "react-vis": "1.11.12",
     "react-vis-force": "^0.3.1",
     "react-window": "^1.8.10",
+    "recharts": "^2.15.1",
     "redux": "^5.0.1",
     "redux-actions": "2.6.5",
     "redux-first-history": "^5.2.0",

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.css
@@ -14,10 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.TraceResultsScatterPlot .rv-xy-plot__series.rv-xy-plot__series--mark {
-  cursor: pointer;
-}
-
 .scatter-plot-hint {
   color: #444;
   background: #f8f8f8;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
@@ -122,18 +122,26 @@ export default function ScatterPlot({
               domain={[xMin, xMax]}
               ticks={generateUniqueTicks(xMin, xMax, 10)}
               tickFormatter={t => dayjs(t / ONE_MILLISECOND).format('hh:mm:ss a')}
-              tick={{ fontSize: 11 }}
+              tick={{ fontSize: 11, dy: 5 }}
               axisLine={{ stroke: '#e6e6e9', strokeWidth: 2 }}
               tickLine={{ stroke: '#e6e6e9', strokeWidth: 1 }}
               allowDecimals={false}
               interval="equidistantPreserveStart"
-            />
+            >
+              <Label
+                value="Time"
+                position="insideTopRight"
+                offset={15}
+                fontSize={11}
+                style={{ textAnchor: 'start' }}
+              />
+            </XAxis>
             <YAxis
               type="number"
               dataKey="y"
               name="Duration"
               tickFormatter={t => formatDuration(t)}
-              tick={{ fontSize: 11 }}
+              tick={{ fontSize: 11, dx: -5 }}
               axisLine={{ stroke: '#e6e6e9', strokeWidth: 2 }}
               tickLine={{ stroke: '#e6e6e9', strokeWidth: 1 }}
               tickCount={4}
@@ -142,11 +150,11 @@ export default function ScatterPlot({
             >
               <Label
                 value="Duration"
-                position="insideLeft"
-                angle={-90}
-                offset={75}
+                position="insideTopLeft"
+                offset={0}
                 fontSize={11}
-                style={{ textAnchor: 'middle' }}
+                style={{ textAnchor: 'end' }}
+                angle={-90}
               />
             </YAxis>
             <ZAxis dataKey="size" type="number" range={[1, 300]} />
@@ -160,7 +168,6 @@ export default function ScatterPlot({
               })}
               onClick={onValueClick}
               shape={<RenderDot />}
-              fill={point => point.fill}
             />
           </ScatterChart>
         </ResponsiveContainer>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
@@ -32,7 +32,7 @@ import { ONE_MILLISECOND, formatDuration } from '../../../utils/date';
 
 import './ScatterPlot.css';
 
-const CustomTooltip = ({ active, payload }) => {
+export const CustomTooltip = ({ active, payload }) => {
   if (active && payload && payload.length) {
     return (
       <div className="scatter-plot-hint">
@@ -43,7 +43,7 @@ const CustomTooltip = ({ active, payload }) => {
   return null;
 };
 
-const RenderDot = ({ cx, cy, fill, size }) => {
+export const RenderDot = ({ cx, cy, fill, size }) => {
   const maxSize = Math.min(300, size);
   return (
     <Dot cx={cx} cy={cy} fill={fill} fillOpacity={0.5} r={maxSize * 0.035} style={{ cursor: 'pointer' }} />

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.jsx
@@ -15,13 +15,40 @@
 import React, { useRef, useState, useLayoutEffect } from 'react';
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
-import { XYPlot, XAxis, YAxis, MarkSeries, Hint } from 'react-vis';
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ZAxis,
+  Label,
+  Dot,
+} from 'recharts';
 
 import { FALLBACK_TRACE_NAME } from '../../../constants';
 import { ONE_MILLISECOND, formatDuration } from '../../../utils/date';
 
-import 'react-vis/dist/style.css';
 import './ScatterPlot.css';
+
+const CustomTooltip = ({ active, payload }) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="scatter-plot-hint">
+        <h4>{payload[0].payload.name || FALLBACK_TRACE_NAME}</h4>
+      </div>
+    );
+  }
+  return null;
+};
+
+const RenderDot = ({ cx, cy, fill, size }) => {
+  const maxSize = Math.min(300, size);
+  return (
+    <Dot cx={cx} cy={cy} fill={fill} fillOpacity={0.5} r={maxSize * 0.035} style={{ cursor: 'pointer' }} />
+  );
+};
 
 export default function ScatterPlot({
   data,
@@ -32,16 +59,6 @@ export default function ScatterPlot({
 }) {
   const containerRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(0);
-
-  const [overValue, setValueOver] = useState(null);
-
-  const onValueOver = value => {
-    setValueOver(value);
-  };
-
-  const onValueOut = () => {
-    setValueOver(null);
-  };
 
   useLayoutEffect(() => {
     function updateContainerWidth() {
@@ -58,37 +75,95 @@ export default function ScatterPlot({
     return () => window.removeEventListener('resize', updateContainerWidth);
   }, []);
 
+  const xMin = Math.min(...data.map(d => d.x));
+  const xMax = Math.max(...data.map(d => d.x));
+
+  /*
+  This function generates unique ticks for the x-axis.
+  It ensures that the ticks are unique by checking if the label for a given tick value has already been used.
+  If it has, the tick is not added to the list of ticks.
+  */
+  const generateUniqueTicks = (min, max, count) => {
+    const step = (max - min) / (count - 1);
+    const ticks = [];
+    const seenLabels = new Set();
+
+    for (let i = 0; i < count; i++) {
+      const value = min + step * i;
+      ticks.push(value);
+    }
+
+    return ticks.filter(tick => {
+      const label = dayjs(tick / ONE_MILLISECOND).format('hh:mm:ss a');
+      if (seenLabels.has(label)) {
+        return false;
+      }
+      seenLabels.add(label);
+      return true;
+    });
+  };
+
   return (
-    <div className="TraceResultsScatterPlot" ref={containerRef}>
-      {containerWidth && (
-        <XYPlot
-          margin={{
-            left: 70,
-          }}
-          width={containerWidth}
-          colorType="literal"
-          height={200}
-        >
-          <XAxis
-            title="Time"
-            tickTotal={4}
-            tickFormat={t => dayjs(t / ONE_MILLISECOND).format('hh:mm:ss a')}
-          />
-          <YAxis title="Duration" tickTotal={3} tickFormat={t => formatDuration(t)} />
-          <MarkSeries
-            sizeRange={[3, 10]}
-            opacity={0.5}
-            onValueClick={onValueClick}
-            onValueMouseOver={onValueOver}
-            onValueMouseOut={onValueOut}
-            data={data}
-          />
-          {overValue && (
-            <Hint value={overValue}>
-              <h4 className="scatter-plot-hint">{overValue.name || FALLBACK_TRACE_NAME}</h4>
-            </Hint>
-          )}
-        </XYPlot>
+    <div className="TraceResultsScatterPlot" ref={containerRef} style={{ width: '100%', height: 200 }}>
+      {containerWidth > 0 && (
+        <ResponsiveContainer>
+          <ScatterChart
+            margin={{
+              top: 10,
+              right: 20,
+              left: 10,
+              bottom: 10,
+            }}
+          >
+            <XAxis
+              type="number"
+              dataKey="x"
+              name="Time"
+              domain={[xMin, xMax]}
+              ticks={generateUniqueTicks(xMin, xMax, 10)}
+              tickFormatter={t => dayjs(t / ONE_MILLISECOND).format('hh:mm:ss a')}
+              tick={{ fontSize: 11 }}
+              axisLine={{ stroke: '#e6e6e9', strokeWidth: 2 }}
+              tickLine={{ stroke: '#e6e6e9', strokeWidth: 1 }}
+              allowDecimals={false}
+              interval="equidistantPreserveStart"
+            />
+            <YAxis
+              type="number"
+              dataKey="y"
+              name="Duration"
+              tickFormatter={t => formatDuration(t)}
+              tick={{ fontSize: 11 }}
+              axisLine={{ stroke: '#e6e6e9', strokeWidth: 2 }}
+              tickLine={{ stroke: '#e6e6e9', strokeWidth: 1 }}
+              tickCount={4}
+              allowDecimals={false}
+              domain={['auto', 'auto']}
+            >
+              <Label
+                value="Duration"
+                position="insideLeft"
+                angle={-90}
+                offset={75}
+                fontSize={11}
+                style={{ textAnchor: 'middle' }}
+              />
+            </YAxis>
+            <ZAxis dataKey="size" type="number" range={[1, 300]} />
+            <Tooltip content={<CustomTooltip />} cursor={false} isAnimationActive={false} />
+            <Scatter
+              data={data.map(point => {
+                return {
+                  ...point,
+                  fill: point.color,
+                };
+              })}
+              onClick={onValueClick}
+              shape={<RenderDot />}
+              fill={point => point.fill}
+            />
+          </ScatterChart>
+        </ResponsiveContainer>
       )}
     </div>
   );

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.test.js
@@ -16,8 +16,9 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import ScatterPlot from './ScatterPlot';
+import ScatterPlot, { CustomTooltip } from './ScatterPlot';
 import { ONE_MILLISECOND } from '../../../utils/date';
+import { FALLBACK_TRACE_NAME } from '../../../constants';
 
 // Mock ResizeObserver which is not available in JSDOM but required by Recharts
 class MockResizeObserver {
@@ -255,5 +256,42 @@ describe('ScatterPlot', () => {
 
     expect(firstSymbol).toBeTruthy();
     expect(secondSymbol).toBeTruthy();
+  });
+});
+
+describe('CustomTooltip', () => {
+  it('renders with trace name when active and payload is provided', () => {
+    const traceName = 'Test Trace Name';
+    const { container } = render(<CustomTooltip active payload={[{ payload: { name: traceName } }]} />);
+
+    const tooltipElement = container.querySelector('.scatter-plot-hint');
+    expect(tooltipElement).toBeTruthy();
+    expect(tooltipElement.querySelector('h4').textContent).toBe(traceName);
+  });
+
+  it('renders with fallback name when trace has no name', () => {
+    const { container } = render(<CustomTooltip active payload={[{ payload: {} }]} />);
+
+    const tooltipElement = container.querySelector('.scatter-plot-hint');
+    expect(tooltipElement).toBeTruthy();
+    expect(tooltipElement.querySelector('h4').textContent).toBe(FALLBACK_TRACE_NAME);
+  });
+
+  it('returns null when not active', () => {
+    const { container } = render(<CustomTooltip payload={[{ payload: { name: 'Test' } }]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when payload is empty', () => {
+    const { container } = render(<CustomTooltip active payload={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when payload is not provided', () => {
+    const { container } = render(<CustomTooltip active />);
+
+    expect(container.firstChild).toBeNull();
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger-ui/issues/1597

## Description of the changes
- This PR replaces react-vis in ScatterPlot component with Recharts

## How was this change tested?
- manually and testing lib

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
