### PR TITLE
Replace deprecated `overlayClassName` with `classNames.root`

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -79,7 +79,7 @@ export default class Header extends React.PureComponent<TProps> {
     }
 
     return (
-      <Tooltip overlayClassName="DdgHeader--uiFindInfo--tooltip" placement="topRight" title={tipText}>
+      <Tooltip classNames={{root: "DdgHeader--uiFindInfo--tooltip"}} placement="topRight" title={tipText}>
         {/* arbitrary span is necessary as Tooltip alters child's styling */}
         <span>
           <button

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.tsx
@@ -79,7 +79,7 @@ export default class Header extends React.PureComponent<TProps> {
     }
 
     return (
-      <Tooltip classNames={{root: "DdgHeader--uiFindInfo--tooltip"}} placement="topRight" title={tipText}>
+      <Tooltip classNames={{ root: 'DdgHeader--uiFindInfo--tooltip' }} placement="topRight" title={tipText}>
         {/* arbitrary span is necessary as Tooltip alters child's styling */}
         <span>
           <button

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
@@ -79,7 +79,7 @@ exports[`<OperationTableDetails> Table rendered successfully 1`] = `
               <Tooltip
                 classNames={
                   Object {
-                    "root": "\\"impact-tooltip\\"",
+                    "root": "impact-tooltip",
                   }
                 }
                 placement="top"

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/__snapshots__/index.test.js.snap
@@ -77,7 +77,11 @@ exports[`<OperationTableDetails> Table rendered successfully 1`] = `
               Impact
                 
               <Tooltip
-                overlayClassName="impact-tooltip"
+                classNames={
+                  Object {
+                    "root": "\\"impact-tooltip\\"",
+                  }
+                }
                 placement="top"
                 title="The result of multiplying avg. duration and requests per minute, showing the most used and slowest endpoints"
               >

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -162,7 +162,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
             <span style={{ float: 'left', color: '#459798' }}>
               {tableTitles.get('impact')} &nbsp;
               <Tooltip
-                classNames={{ root: "impact-tooltip" }}
+                classNames={{ root: 'impact-tooltip' }}
                 placement="top"
                 title="The result of multiplying avg. duration and requests per minute, showing the most used and slowest endpoints"
               >

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -162,7 +162,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
             <span style={{ float: 'left', color: '#459798' }}>
               {tableTitles.get('impact')} &nbsp;
               <Tooltip
-                overlayClassName="impact-tooltip"
+                classNames={{ root: '"impact-tooltip"' }}
                 placement="top"
                 title="The result of multiplying avg. duration and requests per minute, showing the most used and slowest endpoints"
               >

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.tsx
@@ -162,7 +162,7 @@ export class OperationTableDetails extends React.PureComponent<TProps, TState> {
             <span style={{ float: 'left', color: '#459798' }}>
               {tableTitles.get('impact')} &nbsp;
               <Tooltip
-                classNames={{ root: '"impact-tooltip"' }}
+                classNames={{ root: "impact-tooltip" }}
                 placement="top"
                 title="The result of multiplying avg. duration and requests per minute, showing the most used and slowest endpoints"
               >

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/__snapshots__/renderNode.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`drawNode diffNode renders as expected when props.a and props.b are the same 1`] = `
 <Popover
+  classNames={
+    Object {
+      "root": "DiffNode--popover is-same",
+    }
+  }
   content={
     <table
       className="DiffNode is-same"
@@ -42,7 +47,6 @@ exports[`drawNode diffNode renders as expected when props.a and props.b are the 
     </table>
   }
   mouseEnterDelay={0.25}
-  overlayClassName="DiffNode--popover is-same"
 >
   <table
     className="DiffNode is-same"
@@ -86,6 +90,11 @@ exports[`drawNode diffNode renders as expected when props.a and props.b are the 
 
 exports[`drawNode diffNode renders as expected when props.a is 0 1`] = `
 <Popover
+  classNames={
+    Object {
+      "root": "DiffNode--popover is-changed is-added",
+    }
+  }
   content={
     <table
       className="DiffNode is-changed is-added"
@@ -146,7 +155,6 @@ exports[`drawNode diffNode renders as expected when props.a is 0 1`] = `
     </table>
   }
   mouseEnterDelay={0.25}
-  overlayClassName="DiffNode--popover is-changed is-added"
 >
   <table
     className="DiffNode is-changed is-added"
@@ -210,6 +218,11 @@ exports[`drawNode diffNode renders as expected when props.a is 0 1`] = `
 
 exports[`drawNode diffNode renders as expected when props.a is less than props.b 1`] = `
 <Popover
+  classNames={
+    Object {
+      "root": "DiffNode--popover is-changed is-more",
+    }
+  }
   content={
     <table
       className="DiffNode is-changed is-more"
@@ -270,7 +283,6 @@ exports[`drawNode diffNode renders as expected when props.a is less than props.b
     </table>
   }
   mouseEnterDelay={0.25}
-  overlayClassName="DiffNode--popover is-changed is-more"
 >
   <table
     className="DiffNode is-changed is-more"
@@ -334,6 +346,11 @@ exports[`drawNode diffNode renders as expected when props.a is less than props.b
 
 exports[`drawNode diffNode renders as expected when props.a is more than props.b 1`] = `
 <Popover
+  classNames={
+    Object {
+      "root": "DiffNode--popover is-changed is-less",
+    }
+  }
   content={
     <table
       className="DiffNode is-changed is-less"
@@ -394,7 +411,6 @@ exports[`drawNode diffNode renders as expected when props.a is more than props.b
     </table>
   }
   mouseEnterDelay={0.25}
-  overlayClassName="DiffNode--popover is-changed is-less"
 >
   <table
     className="DiffNode is-changed is-less"
@@ -458,6 +474,11 @@ exports[`drawNode diffNode renders as expected when props.a is more than props.b
 
 exports[`drawNode diffNode renders as expected when props.b is 0 1`] = `
 <Popover
+  classNames={
+    Object {
+      "root": "DiffNode--popover is-changed is-removed",
+    }
+  }
   content={
     <table
       className="DiffNode is-changed is-removed"
@@ -518,7 +539,6 @@ exports[`drawNode diffNode renders as expected when props.b is 0 1`] = `
     </table>
   }
   mouseEnterDelay={0.25}
-  overlayClassName="DiffNode--popover is-changed is-removed"
 >
   <table
     className="DiffNode is-changed is-removed"
@@ -582,6 +602,11 @@ exports[`drawNode diffNode renders as expected when props.b is 0 1`] = `
 
 exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 1`] = `
 <Popover
+  classNames={
+    Object {
+      "root": "DiffNode--popover is-same",
+    }
+  }
   content={
     <table
       className="DiffNode is-same"
@@ -622,7 +647,6 @@ exports[`drawNode diffNode renders as expected when props.isUiFindMatch is true 
     </table>
   }
   mouseEnterDelay={0.25}
-  overlayClassName="DiffNode--popover is-same"
 >
   <table
     className="DiffNode is-same"

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.tsx
@@ -79,7 +79,7 @@ export class DiffNode extends React.PureComponent<Props> {
     );
 
     return (
-      <Popover overlayClassName={`DiffNode--popover ${className}`} mouseEnterDelay={0.25} content={table}>
+      <Popover classNames={{ root: `DiffNode--popover ${className}` }} mouseEnterDelay={0.25} content={table}>
         {table}
       </Popover>
     );

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceDiffHeader.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceDiffHeader.tsx
@@ -97,7 +97,7 @@ export default class TraceDiffHeader extends React.PureComponent<Props, State> {
           <h1 className="ub-m0">A</h1>
         </div>
         <Popover
-          overlayClassName="TraceDiffHeader--popover"
+          classNames={{ root: 'TraceDiffHeader--popover' }}
           trigger="click"
           placement="bottomLeft"
           title={<TraceIdInput selectTrace={this._diffSetA} />}
@@ -124,7 +124,7 @@ export default class TraceDiffHeader extends React.PureComponent<Props, State> {
           <h1 className="ub-m0">B</h1>
         </div>
         <Popover
-          overlayClassName="TraceDiffHeader--popover"
+          classNames={{ root: 'TraceDiffHeader--popover' }}
           trigger="click"
           placement="bottomLeft"
           title={<TraceIdInput selectTrace={this._diffSetB} />}

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceDiffHeader.test.js.snap
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/__snapshots__/TraceDiffHeader.test.js.snap
@@ -14,6 +14,11 @@ exports[`TraceDiffHeader handles absent a & b 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -90,7 +95,6 @@ exports[`TraceDiffHeader handles absent a & b 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -124,6 +128,11 @@ exports[`TraceDiffHeader handles absent a & b 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -200,7 +209,6 @@ exports[`TraceDiffHeader handles absent a & b 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -232,6 +240,11 @@ exports[`TraceDiffHeader handles absent a 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -314,7 +327,6 @@ exports[`TraceDiffHeader handles absent a 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -348,6 +360,11 @@ exports[`TraceDiffHeader handles absent a 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -431,7 +448,6 @@ exports[`TraceDiffHeader handles absent a 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -471,6 +487,11 @@ exports[`TraceDiffHeader handles absent b 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -554,7 +575,6 @@ exports[`TraceDiffHeader handles absent b 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -596,6 +616,11 @@ exports[`TraceDiffHeader handles absent b 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -678,7 +703,6 @@ exports[`TraceDiffHeader handles absent b 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -710,6 +734,11 @@ exports[`TraceDiffHeader renders as expected 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -796,7 +825,6 @@ exports[`TraceDiffHeader renders as expected 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput
@@ -838,6 +866,11 @@ exports[`TraceDiffHeader renders as expected 1`] = `
     </h1>
   </div>
   <Popover
+    classNames={
+      Object {
+        "root": "TraceDiffHeader--popover",
+      }
+    }
     content={
       <CohortTable
         cohort={
@@ -924,7 +957,6 @@ exports[`TraceDiffHeader renders as expected 1`] = `
     }
     onOpenChange={[Function]}
     open={false}
-    overlayClassName="TraceDiffHeader--popover"
     placement="bottomLeft"
     title={
       <TraceIdInput

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
@@ -116,7 +116,7 @@ export default class OpNode extends React.PureComponent<Props> {
     const popoverContent = <div className="OpNode--popoverContent">{table}</div>;
 
     return (
-      <Popover classNames={{ root: "OpNode--popover" }} mouseEnterDelay={0.25} content={popoverContent}>
+      <Popover classNames={{ root: 'OpNode--popover' }} mouseEnterDelay={0.25} content={popoverContent}>
         {table}
       </Popover>
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
@@ -116,7 +116,7 @@ export default class OpNode extends React.PureComponent<Props> {
     const popoverContent = <div className="OpNode--popoverContent">{table}</div>;
 
     return (
-      <Popover overlayClassName="OpNode--popover" mouseEnterDelay={0.25} content={popoverContent}>
+      <Popover classNames={{ root: "OpNode--popover" }} mouseEnterDelay={0.25} content={popoverContent}>
         {table}
       </Popover>
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
@@ -61,7 +61,7 @@ export default class ReferencesButton extends React.PureComponent<TReferencesBut
       mouseLeaveDelay: 0.5,
       placement: 'bottom' as TooltipPlacement,
       title: tooltipText,
-      overlayClassName: 'ReferencesButton--tooltip',
+      classNames: { root: 'ReferencesButton--tooltip' },
     };
 
     if (references.length > 1) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
@@ -147,8 +147,8 @@ function SpanBar(props: TCommonProps) {
         {Object.keys(logGroups).map(positionKey => (
           <Popover
             key={positionKey}
-            arrowPointAtCenter
-            overlayClassName="SpanBar--logHint"
+            arrow={{ pointAtCenter: true }}
+            classNames={{ root: 'SpanBar--logHint' }}
             placement="topLeft"
             content={
               <AccordianLogs

--- a/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
@@ -81,7 +81,7 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
           value={value}
         />
         <div className="DetailTableDropdown--Footer">
-          <Tooltip overlayClassName="DetailTableDropdown--Tooltip" title="Remove filter from this column">
+          <Tooltip classNames={{ root: 'DetailTableDropdown--Tooltip' }} title="Remove filter from this column">
             <Button className="DetailTableDropdown--Btn Clear" onClick={clearFilters}>
               <IoTrash size={18} />
               Clear Filter
@@ -89,7 +89,7 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
           </Tooltip>
           <div className="DetailTableDropdown--Footer--CancelConfirm">
             <Tooltip
-              overlayClassName="DetailTableDropdown--Tooltip"
+              classNames={{ root: 'DetailTableDropdown--Tooltip' }}
               title="Cancel changes to this column's filter"
             >
               <Button className="DetailTableDropdown--Btn Cancel" onClick={this.cancel}>
@@ -98,7 +98,7 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
               </Button>
             </Tooltip>
             <Tooltip
-              overlayClassName="DetailTableDropdown--Tooltip"
+              classNames={{ root: 'DetailTableDropdown--Tooltip' }}
               title={
                 <div className="DetailTableDropdown--Tooltip--Body">
                   <span>Apply changes to this column&apos;s filter</span>

--- a/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.tsx
@@ -81,7 +81,10 @@ export default class DetailTableDropdown extends React.PureComponent<TProps> {
           value={value}
         />
         <div className="DetailTableDropdown--Footer">
-          <Tooltip classNames={{ root: 'DetailTableDropdown--Tooltip' }} title="Remove filter from this column">
+          <Tooltip
+            classNames={{ root: 'DetailTableDropdown--Tooltip' }}
+            title="Remove filter from this column"
+          >
             <Button className="DetailTableDropdown--Btn Clear" onClick={clearFilters}>
               <IoTrash size={18} />
               Clear Filter

--- a/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/__snapshots__/DetailTableDropdown.test.js.snap
@@ -25,7 +25,11 @@ exports[`DetailTable render renders as expected 1`] = `
     className="DetailTableDropdown--Footer"
   >
     <Tooltip
-      overlayClassName="DetailTableDropdown--Tooltip"
+      classNames={
+        Object {
+          "root": "DetailTableDropdown--Tooltip",
+        }
+      }
       title="Remove filter from this column"
     >
       <Button
@@ -42,7 +46,11 @@ exports[`DetailTable render renders as expected 1`] = `
       className="DetailTableDropdown--Footer--CancelConfirm"
     >
       <Tooltip
-        overlayClassName="DetailTableDropdown--Tooltip"
+        classNames={
+          Object {
+            "root": "DetailTableDropdown--Tooltip",
+          }
+        }
         title="Cancel changes to this column's filter"
       >
         <Button
@@ -56,7 +64,11 @@ exports[`DetailTable render renders as expected 1`] = `
         </Button>
       </Tooltip>
       <Tooltip
-        overlayClassName="DetailTableDropdown--Tooltip"
+        classNames={
+          Object {
+            "root": "DetailTableDropdown--Tooltip",
+          }
+        }
         title={
           <div
             className="DetailTableDropdown--Tooltip--Body"

--- a/packages/jaeger-ui/src/components/common/NameSelector.tsx
+++ b/packages/jaeger-ui/src/components/common/NameSelector.tsx
@@ -112,7 +112,7 @@ export default class NameSelector extends React.PureComponent<TProps, TState> {
     }
     return (
       <Popover
-        overlayClassName="NameSelector--overlay u-rm-popover-content-padding"
+        classNames={{ root: 'NameSelector--overlay u-rm-popover-content-padding' }}
         onOpenChange={this.onPopoverVisibleChanged}
         placement="bottomLeft"
         content={


### PR DESCRIPTION
## Summary

This PR addresses the deprecation warning related to the `overlayClassName` prop used in Ant Design’s `Tooltip` and `Popover` components.

## Changes

- Replaced all instances of the deprecated `overlayClassName` prop with the recommended `classNames={{ root: "<className>" }}` syntax throughout the codebase.
- Updated relevant test snapshots to reflect these changes.
- Ran all tests to ensure nothing is broken and update the snapshot files.

## Background

The `overlayClassName` prop is deprecated in Ant Design components such as `Tooltip` and `Popover`. The new API requires using the `classNames` prop with an object that specifies the `root` key for custom class names. See [Ant Design Tooltip docs](https://ant.design/components/tooltip/) for more info.

---

This PR helps keep the project up to date and warning-free with respect to UI library best practices.
