### PR TITLE
Refactor: move action menu to a re-usable component

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/__snapshots__/index.test.js.snap
@@ -101,99 +101,82 @@ exports[`<DdgNodeContent> omits the operation if it is null 1`] = `
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -234,99 +217,82 @@ exports[`<DdgNodeContent> omits the operation if it is null 2`] = `
       </h4>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -381,99 +347,82 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 1`]
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -528,99 +477,82 @@ exports[`<DdgNodeContent> renders correctly when decorationValue is a string 2`]
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -675,99 +607,82 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 1`]
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -825,99 +740,82 @@ exports[`<DdgNodeContent> renders correctly when given decorationProgressbar 2`]
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -972,99 +870,82 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -1119,26 +1000,82 @@ exports[`<DdgNodeContent> renders correctly when isFocalNode = true and focalNod
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": undefined,
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": false,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": false,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": false,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -1193,99 +1130,82 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;
 
@@ -1358,98 +1278,81 @@ exports[`<DdgNodeContent> renders the number of operations if there are multiple
       </div>
     </div>
   </div>
-  <div
+  <ActionsMenu
     className="DdgNodeContent--actionsWrapper"
-  >
-    <a
-      className="DdgNodeContent--actionsItem"
-      href="some-url"
-      onClick={[Function]}
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <svg
-          className="DdgNode--SetFocusIcon"
-          height="100"
-          viewBox="0 0 100 100"
-          width="100"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g>
-            <path
-              d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
-              fill="currentColor"
-            />
-            <path
-              d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
-              fill="currentColor"
-            />
-            <path
-              d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
-              fill="currentColor"
-            />
-            <path
-              d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Set focus
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <NewWindowIcon />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        View traces
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoLocate />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Focus paths through this node
-      </span>
-    </a>
-    <a
-      className="DdgNodeContent--actionsItem"
-      onClick={[Function]}
-      role="button"
-    >
-      <span
-        className="DdgNodeContent--actionsItemIconWrapper"
-      >
-        <IoEyeOff />
-      </span>
-      <span
-        className="DdgNodeContent--actionsItemText"
-      >
-        Hide node
-      </span>
-    </a>
-  </div>
+    items={
+      Array [
+        Object {
+          "href": "some-url",
+          "icon": <svg
+            className="DdgNode--SetFocusIcon"
+            height="100"
+            viewBox="0 0 100 100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M50.0001 -1L61.0557 22.1383H38.9444L50.0001 -1Z"
+                fill="currentColor"
+              />
+              <path
+                d="M49.9999 99L38.9443 75.8617L61.0556 75.8617L49.9999 99Z"
+                fill="currentColor"
+              />
+              <path
+                d="M100 49L76.8617 60.0556L76.8617 37.9444L100 49Z"
+                fill="currentColor"
+              />
+              <path
+                d="M1.57361e-06 49L23.1383 37.9444L23.1383 60.0556L1.57361e-06 49Z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>,
+          "id": "set-focus",
+          "isVisible": true,
+          "label": "Set focus",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <NewWindowIcon />,
+          "id": "view-traces",
+          "label": "View traces",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoLocate />,
+          "id": "focus-paths",
+          "isVisible": true,
+          "label": "Focus paths through this node",
+          "onClick": [Function],
+        },
+        Object {
+          "icon": <IoEyeOff />,
+          "id": "hide-node",
+          "isVisible": true,
+          "label": "Hide node",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-parents",
+          "isVisible": false,
+          "label": "View Parents",
+          "onClick": [Function],
+        },
+        Object {
+          "checkboxProps": undefined,
+          "icon": null,
+          "id": "view-children",
+          "isVisible": false,
+          "label": "View Children",
+          "onClick": [Function],
+        },
+      ]
+    }
+  />
 </div>
 `;

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.css
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.css
@@ -90,36 +90,3 @@ limitations under the License.
   pointer-events: all;
   transition-delay: 0s;
 }
-
-.DdgNodeContent--actionsItem {
-  align-items: center;
-  display: flex;
-  padding: 0.5em;
-}
-
-.DdgNodeContent--actionsItem:not(:hover) {
-  color: inherit;
-}
-
-.DdgNodeContent--actionsItemIconWrapper {
-  flex: none;
-  height: 16px;
-  width: 16px;
-}
-
-.DdgNodeContent--actionsItemIconWrapper > * {
-  height: 16px;
-  position: absolute;
-  width: 16px;
-}
-
-.DdgNodeContent--actionsItemIconWrapper > * > .ant-checkbox {
-  vertical-align: unset;
-  top: unset;
-}
-
-.DdgNodeContent--actionsItemText {
-  font-size: 0.9em;
-  line-height: normal;
-  margin-left: 0.5em;
-}

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.js
@@ -252,301 +252,6 @@ describe('<DdgNodeContent>', () => {
     });
   });
 
-  describe('node interactions', () => {
-    describe('focusPaths', () => {
-      beforeEach(() => {
-        props.focusPathsThroughVertex.mockReset();
-      });
-
-      it('calls this.props.focusPathsThroughVertex with this.props.vertexKey', () => {
-        wrapper.find('.DdgNodeContent--actionsItem').at(2).simulate('click');
-
-        expect(props.focusPathsThroughVertex).toHaveBeenCalledWith(props.vertexKey);
-        expect(props.focusPathsThroughVertex).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('hideVertex', () => {
-      beforeEach(() => {
-        props.hideVertex.mockReset();
-      });
-
-      it('calls this.props.hideVertex with this.props.vertexKey', () => {
-        wrapper.find('.DdgNodeContent--actionsItem').at(3).simulate('click');
-
-        expect(props.hideVertex).toHaveBeenCalledWith(props.vertexKey);
-        expect(props.hideVertex).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('setFocus', () => {
-      let trackSetFocusSpy;
-
-      beforeAll(() => {
-        trackSetFocusSpy = jest.spyOn(track, 'trackSetFocus');
-      });
-
-      it('tracks when setFocus link is clicked', () => {
-        expect(trackSetFocusSpy).toHaveBeenCalledTimes(0);
-        wrapper.find(`[href="${props.focalNodeUrl}"]`).simulate('click');
-        expect(trackSetFocusSpy).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('setOperation', () => {
-      let trackSetOpSpy;
-
-      beforeAll(() => {
-        trackSetOpSpy = jest.spyOn(track, 'trackVertexSetOperation');
-      });
-
-      it('tracks when popover sets a value', () => {
-        wrapper.setProps({ operation: operationArray });
-        expect(trackSetOpSpy).not.toHaveBeenCalled();
-
-        const list = shallow(<div>{wrapper.find(Popover).prop('content')}</div>).find(FilteredList);
-        expect(list.prop('options')).toBe(operationArray);
-        expect(trackSetOpSpy).not.toHaveBeenCalled();
-
-        list.prop('setValue')(operationArray[operationArray.length - 1]);
-        expect(props.setOperation).toHaveBeenCalledWith(operationArray[operationArray.length - 1]);
-        expect(trackSetOpSpy).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('updateChildren', () => {
-      it('renders children visibility status indicator iff state.childrenVisibility is provided', () => {
-        const initialItemCount = wrapper.find('.DdgNodeContent--actionsItem').length;
-
-        wrapper.setState({ childrenVisibility: ECheckedStatus.Empty });
-        expect(wrapper.find('.DdgNodeContent--actionsItem').length).toBe(initialItemCount + 1);
-        expect(wrapper.find(Checkbox).props()).toEqual(
-          expect.objectContaining({
-            checked: false,
-            indeterminate: false,
-          })
-        );
-
-        wrapper.setState({ childrenVisibility: ECheckedStatus.Partial });
-        expect(wrapper.find('.DdgNodeContent--actionsItem').length).toBe(initialItemCount + 1);
-        expect(wrapper.find(Checkbox).props()).toEqual(
-          expect.objectContaining({
-            checked: false,
-            indeterminate: true,
-          })
-        );
-
-        wrapper.setState({ childrenVisibility: ECheckedStatus.Full });
-        expect(wrapper.find('.DdgNodeContent--actionsItem').length).toBe(initialItemCount + 1);
-        expect(wrapper.find(Checkbox).props()).toEqual(
-          expect.objectContaining({
-            checked: true,
-            indeterminate: false,
-          })
-        );
-      });
-
-      it('calls this.props.updateGenerationVisibility with this.props.vertexKey', () => {
-        wrapper.setState({ childrenVisibility: ECheckedStatus.Empty });
-        wrapper.find('.DdgNodeContent--actionsItem').last().simulate('click');
-
-        expect(props.updateGenerationVisibility).toHaveBeenCalledWith(props.vertexKey, EDirection.Downstream);
-        expect(props.updateGenerationVisibility).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('updateParents', () => {
-      it('renders parent visibility status indicator iff state.parentVisibility is provided', () => {
-        const initialItemCount = wrapper.find('.DdgNodeContent--actionsItem').length;
-
-        wrapper.setState({ parentVisibility: ECheckedStatus.Empty });
-        expect(wrapper.find('.DdgNodeContent--actionsItem').length).toBe(initialItemCount + 1);
-        expect(wrapper.find(Checkbox).props()).toEqual(
-          expect.objectContaining({
-            checked: false,
-            indeterminate: false,
-          })
-        );
-
-        wrapper.setState({ parentVisibility: ECheckedStatus.Partial });
-        expect(wrapper.find('.DdgNodeContent--actionsItem').length).toBe(initialItemCount + 1);
-        expect(wrapper.find(Checkbox).props()).toEqual(
-          expect.objectContaining({
-            checked: false,
-            indeterminate: true,
-          })
-        );
-
-        wrapper.setState({ parentVisibility: ECheckedStatus.Full });
-        expect(wrapper.find('.DdgNodeContent--actionsItem').length).toBe(initialItemCount + 1);
-        expect(wrapper.find(Checkbox).props()).toEqual(
-          expect.objectContaining({
-            checked: true,
-            indeterminate: false,
-          })
-        );
-      });
-
-      it('calls this.props.updateGenerationVisibility with this.props.vertexKey', () => {
-        wrapper.setState({ parentVisibility: ECheckedStatus.Empty });
-        wrapper.find('.DdgNodeContent--actionsItem').last().simulate('click');
-
-        expect(props.updateGenerationVisibility).toHaveBeenCalledWith(props.vertexKey, EDirection.Upstream);
-        expect(props.updateGenerationVisibility).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('viewTraces', () => {
-      const click = () => wrapper.find('.DdgNodeContent--actionsItem').at(1).simulate('click');
-      const pad = num => `000${num}`.slice(-4);
-      const mockReturn = ids =>
-        props.getVisiblePathElems.mockReturnValue(ids.map(traceIDs => ({ memberOf: { traceIDs } })));
-      const calcIdxWithinLimit = arr => Math.floor(0.75 * arr.length);
-      const falsifyDuplicateAndMock = ids => {
-        const withFalsyAndDuplicate = ids.map(arr => arr.slice());
-        withFalsyAndDuplicate[0].splice(
-          calcIdxWithinLimit(withFalsyAndDuplicate[0]),
-          0,
-          withFalsyAndDuplicate[1][calcIdxWithinLimit(withFalsyAndDuplicate[1])],
-          ''
-        );
-        withFalsyAndDuplicate[1].splice(
-          calcIdxWithinLimit(withFalsyAndDuplicate[1]),
-          0,
-          withFalsyAndDuplicate[0][calcIdxWithinLimit(withFalsyAndDuplicate[0])],
-          ''
-        );
-        mockReturn(withFalsyAndDuplicate);
-      };
-      const makeIDsAndMock = (idCounts, makeID = count => `test traceID${count}`) => {
-        let idCount = 0;
-        const ids = idCounts.map(count => {
-          const rv = [];
-          for (let i = 0; i < count; i++) {
-            rv.push(makeID(pad(idCount++)));
-          }
-          return rv;
-        });
-        mockReturn(ids);
-        return ids;
-      };
-      let getSearchUrlSpy;
-      let trackViewTracesSpy;
-      const verifyLastIDs = expectedIDs => {
-        const getSearchUrlCallCount = getSearchUrlSpy.mock.calls.length;
-        const actualIDs = getSearchUrlSpy.mock.calls[getSearchUrlCallCount - 1][0].traceID;
-
-        expect(actualIDs.sort()).toEqual(expectedIDs.sort());
-        expect(trackViewTracesSpy).toHaveBeenCalledTimes(getSearchUrlCallCount);
-      };
-      let originalOpen;
-
-      beforeAll(() => {
-        originalOpen = window.open;
-        window.open = jest.fn();
-        getSearchUrlSpy = jest.spyOn(getSearchUrl, 'getUrl');
-        trackViewTracesSpy = jest.spyOn(track, 'trackViewTraces');
-      });
-
-      beforeEach(() => {
-        getSearchUrlSpy.mockClear();
-        window.open.mockReset();
-        trackViewTracesSpy.mockReset();
-      });
-
-      afterAll(() => {
-        window.open = originalOpen;
-      });
-
-      it('no-ops if there are no elems for key', () => {
-        props.getVisiblePathElems.mockReturnValue();
-        click();
-        expect(window.open).not.toHaveBeenCalled();
-      });
-
-      it('opens new tab viewing single traceID from single elem', () => {
-        const ids = makeIDsAndMock([1]);
-        click();
-
-        verifyLastIDs([].concat(...ids));
-        expect(props.getVisiblePathElems).toHaveBeenCalledTimes(1);
-        expect(props.getVisiblePathElems).toHaveBeenCalledWith(vertexKey);
-      });
-
-      it('opens new tab viewing multiple traceIDs from single elem', () => {
-        const ids = makeIDsAndMock([3]);
-        click();
-
-        verifyLastIDs([].concat(...ids));
-      });
-
-      it('opens new tab viewing multiple traceIDs from multiple elems', () => {
-        const ids = makeIDsAndMock([3, 2]);
-        click();
-
-        verifyLastIDs([].concat(...ids));
-      });
-
-      it('ignores falsy and duplicate IDs', () => {
-        const ids = makeIDsAndMock([3, 3]);
-        falsifyDuplicateAndMock(ids);
-        click();
-
-        verifyLastIDs([].concat(...ids));
-      });
-
-      describe('MAX_LINKED_TRACES', () => {
-        const ids = makeIDsAndMock([MAX_LINKED_TRACES, MAX_LINKED_TRACES, 1]);
-        const expected = [
-          ...ids[0].slice(MAX_LINKED_TRACES / 2 + 1),
-          ...ids[1].slice(MAX_LINKED_TRACES / 2 + 1),
-          ids[2][0],
-        ].sort();
-
-        it('limits link to only include MAX_LINKED_TRACES, taking equal from each pathElem', () => {
-          mockReturn(ids);
-          click();
-
-          verifyLastIDs(expected);
-        });
-
-        it('does not count falsy and duplicate IDs towards MAX_LINKED_TRACES', () => {
-          falsifyDuplicateAndMock(ids);
-          click();
-
-          verifyLastIDs(expected);
-        });
-      });
-
-      describe('MAX_LENGTH', () => {
-        const effectiveMaxLength = MAX_LENGTH - MIN_LENGTH;
-        const TARGET_ID_COUNT = 31;
-        const paddingLength = Math.floor(effectiveMaxLength / TARGET_ID_COUNT) - PARAM_NAME_LENGTH;
-        const idPadding = 'x'.repeat(paddingLength - pad(0).length);
-        const ids = makeIDsAndMock([TARGET_ID_COUNT, TARGET_ID_COUNT, 1], num => `${idPadding}${num}`);
-        const expected = [
-          ...ids[0].slice(TARGET_ID_COUNT / 2 + 1),
-          ...ids[1].slice(TARGET_ID_COUNT / 2 + 1),
-          ids[2][0],
-        ].sort();
-
-        it('limits link to only include MAX_LENGTH, taking equal from each pathElem', () => {
-          mockReturn(ids);
-          click();
-
-          verifyLastIDs(expected);
-        });
-
-        it('does not count falsy and duplicate IDs towards MAX_LEN', () => {
-          falsifyDuplicateAndMock(ids);
-          click();
-
-          verifyLastIDs(expected);
-        });
-      });
-    });
-  });
-
   describe('getNodeRenderer()', () => {
     const ddgVertex = {
       isFocalNode: false,
@@ -581,6 +286,152 @@ describe('<DdgNodeContent>', () => {
     it('creates the actions correctly', () => {
       expect(mapDispatchToProps(() => {})).toEqual({
         getDecoration: expect.any(Function),
+      });
+    });
+  });
+
+  describe('event handlers', () => {
+    beforeEach(() => {
+      jest.spyOn(track, 'trackSetFocus');
+      jest.spyOn(track, 'trackViewTraces');
+      jest.spyOn(track, 'trackVertexSetOperation');
+      jest.spyOn(getSearchUrl, 'getUrl');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe('focusPaths', () => {
+      it('calls focusPathsThroughVertex with vertexKey', () => {
+        wrapper.instance().focusPaths();
+        expect(props.focusPathsThroughVertex).toHaveBeenCalledWith(vertexKey);
+      });
+    });
+
+    describe('hideVertex', () => {
+      it('calls hideVertex with vertexKey', () => {
+        wrapper.instance().hideVertex();
+        expect(props.hideVertex).toHaveBeenCalledWith(vertexKey);
+      });
+    });
+
+    describe('setOperation', () => {
+      it('calls setOperation with the provided operation and tracks the event', () => {
+        const newOperation = 'new-operation';
+        wrapper.instance().setOperation(newOperation);
+        expect(props.setOperation).toHaveBeenCalledWith(newOperation);
+        expect(track.trackVertexSetOperation).toHaveBeenCalled();
+      });
+    });
+
+    describe('updateChildren', () => {
+      it('calls updateGenerationVisibility with vertexKey and Downstream direction', () => {
+        wrapper.instance().updateChildren();
+        expect(props.updateGenerationVisibility).toHaveBeenCalledWith(vertexKey, EDirection.Downstream);
+      });
+    });
+
+    describe('updateParents', () => {
+      it('calls updateGenerationVisibility with vertexKey and Upstream direction', () => {
+        wrapper.instance().updateParents();
+        expect(props.updateGenerationVisibility).toHaveBeenCalledWith(vertexKey, EDirection.Upstream);
+      });
+    });
+
+    describe('viewTraces', () => {
+      const mockTraceIds = ['trace1', 'trace2', 'trace3'];
+      const mockPathElems = [
+        { memberOf: { traceIDs: ['trace1'] } },
+        { memberOf: { traceIDs: ['trace2'] } },
+        { memberOf: { traceIDs: ['trace3'] } },
+      ];
+
+      beforeEach(() => {
+        props.getVisiblePathElems.mockReturnValue(mockPathElems);
+        getSearchUrl.getUrl.mockImplementation(params => `mock-search-url-${params.traceID.join('-')}`);
+      });
+
+      it('opens search URL with trace IDs and tracks the event', () => {
+        const windowSpy = jest.spyOn(window, 'open').mockImplementation();
+        wrapper.instance().viewTraces();
+
+        expect(track.trackViewTraces).toHaveBeenCalled();
+        expect(getSearchUrl.getUrl).toHaveBeenCalledWith({ traceID: mockTraceIds });
+        expect(windowSpy).toHaveBeenCalledWith('mock-search-url-trace1-trace2-trace3', '_blank');
+        windowSpy.mockRestore();
+      });
+
+      it('handles case when getVisiblePathElems returns undefined', () => {
+        props.getVisiblePathElems.mockReturnValue(undefined);
+        const windowSpy = jest.spyOn(window, 'open').mockImplementation();
+        wrapper.instance().viewTraces();
+
+        expect(track.trackViewTraces).toHaveBeenCalled();
+        expect(getSearchUrl.getUrl).not.toHaveBeenCalled();
+        expect(windowSpy).not.toHaveBeenCalled();
+        windowSpy.mockRestore();
+      });
+
+      it('respects MAX_LINKED_TRACES limit', () => {
+        const mockElems = [];
+        for (let i = 0; i < MAX_LINKED_TRACES + 5; i++) {
+          mockElems.push({
+            memberOf: {
+              traceIDs: [`trace-${i}`],
+            },
+          });
+        }
+        props.getVisiblePathElems.mockReturnValue(mockElems);
+
+        const windowSpy = jest.spyOn(window, 'open').mockImplementation();
+        wrapper.instance().viewTraces();
+
+        const expectedTraceIds = mockElems.slice(0, MAX_LINKED_TRACES).map(elem => elem.memberOf.traceIDs[0]);
+        expect(getSearchUrl.getUrl).toHaveBeenCalledWith({
+          traceID: expectedTraceIds,
+        });
+        expect(windowSpy).toHaveBeenCalledWith(`mock-search-url-${expectedTraceIds.join('-')}`, '_blank');
+        windowSpy.mockRestore();
+      });
+
+      it('respects MAX_LENGTH limit', () => {
+        const longTraceId = 'a'.repeat(MAX_LENGTH - MIN_LENGTH - PARAM_NAME_LENGTH);
+        const shortTraceId = 'b'.repeat(10);
+
+        const mockElems = [
+          { memberOf: { traceIDs: [longTraceId] } },
+          { memberOf: { traceIDs: [shortTraceId] } },
+        ];
+        props.getVisiblePathElems.mockReturnValue(mockElems);
+
+        const windowSpy = jest.spyOn(window, 'open').mockImplementation();
+        wrapper.instance().viewTraces();
+
+        expect(getSearchUrl.getUrl).toHaveBeenCalledWith({
+          traceID: [longTraceId],
+        });
+        expect(windowSpy).toHaveBeenCalledWith(`mock-search-url-${longTraceId}`, '_blank');
+        windowSpy.mockRestore();
+      });
+
+      it('handles duplicate trace IDs', () => {
+        const traceId = 'duplicate-trace';
+        const mockElems = [
+          { memberOf: { traceIDs: [traceId] } },
+          { memberOf: { traceIDs: [traceId] } },
+          { memberOf: { traceIDs: [null, traceId] } },
+        ];
+        props.getVisiblePathElems.mockReturnValue(mockElems);
+
+        const windowSpy = jest.spyOn(window, 'open').mockImplementation();
+        wrapper.instance().viewTraces();
+
+        expect(getSearchUrl.getUrl).toHaveBeenCalledWith({
+          traceID: [traceId],
+        });
+        expect(windowSpy).toHaveBeenCalledWith(`mock-search-url-${traceId}`, '_blank');
+        windowSpy.mockRestore();
       });
     });
   });

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.js
@@ -22,7 +22,6 @@ jest.mock('./calc-positioning', () => () => ({
 /* eslint-disable import/first */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Checkbox, Popover } from 'antd';
 
 import {
   getNodeRenderer,

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Checkbox, Popover } from 'antd';
+import { Popover } from 'antd';
 import cx from 'classnames';
 import { TLayoutVertex } from '@jaegertracing/plexus/lib/types';
 import { IoLocate, IoEyeOff } from 'react-icons/io5';
@@ -51,6 +51,7 @@ import extractDecorationFromState, {
   TDecorationFromState,
 } from '../../../../model/path-agnostic-decorations';
 import { ReduxState } from '../../../../types/index';
+import ActionsMenu, { IActionMenuItem } from '../../../common/ActionMenu/ActionsMenu';
 
 import './index.css';
 
@@ -268,6 +269,63 @@ export class UnconnectedDdgNodeContent extends React.PureComponent<TProps, TStat
     const scaleFactor = trueRadius / radius;
     const transform = `translate(${RADIUS - radius}px, ${RADIUS - radius}px) scale(${scaleFactor})`;
 
+    const menuItems: IActionMenuItem[] = [
+      {
+        id: 'set-focus',
+        label: 'Set focus',
+        icon: setFocusIcon,
+        href: focalNodeUrl || undefined,
+        onClick: trackSetFocus,
+        isVisible: Boolean(focalNodeUrl),
+      },
+      {
+        id: 'view-traces',
+        label: 'View traces',
+        icon: <NewWindowIcon />,
+        onClick: this.viewTraces,
+      },
+      {
+        id: 'focus-paths',
+        label: 'Focus paths through this node',
+        icon: <IoLocate />,
+        onClick: this.focusPaths,
+        isVisible: !isFocalNode,
+      },
+      {
+        id: 'hide-node',
+        label: 'Hide node',
+        icon: <IoEyeOff />,
+        onClick: this.hideVertex,
+        isVisible: !isFocalNode,
+      },
+      {
+        id: 'view-parents',
+        label: 'View Parents',
+        icon: null,
+        onClick: this.updateParents,
+        isVisible: Boolean(parentVisibility),
+        checkboxProps: parentVisibility
+          ? {
+              checked: parentVisibility === ECheckedStatus.Full,
+              indeterminate: parentVisibility === ECheckedStatus.Partial,
+            }
+          : undefined,
+      },
+      {
+        id: 'view-children',
+        label: 'View Children',
+        icon: null,
+        onClick: this.updateChildren,
+        isVisible: Boolean(childrenVisibility),
+        checkboxProps: childrenVisibility
+          ? {
+              checked: childrenVisibility === ECheckedStatus.Full,
+              indeterminate: childrenVisibility === ECheckedStatus.Partial,
+            }
+          : undefined,
+      },
+    ];
+
     return (
       <div className="DdgNodeContent" onMouseOver={this.onMouseUx} onMouseOut={this.onMouseUx}>
         {decorationProgressbar}
@@ -309,58 +367,7 @@ export class UnconnectedDdgNodeContent extends React.PureComponent<TProps, TStat
             )}
           </div>
         </div>
-        <div className="DdgNodeContent--actionsWrapper">
-          {focalNodeUrl && (
-            <a href={focalNodeUrl} className="DdgNodeContent--actionsItem" onClick={trackSetFocus}>
-              <span className="DdgNodeContent--actionsItemIconWrapper">{setFocusIcon}</span>
-              <span className="DdgNodeContent--actionsItemText">Set focus</span>
-            </a>
-          )}
-          <a className="DdgNodeContent--actionsItem" onClick={this.viewTraces} role="button">
-            <span className="DdgNodeContent--actionsItemIconWrapper">
-              <NewWindowIcon />
-            </span>
-            <span className="DdgNodeContent--actionsItemText">View traces</span>
-          </a>
-          {!isFocalNode && (
-            <a className="DdgNodeContent--actionsItem" onClick={this.focusPaths} role="button">
-              <span className="DdgNodeContent--actionsItemIconWrapper">
-                <IoLocate />
-              </span>
-              <span className="DdgNodeContent--actionsItemText">Focus paths through this node</span>
-            </a>
-          )}
-          {!isFocalNode && (
-            <a className="DdgNodeContent--actionsItem" onClick={this.hideVertex} role="button">
-              <span className="DdgNodeContent--actionsItemIconWrapper">
-                <IoEyeOff />
-              </span>
-              <span className="DdgNodeContent--actionsItemText">Hide node</span>
-            </a>
-          )}
-          {parentVisibility && (
-            <a className="DdgNodeContent--actionsItem" onClick={this.updateParents} role="button">
-              <span className="DdgNodeContent--actionsItemIconWrapper">
-                <Checkbox
-                  checked={parentVisibility === ECheckedStatus.Full}
-                  indeterminate={parentVisibility === ECheckedStatus.Partial}
-                />
-              </span>
-              <span className="DdgNodeContent--actionsItemText">View Parents</span>
-            </a>
-          )}
-          {childrenVisibility && (
-            <a className="DdgNodeContent--actionsItem" onClick={this.updateChildren} role="button">
-              <span className="DdgNodeContent--actionsItemIconWrapper">
-                <Checkbox
-                  checked={childrenVisibility === ECheckedStatus.Full}
-                  indeterminate={childrenVisibility === ECheckedStatus.Partial}
-                />
-              </span>
-              <span className="DdgNodeContent--actionsItemText">View Children</span>
-            </a>
-          )}
-        </div>
+        <ActionsMenu items={menuItems} className="DdgNodeContent--actionsWrapper" />
       </div>
     );
   }

--- a/packages/jaeger-ui/src/components/common/ActionMenu/ActionMenu.test.js
+++ b/packages/jaeger-ui/src/components/common/ActionMenu/ActionMenu.test.js
@@ -1,0 +1,157 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Checkbox } from 'antd';
+import { IoLocate } from 'react-icons/io5';
+import NewWindowIcon from '../NewWindowIcon';
+import ActionsMenu from './ActionsMenu';
+
+describe('<ActionsMenu>', () => {
+  const mockOnClick = jest.fn();
+  const mockHref = 'http://example.com';
+  const mockIcon = <IoLocate />;
+  const mockNewWindowIcon = <NewWindowIcon />;
+
+  const defaultProps = {
+    items: [
+      {
+        id: 'action1',
+        label: 'Action 1',
+        icon: mockIcon,
+        onClick: mockOnClick,
+        isVisible: true,
+      },
+      {
+        id: 'action2',
+        label: 'Action 2',
+        icon: mockNewWindowIcon,
+        href: mockHref,
+        isVisible: true,
+      },
+      {
+        id: 'action3',
+        label: 'Action 3',
+        icon: null,
+        onClick: mockOnClick,
+        isVisible: true,
+        checkboxProps: {
+          checked: true,
+          indeterminate: false,
+        },
+      },
+    ],
+  };
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<ActionsMenu {...defaultProps} />);
+    jest.clearAllMocks();
+  });
+
+  it('renders without exploding', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders all visible menu items', () => {
+    const menuItems = wrapper.find('.NodeContent--actionsItem');
+    expect(menuItems).toHaveLength(3);
+  });
+
+  it('does not render hidden menu items', () => {
+    const itemsWithHidden = [
+      ...defaultProps.items,
+      {
+        id: 'hidden',
+        label: 'Hidden Action',
+        icon: mockIcon,
+        onClick: mockOnClick,
+        isVisible: false,
+      },
+    ];
+    wrapper.setProps({ items: itemsWithHidden });
+    const menuItems = wrapper.find('.NodeContent--actionsItem');
+    expect(menuItems).toHaveLength(3);
+  });
+
+  it('renders menu items with icons', () => {
+    const firstItem = wrapper.find('.NodeContent--actionsItem').first();
+    expect(firstItem.find('.NodeContent--actionsItemIconWrapper').find(IoLocate)).toHaveLength(1);
+  });
+
+  it('renders menu items with links', () => {
+    const secondItem = wrapper.find('.NodeContent--actionsItem').at(1);
+    expect(secondItem.prop('href')).toBe(mockHref);
+  });
+
+  it('renders menu items with checkboxes', () => {
+    const thirdItem = wrapper.find('.NodeContent--actionsItem').last();
+    const checkbox = thirdItem.find('.NodeContent--actionsItemIconWrapper').find(Checkbox);
+    expect(checkbox).toHaveLength(1);
+    expect(checkbox.prop('checked')).toBe(true);
+    expect(checkbox.prop('indeterminate')).toBe(false);
+  });
+
+  it('calls onClick handler when clicking a menu item', () => {
+    const firstItem = wrapper.find('.NodeContent--actionsItem').first();
+    firstItem.simulate('click');
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles menu items without icons', () => {
+    const thirdItem = wrapper.find('.NodeContent--actionsItem').last();
+    const iconWrapper = thirdItem.find('.NodeContent--actionsItemIconWrapper');
+    expect(iconWrapper.find(IoLocate)).toHaveLength(0);
+    expect(iconWrapper.find(Checkbox)).toHaveLength(1);
+  });
+
+  it('applies custom className when provided', () => {
+    const customClass = 'custom-class';
+    wrapper.setProps({ className: customClass });
+    expect(wrapper.find(`.${customClass}`)).toHaveLength(1);
+  });
+
+  it('renders menu items with proper accessibility attributes', () => {
+    const menuItems = wrapper.find('.NodeContent--actionsItem');
+    menuItems.forEach((item, _) => {
+      expect(item.prop('tabIndex')).toBe(0);
+      if (!item.prop('href')) {
+        expect(item.prop('role')).toBe('button');
+      }
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('handles Enter key press', () => {
+      const firstItem = wrapper.find('.NodeContent--actionsItem').first();
+      firstItem.simulate('keyDown', { key: 'Enter', preventDefault: jest.fn() });
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles Space key press', () => {
+      const firstItem = wrapper.find('.NodeContent--actionsItem').first();
+      firstItem.simulate('keyDown', { key: ' ', preventDefault: jest.fn() });
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not trigger onClick for other keys', () => {
+      const firstItem = wrapper.find('.NodeContent--actionsItem').first();
+      firstItem.simulate('keyDown', { key: 'Tab', preventDefault: jest.fn() });
+      expect(mockOnClick).not.toHaveBeenCalled();
+    });
+  });
+
+  it('handles empty items array', () => {
+    wrapper.setProps({ items: [] });
+    const menuItems = wrapper.find('.NodeContent--actionsItem');
+    expect(menuItems).toHaveLength(0);
+  });
+
+  it('handles undefined items prop', () => {
+    wrapper.setProps({ items: undefined });
+    const menuItems = wrapper.find('.NodeContent--actionsItem');
+    expect(menuItems).toHaveLength(0);
+  });
+});

--- a/packages/jaeger-ui/src/components/common/ActionMenu/ActionsMenu.css
+++ b/packages/jaeger-ui/src/components/common/ActionMenu/ActionsMenu.css
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2025 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+.NodeContent--actionsItemIconWrapper {
+  flex: none;
+  height: 16px;
+  width: 16px;
+}
+
+.NodeContent--actionsItemIconWrapper > * {
+  height: 16px;
+  position: absolute;
+  width: 16px;
+}
+
+.NodeContent--actionsItemIconWrapper > * > .ant-checkbox {
+  vertical-align: unset;
+  top: unset;
+}
+
+.NodeContent--actionsItemText {
+  font-size: 0.9em;
+  line-height: normal;
+  margin-left: 0.5em;
+}
+
+.NodeContent--actionsItem {
+  align-items: center;
+  display: flex;
+  padding: 0.5em;
+}
+
+.NodeContent--actionsItem:not(:hover) {
+  color: inherit;
+}

--- a/packages/jaeger-ui/src/components/common/ActionMenu/ActionsMenu.tsx
+++ b/packages/jaeger-ui/src/components/common/ActionMenu/ActionsMenu.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { Checkbox } from 'antd';
+import './ActionsMenu.css';
+
+export interface IActionMenuItem {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  href?: string;
+  onClick?: () => void;
+  isVisible?: boolean;
+  checkboxProps?: {
+    checked: boolean;
+    indeterminate?: boolean;
+  };
+}
+
+interface IActionsMenuProps {
+  items?: IActionMenuItem[];
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export const ActionsMenu: React.FC<IActionsMenuProps> = ({ items = [], className, style }) => {
+  const handleKeyDown = (item: IActionMenuItem) => (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      item.onClick?.();
+    }
+  };
+
+  return (
+    <div className={className} style={style}>
+      {items.map(item => {
+        if (item.isVisible === false) return null;
+
+        const content = (
+          <>
+            <span className="NodeContent--actionsItemIconWrapper">
+              {item.checkboxProps ? (
+                <Checkbox
+                  checked={item.checkboxProps.checked}
+                  indeterminate={item.checkboxProps.indeterminate}
+                />
+              ) : (
+                item.icon
+              )}
+            </span>
+            <span className="NodeContent--actionsItemText">{item.label}</span>
+          </>
+        );
+
+        if (item.href) {
+          return (
+            <a
+              key={item.id}
+              href={item.href}
+              className="NodeContent--actionsItem"
+              onClick={item.onClick}
+              onKeyDown={handleKeyDown(item)}
+              tabIndex={0}
+            >
+              {content}
+            </a>
+          );
+        }
+
+        return (
+          <a
+            key={item.id}
+            className="NodeContent--actionsItem"
+            onClick={item.onClick}
+            onKeyDown={handleKeyDown(item)}
+            role="button"
+            tabIndex={0}
+          >
+            {content}
+          </a>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ActionsMenu;


### PR DESCRIPTION
## Which problem is this PR solving?
- part of #2699 

## Description of the changes
- This PR moves the Action Menu (the one that we see when hovering over a node in DDG) in DDG to a common component so we can re-use it later in SDG component
- There is no styling change or functional change to the component behavior

## How was this change tested?
- Manually

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
