### PR TITLE
Migrate CanvasSpanGraph tests

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/CanvasSpanGraph.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/CanvasSpanGraph.test.js
@@ -13,20 +13,54 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import CanvasSpanGraph from './CanvasSpanGraph';
+import * as renderUtils from './render-into-canvas'; // Import the module to mock
 
-describe('<CanvasSpanGraph>', () => {
-  it('renders without exploding', () => {
-    const items = [{ valueWidth: 1, valueOffset: 1, serviceName: 'service-name-0' }];
-    const wrapper = shallow(<CanvasSpanGraph items={[]} valueWidth={4000} />);
-    expect(wrapper).toBeDefined();
-    wrapper.instance()._setCanvasRef({
-      getContext: () => ({
-        fillRect: () => {},
-      }),
+// Mock the renderIntoCanvas function
+jest.mock('./render-into-canvas');
+
+describe('<CanvasSpanGraph />', () => {
+  const items = [{ valueWidth: 1, valueOffset: 1, serviceName: 'service-name-0' }];
+  const props = {
+    items: [],
+    valueWidth: 4000,
+  };
+
+  // Store the original prototype
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+  beforeEach(() => {
+    // Mock getContext before each test
+    HTMLCanvasElement.prototype.getContext = () => ({
+      fillRect: jest.fn(),
+      clearRect: jest.fn(),
+      // Add other methods if needed by renderIntoCanvas
     });
-    wrapper.setProps({ items });
+    // Reset the mock before each test
+    renderUtils.default.mockClear();
+  });
+
+  afterEach(() => {
+    // Restore the original prototype after each test
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+  });
+
+  it('renders without exploding', () => {
+    const { container, rerender } = render(<CanvasSpanGraph {...props} />);
+    const canvas = container.querySelector('.CanvasSpanGraph');
+
+    expect(canvas).toBeInTheDocument();
+    // Check if renderIntoCanvas was called on mount
+    expect(renderUtils.default).toHaveBeenCalledTimes(1);
+
+    // Update props and rerender
+    rerender(<CanvasSpanGraph {...props} items={items} />);
+
+    // Check if renderIntoCanvas was called again on update
+    expect(renderUtils.default).toHaveBeenCalledTimes(2);
+    expect(renderUtils.default).toHaveBeenCalledWith(canvas, items, props.valueWidth, expect.any(Function));
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `CanvasSpanGraph` test

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`