### PR TITLE
Migrate TickLabels tests

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.test.js
@@ -76,5 +76,4 @@ describe('<TickLabels>', () => {
       expect(ticks[i + 1]).toHaveStyle(`left: ${pos}`);
     });
   });
-
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.test.js
@@ -13,9 +13,16 @@
 // limitations under the License.
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import TickLabels from './TickLabels';
+import { formatDuration } from '../../../../utils/date';
+
+// Mock the formatDuration function
+jest.mock('../../../../utils/date', () => ({
+  formatDuration: jest.fn(duration => `formatted:${duration}`),
+}));
 
 describe('<TickLabels>', () => {
   const defaultProps = {
@@ -23,37 +30,52 @@ describe('<TickLabels>', () => {
     duration: 5000,
   };
 
-  let wrapper;
-  let ticks;
-
   beforeEach(() => {
-    wrapper = shallow(<TickLabels {...defaultProps} />);
-    ticks = wrapper.find('[data-test="tick"]');
+    // Reset the mock before each test if needed, though it might not be strictly necessary here
+    formatDuration.mockClear();
+    render(<TickLabels {...defaultProps} />);
   });
 
   it('renders the right number of ticks', () => {
+    const ticks = screen.getAllByTestId('tick');
     expect(ticks.length).toBe(defaultProps.numTicks + 1);
   });
 
+  it('renders the correct tick labels', () => {
+    expect(formatDuration).toHaveBeenCalledTimes(defaultProps.numTicks + 1);
+    expect(formatDuration).toHaveBeenCalledWith(0); // 0/4 * 5000
+    expect(formatDuration).toHaveBeenCalledWith(1250); // 1/4 * 5000
+    expect(formatDuration).toHaveBeenCalledWith(2500); // 2/4 * 5000
+    expect(formatDuration).toHaveBeenCalledWith(3750); // 3/4 * 5000
+    expect(formatDuration).toHaveBeenCalledWith(5000); // 4/4 * 5000
+
+    expect(screen.getByText('formatted:0')).toBeInTheDocument();
+    expect(screen.getByText('formatted:1250')).toBeInTheDocument();
+    expect(screen.getByText('formatted:2500')).toBeInTheDocument();
+    expect(screen.getByText('formatted:3750')).toBeInTheDocument();
+    expect(screen.getByText('formatted:5000')).toBeInTheDocument();
+  });
+
   it('places the first tick on the left', () => {
-    const firstTick = ticks.first();
-    expect(firstTick.prop('style')).toEqual({ left: '0%' });
+    const ticks = screen.getAllByTestId('tick');
+    expect(ticks[0]).toHaveStyle('left: 0%');
   });
 
   it('places the last tick on the right', () => {
-    const lastTick = ticks.last();
-    expect(lastTick.prop('style')).toEqual({ right: '0%' });
+    const ticks = screen.getAllByTestId('tick');
+    expect(ticks[ticks.length - 1]).toHaveStyle('right: 0%');
   });
 
   it('places middle ticks at proper intervals', () => {
+    const ticks = screen.getAllByTestId('tick');
+    // Skip first (index 0) and last (index numTicks)
     const positions = ['25%', '50%', '75%'];
     positions.forEach((pos, i) => {
-      const tick = ticks.at(i + 1);
-      expect(tick.prop('style')).toEqual({ left: pos });
+      // Tick elements are indexed starting from 0,
+      // middle ticks start at index 1
+      expect(ticks[i + 1]).toHaveStyle(`left: ${pos}`);
     });
   });
 
-  it("doesn't explode if no trace is present", () => {
-    expect(() => shallow(<TickLabels {...defaultProps} trace={null} />)).not.toThrow();
-  });
+  // Removed the "doesn't explode if no trace is present" test as 'trace' is not a prop
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.test.js
@@ -77,5 +77,4 @@ describe('<TickLabels>', () => {
     });
   });
 
-  // Removed the "doesn't explode if no trace is present" test as 'trace' is not a prop
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/TickLabels.tsx
@@ -31,7 +31,7 @@ export default function TickLabels(props: TickLabelsProps) {
     const portion = i / numTicks;
     const style = portion === 1 ? { right: '0%' } : { left: `${portion * 100}%` };
     ticks.push(
-      <div key={portion} className="TickLabels--label" style={style} data-test="tick">
+      <div key={portion} className="TickLabels--label" style={style} data-testid="tick">
         {formatDuration(duration * portion)}
       </div>
     );


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of https://github.com/jaegertracing/jaeger-ui/issues/1668

## Description of the changes
- Migrates `TickLabels` tests

## How was this change tested?
- Test itself.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`