### PR TITLE
Feat: change DAG styling and add Search functionality

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.css
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.css
@@ -103,6 +103,29 @@
   color: #000;
 }
 
+.search-input-container {
+  min-width: 200px;
+}
+
+.search-input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.search-input {
+  flex: 1;
+}
+
+.search-match-count {
+  font-size: 12px;
+  color: #666;
+  white-space: nowrap;
+  padding: 2px 4px;
+  border-radius: 4px;
+  background-color: #fffb8f;
+}
+
 .data-selector {
   margin-left: auto;
   align-self: flex-end;

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.js
@@ -18,6 +18,13 @@ import '@testing-library/jest-dom';
 import DAGOptions from './DAGOptions';
 import * as constants from '../../utils/constants';
 
+// Mock UiFindInput and its store dependencies
+jest.mock('../common/UiFindInput', () => {
+  return function MockUiFindInput({ inputProps }) {
+    return <input data-testid="search-input" className={inputProps?.className} />;
+  };
+});
+
 const mockDependencies = [
   { parent: 'service-1', child: 'service-2', callCount: 1000 },
   { parent: 'service-2', child: 'service-3', callCount: 2000 },
@@ -36,6 +43,8 @@ const defaultProps = {
   selectedSampleDatasetType: null,
   onSampleDatasetTypeChange: jest.fn(),
   sampleDatasetTypes: ['Small Graph', 'Large Graph'],
+  uiFind: 'test',
+  matchCount: 3,
 };
 
 describe('DAGOptions', () => {
@@ -327,5 +336,32 @@ describe('DAGOptions', () => {
     const sampleDatasetTypeValue = within(sampleDatasetTypeSelect).getByRole('combobox');
     expect(sampleDatasetTypeValue).toHaveAttribute('aria-expanded', 'false');
     expect(within(sampleDatasetTypeSelect).getByText('Small Graph')).toBeInTheDocument();
+  });
+
+  it('renders search input with match count when uiFind is provided', () => {
+    render(<DAGOptions {...defaultProps} uiFind="test" matchCount={3} />);
+
+    const searchInput = screen.getByTestId('search-input');
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveClass('search-input');
+    expect(screen.getByText('3 matches')).toBeInTheDocument();
+  });
+
+  it('renders search input without match count when uiFind is not provided', () => {
+    render(<DAGOptions {...defaultProps} uiFind={undefined} matchCount={undefined} />);
+
+    const searchInput = screen.getByTestId('search-input');
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveClass('search-input');
+    expect(screen.queryByText(/match/)).not.toBeInTheDocument();
+  });
+
+  it('renders search input with single match count', () => {
+    render(<DAGOptions {...defaultProps} uiFind="test" matchCount={1} />);
+
+    const searchInput = screen.getByTestId('search-input');
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveClass('search-input');
+    expect(screen.getByText('1 match')).toBeInTheDocument();
   });
 });

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 import { Select, InputNumber, Popover } from 'antd';
 import { IoHelp, IoRefresh } from 'react-icons/io5';
 import SearchableSelect from '../common/SearchableSelect';
+import UiFindInput from '../common/UiFindInput';
 import './DAGOptions.css';
 import { getAppEnvironment } from '../../utils/constants';
 
@@ -40,6 +41,8 @@ interface IDAGOptionsProps {
   selectedSampleDatasetType: string;
   onSampleDatasetTypeChange: (type: string) => void;
   sampleDatasetTypes: string[];
+  uiFind?: string;
+  matchCount?: number;
 }
 
 const LAYOUT_OPTIONS = [
@@ -60,6 +63,8 @@ const DAGOptions: React.FC<IDAGOptionsProps> = ({
   selectedSampleDatasetType,
   onSampleDatasetTypeChange,
   sampleDatasetTypes,
+  uiFind,
+  matchCount,
 }) => {
   const services = React.useMemo(() => {
     const uniqueServices = new Set<string>();
@@ -180,6 +185,35 @@ const DAGOptions: React.FC<IDAGOptionsProps> = ({
             style={{ marginLeft: '8px', cursor: 'pointer' }}
             data-testid="reset-button"
           />
+        </div>
+      </div>
+      <div className="selector-container">
+        <div className="selector-label-container">
+          <span className="selector-label">Search</span>
+          <Popover
+            placement="topLeft"
+            trigger="click"
+            content={
+              <div>
+                <ul className="hint-info">
+                  <li>Search for nodes in the graph</li>
+                  <li>Matching nodes will be highlighted</li>
+                </ul>
+              </div>
+            }
+          >
+            <IoHelp className="hint-trigger" data-testid="search-help-icon" />
+          </Popover>
+        </div>
+        <div className="search-input-container">
+          <div className="search-input-wrapper">
+            <UiFindInput allowClear inputProps={{ className: 'search-input' }} />
+            {uiFind && (
+              <div className="search-match-count">
+                {matchCount} match{matchCount !== 1 ? 'es' : ''}
+              </div>
+            )}
+          </div>
         </div>
       </div>
       {getAppEnvironment() === 'development' && (

--- a/packages/jaeger-ui/src/components/DependencyGraph/dag.css
+++ b/packages/jaeger-ui/src/components/DependencyGraph/dag.css
@@ -23,7 +23,14 @@
 
 .DAG--dag {
   background: #fafafa;
-  stroke-width: 0.85;
+  stroke-width: 0.7;
+  stroke: #444;
+}
+
+.DAG--dag marker {
+  stroke-width: 0.7;
+  stroke: #444;
+  fill: #444;
 }
 
 .DAG--node {
@@ -34,11 +41,27 @@
 }
 
 .DAG--nodeCircle {
-  background-color: #10939b;
+  background-color: #dddddd;
   border-radius: 50%;
   height: 3rem;
   width: 3rem;
   margin-bottom: 1.75rem;
+  border: 1px solid #bbb;
+  box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.15);
+}
+
+.DAG--nodeCircle.is-focalNode {
+  border: 2px solid #eb2f96;
+  background-image: repeating-linear-gradient(30deg, transparent, #eb2f96 3px, transparent 5px);
+}
+
+.DAG--nodeCircle.is-match {
+  background-image: repeating-linear-gradient(-60deg, #fffb8f, #fff566 3px, #fffb8f 5px);
+  border: 1px dashed rgba(173, 139, 0, 0.5);
+}
+
+.DAG--nodeCircle.is-match.is-focalNode {
+  background-image: repeating-linear-gradient(30deg, #fffb8f, #eb2f96 3px, #fffb8f 5px);
 }
 
 .DAG--nodeLabel {

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
@@ -27,6 +27,7 @@ import * as jaegerApiActions from '../../actions/jaeger-api';
 import { FALLBACK_DAG_MAX_NUM_SERVICES } from '../../constants';
 import { nodesPropTypes, linksPropTypes } from '../../propTypes/dependencies';
 import { getConfigValue } from '../../utils/config/get-config';
+import { extractUiFindFromState } from '../common/UiFindInput';
 
 import './index.css';
 import withRouteProps from '../../utils/withRouteProps';
@@ -71,12 +72,14 @@ export class DependencyGraphPageImpl extends Component {
     loading: PropTypes.bool.isRequired,
     // eslint-disable-next-line react/forbid-prop-types
     error: PropTypes.object,
+    uiFind: PropTypes.string,
   };
 
   static defaultProps = {
     nodes: null,
     links: null,
     error: null,
+    uiFind: undefined,
   };
 
   debouncedDepthChange = debounce(value => {
@@ -91,6 +94,7 @@ export class DependencyGraphPageImpl extends Component {
       selectedDepth: 5,
       debouncedDepth: 5,
       selectedSampleDatasetType: 'Backend',
+      matchCount: 0,
     };
   }
 
@@ -148,10 +152,20 @@ export class DependencyGraphPageImpl extends Component {
     });
   };
 
+  handleMatchCountChange = count => {
+    this.setState({ matchCount: count });
+  };
+
   render() {
-    const { nodes, links, error, loading, dependencies } = this.props;
-    const { selectedService, selectedLayout, selectedDepth, debouncedDepth, selectedSampleDatasetType } =
-      this.state;
+    const { nodes, links, error, loading, dependencies, uiFind } = this.props;
+    const {
+      selectedService,
+      selectedLayout,
+      selectedDepth,
+      debouncedDepth,
+      selectedSampleDatasetType,
+      matchCount,
+    } = this.state;
 
     if (loading) {
       return <LoadingIndicator className="u-mt-vast" centered />;
@@ -194,6 +208,8 @@ export class DependencyGraphPageImpl extends Component {
             selectedSampleDatasetType={selectedSampleDatasetType}
             onSampleDatasetTypeChange={this.handleSampleDatasetTypeChange}
             sampleDatasetTypes={sampleDatasetTypes}
+            uiFind={uiFind}
+            matchCount={matchCount}
           />
         </div>
         <div className="DependencyGraph--graphWrapper">
@@ -202,6 +218,8 @@ export class DependencyGraphPageImpl extends Component {
             selectedLayout={selectedLayout}
             selectedDepth={debouncedDepth}
             selectedService={selectedService}
+            uiFind={uiFind}
+            onMatchCountChange={this.handleMatchCountChange}
           />
         </div>
       </div>
@@ -269,6 +287,7 @@ export function mapStateToProps(state) {
     nodes,
     links,
     dependencies: dataset,
+    ...extractUiFindFromState(state),
   };
 }
 

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
@@ -18,6 +18,8 @@ import * as constants from '../../utils/constants';
 
 import { DependencyGraphPageImpl as DependencyGraph, mapDispatchToProps, mapStateToProps } from './index';
 import LoadingIndicator from '../common/LoadingIndicator';
+import DAGOptions from './DAGOptions';
+import DAG from './DAG';
 
 const childId = 'boomya';
 const parentId = 'elder-one';
@@ -34,6 +36,11 @@ const state = {
     dependencies,
     error: null,
     loading: false,
+  },
+  router: {
+    location: {
+      search: '',
+    },
   },
 };
 
@@ -80,6 +87,7 @@ describe('<DependencyGraph>', () => {
       expect(wrapper.state('selectedLayout')).toBe('dot');
       expect(wrapper.state('selectedDepth')).toBe(5);
       expect(wrapper.state('debouncedDepth')).toBe(5);
+      expect(wrapper.state('matchCount')).toBe(0);
     });
 
     it('handles service selection', () => {
@@ -228,6 +236,23 @@ describe('<DependencyGraph>', () => {
       expect(wrapper.state('selectedSampleDatasetType')).toBe(null);
 
       await wrapper.instance().handleSampleDatasetTypeChange(null);
+    });
+
+    it('handles match count change', () => {
+      const matchCount = 3;
+      wrapper.instance().handleMatchCountChange(matchCount);
+      expect(wrapper.state('matchCount')).toBe(matchCount);
+    });
+
+    it('passes match count to DAGOptions', () => {
+      wrapper.setState({ matchCount: 5 });
+      const dagOptions = wrapper.find(DAGOptions);
+      expect(dagOptions.prop('matchCount')).toBe(5);
+    });
+
+    it('passes onMatchCountChange to DAG', () => {
+      const dag = wrapper.find(DAG);
+      expect(dag.prop('onMatchCountChange')).toBeDefined();
     });
   });
 });

--- a/packages/jaeger-ui/src/components/DependencyGraph/out.txt
+++ b/packages/jaeger-ui/src/components/DependencyGraph/out.txt
@@ -1,0 +1,291 @@
+
+> jaeger-ui-monorepo@0.0.1 test
+> npm run --workspaces test -- DAG.test
+
+
+> @jaegertracing/plexus@0.2.0 test
+> echo 'NO TESTS YET' DAG.test
+
+NO TESTS YET DAG.test
+
+> jaeger-ui@1.67.0 test
+> jest --maxWorkers=50% DAG.test
+
+  console.error
+    Error: Uncaught [Error: Inline worker is not supported]
+        at reportException (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+        at innerInvokeEventListeners (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+        at invokeEventListeners (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+        at HTMLUnknownElementImpl._dispatch (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+        at HTMLUnknownElementImpl.dispatchEvent (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+        at HTMLUnknownElement.dispatchEvent (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+        at Object.dispatchEvent (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:4213:16)
+        at apply (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:4277:31)
+        at invokeGuardedCallback (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:22877:5)
+        at reportUncaughtErrorInDEV (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:27165:5)
+        at captureCommitPhaseError (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24729:9)
+        at commitLayoutMountEffects_complete (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+        at commitLayoutEffects_begin (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+        at commitLayoutEffects (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+        at commitRootImpl (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+        at commitRoot (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+        at finishConcurrentRender (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+        at callback (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2667:24)
+        at flushActQueue (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2582:11)
+        at actImplementation (/home/hariomgupta/jaeger/jaeger-ui/node_modules/@testing-library/react/dist/act-compat.js:47:25)
+        at Object.<anonymous> (/home/hariomgupta/jaeger/jaeger-ui/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js:214:8)
+        at Promise.then.completed (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:298:28)
+        at new Promise (<anonymous>)
+        at callAsyncCircusFn (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:231:10)
+        at _callCircusTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:316:40)
+        at _runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:252:3)
+        at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:126:9)
+        at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:121:9)
+        at run (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:71:3)
+        at runAndTransformResultsToJestFormat (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+        at jestAdapter (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:74:19)
+        at runTestInternal (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:281:16)
+        at runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:341:7) {
+      detail: Error: Inline worker is not supported
+          at Error (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/layout.worker.bundled.js:1:422)
+          at new E (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/layout.worker.bundled.js:1:912)
+          at Coordinator._initWorker (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/Coordinator.js:149:20)
+          at Coordinator._initWorker [as _postWork] (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/Coordinator.js:176:51)
+          at Coordinator._postWork (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/Coordinator.js:139:10)
+          at LayoutManager.getLayout (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/LayoutManager.js:85:22)
+          at getLayout (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/index.js:74:25)
+          at MeasurableNodesLayer.setSizeVertices [as measureNodes] (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/MeasurableNodesLayer.js:109:5)
+          at MeasurableNodesLayer.measureNodes [as componentDidMount] (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/MeasurableNodesLayer.js:57:10)
+          at componentDidMount (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:23349:28)
+          at commitLayoutEffectOnFiber (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24727:9)
+          at commitLayoutMountEffects_complete (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+          at commitLayoutEffects_begin (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+          at commitLayoutEffects (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+          at commitRootImpl (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+          at commitRoot (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+          at finishConcurrentRender (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+          at callback (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2667:24)
+          at flushActQueue (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2582:11)
+          at actImplementation (/home/hariomgupta/jaeger/jaeger-ui/node_modules/@testing-library/react/dist/act-compat.js:47:25)
+          at Object.<anonymous> (/home/hariomgupta/jaeger/jaeger-ui/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js:214:8)
+          at Promise.then.completed (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:298:28)
+          at new Promise (<anonymous>)
+          at callAsyncCircusFn (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:231:10)
+          at _callCircusTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:316:40)
+          at _runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:252:3)
+          at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:126:9)
+          at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:121:9)
+          at run (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:71:3)
+          at runAndTransformResultsToJestFormat (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+          at jestAdapter (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:74:19)
+          at runTestInternal (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:281:16)
+          at runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:341:7),
+      type: 'unhandled exception'
+    }
+
+      212 |     ];
+      213 |
+    > 214 |     act(() => {
+          |        ^
+      215 |       render(
+      216 |         <DAG
+      217 |           serviceCalls={serviceCalls}
+
+      at VirtualConsole.<anonymous> (../../node_modules/jest-environment-jsdom/build/index.js:65:23)
+      at Object.dispatchEvent (../../node_modules/react-dom/cjs/react-dom.development.js:4213:16)
+      at apply (../../node_modules/react-dom/cjs/react-dom.development.js:4277:31)
+      at invokeGuardedCallback (../../node_modules/react-dom/cjs/react-dom.development.js:22877:5)
+      at reportUncaughtErrorInDEV (../../node_modules/react-dom/cjs/react-dom.development.js:27165:5)
+      at captureCommitPhaseError (../../node_modules/react-dom/cjs/react-dom.development.js:24729:9)
+      at commitLayoutMountEffects_complete (../../node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+      at commitLayoutEffects_begin (../../node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+      at commitLayoutEffects (../../node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+      at commitRootImpl (../../node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+      at commitRoot (../../node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+      at finishConcurrentRender (../../node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+      at callback (../../node_modules/react/cjs/react.development.js:2667:24)
+      at flushActQueue (../../node_modules/react/cjs/react.development.js:2582:11)
+      at actImplementation (../../node_modules/@testing-library/react/dist/act-compat.js:47:25)
+      at Object.<anonymous> (src/components/DependencyGraph/DAG.test.js:214:8)
+
+  console.error
+    The above error occurred in the <MeasurableNodesLayer> component:
+    
+        at MeasurableNodesLayer (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/MeasurableNodesLayer.js:44:5)
+        at div
+        at div
+        at Digraph (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/index.js:39:5)
+        at div
+        at serviceCalls (/home/hariomgupta/jaeger/jaeger-ui/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx:140:3)
+    
+    Consider adding an error boundary to your tree to customize error handling behavior.
+    Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.
+
+      212 |     ];
+      213 |
+    > 214 |     act(() => {
+          |        ^
+      215 |       render(
+      216 |         <DAG
+      217 |           serviceCalls={serviceCalls}
+
+      at logCapturedError (../../node_modules/react-dom/cjs/react-dom.development.js:18704:23)
+      at logCapturedError (../../node_modules/react-dom/cjs/react-dom.development.js:18737:5)
+      at call (../../node_modules/react-dom/cjs/react-dom.development.js:15036:12)
+      at callCallback (../../node_modules/react-dom/cjs/react-dom.development.js:15057:9)
+      at commitUpdateQueue (../../node_modules/react-dom/cjs/react-dom.development.js:23430:13)
+      at commitLayoutEffectOnFiber (../../node_modules/react-dom/cjs/react-dom.development.js:24727:9)
+      at commitLayoutMountEffects_complete (../../node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+      at commitLayoutEffects_begin (../../node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+      at commitLayoutEffects (../../node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+      at commitRootImpl (../../node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+      at commitRoot (../../node_modules/react-dom/cjs/react-dom.development.js:26156:3)
+      at callback (../../node_modules/react-dom/cjs/react-dom.development.js:12042:22)
+      at flushSyncCallbacks (../../node_modules/react-dom/cjs/react-dom.development.js:26998:3)
+      at commitRootImpl (../../node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+      at commitRoot (../../node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+      at finishConcurrentRender (../../node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+      at callback (../../node_modules/react/cjs/react.development.js:2667:24)
+      at flushActQueue (../../node_modules/react/cjs/react.development.js:2582:11)
+      at actImplementation (../../node_modules/@testing-library/react/dist/act-compat.js:47:25)
+      at Object.<anonymous> (src/components/DependencyGraph/DAG.test.js:214:8)
+
+  console.error
+    Error: Uncaught [Error: Inline worker is not supported]
+        at reportException (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
+        at innerInvokeEventListeners (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
+        at invokeEventListeners (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
+        at HTMLUnknownElementImpl._dispatch (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
+        at HTMLUnknownElementImpl.dispatchEvent (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
+        at HTMLUnknownElement.dispatchEvent (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
+        at Object.dispatchEvent (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:4213:16)
+        at apply (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:4277:31)
+        at invokeGuardedCallback (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:22877:5)
+        at reportUncaughtErrorInDEV (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:27165:5)
+        at captureCommitPhaseError (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24729:9)
+        at commitLayoutMountEffects_complete (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+        at commitLayoutEffects_begin (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+        at commitLayoutEffects (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+        at commitRootImpl (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+        at commitRoot (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+        at finishConcurrentRender (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+        at callback (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2667:24)
+        at flushActQueue (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2582:11)
+        at actImplementation (/home/hariomgupta/jaeger/jaeger-ui/node_modules/@testing-library/react/dist/act-compat.js:47:25)
+        at Object.<anonymous> (/home/hariomgupta/jaeger/jaeger-ui/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js:236:8)
+        at Promise.then.completed (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:298:28)
+        at new Promise (<anonymous>)
+        at callAsyncCircusFn (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:231:10)
+        at _callCircusTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:316:40)
+        at _runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:252:3)
+        at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:126:9)
+        at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:121:9)
+        at run (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:71:3)
+        at runAndTransformResultsToJestFormat (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+        at jestAdapter (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:74:19)
+        at runTestInternal (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:281:16)
+        at runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:341:7) {
+      detail: Error: Inline worker is not supported
+          at Error (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/layout.worker.bundled.js:1:422)
+          at new E (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/layout.worker.bundled.js:1:912)
+          at Coordinator._initWorker (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/Coordinator.js:149:20)
+          at Coordinator._initWorker [as _postWork] (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/Coordinator.js:176:51)
+          at Coordinator._postWork (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/Coordinator.js:139:10)
+          at LayoutManager.getLayout (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/LayoutManager/LayoutManager.js:85:22)
+          at getLayout (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/index.js:74:25)
+          at MeasurableNodesLayer.setSizeVertices [as measureNodes] (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/MeasurableNodesLayer.js:109:5)
+          at MeasurableNodesLayer.measureNodes [as componentDidMount] (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/MeasurableNodesLayer.js:57:10)
+          at componentDidMount (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:23349:28)
+          at commitLayoutEffectOnFiber (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24727:9)
+          at commitLayoutMountEffects_complete (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+          at commitLayoutEffects_begin (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+          at commitLayoutEffects (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+          at commitRootImpl (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+          at commitRoot (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+          at finishConcurrentRender (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+          at callback (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2667:24)
+          at flushActQueue (/home/hariomgupta/jaeger/jaeger-ui/node_modules/react/cjs/react.development.js:2582:11)
+          at actImplementation (/home/hariomgupta/jaeger/jaeger-ui/node_modules/@testing-library/react/dist/act-compat.js:47:25)
+          at Object.<anonymous> (/home/hariomgupta/jaeger/jaeger-ui/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js:236:8)
+          at Promise.then.completed (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:298:28)
+          at new Promise (<anonymous>)
+          at callAsyncCircusFn (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/utils.js:231:10)
+          at _callCircusTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:316:40)
+          at _runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:252:3)
+          at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:126:9)
+          at _runTestsForDescribeBlock (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:121:9)
+          at run (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/run.js:71:3)
+          at runAndTransformResultsToJestFormat (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+          at jestAdapter (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:74:19)
+          at runTestInternal (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:281:16)
+          at runTest (/home/hariomgupta/jaeger/jaeger-ui/node_modules/jest-runner/build/runTest.js:341:7),
+      type: 'unhandled exception'
+    }
+
+      234 |     ];
+      235 |
+    > 236 |     act(() => {
+          |        ^
+      237 |       render(
+      238 |         <DAG
+      239 |           serviceCalls={serviceCalls}
+
+      at VirtualConsole.<anonymous> (../../node_modules/jest-environment-jsdom/build/index.js:65:23)
+      at Object.dispatchEvent (../../node_modules/react-dom/cjs/react-dom.development.js:4213:16)
+      at apply (../../node_modules/react-dom/cjs/react-dom.development.js:4277:31)
+      at invokeGuardedCallback (../../node_modules/react-dom/cjs/react-dom.development.js:22877:5)
+      at reportUncaughtErrorInDEV (../../node_modules/react-dom/cjs/react-dom.development.js:27165:5)
+      at captureCommitPhaseError (../../node_modules/react-dom/cjs/react-dom.development.js:24729:9)
+      at commitLayoutMountEffects_complete (../../node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+      at commitLayoutEffects_begin (../../node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+      at commitLayoutEffects (../../node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+      at commitRootImpl (../../node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+      at commitRoot (../../node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+      at finishConcurrentRender (../../node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+      at callback (../../node_modules/react/cjs/react.development.js:2667:24)
+      at flushActQueue (../../node_modules/react/cjs/react.development.js:2582:11)
+      at actImplementation (../../node_modules/@testing-library/react/dist/act-compat.js:47:25)
+      at Object.<anonymous> (src/components/DependencyGraph/DAG.test.js:236:8)
+
+  console.error
+    The above error occurred in the <MeasurableNodesLayer> component:
+    
+        at MeasurableNodesLayer (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/MeasurableNodesLayer.js:44:5)
+        at div
+        at div
+        at Digraph (/home/hariomgupta/jaeger/jaeger-ui/packages/plexus/lib/Digraph/index.js:39:5)
+        at div
+        at serviceCalls (/home/hariomgupta/jaeger/jaeger-ui/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx:140:3)
+    
+    Consider adding an error boundary to your tree to customize error handling behavior.
+    Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.
+
+      234 |     ];
+      235 |
+    > 236 |     act(() => {
+          |        ^
+      237 |       render(
+      238 |         <DAG
+      239 |           serviceCalls={serviceCalls}
+
+      at logCapturedError (../../node_modules/react-dom/cjs/react-dom.development.js:18704:23)
+      at logCapturedError (../../node_modules/react-dom/cjs/react-dom.development.js:18737:5)
+      at call (../../node_modules/react-dom/cjs/react-dom.development.js:15036:12)
+      at callCallback (../../node_modules/react-dom/cjs/react-dom.development.js:15057:9)
+      at commitUpdateQueue (../../node_modules/react-dom/cjs/react-dom.development.js:23430:13)
+      at commitLayoutEffectOnFiber (../../node_modules/react-dom/cjs/react-dom.development.js:24727:9)
+      at commitLayoutMountEffects_complete (../../node_modules/react-dom/cjs/react-dom.development.js:24713:7)
+      at commitLayoutEffects_begin (../../node_modules/react-dom/cjs/react-dom.development.js:24651:3)
+      at commitLayoutEffects (../../node_modules/react-dom/cjs/react-dom.development.js:26862:5)
+      at commitRootImpl (../../node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+      at commitRoot (../../node_modules/react-dom/cjs/react-dom.development.js:26156:3)
+      at callback (../../node_modules/react-dom/cjs/react-dom.development.js:12042:22)
+      at flushSyncCallbacks (../../node_modules/react-dom/cjs/react-dom.development.js:26998:3)
+      at commitRootImpl (../../node_modules/react-dom/cjs/react-dom.development.js:26721:5)
+      at commitRoot (../../node_modules/react-dom/cjs/react-dom.development.js:26020:9)
+      at finishConcurrentRender (../../node_modules/react-dom/cjs/react-dom.development.js:25848:7)
+      at callback (../../node_modules/react/cjs/react.development.js:2667:24)
+      at flushActQueue (../../node_modules/react/cjs/react.development.js:2582:11)
+      at actImplementation (../../node_modules/@testing-library/react/dist/act-compat.js:47:25)
+      at Object.<anonymous> (src/components/DependencyGraph/DAG.test.js:236:8)
+


### PR DESCRIPTION
## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger-ui/issues/2700, https://github.com/jaegertracing/jaeger-ui/issues/2699

## Description of the changes
- This PR adds a new Search Bar functionality in the DAG view that would allow users to search the node. The matching node would be highlighted in yellowish color just like in DDG
- This also adds node highlight for focal service

## How was this change tested?
- Locally

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
