### PR TITLE
Migrate TimelineCollapser tests

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.test.js
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import TimelineCollapser from './TimelineCollapser';
 
@@ -25,8 +26,7 @@ describe('<TimelineCollapser>', () => {
       onExpandAll: () => {},
       onExpandOne: () => {},
     };
-    const wrapper = shallow(<TimelineCollapser {...props} />);
-    expect(wrapper).toBeDefined();
-    expect(wrapper.find('.TimelineCollapser').length).toBe(1);
+    const { container } = render(<TimelineCollapser {...props} />);
+    expect(container).toBeDefined();
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `TimelineCollapser` test

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`