### PR TITLE
[Feat]: Add context menu on node to DAG

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -17,8 +17,15 @@ import ShallowRenderer from 'react-test-renderer/shallow';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { LayoutManager } from '@jaegertracing/plexus';
-import DAG, { renderNode } from './DAG';
+import DAG, {
+  renderNode,
+  handleViewTraces,
+  createHandleNodeClick,
+  createHandleCanvasClick,
+  createMenuItems,
+} from './DAG';
 import { DAG_MAX_NUM_SERVICES } from '../../constants';
+import * as urlModule from '../SearchTracePage/url';
 
 // Mock useEffect to handle cleanup functions and uiFind match count
 jest.spyOn(React, 'useEffect').mockImplementation(f => {
@@ -354,6 +361,28 @@ describe('renderNode', () => {
 
     expect(element.textContent).toBe('');
   });
+
+  it('should call onClick when provided', () => {
+    const vertex = { key: 'test-service' };
+    const event = { clientX: 100, clientY: 200 };
+    const onClick = jest.fn();
+    const uiFind = '';
+
+    const result = renderNode(vertex, null, uiFind, null, null, onClick);
+    result.props.onClick(event);
+
+    expect(onClick).toHaveBeenCalledWith(vertex, event);
+  });
+
+  it('should handle onMouseEnter with optional chaining when onMouseEnter is undefined', () => {
+    const vertex = { key: 'test-service' };
+    const event = { clientX: 100, clientY: 200 };
+    const uiFind = '';
+
+    const result = renderNode(vertex, null, uiFind, undefined);
+
+    expect(() => result.props.onMouseEnter(event)).not.toThrow();
+  });
 });
 
 describe('clean up', () => {
@@ -374,5 +403,205 @@ describe('clean up', () => {
     cleanupFunctions.forEach(cleanup => cleanup());
 
     expect(stopAndReleaseSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleViewTraces', () => {
+  let windowOpenSpy;
+  let getSearchUrlSpy;
+
+  beforeEach(() => {
+    windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    getSearchUrlSpy = jest.spyOn(urlModule, 'getUrl').mockReturnValue('http://test-url');
+  });
+
+  afterEach(() => {
+    windowOpenSpy.mockRestore();
+    getSearchUrlSpy.mockRestore();
+  });
+
+  it('should open a new window with the correct URL when a node is provided', () => {
+    const hoveredNode = { key: 'test-service' };
+
+    handleViewTraces(hoveredNode);
+
+    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: 'test-service' });
+    expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
+  });
+
+  it('should handle null node gracefully', () => {
+    handleViewTraces(null);
+
+    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: undefined });
+    expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
+  });
+});
+
+describe('handleNodeClick and handleCanvasClick', () => {
+  let setHoveredNodeMock;
+  let setMenuPositionMock;
+  let setIsMenuVisibleMock;
+
+  beforeEach(() => {
+    setHoveredNodeMock = jest.fn();
+    setMenuPositionMock = jest.fn();
+    setIsMenuVisibleMock = jest.fn();
+  });
+
+  it('should toggle menu visibility when clicking the same node', () => {
+    const vertex = { key: 'test-service' };
+    const event = {
+      stopPropagation: jest.fn(),
+      clientX: 100,
+      clientY: 200,
+    };
+
+    const handleNodeClick = createHandleNodeClick(
+      null,
+      setHoveredNodeMock,
+      setMenuPositionMock,
+      setIsMenuVisibleMock
+    );
+    handleNodeClick(vertex, event);
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(setHoveredNodeMock).toHaveBeenCalledWith(vertex);
+    expect(setMenuPositionMock).toHaveBeenCalledWith({ x: 100, y: 200 });
+    expect(setIsMenuVisibleMock).toHaveBeenCalledWith(true);
+
+    setHoveredNodeMock.mockClear();
+    setMenuPositionMock.mockClear();
+    setIsMenuVisibleMock.mockClear();
+    event.stopPropagation.mockClear();
+
+    const handleNodeClickWithHoveredNode = createHandleNodeClick(
+      vertex,
+      setHoveredNodeMock,
+      setMenuPositionMock,
+      setIsMenuVisibleMock
+    );
+    handleNodeClickWithHoveredNode(vertex, event);
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(setHoveredNodeMock).toHaveBeenCalledWith(null);
+    expect(setMenuPositionMock).toHaveBeenCalledWith(null);
+    expect(setIsMenuVisibleMock).toHaveBeenCalledWith(false);
+  });
+
+  it('should close menu when clicking canvas', () => {
+    const handleCanvasClick = createHandleCanvasClick(
+      setHoveredNodeMock,
+      setMenuPositionMock,
+      setIsMenuVisibleMock
+    );
+    handleCanvasClick();
+
+    expect(setIsMenuVisibleMock).toHaveBeenCalledWith(false);
+    expect(setHoveredNodeMock).toHaveBeenCalledWith(null);
+    expect(setMenuPositionMock).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('createMenuItems', () => {
+  it('should return empty array when hoveredNode is null', () => {
+    const result = createMenuItems(null);
+    expect(result).toEqual([]);
+  });
+
+  it('should return menu items when hoveredNode is provided', () => {
+    const hoveredNode = { key: 'test-service' };
+    const onServiceSelect = jest.fn();
+
+    const result = createMenuItems(hoveredNode, onServiceSelect);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('set-focus');
+    expect(result[0].label).toBe('Set focus');
+    expect(result[1].id).toBe('view-traces');
+    expect(result[1].label).toBe('View traces');
+
+    result[0].onClick();
+    expect(onServiceSelect).toHaveBeenCalledWith('test-service');
+
+    const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    result[1].onClick();
+    expect(windowOpenSpy).toHaveBeenCalled();
+    windowOpenSpy.mockRestore();
+  });
+});
+
+describe('DAGMenu', () => {
+  let renderer;
+
+  beforeEach(() => {
+    renderer = new ShallowRenderer();
+  });
+
+  it('should render menu when all conditions are met', () => {
+    const menuPosition = { x: 100, y: 200 };
+    const hoveredNode = { key: 'test-service' };
+    const isMenuVisible = true;
+    const menuItems = [
+      { id: 'set-focus', label: 'Set focus', icon: <div />, onClick: jest.fn() },
+      { id: 'view-traces', label: 'View traces', icon: <div />, onClick: jest.fn() },
+    ];
+
+    const DAGComponent = renderer.render(
+      <DAG serviceCalls={[]} selectedLayout="dot" selectedDepth={1} selectedService="" />
+    );
+
+    const DAGMenuComponent = DAGComponent.props.children[1];
+
+    const result = DAGMenuComponent.type({
+      menuPosition,
+      hoveredNode,
+      isMenuVisible,
+      menuItems,
+    });
+
+    expect(result).toBeTruthy();
+    expect(result.props.role).toBe('menu');
+    expect(result.props.style).toEqual({
+      position: 'fixed',
+      left: 100,
+      top: 190,
+      zIndex: 1000,
+      pointerEvents: 'auto',
+    });
+
+    const renderedMenuItems = result.props.children.props.items;
+    expect(renderedMenuItems).toEqual(menuItems);
+  });
+
+  it('should not render menu when any condition is not met', () => {
+    const DAGComponent = renderer.render(
+      <DAG serviceCalls={[]} selectedLayout="dot" selectedDepth={1} selectedService="" />
+    );
+
+    const DAGMenuComponent = DAGComponent.props.children[1];
+
+    const result1 = DAGMenuComponent.type({
+      menuPosition: null,
+      hoveredNode: { key: 'test-service' },
+      isMenuVisible: true,
+      menuItems: [],
+    });
+    expect(result1).toBeNull();
+
+    const result2 = DAGMenuComponent.type({
+      menuPosition: { x: 100, y: 200 },
+      hoveredNode: null,
+      isMenuVisible: true,
+      menuItems: [],
+    });
+    expect(result2).toBeNull();
+
+    const result3 = DAGMenuComponent.type({
+      menuPosition: { x: 100, y: 200 },
+      hoveredNode: { key: 'test-service' },
+      isMenuVisible: false,
+      menuItems: [],
+    });
+    expect(result3).toBeNull();
   });
 });

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -34,8 +34,6 @@ jest.spyOn(React, 'useState').mockImplementation(initialValue => [initialValue, 
 
 jest.spyOn(React, 'useRef').mockImplementation(() => ({ current: null }));
 
-jest.spyOn(React, 'useCallback').mockImplementation(fn => fn);
-
 // mock canvas API (we don't care about canvas results)
 
 window.HTMLCanvasElement.prototype.getContext = function getContext() {

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { ReactNode, useState, useCallback, useRef } from 'react';
+import React, { ReactNode, useState, useRef } from 'react';
 import { Digraph, LayoutManager } from '@jaegertracing/plexus';
 import { TEdge, TVertex } from '@jaegertracing/plexus/lib/types';
 import { TLayoutOptions } from '@jaegertracing/plexus/lib/LayoutManager/types';
@@ -172,7 +172,7 @@ export default function DAG({
   const [isMenuVisible, setIsMenuVisible] = useState(false);
   const showMenuTimeout = useRef<NodeJS.Timeout>();
 
-  const handleNodeMouseEnter = useCallback((vertex: TVertex, event: React.MouseEvent) => {
+  const handleNodeMouseEnter = (vertex: TVertex, event: React.MouseEvent) => {
     setHoveredNode(vertex);
     if (showMenuTimeout.current) {
       clearTimeout(showMenuTimeout.current);
@@ -181,9 +181,9 @@ export default function DAG({
       setMenuPosition({ x: event.clientX, y: event.clientY });
       setIsMenuVisible(true);
     }, 1000);
-  }, []);
+  };
 
-  const handleNodeMouseLeave = useCallback(() => {
+  const handleNodeMouseLeave = () => {
     if (showMenuTimeout.current) {
       clearTimeout(showMenuTimeout.current);
     }
@@ -191,35 +191,35 @@ export default function DAG({
       setHoveredNode(null);
       setMenuPosition(null);
     }
-  }, [isMenuHovered, isMenuVisible]);
+  };
 
-  const handleNodeClick = useCallback((vertex: TVertex, event: React.MouseEvent) => {
+  const handleNodeClick = (vertex: TVertex, event: React.MouseEvent) => {
     setHoveredNode(vertex);
     setMenuPosition({ x: event.clientX, y: event.clientY });
     setIsMenuVisible(true);
-  }, []);
+  };
 
-  const handleMenuMouseEnter = useCallback(() => {
+  const handleMenuMouseEnter = () => {
     setIsMenuHovered(true);
-  }, []);
+  };
 
-  const handleMenuMouseLeave = useCallback(() => {
+  const handleMenuMouseLeave = () => {
     setIsMenuHovered(false);
     if (!isMenuVisible) {
       setHoveredNode(null);
       setMenuPosition(null);
     }
-  }, [isMenuVisible]);
+  };
 
   const handleViewTraces = () => {
     window.open(getSearchUrl({ service: hoveredNode?.key }), '_blank');
   };
 
-  const handleCanvasClick = useCallback(() => {
+  const handleCanvasClick = () => {
     setIsMenuVisible(false);
     setHoveredNode(null);
     setMenuPosition(null);
-  }, []);
+  };
 
   React.useEffect(() => {
     return () => {

--- a/packages/jaeger-ui/src/components/DependencyGraph/dag.css
+++ b/packages/jaeger-ui/src/components/DependencyGraph/dag.css
@@ -77,3 +77,14 @@
 .DAG--error {
   margin: 10px;
 }
+
+.DAG .NodeContent--actionsItemIconWrapper > * {
+  position: static;
+}
+
+.DAG > div:last-child {
+  position: fixed;
+  z-index: 1000;
+  background: #fafafa;
+  border: 1px solid #d0d0d0;
+}

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
@@ -219,6 +219,7 @@ export class DependencyGraphPageImpl extends Component {
             selectedDepth={debouncedDepth}
             selectedService={selectedService}
             uiFind={uiFind}
+            onServiceSelect={this.handleServiceSelect}
             onMatchCountChange={this.handleMatchCountChange}
           />
         </div>


### PR DESCRIPTION
## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger-ui/issues/2700, https://github.com/jaegertracing/jaeger-ui/issues/2699

## Description of the changes
- This PR adds a context menu that appears when the node is clicked.
- The menu shows options:
   - View Traces: This opens the traces in a new window something like DDG
   - Focus: This focuses the current node

## How was this change tested?
- Manually

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
