### PR TITLE
Migrate ResultItem tests

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
@@ -30,7 +30,10 @@ const renderWithRouter = ui => {
 let trace; // Use let to allow modification in tests
 
 beforeEach(() => {
-  // Reset trace data before each test
+  // Reset trace data before each test.
+  // Some tests modify the trace object (e.g., adding tags).
+  // Resetting ensures that each test starts with a clean, unmodified trace,
+  // preventing side effects between tests and maintaining test isolation.
   trace = transformTraceData(traceGenerator.trace({}));
 });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -101,7 +101,7 @@ export default class ResultItem extends React.PureComponent<Props, State> {
         <Link to={linkTo}>
           <Row>
             <Col span={4} className="ub-p2">
-              <Tag className="ub-m1" data-test={markers.NUM_SPANS}>
+              <Tag className="ub-m1" data-testid={markers.NUM_SPANS}>
                 {this.state.numSpans} Span{this.state.numSpans > 1 && 's'}
               </Tag>
               {Boolean(this.state.numErredSpans) && (
@@ -111,7 +111,7 @@ export default class ResultItem extends React.PureComponent<Props, State> {
               )}
             </Col>
             <Col span={16} className="ub-p2">
-              <ul className="ub-list-reset" data-test={markers.SERVICE_TAGS}>
+              <ul className="ub-list-reset" data-testid={markers.SERVICE_TAGS}>
                 {_sortBy(services, s => s.name).map(service => {
                   const { name, numberOfSpans: count } = service;
                   return (


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `ResultItem` test

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`