### PR TITLE
Migrate Ticks tests

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.test.js
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import Ticks from './Ticks';
 
 describe('<Ticks>', () => {
   it('renders without exploding', () => {
-    const wrapper = shallow(<Ticks endTime={200} numTicks={5} showLabels startTime={100} />);
-    expect(wrapper).toBeDefined();
+    const { container } = render(<Ticks endTime={200} numTicks={5} showLabels startTime={100} />);
+    expect(container).toBeDefined();
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `Ticks` test

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`