### PR TITLE
fix: disable archive button for in-memory storage

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -21,6 +21,7 @@ import _mapValues from 'lodash/mapValues';
 import _memoize from 'lodash/memoize';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
+import { message } from 'antd';
 
 import ArchiveNotifier from './ArchiveNotifier';
 import { actions as archiveActions } from './ArchiveNotifier/duck';
@@ -285,7 +286,10 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
   };
 
   archiveTrace = () => {
-    const { id, archiveTrace } = this.props;
+    const { id, archiveTrace, storageCapabilities } = this.props;
+    if (storageCapabilities?.storageType === 'memory') {
+      message.warning('Warning: Archiving with in-memory storage is not persistent. Traces will be lost on restart.');
+    }
     archiveTrace(id);
   };
 
@@ -362,6 +366,8 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
 
     const isEmbedded = Boolean(embedded);
     const hasArchiveStorage = Boolean(storageCapabilities?.archiveStorage);
+    const isMemoryStorage = storageCapabilities?.storageType === 'memory';
+    const showArchiveButton = !isEmbedded && archiveEnabled && hasArchiveStorage && !isMemoryStorage;
     const headerProps = {
       focusUiFindMatches: this.focusUiFindMatches,
       slimView,
@@ -383,7 +389,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
       ref: this._searchBar,
       resultCount: findCount,
       disableJsonView,
-      showArchiveButton: !isEmbedded && archiveEnabled && hasArchiveStorage,
+      showArchiveButton,
       showShortcutsHelp: !isEmbedded,
       showStandaloneLink: isEmbedded,
       showViewOptions: !isEmbedded,


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2201

## Description of the changes
- Disables the archive button for in-memory storage in the TracePage component.
- Displays a warning message if a user attempts to archive a trace while using in-memory storage.
- Prevents users from mistakenly archiving traces that will not persist after a restart.

## How was this change tested?
- Verified that the archive button is hidden when Jaeger is running with in-memory storage.
- Confirmed that a warning message is shown if archive is attempted with in-memory storage.
- Tested the functionality to ensure that the warning message appears correctly.

## Documentation

**Note:**  
The main documentation in the [jaegertracing/jaeger](https://github.com/jaegertracing/jaeger) repository should be updated to reflect this new behavior and clarify that persistent storage is required for archiving traces.  


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`