### PR TITLE
Fix DependencyGraph dag extra render

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -173,7 +173,7 @@ describe('<DAG>', () => {
     });
     const data = {
       nodes: Array.from(nodes).map(key => ({ key })),
-      edges: edges,
+      edges,
     };
 
     renderer.render(<DAG data={data} selectedLayout="sfdp" />);
@@ -247,7 +247,7 @@ describe('<DAG>', () => {
     });
     const data = {
       nodes: Array.from(nodes).map(key => ({ key })),
-      edges: edges,
+      edges,
     };
     expect(data.nodes.length).toBeGreaterThan(DAG_MAX_NUM_SERVICES);
 

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
@@ -280,7 +280,6 @@ describe('<DependencyGraph>', () => {
   });
 
   describe('<DependencyGraph> filtering logic (findConnectedServices)', () => {
-    let wrapper;
     const baseProps = {
       fetchDependencies: jest.fn(),
       nodes: [{ key: 'dummyNode' }],

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.test.js
@@ -87,7 +87,6 @@ describe('<DependencyGraph>', () => {
       expect(wrapper.state('selectedLayout')).toBe('dot');
       expect(wrapper.state('selectedDepth')).toBe(5);
       expect(wrapper.state('debouncedDepth')).toBe(5);
-      expect(wrapper.state('matchCount')).toBe(0);
     });
 
     it('handles service selection', () => {
@@ -248,21 +247,35 @@ describe('<DependencyGraph>', () => {
       await wrapper.instance().handleSampleDatasetTypeChange(null);
     });
 
-    it('handles match count change', () => {
-      const matchCount = 3;
-      wrapper.instance().handleMatchCountChange(matchCount);
-      expect(wrapper.state('matchCount')).toBe(matchCount);
-    });
+    it('passes computed match count to DAGOptions based on uiFind and dependencies', () => {
+      const sampleDependencies = [
+        { parent: 'serviceA', child: 'serviceB', callCount: 10 },
+        { parent: 'serviceB', child: 'anotherService', callCount: 5 },
+        { parent: 'serviceA', child: 'anotherService', callCount: 2 },
+      ];
 
-    it('passes match count to DAGOptions', () => {
-      wrapper.setState({ matchCount: 5 });
+      const uiFindTerm = 'service';
+      const expectedMatchCount = 3;
+
+      wrapper.setProps({ dependencies: sampleDependencies, uiFind: uiFindTerm });
+      wrapper.setState({ selectedService: null });
+
+      wrapper.update();
+
       const dagOptions = wrapper.find(DAGOptions);
-      expect(dagOptions.prop('matchCount')).toBe(5);
-    });
+      expect(dagOptions.prop('matchCount')).toBe(expectedMatchCount);
 
-    it('passes onMatchCountChange to DAG', () => {
-      const dag = wrapper.find(DAG);
-      expect(dag.prop('onMatchCountChange')).toBeDefined();
+      const uiFindTerm2 = 'another';
+      const expectedMatchCount2 = 1;
+      wrapper.setProps({ uiFind: uiFindTerm2 });
+      wrapper.update();
+      const dagOptions2 = wrapper.find(DAGOptions);
+      expect(dagOptions2.prop('matchCount')).toBe(expectedMatchCount2);
+
+      wrapper.setProps({ uiFind: undefined });
+      wrapper.update();
+      const dagOptions3 = wrapper.find(DAGOptions);
+      expect(dagOptions3.prop('matchCount')).toBe(0);
     });
   });
 });

--- a/packages/jaeger-ui/tsconfig.lint.json
+++ b/packages/jaeger-ui/tsconfig.lint.json
@@ -32,7 +32,7 @@
     "src/actions/jaeger-api.js",
     "src/api/jaeger.js",
     "src/components/App/index.jsx",
-    "src/components/DependencyGraph/index.jsx",
+    "src/components/DependencyGraph/index.tsx",
     "src/components/SearchTracePage/index.jsx",
     "src/components/SearchTracePage/SearchForm.jsx",
     "src/components/SearchTracePage/SearchForm.markers.js",


### PR DESCRIPTION
## Which problem is this PR solving?
https://github.com/jaegertracing/jaeger-ui/issues/2715

## Description of the changes
- Removes unneeded useEffect hook and simplifies logic
- Converts DependencyGraph/index.jsx to TS because above change had moved typed functions to an untyped file

## How was this change tested?
- Generated dependencies locally with HotRod and validated visually + logged render count to verify DAG component no longer double renders
- Passes existing tests (some unit tests were updated)

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
