### PR TITLE
[Fix]: Reduce default minimum allowed zoom

### DIFF
--- a/packages/plexus/src/zoom/utils.tsx
+++ b/packages/plexus/src/zoom/utils.tsx
@@ -35,7 +35,11 @@ function boundValue(min: number, max: number, value: number) {
 function getFittedScale(width: number, height: number, viewWidth: number, viewHeight: number) {
   return Math.max(
     SCALE_MIN,
-    Math.min(((1 - SCALE_MARGIN) * viewWidth) / width, ((1 - SCALE_MARGIN) * viewHeight) / height, SCALE_MAX)
+    Math.min(
+      ((1 - SCALE_MARGIN) * viewWidth) / 1.5 / width,
+      ((1 - SCALE_MARGIN) * viewHeight) / 1.5 / height,
+      SCALE_MAX
+    )
   );
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- fixes https://github.com/jaegertracing/jaeger-ui/issues/2699

## Description of the changes
- This PR allows reducing the default minimum zoon value so less number of nodes doesn't get too scaled

## How was this change tested?
- Manually

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
