### PR TITLE
test: add test coverage for button click handler 

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/EmptyState/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/EmptyState/index.test.js
@@ -13,16 +13,39 @@
 // limitations under the License.
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MonitorATMEmptyState from '.';
+import { getConfigValue } from '../../../utils/config/get-config';
+
+jest.mock('../../../utils/config/get-config', () => ({
+  getConfigValue: jest.fn(),
+}));
 
 describe('<MonitorATMEmptyState>', () => {
+  const mockClickHandler = jest.fn();
+
   beforeEach(() => {
+    getConfigValue.mockReturnValue({
+      mainTitle: 'Get started with Service Performance Monitoring',
+      subTitle: 'subtitle',
+      description: 'description',
+      button: {
+        text: 'Click Me',
+        onClick: mockClickHandler,
+      },
+    });
+
     render(<MonitorATMEmptyState />);
   });
 
   it('renders the title', () => {
     expect(screen.getByText('Get started with Service Performance Monitoring')).toBeInTheDocument();
+  });
+
+  it('calls the onClick handler when button is clicked', () => {
+    const button = screen.getByText('Click Me');
+    fireEvent.click(button);
+    expect(mockClickHandler).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR improves test coverage in the MonitorATMEmptyState component by mocking the getConfigValue function to include a button with an onClick handler. The component is then rendered with this mocked configuration, and a simulated button click is performed using fireEvent.click. The test asserts that the onClick handler is invoked as expected. As a result of this addition, the test coverage for the component increased from 75% to 100%.

Closes #2785 