### PR TITLE
[Fix]: make reset icon in SDG more intuitive

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -213,6 +213,26 @@ describe('<DAG>', () => {
     expect(digraph.props.edges).toHaveLength(0);
   });
 
+  it('handles null or undefined maxDepth values', () => {
+    const serviceCalls = [
+      { parent: 'service-a', child: 'service-b', callCount: 1 },
+      { parent: 'service-b', child: 'service-c', callCount: 2 },
+    ];
+
+    renderer.render(
+      <DAG
+        serviceCalls={serviceCalls}
+        selectedService="service-a"
+        selectedDepth={null}
+        selectedLayout="dot"
+      />
+    );
+    const element = renderer.getRenderOutput();
+    const digraph = element.props.children[0];
+    expect(digraph.props.vertices).toHaveLength(3);
+    expect(digraph.props.edges).toHaveLength(2);
+  });
+
   it('shows error message when too many services to render', () => {
     const serviceCalls = Array.from({ length: DAG_MAX_NUM_SERVICES + 1 }, (_, i) => ({
       parent: `service-${i}`,

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -75,15 +75,17 @@ export const renderNode = (
 const findConnectedServices = (
   serviceCalls: TServiceCall[],
   startService: string,
-  maxDepth: number
+  maxDepth: number | null | undefined
 ): { nodes: Set<string>; edges: TServiceCall[] } => {
   const nodes = new Set<string>([startService]);
   const edges: TServiceCall[] = [];
   const queue: { service: string; depth: number }[] = [{ service: startService, depth: 0 }];
 
+  const maxDepthValue = maxDepth ?? Number.MAX_SAFE_INTEGER;
+
   while (queue.length > 0) {
     const { service, depth } = queue.shift()!;
-    if (depth >= maxDepth) continue;
+    if (depth >= maxDepthValue) continue;
 
     serviceCalls.forEach(call => {
       if (call.parent === service && !nodes.has(call.child)) {
@@ -165,7 +167,7 @@ export const createMenuItems = (
 const formatServiceCalls = (
   serviceCalls: TServiceCall[],
   selectedService: string | null,
-  selectedDepth: number
+  selectedDepth: number | null | undefined
 ): {
   nodes: TVertex[];
   edges: TEdge[];

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.css
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.css
@@ -93,9 +93,17 @@
   border-color: #000;
 }
 
+.reset-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 200px;
+}
+
 .reset-icon {
   color: #999;
   cursor: pointer;
+  font-size: 20px;
   transition: color 0.3s ease;
 }
 
@@ -130,4 +138,22 @@
   margin-left: auto;
   align-self: flex-end;
   min-width: 200px;
+}
+
+.reset-button {
+  margin-left: 8px;
+  margin-right: 30px;
+  height: 32px;
+  background-color: #f5f5f5;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  color: rgba(0, 0, 0, 0.85);
+  font-size: 14px;
+  transition: all 0.3s;
+}
+
+.reset-button:hover {
+  background-color: #e6e6e6;
+  border-color: #d9d9d9;
+  color: rgba(0, 0, 0, 0.85);
 }

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.js
@@ -139,6 +139,24 @@ describe('DAGOptions', () => {
     expect(defaultProps.onDepthChange).toHaveBeenCalledWith(10);
   });
 
+  it('handles empty depth value', () => {
+    render(<DAGOptions {...defaultProps} selectedService="service-1" />);
+
+    const depthInput = screen.getByTestId('depth-input');
+    fireEvent.change(depthInput, { target: { value: '' } });
+
+    expect(defaultProps.onDepthChange).toHaveBeenCalledWith(null);
+  });
+
+  it('handles undefined depth value', () => {
+    render(<DAGOptions {...defaultProps} selectedService="service-1" />);
+
+    const depthInput = screen.getByTestId('depth-input');
+    fireEvent.change(depthInput, { target: { value: '' } });
+
+    expect(defaultProps.onDepthChange).toHaveBeenCalledWith(null);
+  });
+
   it('handles reset button click', () => {
     render(<DAGOptions {...defaultProps} />);
 

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.tsx
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { Select, InputNumber, Popover } from 'antd';
-import { IoHelp, IoRefresh } from 'react-icons/io5';
+import { Select, InputNumber, Popover, Button } from 'antd';
+import { IoHelp } from 'react-icons/io5';
 import SearchableSelect from '../common/SearchableSelect';
 import UiFindInput from '../common/UiFindInput';
 import './DAGOptions.css';
@@ -179,12 +179,15 @@ const DAGOptions: React.FC<IDAGOptionsProps> = ({
             disabled={!selectedService}
             data-testid="depth-input"
           />
-          <IoRefresh
-            className="reset-icon"
+          <Button
             onClick={onReset}
-            style={{ marginLeft: '8px', cursor: 'pointer' }}
             data-testid="reset-button"
-          />
+            type="default"
+            className="reset-button"
+            size="small"
+          >
+            Reset
+          </Button>
         </div>
       </div>
       <div className="selector-container">

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.jsx
@@ -128,12 +128,15 @@ export class DependencyGraphPageImpl extends Component {
 
   handleDepthChange = value => {
     if (value === null || value === undefined) {
-      return;
-    }
-    const numValue = Number(value);
-    if (Number.isInteger(numValue) && numValue >= 0) {
-      this.setState({ selectedDepth: numValue });
-      this.debouncedDepthChange(numValue);
+      this.setState({ selectedDepth: value, debouncedDepth: value });
+    } else {
+      const numValue = Number(value);
+      if (Number.isInteger(numValue) && numValue >= 0) {
+        this.setState({ selectedDepth: numValue });
+        this.debouncedDepthChange(numValue);
+      } else {
+        this.setState({ selectedDepth: 0, debouncedDepth: 0 });
+      }
     }
   };
 

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
@@ -165,18 +165,36 @@ describe('<DependencyGraph>', () => {
       });
     });
 
-    it('handles depth change', () => {
+    it('handles depth change with numeric value', () => {
       const depth = 3;
       wrapper.instance().handleDepthChange(depth);
       expect(wrapper.state('selectedDepth')).toBe(depth);
     });
 
-    it('ignores invalid depth values', () => {
-      const initialDepth = wrapper.state('selectedDepth');
-      wrapper.instance().handleDepthChange('invalid');
-      expect(wrapper.state('selectedDepth')).toBe(initialDepth);
-      wrapper.instance().handleDepthChange(-1);
-      expect(wrapper.state('selectedDepth')).toBe(initialDepth);
+    it('handles depth change with negative value', () => {
+      const depth = -1;
+      wrapper.instance().handleDepthChange(depth);
+      expect(wrapper.state('selectedDepth')).toBe(0);
+    });
+
+    it('handles depth change with null value', () => {
+      const instance = wrapper.instance();
+      jest.spyOn(instance, 'setState');
+
+      instance.handleDepthChange(null);
+      expect(instance.setState).toHaveBeenCalledWith({ selectedDepth: null, debouncedDepth: null });
+      expect(wrapper.state('selectedDepth')).toBe(null);
+      expect(wrapper.state('debouncedDepth')).toBe(null);
+    });
+
+    it('handles depth change with undefined value', () => {
+      const instance = wrapper.instance();
+      jest.spyOn(instance, 'setState');
+
+      instance.handleDepthChange(undefined);
+      expect(instance.setState).toHaveBeenCalledWith({ selectedDepth: undefined, debouncedDepth: undefined });
+      expect(wrapper.state('selectedDepth')).toBe(undefined);
+      expect(wrapper.state('debouncedDepth')).toBe(undefined);
     });
 
     it('handles reset', () => {
@@ -203,14 +221,6 @@ describe('<DependencyGraph>', () => {
         <DependencyGraph {...props} dependencies={manyDependencies} fetchDependencies={() => {}} />
       );
       expect(newWrapper.state('selectedLayout')).toBe('sfdp');
-    });
-
-    it('ignores undefined or null depth values', () => {
-      const initialDepth = wrapper.state('selectedDepth');
-      wrapper.instance().handleDepthChange(undefined);
-      expect(wrapper.state('selectedDepth')).toBe(initialDepth);
-      wrapper.instance().handleDepthChange(null);
-      expect(wrapper.state('selectedDepth')).toBe(initialDepth);
     });
 
     it('debounces depth changes', done => {


### PR DESCRIPTION
## Which problem is this PR solving?
- part of https://github.com/jaegertracing/jaeger-ui/issues/2699

## Description of the changes
- Make the Reset icon more intuitive

## How was this change tested?
- Manually, Unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
