### PR TITLE
Migrate TextList test

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/TextList.test.js
@@ -13,28 +13,34 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
 import TextList from './TextList';
 
 describe('<TextList>', () => {
-  let wrapper;
-
-  const data = [
-    { key: 'span.kind', value: 'client' },
-    { key: 'omg', value: 'mos-def' },
-  ];
-
-  beforeEach(() => {
-    wrapper = shallow(<TextList data={data} />);
-  });
+  const data = ['string 1', 'string 2', 'another string'];
 
   it('renders without exploding', () => {
-    expect(wrapper).toBeDefined();
-    expect(wrapper.find('.TextList').length).toBe(1);
+    render(<TextList data={data} />);
+    // Check if the list container is rendered (optional, but confirms basic rendering)
+    expect(screen.getByRole('list')).toBeInTheDocument();
   });
 
-  it('renders a table row for each data element', () => {
-    const trs = wrapper.find('li');
-    expect(trs.length).toBe(data.length);
+  it('renders a list item for each data element', () => {
+    render(<TextList data={data} />);
+    const listItems = screen.getAllByRole('listitem');
+    expect(listItems).toHaveLength(data.length);
+
+    // Verify the content of each list item
+    listItems.forEach((item, index) => {
+      expect(item).toHaveTextContent(data[index]);
+    });
+  });
+
+  it('renders nothing if data is empty', () => {
+    render(<TextList data={[]} />);
+    const listItems = screen.queryAllByRole('listitem');
+    expect(listItems).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `TextList` test

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`