### PR TITLE
Migrate TraceIdInput test

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceIdInput.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceIdInput.test.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Input } from 'antd';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import TraceIdInput from './TraceIdInput';
 
@@ -22,11 +22,17 @@ describe('TraceIdInput', () => {
   const props = {
     selectTrace: jest.fn(),
   };
-  const { Search } = Input;
 
   it('renders as expected', () => {
-    const wrapper = shallow(<TraceIdInput {...props} />);
-    expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find(Search).prop('onSearch')).toBe(props.selectTrace);
+    render(<TraceIdInput {...props} />);
+
+    // Check for the text rendered by addonBefore
+    expect(screen.getByText('Select by Trace ID')).toBeInTheDocument();
+
+    // Check for the input element
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+
+    // Check for the search button (Ant Design Search renders a button)
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
 });

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceIdInput.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceIdInput.test.js.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`TraceIdInput renders as expected 1`] = `
-<Search
-  addonBefore="Select by Trace ID"
-  enterButton={true}
-  onSearch={[MockFunction]}
-/>
-`;


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `TracedInput` test

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`