### PR TITLE
docs: remove redundant UI config link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ See the [configuration guide](https://www.jaegertracing.io/docs/latest/frontend-
 
 ```
 
-See the [configuration guide](https://www.jaegertracing.io/docs/latest/frontend-ui/) for details on configuring Google Analytics tracking, menu customizations, and other aspects of UI behavior.
-
 ## License
 
 [Apache 2.0 License](./LICENSE).


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Cleans up the README by removing a redundant link to the UI configuration guide that was repeated in the "Debug unit tests from Vscode" section.

## Description of the changes
- Removed a duplicate reference to the UI configuration guide at the end of the "Debug unit tests from Vscode" section in `README.md`.
- The guide is already properly referenced in the dedicated "UI Configuration" section.
- This change improves clarity and prevents repetition in the documentation.

## How was this change tested?
- Manually reviewed the `README.md` to ensure formatting remained intact after removal.
- Verified that the remaining UI configuration reference is still present and accessible.

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality (N/A for docs)
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
