### PR TITLE
Migrate GraphTicks tests

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/GraphTicks.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/GraphTicks.test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import GraphTicks from './GraphTicks';
 
@@ -27,18 +27,20 @@ describe('<GraphTicks>', () => {
     numTicks: 4,
   };
 
-  let ticksG;
+  let container;
 
-  beforeEach(() => {
-    const wrapper = shallow(<GraphTicks {...defaultProps} />);
-    ticksG = wrapper.find('[data-test="ticks"]');
+  beforeEach(async () => {
+    const { container: c } = render(<GraphTicks {...defaultProps} />);
+    container = c;
   });
 
-  it('creates a <g> for ticks', () => {
+  it('creates a <g> for ticks', async () => {
+    const ticksG = await container.querySelectorAll('[data-test="ticks"]');
     expect(ticksG.length).toBe(1);
   });
 
-  it('creates a line for each ticks excluding the first and last', () => {
-    expect(ticksG.find('line').length).toBe(defaultProps.numTicks - 1);
+  it('creates a line for each ticks excluding the first and last', async () => {
+    const lines = await container.querySelectorAll('[data-test="ticks"]:nth-child(1) line');
+    expect(lines.length).toBe(defaultProps.numTicks - 1);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/GraphTicks.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/GraphTicks.test.js
@@ -29,18 +29,18 @@ describe('<GraphTicks>', () => {
 
   let container;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     const { container: c } = render(<GraphTicks {...defaultProps} />);
     container = c;
   });
 
-  it('creates a <g> for ticks', async () => {
-    const ticksG = await container.querySelectorAll('[data-test="ticks"]');
+  it('creates a <g> for ticks', () => {
+    const ticksG = container.querySelectorAll('[data-test="ticks"]');
     expect(ticksG.length).toBe(1);
   });
 
-  it('creates a line for each ticks excluding the first and last', async () => {
-    const lines = await container.querySelectorAll('[data-test="ticks"]:nth-child(1) line');
+  it('creates a line for each ticks excluding the first and last', () => {
+    const lines = container.querySelectorAll('[data-test="ticks"]:nth-child(1) line');
     expect(lines.length).toBe(defaultProps.numTicks - 1);
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `GraphTicks` test

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`