### PR TITLE
Add sfdp engine in @jaegertracing/plexus

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -15,7 +15,6 @@
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import { render, screen } from '@testing-library/react';
-import { shallow } from 'enzyme';
 import { LayoutManager } from '@jaegertracing/plexus';
 import DAG, { renderNode } from './DAG';
 

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -16,6 +16,7 @@ import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import { render, screen } from '@testing-library/react';
 import { shallow } from 'enzyme';
+import { LayoutManager } from '@jaegertracing/plexus';
 import DAG, { renderNode } from './DAG';
 
 // mock canvas API (we don't care about canvas results)
@@ -171,9 +172,9 @@ describe('renderNode', () => {
 
 describe('clean up', () => {
   it('stops LayoutManager before unmounting', () => {
-    const wrapper = shallow(<DAG serviceCalls={[]} />);
-    const stopAndReleaseSpy = jest.spyOn(wrapper.instance().layoutManager, 'stopAndRelease');
-    wrapper.unmount();
+    const stopAndReleaseSpy = jest.spyOn(LayoutManager.prototype, 'stopAndRelease');
+    const { unmount } = render(<DAG serviceCalls={[]} />);
+    unmount();
     expect(stopAndReleaseSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -76,64 +76,55 @@ const formatServiceCalls = (
 
 const { classNameIsSmall } = Digraph.propsFactories;
 
-export default class DAG extends React.Component<TProps> {
-  static defaultProps = {
-    serviceCalls: [],
-  };
+export default function DAG({ serviceCalls = [] }: TProps) {
+  const data = React.useMemo(() => formatServiceCalls(serviceCalls), [serviceCalls]);
 
-  private data: {
-    nodes: TVertex[];
-    edges: TEdge[];
-  };
+  const layoutManager = React.useMemo(
+    () =>
+      new LayoutManager({
+        nodesep: 1.5,
+        ranksep: 1.6,
+        rankdir: 'TB',
+        splines: 'polyline',
+        useDotEdges: true,
+      }),
+    []
+  );
 
-  private layoutManager: LayoutManager = new LayoutManager({
-    nodesep: 1.5,
-    ranksep: 1.6,
-    rankdir: 'TB',
-    splines: 'polyline',
-    useDotEdges: true,
-  });
+  React.useEffect(() => {
+    return () => {
+      layoutManager.stopAndRelease();
+    };
+  }, [layoutManager]);
 
-  constructor(props: TProps) {
-    super(props);
-
-    this.data = formatServiceCalls(props.serviceCalls);
-  }
-
-  componentWillUnmount() {
-    this.layoutManager.stopAndRelease();
-  }
-
-  render() {
-    return (
-      <div className="DAG">
-        <Digraph<TVertex>
-          zoom
-          minimap
-          className="DAG--dag"
-          setOnGraph={classNameIsSmall}
-          minimapClassName="u-miniMap"
-          layoutManager={this.layoutManager}
-          measurableNodesKey="nodes"
-          layers={[
-            {
-              key: 'edges',
-              defs: [{ localId: 'arrowHead' }],
-              edges: true,
-              layerType: 'svg',
-              markerEndId: 'arrowHead',
-            },
-            {
-              key: 'nodes',
-              layerType: 'html',
-              measurable: true,
-              renderNode,
-            },
-          ]}
-          edges={this.data.edges}
-          vertices={this.data.nodes}
-        />
-      </div>
-    );
-  }
+  return (
+    <div className="DAG">
+      <Digraph<TVertex>
+        zoom
+        minimap
+        className="DAG--dag"
+        setOnGraph={classNameIsSmall}
+        minimapClassName="u-miniMap"
+        layoutManager={layoutManager}
+        measurableNodesKey="nodes"
+        layers={[
+          {
+            key: 'edges',
+            defs: [{ localId: 'arrowHead' }],
+            edges: true,
+            layerType: 'svg',
+            markerEndId: 'arrowHead',
+          },
+          {
+            key: 'nodes',
+            layerType: 'html',
+            measurable: true,
+            renderNode,
+          },
+        ]}
+        edges={data.edges}
+        vertices={data.nodes}
+      />
+    </div>
+  );
 }

--- a/packages/plexus/src/LayoutManager/dot/conv-coord.tsx
+++ b/packages/plexus/src/LayoutManager/dot/conv-coord.tsx
@@ -13,12 +13,18 @@
 // limitations under the License.
 
 import { TLayoutEdge, TLayoutGraph, TLayoutVertex, TSizeVertex } from '../../types';
+import { TLayoutOptions } from '../types';
 
 const round = Math.round;
 
-const DPI = 72;
+export function getDpi(options?: TLayoutOptions | void): number {
+  const DEFAULT_DPI = 72;
+  const dpi = options?.dpi ?? DEFAULT_DPI;
+  return dpi;
+}
 
-export function vertexToDot(v: TSizeVertex): TSizeVertex {
+export function vertexToDot(v: TSizeVertex, options?: TLayoutOptions | void): TSizeVertex {
+  const DPI = getDpi(options);
   // expect only width and height for going to dot
   const { vertex, height, width } = v;
   return {
@@ -28,7 +34,12 @@ export function vertexToDot(v: TSizeVertex): TSizeVertex {
   };
 }
 
-export function edgeToPixels(graph: TLayoutGraph, e: TLayoutEdge<{}>): TLayoutEdge<{}> {
+export function edgeToPixels(
+  graph: TLayoutGraph,
+  e: TLayoutEdge<{}>,
+  options?: TLayoutOptions | void
+): TLayoutEdge<{}> {
+  const DPI = getDpi(options);
   const { height: h } = graph;
   const { edge, pathPoints } = e;
   return {
@@ -38,7 +49,8 @@ export function edgeToPixels(graph: TLayoutGraph, e: TLayoutEdge<{}>): TLayoutEd
   };
 }
 
-export function graphToPixels(graph: TLayoutGraph) {
+export function graphToPixels(graph: TLayoutGraph, options?: TLayoutOptions | void) {
+  const DPI = getDpi(options);
   const { height, scale, width } = graph;
   return {
     scale,
@@ -47,7 +59,12 @@ export function graphToPixels(graph: TLayoutGraph) {
   };
 }
 
-export function vertexToPixels(graph: TLayoutGraph, v: TLayoutVertex): TLayoutVertex {
+export function vertexToPixels(
+  graph: TLayoutGraph,
+  v: TLayoutVertex,
+  options?: TLayoutOptions | void
+): TLayoutVertex {
+  const DPI = getDpi(options);
   const { height: h } = graph;
   const { vertex, height, left, top, width } = v;
   return {

--- a/packages/plexus/src/LayoutManager/dot/toDot.tsx
+++ b/packages/plexus/src/LayoutManager/dot/toDot.tsx
@@ -26,12 +26,32 @@ const DEFAULT_GRAPH_ATTRS = {
   splines: 'true',
 };
 
+const DEFAULT_SFDP_GRAPH_ATTRS = {
+  sfdpOptions: {
+    overlap: false,
+    maxiter: 10,
+    dim: 2,
+  },
+};
+
 function makeGraphWrapper(options?: TLayoutOptions | null) {
-  const { nodesep, rankdir, ranksep, sep, shape, splines } = { ...DEFAULT_GRAPH_ATTRS, ...options };
+  const { nodesep, rankdir, ranksep, sep, shape, splines, sfdpOptions, engine } = {
+    ...DEFAULT_GRAPH_ATTRS,
+    ...DEFAULT_SFDP_GRAPH_ATTRS,
+    ...options,
+  };
+  const sfdpAttrs =
+    sfdpOptions && engine === 'sfdp'
+      ? `layout=sfdp, ${Object.entries(sfdpOptions)
+          .map(([key, value]) => `${key}=${value}`)
+          .join(', ')}`
+      : '';
   return `digraph G {
-  graph[nodesep=${nodesep.toFixed(3)}, rankdir=${rankdir}, ranksep=${ranksep.toFixed(3)}, sep=${sep.toFixed(
-    3
-  )}, splines=${splines}];
+  graph[${
+    engine === 'sfdp'
+      ? sfdpAttrs
+      : `nodesep=${nodesep.toFixed(3)}, rankdir=${rankdir}, ranksep=${ranksep.toFixed(3)}`
+  }, sep=${sep.toFixed(3)}, splines=${splines}];
   node [shape=${shape}, fixedsize=true, label="", color="_", fillcolor="_"];
   edge [arrowhead=none, arrowtail=none];`;
 }

--- a/packages/plexus/src/LayoutManager/getLayout.tsx
+++ b/packages/plexus/src/LayoutManager/getLayout.tsx
@@ -105,8 +105,11 @@ export default async function getLayout(
   layoutOptions: TLayoutOptions | null
 ) {
   const dot = toDot(inEdges, inVertices, layoutOptions);
-  const { totalMemory = undefined } = layoutOptions || {};
-  const options = { totalMemory, engine: phase === EWorkerPhase.Edges ? 'neato' : 'dot', format: 'plain' };
+  const { totalMemory = undefined, engine } = layoutOptions || {};
+  const defaultEngine = phase === EWorkerPhase.Edges ? 'neato' : 'dot';
+  const selectedEngine = engine || defaultEngine;
+
+  const options = { totalMemory, engine: selectedEngine, format: 'plain' };
 
   const viz = await instance();
   const plainOut = viz.renderString(dot, options);

--- a/packages/plexus/src/LayoutManager/types.tsx
+++ b/packages/plexus/src/LayoutManager/types.tsx
@@ -42,6 +42,14 @@ export type TLayoutOptions = {
   splines?: string;
   useDotEdges?: boolean;
   totalMemory?: number;
+  engine?: 'dot' | 'neato' | 'sfdp';
+  sfdpOptions?: {
+    repulsiveforce?: number;
+    overlap?: boolean;
+    maxiter?: number;
+    dim?: 2 | 3;
+  };
+  dpi?: number;
 };
 
 export type TLayoutWorkerMeta = {


### PR DESCRIPTION
## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger-ui/issues/2534

## Description of the changes
- Added scalable forced directed placement (sfdp) Layout Engine in plexus graph lib.
- Have added new options specific to sfdp engine so we can maintain backward compatibility with other part of the code.
- converted DAG.tsx from class component to functional component

## How was this change tested?
- manually

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
