### PR TITLE
Add Handling or error for invalid json formats and tests

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
@@ -137,7 +137,7 @@ export class SearchTracePageImpl extends Component {
         <Col span={!embedded ? 18 : 24} className="SearchTracePage--column">
           {showErrors && (
             <div className="js-test-error-message">
-              <h2>There was an error querying for traces:</h2>
+              <h2>Cannot parse uploaded file</h2>
               {errors.map(err => (
                 <ErrorMessage key={err.message} error={err} />
               ))}

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.jsx
@@ -137,7 +137,7 @@ export class SearchTracePageImpl extends Component {
         <Col span={!embedded ? 18 : 24} className="SearchTracePage--column">
           {showErrors && (
             <div className="js-test-error-message">
-              <h2>Cannot parse uploaded file</h2>
+              <h2>There was an error loading traces: </h2>
               {errors.map(err => (
                 <ErrorMessage key={err.message} error={err} />
               ))}

--- a/packages/jaeger-ui/src/reducers/trace.js
+++ b/packages/jaeger-ui/src/reducers/trace.js
@@ -132,18 +132,23 @@ function loadJsonStarted(state) {
 }
 
 function loadJsonDone(state, { payload }) {
-  const processed = payload.data.map(transformTraceData);
-  const resultTraces = {};
-  const results = new Set(state.search.results);
-  for (let i = 0; i < processed.length; i++) {
-    const data = processed[i];
-    const id = data.traceID;
-    resultTraces[id] = { data, id, state: fetchedState.DONE };
-    results.add(id);
+  try {
+    const processed = payload.data.map(transformTraceData);
+    const resultTraces = {};
+    const results = new Set(state.search.results);
+    for (let i = 0; i < processed.length; i++) {
+      const data = processed[i];
+      const id = data.traceID;
+      resultTraces[id] = { data, id, state: fetchedState.DONE };
+      results.add(id);
+    }
+    const traces = { ...state.traces, ...resultTraces };
+    const search = { ...state.search, results: Array.from(results), state: fetchedState.DONE };
+    return { ...state, search, traces };
+  } catch (error) {
+    const search = { error, results: [], state: fetchedState.ERROR };
+    return { ...state, search };
   }
-  const traces = { ...state.traces, ...resultTraces };
-  const search = { ...state.search, results: Array.from(results), state: fetchedState.DONE };
-  return { ...state, search, traces };
 }
 
 function loadJsonErred(state, { payload }) {

--- a/packages/jaeger-ui/src/reducers/trace.test.js
+++ b/packages/jaeger-ui/src/reducers/trace.test.js
@@ -305,7 +305,7 @@ describe('load json traces', () => {
     };
     const corruptedTrace = {
       ...trace,
-      spans: null
+      spans: null,
     };
 
     const state = traceReducer(initialState, {

--- a/packages/jaeger-ui/src/reducers/trace.test.js
+++ b/packages/jaeger-ui/src/reducers/trace.test.js
@@ -294,4 +294,30 @@ describe('load json traces', () => {
     };
     expect(state.search).toEqual(outcome);
   });
+
+  it('handles error when processing json trace data', () => {
+    const initialState = {
+      traces: {},
+      search: {
+        results: ['existing-trace-id'],
+        state: fetchedState.LOADING,
+      },
+    };
+    const corruptedTrace = {
+      ...trace,
+      spans: null
+    };
+
+    const state = traceReducer(initialState, {
+      type: `${fileReaderActions.loadJsonTraces}${ACTION_POSTFIX_FULFILLED}`,
+      payload: { data: [corruptedTrace] },
+    });
+
+    expect(state.search).toEqual({
+      error: expect.any(Error),
+      results: [],
+      state: fetchedState.ERROR,
+    });
+    expect(state.traces).toEqual({});
+  });
 });


### PR DESCRIPTION
Here's a fixed version of the PR description:

## Which problem is this PR solving?
- Resolves #2678

## Description of the changes
- Add proper error handling for invalid JSON formats

## How was this change tested?
- Tested with the exact OpenTelemetry span format from the issue
- Validated with JSON generated from hotrod traces

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`

![invalid-trace](https://github.com/user-attachments/assets/a179c777-7fea-4e10-8ba1-6e45a03aca3f)

