### PR TITLE
Fix grouping on trace statistics page for tags

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
@@ -26,6 +26,7 @@ import traceWithOverlappingChildren from './tableValuesTestTrace/traceWithOverla
 import traceWithSingleChildLongerThanParentAndStartsAfterParent from './tableValuesTestTrace/traceWithSingleChildLongerThanParentAndStartsAfterParent.json';
 import traceWithThreeShortChildren from './tableValuesTestTrace/traceWithThreeShortChildren.json';
 import traceWithTwoChildrenStartedAtTraceStart from './tableValuesTestTrace/traceWithTwoChildrenStartedAtTraceStart.json';
+import traceWithMultipleSpansWithTheSameValueInDifferentTags from './tableValuesTestTrace/traceWithMultipleSpansWithTheSameValueInDifferentTags.json';
 
 const transformedTrace = transformTraceData(testTraceNormal);
 const transformedTraceSpanAmongEachOthe = transformTraceData(traceSpanAmongEachOther);
@@ -45,6 +46,10 @@ const transformedtraceWithSingleChildLongerThanParentAndStartsAfterParent = tran
 const transformedTraceWithThreeShortChildren = transformTraceData(traceWithThreeShortChildren);
 const transformedTraceWithTwoChildrenStartedAtTraceStart = transformTraceData(
   traceWithTwoChildrenStartedAtTraceStart
+);
+
+const transformedTraceWithMultipleSpansWithTheSameValueInDifferentTags = transformTraceData(
+  traceWithMultipleSpansWithTheSameValueInDifferentTags
 );
 
 describe('tableValues', () => {
@@ -535,5 +540,56 @@ describe('check self time', () => {
   it('span with two children started at trace start time', () => {
     const [serviceOne] = getColumnValues('Service Name', transformedTraceWithTwoChildrenStartedAtTraceStart);
     expect(serviceOne.selfTotal).toBe(0);
+  });
+
+  it('two spans with different tags and the same value, spans without app.test should be in other group', () => {
+    const resultArray = getColumnValues(
+      'app.test',
+      transformedTraceWithMultipleSpansWithTheSameValueInDifferentTags
+    );
+
+    const appTestGroup = resultArray[0];
+    const otherGroup = resultArray[1];
+
+    expect(appTestGroup.count).toBe(2);
+    expect(otherGroup.count).toBe(2);
+    expect(resultArray.length).toBe(2);
+  });
+
+  it('two spans with different tags and the same value, second dropdown', () => {
+    const resultArray = getColumnValues(
+      'app.test',
+      transformedTraceWithMultipleSpansWithTheSameValueInDifferentTags
+    );
+
+    const resultArraySecondGroupBy = getColumnValuesSecondDropdown(
+      resultArray,
+      'app.test',
+      'Operation Name',
+      transformedTraceWithMultipleSpansWithTheSameValueInDifferentTags
+    );
+
+    const detailsWithAppTestTag = resultArraySecondGroupBy.filter(x => x.isDetail);
+    expect(detailsWithAppTestTag.length).toBe(2);
+    expect(resultArraySecondGroupBy.length).toBe(4);
+  });
+
+  it('two spans with different tags and the same value, second dropdown with tag', () => {
+    const resultArray = getColumnValues(
+      'app.test',
+      transformedTraceWithMultipleSpansWithTheSameValueInDifferentTags
+    );
+
+    const resultArraySecondGroupBy = getColumnValuesSecondDropdown(
+      resultArray,
+      'app.test',
+      'app.test-group2',
+      transformedTraceWithMultipleSpansWithTheSameValueInDifferentTags
+    );
+
+    const detailsWithAppTestTag = resultArraySecondGroupBy.filter(x => x.isDetail);
+    expect(detailsWithAppTestTag.length).toBe(1);
+    expect(detailsWithAppTestTag[0].count).toBe(1);
+    expect(resultArraySecondGroupBy.length).toBe(3);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.tsx
@@ -157,7 +157,10 @@ function valueFirstDropdown(selectedTagKey: string, trace: Trace) {
       } else {
         // used when a tag is selected
         for (let l = 0; l < allSpans[j].tags.length; l++) {
-          if (allSpans[j].tags[l].value === allDiffColumnValues[i]) {
+          if (
+            allSpans[j].tags[l].key === selectedTagKey &&
+            allSpans[j].tags[l].value === allDiffColumnValues[i]
+          ) {
             resultValue = computeColumnValues(trace, allSpans[j], allSpans, resultValue);
           }
         }
@@ -193,6 +196,10 @@ function valueFirstDropdown(selectedTagKey: string, trace: Trace) {
     for (let i = 0; i < allSpans.length; i++) {
       let isIn = false;
       for (let j = 0; j < allSpans[i].tags.length; j++) {
+        if (allSpans[i].tags[j].key !== selectedTagKey) {
+          continue;
+        }
+
         for (let l = 0; l < allDiffColumnValues.length; l++) {
           if (allSpans[i].tags[j].value === allDiffColumnValues[l]) {
             isIn = true;
@@ -280,7 +287,10 @@ function buildDetail(
     for (let l = 0; l < tempArray.length; l++) {
       if (isDetail) {
         for (let a = 0; a < tempArray[l].tags.length; a++) {
-          if (diffNamesA[j] === tempArray[l].tags[a].value) {
+          if (
+            tempArray[l].tags[a].key === selectedTagKeySecond &&
+            diffNamesA[j] === tempArray[l].tags[a].value
+          ) {
             resultValue = computeColumnValues(trace, tempArray[l], allSpans, resultValue);
           }
         }
@@ -422,7 +432,10 @@ function valueSecondDropdown(
           // if first dropdown is a tag
         } else {
           for (let l = 0; l < allSpans[j].tags.length; l++) {
-            if (actualTableValues[i].name === allSpans[j].tags[l].value) {
+            if (
+              allSpans[j].tags[l].key === selectedTagKey &&
+              actualTableValues[i].name === allSpans[j].tags[l].value
+            ) {
               tempArray.push(allSpans[j]);
               if (selectedTagKeySecond === operationName) {
                 diffNamesA.push(allSpans[j].operationName);

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithMultipleSpansWithTheSameValueInDifferentTags.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValuesTestTrace/traceWithMultipleSpansWithTheSameValueInDifferentTags.json
@@ -1,0 +1,125 @@
+{
+  "traceID": "006c3cf93508f205",
+  "spans": [
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "006c3cf93508f205",
+      "flags": 1,
+      "operationName": "send",
+      "references": [],
+      "startTime": 100,
+      "duration": 40,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "producer"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "span with test",
+      "startTime": 110,
+      "duration": 10,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        },
+        {
+          "key": "app.test",
+          "type": "string",
+          "value": "1"
+        },
+        {
+          "key": "app.test-group2",
+          "type": "string",
+          "value": "group2"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "2dc4b796e2127e32",
+      "flags": 1,
+      "operationName": "another span with test",
+      "startTime": 110,
+      "duration": 10,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        },
+        {
+          "key": "app.test",
+          "type": "string",
+          "value": "1"
+        },
+        {
+          "key": "app.test-group3",
+          "type": "string",
+          "value": "group2"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    },
+    {
+      "traceID": "006c3cf93508f205",
+      "spanID": "5d423585b4c63d48",
+      "flags": 1,
+      "operationName": "span with test1",
+      "startTime": 500,
+      "duration": 100,
+      "tags": [
+        {
+          "key": "span.kind",
+          "type": "string",
+          "value": "client"
+        },
+        {
+          "key": "http.method",
+          "type": "string",
+          "value": "POST"
+        },
+        {
+          "key": "app.test1",
+          "type": "string",
+          "value": "1"
+        }
+      ],
+      "logs": [],
+      "processID": "p1",
+      "warnings": null
+    }
+  ],
+  "processes": {
+    "p1": {
+      "serviceName": "service-one",
+      "tags": []
+    }
+  },
+  "warnings": null
+}


### PR DESCRIPTION
Closes https://github.com/jaegertracing/jaeger-ui/issues/669

I noticed this issue (and found existing issue on github) when I started working on improving performance of calculating the groups.  
I wanted to fix this bug before I start improving performance of trace statistics page.

Previously spans with different tags,
but the same value were displayed as a single group:

## Data
* span1 - tag1: value1
* span2 - tag2: value1

## Expected result (grouped by tag1)

```
Group  | Count
---------------
value1 | 1
Other (without tag) | 1
```

## Previous result (grouped by tag1)

```
Group  | Count
---------------
value1 | 2
```



## Before
![before](https://github.com/user-attachments/assets/cb362034-d969-4ae3-961b-e9ec8b8025e3)

## After

![after](https://github.com/user-attachments/assets/2ed8229b-169e-4ba2-937c-5da4ece606f7)


