### PR TITLE
Improve performance of Trace Statistics page when grouping by tag

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -203,11 +203,7 @@ export default class TraceStatisticsHeader extends Component<Props, State> {
 
   render() {
     const optionsNameSelector1 = generateDropdownValue(this.props.trace);
-    const optionsNameSelector2 = generateSecondDropdownValue(
-      this.props.wholeTable,
-      this.props.trace,
-      this.state.valueNameSelector1
-    );
+    const optionsNameSelector2 = generateSecondDropdownValue(this.props.trace, this.state.valueNameSelector1);
 
     return (
       <div className="TraceStatisticsHeader">

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.js
@@ -14,7 +14,6 @@
 
 import { generateDropdownValue, generateSecondDropdownValue } from './generateDropdownValue';
 import transformTraceData from '../../../model/transform-trace-data';
-import { getColumnValues } from './tableValues';
 
 import testTrace from './tableValuesTestTrace/testTrace.json';
 
@@ -29,16 +28,14 @@ describe(' generateDropdownValue', () => {
 
   it('check generateSecondDropdownValue no Tag is selected', () => {
     const expectValues = ['Operation Name', 'span.kind', 'error', 'db.type'];
-    const tableValue = getColumnValues('Service Name', transformedTrace);
-    const values = generateSecondDropdownValue(tableValue, transformedTrace, 'Service Name');
+    const values = generateSecondDropdownValue(transformedTrace, 'Service Name');
 
     expect(values).toEqual(expectValues);
   });
 
   it('check generateSecondDrop Tag is selected', () => {
     const expectValues = ['Service Name', 'Operation Name', 'error'];
-    const tableValue = getColumnValues('span.kind', transformedTrace);
-    const values = generateSecondDropdownValue(tableValue, transformedTrace, 'span.kind');
+    const values = generateSecondDropdownValue(transformedTrace, 'span.kind');
     expect(values).toEqual(expectValues);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.tsx
@@ -23,28 +23,25 @@ const operationName = 'Operation Name';
 /**
  * Used to get the values if tag is picked from the first dropdown.
  */
-function getValueTagIsPicked(tableValue: ITableSpan[], trace: Trace, nameSelectorTitle: string) {
+function getValueTagIsPicked(trace: Trace, tagKeyFromFirstDropdown: string) {
   const allSpans = trace.spans;
-  let spansWithFilterTag = [];
+  const tagKeys = new Set<string>();
 
-  // add all Spans with this tag key
-
-  for (let i = 0; i < tableValue.length; i++) {
-    if (tableValue[i].hasSubgroupValue) {
-      for (let j = 0; j < allSpans.length; j++) {
-        for (let l = 0; l < allSpans[j].tags.length; l++) {
-          if (nameSelectorTitle === allSpans[j].tags[l].key) {
-            spansWithFilterTag.push(allSpans[j]);
-          }
-        }
+  for (let j = 0; j < allSpans.length; j++) {
+    let spanContainsTagFromFirstDropdown = false;
+    for (let l = 0; l < allSpans[j].tags.length; l++) {
+      if (tagKeyFromFirstDropdown === allSpans[j].tags[l].key) {
+        spanContainsTagFromFirstDropdown = true;
+        break;
       }
     }
-  }
-  spansWithFilterTag = _uniq(spansWithFilterTag);
 
-  const tags = spansWithFilterTag.map(o => o.tags);
-  let tagKeys = _uniq(_flatten(tags).map(o => o.key));
-  tagKeys = tagKeys.filter(o => o !== nameSelectorTitle);
+    if (spanContainsTagFromFirstDropdown) {
+      allSpans[j].tags.forEach(x => tagKeys.add(x.key));
+    }
+  }
+
+  tagKeys.delete(tagKeyFromFirstDropdown);
 
   return [serviceName, operationName, ...tagKeys];
 }
@@ -76,10 +73,10 @@ export function generateDropdownValue(trace: Trace) {
   return values;
 }
 
-export function generateSecondDropdownValue(tableValue: ITableSpan[], trace: Trace, dropdownTitle1: string) {
+export function generateSecondDropdownValue(trace: Trace, dropdownTitle1: string) {
   let values;
   if (dropdownTitle1 !== serviceName && dropdownTitle1 !== operationName) {
-    values = getValueTagIsPicked(tableValue, trace, dropdownTitle1);
+    values = getValueTagIsPicked(trace, dropdownTitle1);
   } else {
     values = getValueNoTagIsPicked(trace, dropdownTitle1);
   }


### PR DESCRIPTION


## Which problem is this PR solving?
Related to https://github.com/jaegertracing/jaeger-ui/issues/645

## Description of the changes
Tested with 10k spans - `go run cmd/tracegen/main.go -service abcd -traces 1 -spans 10000`

Previously getValueTagIsPicked took 2s, now this function takes less than 1ms because it is not visible in a profiler

## Before

![image](https://github.com/user-attachments/assets/f1ce3feb-30cf-4649-b46d-dd5a7d953fc9)


## After

Now only `computeSelfTime` is slow, when only first dropdown is used for grouping results

![image](https://github.com/user-attachments/assets/3896fd51-b154-4c04-ab03-228f29286012)

