### PR TITLE
Improve performance when expanding/collapsing span details

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -17,7 +17,7 @@ import cx from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import _isEqual from 'lodash/isEqual';
-import { groupBy } from 'lodash';
+import _groupBy from 'lodash/groupBy';
 
 // import { History as RouterHistory, Location } from 'history';
 
@@ -201,7 +201,7 @@ const memoizedGenerateRowStates = memoizeOne(generateRowStatesFromTrace);
 const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc, _isEqual);
 const memoizedGetCssClasses = memoizeOne(getCssClasses, _isEqual);
 const memoizedCriticalPathsBySpanID = memoizeOne((criticalPath: criticalPathSection[]) =>
-  groupBy(criticalPath, x => x.spanId)
+  _groupBy(criticalPath, x => x.spanId)
 );
 
 // export from tests

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -200,7 +200,9 @@ function mergeChildrenCriticalPath(
 const memoizedGenerateRowStates = memoizeOne(generateRowStatesFromTrace);
 const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc, _isEqual);
 const memoizedGetCssClasses = memoizeOne(getCssClasses, _isEqual);
-const memoizedCriticalPathsBySpanID = memoizeOne((criticalPath: criticalPathSection[]) => groupBy(criticalPath, x => x.spanId));
+const memoizedCriticalPathsBySpanID = memoizeOne((criticalPath: criticalPathSection[]) =>
+  groupBy(criticalPath, x => x.spanId)
+);
 
 // export from tests
 export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceViewProps> {
@@ -376,7 +378,12 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       : this.renderSpanBarRow(span, spanIndex, key, style, attrs);
   };
 
-  getCriticalPathSections(isCollapsed: boolean, trace: Trace, spanID: string, criticalPath: criticalPathSection[]) {
+  getCriticalPathSections(
+    isCollapsed: boolean,
+    trace: Trace,
+    spanID: string,
+    criticalPath: criticalPathSection[]
+  ) {
     if (isCollapsed) {
       return mergeChildrenCriticalPath(trace, spanID, criticalPath);
     }


### PR DESCRIPTION
Improve performance when expanding/collapsing span details (tags/process)

Related to https://github.com/jaegertracing/jaeger-ui/issues/645

Memoize "calculation" of criticalPathSections per span, when span is not collapsed

## Prepare data

Run `go run cmd/tracegen/main.go -service abcd -traces 1 -spans 300` from the jaeger repo

## Perf difference

Total render time from the profiler available in react devtools, after collapsing Tags section

### With these changes

14ms

![image](https://github.com/user-attachments/assets/d07ad165-86ed-4269-b2f2-a8c6e1253507)


### Changes from master

548ms

![image](https://github.com/user-attachments/assets/2c1de506-34d9-4161-b241-c8afea01f93f)




https://github.com/user-attachments/assets/0bfe8f3e-eac4-4d2e-a119-62644c453103

