### PR TITLE
test: achieve 100% coverage for SearchResults components and improve test reliability

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
@@ -21,6 +21,7 @@ import ResultItem from './ResultItem';
 import * as markers from './ResultItem.markers';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
+import * as tracking from './index.track';
 
 // Helper function to wrap component with Router
 const renderWithRouter = ui => {
@@ -43,7 +44,7 @@ it('<ResultItem /> should render base case correctly', () => {
       trace={trace}
       durationPercent={50}
       linkTo=""
-      toggleComparison={() => {}}
+      toggleComparison={() => { }}
       isInDiffCohort={false}
       disableComparision={false}
     />
@@ -61,7 +62,7 @@ it('<ResultItem /> should not render any ServiceTags when there are no services'
       trace={traceWithoutServices}
       durationPercent={50}
       linkTo=""
-      toggleComparison={() => {}}
+      toggleComparison={() => { }}
       isInDiffCohort={false}
       disableComparision={false}
     />
@@ -94,7 +95,7 @@ it('<ResultItem /> should render error icon on ServiceTags that have an error ta
       trace={trace}
       durationPercent={50}
       linkTo=""
-      toggleComparison={() => {}}
+      toggleComparison={() => { }}
       isInDiffCohort={false}
       disableComparision={false}
     />
@@ -109,4 +110,21 @@ it('<ResultItem /> should render error icon on ServiceTags that have an error ta
   // Assert that the specific service tag is found and has the error icon
   expect(errorTag).toBeDefined();
   expect(errorTag.querySelector('.ResultItem--errorIcon')).toBeInTheDocument();
+});
+
+it('calls trackConversions on click', () => {
+  const spy = jest.spyOn(tracking, 'trackConversions');
+  renderWithRouter(
+    <ResultItem
+      trace={trace}
+      durationPercent={50}
+      linkTo=""
+      toggleComparison={() => { }}
+      isInDiffCohort={false}
+      disableComparision={false}
+    />
+  );
+  const resultItem = screen.getByRole('button');
+  resultItem.click();
+  expect(spy).toHaveBeenCalledWith(tracking.EAltViewActions.Traces);
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.js
@@ -44,7 +44,7 @@ it('<ResultItem /> should render base case correctly', () => {
       trace={trace}
       durationPercent={50}
       linkTo=""
-      toggleComparison={() => { }}
+      toggleComparison={() => {}}
       isInDiffCohort={false}
       disableComparision={false}
     />
@@ -62,7 +62,7 @@ it('<ResultItem /> should not render any ServiceTags when there are no services'
       trace={traceWithoutServices}
       durationPercent={50}
       linkTo=""
-      toggleComparison={() => { }}
+      toggleComparison={() => {}}
       isInDiffCohort={false}
       disableComparision={false}
     />
@@ -95,7 +95,7 @@ it('<ResultItem /> should render error icon on ServiceTags that have an error ta
       trace={trace}
       durationPercent={50}
       linkTo=""
-      toggleComparison={() => { }}
+      toggleComparison={() => {}}
       isInDiffCohort={false}
       disableComparision={false}
     />
@@ -119,7 +119,7 @@ it('calls trackConversions on click', () => {
       trace={trace}
       durationPercent={50}
       linkTo=""
-      toggleComparison={() => { }}
+      toggleComparison={() => {}}
       isInDiffCohort={false}
       disableComparision={false}
     />

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.test.js
@@ -77,6 +77,15 @@ describe('ResultItemTitle', () => {
         !defaultProps.isInDiffCohort
       );
     });
+
+    it('calls stopPropagation on checkbox click', () => {
+      const stopPropagation = jest.fn();
+      const fakeEvent = { stopPropagation };
+
+      const checkbox = wrapper.find(Checkbox);
+      checkbox.prop('onClick')(fakeEvent);
+      expect(stopPropagation).toHaveBeenCalled();
+    });
   });
 
   describe('WrapperComponent', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.test.js
@@ -249,6 +249,11 @@ describe('ScatterPlot', () => {
     expect(container.querySelector('.TraceResultsScatterPlot')).toBeTruthy();
     expect(container.querySelector('.recharts-responsive-container')).toBeFalsy();
   });
+
+  it('uses default calculateContainerWidth when prop is not provided', () => {
+    render(<ScatterPlot data={sampleData} onValueClick={jest.fn()} />);
+    expect(document.querySelector('.TraceResultsScatterPlot')).toBeInTheDocument();
+  });
 });
 
 describe('CustomTooltip', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
@@ -47,7 +47,7 @@ describe('<SearchResults>', () => {
     rawTraces = traces;
     props = {
       diffCohort: [],
-      goToTrace: () => {},
+      goToTrace: () => { },
       location: {},
       loading: false,
       maxTraceDuration: 1,
@@ -76,6 +76,54 @@ describe('<SearchResults>', () => {
   it('hide DiffSelection when disableComparisons = true', () => {
     wrapper.setProps({ disableComparisons: true });
     expect(wrapper.find(DiffSelection).length).toBe(0);
+  });
+
+  it('adds or removes trace from cohort based on flag', () => {
+    const cohortAddTrace = jest.fn();
+    const cohortRemoveTrace = jest.fn();
+    wrapper.setProps({ cohortAddTrace, cohortRemoveTrace });
+
+    const instance = wrapper.instance();
+    instance.toggleComparison('id-1');
+    instance.toggleComparison('id-2', true);
+
+    expect(cohortAddTrace).toHaveBeenCalledWith('id-1');
+    expect(cohortRemoveTrace).toHaveBeenCalledWith('id-2');
+  });
+
+  it('sets trace color to red if error tag is present', () => {
+    wrapper.setProps({
+      traces: [{
+        traceID: 'err',
+        traceName: 'T',
+        startTime: 0,
+        duration: 1,
+        processes: {},
+        spans: [{ tags: [{ key: 'error', value: true }] }],
+      }],
+    });
+    const data = wrapper.find(ScatterPlot).prop('data');
+    expect(data[0].color).toBe('red');
+  });
+
+  it('renders DiffSelection when diffCohort is provided', () => {
+    wrapper.setProps({ diffCohort: [{ id: 'id-1' }] });
+    expect(wrapper.find(DiffSelection)).toHaveLength(1);
+  });
+
+  it('calls goToTrace when a ScatterPlot point is clicked', () => {
+    const goToTrace = jest.fn();
+    const trace = {
+      traceID: 'id-1',
+      spans: [],
+      startTime: 0,
+      duration: 1,
+      traceName: 'TraceThis',
+      processes: {},
+    };
+    wrapper.setProps({ traces: [trace], goToTrace });
+    wrapper.find(ScatterPlot).prop('onValueClick')(trace);
+    expect(goToTrace).toHaveBeenCalledWith('id-1');
   });
 
   describe('search finished with results', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.js
@@ -47,7 +47,7 @@ describe('<SearchResults>', () => {
     rawTraces = traces;
     props = {
       diffCohort: [],
-      goToTrace: () => { },
+      goToTrace: () => {},
       location: {},
       loading: false,
       maxTraceDuration: 1,
@@ -93,14 +93,16 @@ describe('<SearchResults>', () => {
 
   it('sets trace color to red if error tag is present', () => {
     wrapper.setProps({
-      traces: [{
-        traceID: 'err',
-        traceName: 'T',
-        startTime: 0,
-        duration: 1,
-        processes: {},
-        spans: [{ tags: [{ key: 'error', value: true }] }],
-      }],
+      traces: [
+        {
+          traceID: 'err',
+          traceName: 'T',
+          startTime: 0,
+          duration: 1,
+          processes: {},
+          spans: [{ tags: [{ key: 'error', value: true }] }],
+        },
+      ],
     });
     const data = wrapper.find(ScatterPlot).prop('data');
     expect(data[0].color).toBe('red');


### PR DESCRIPTION
This PR enhances the test coverage for all components within the src/components/SearchTracePage/SearchResults/ directory, achieving 100% coverage across all files in the folder.

Before 
<img width="1440" alt="Screenshot 2025-05-21 at 7 47 30 PM" src="https://github.com/user-attachments/assets/cc679b10-f9b7-4f64-aa2a-7010ef612c82" />

After
<img width="1440" alt="Screenshot 2025-05-21 at 7 41 28 PM" src="https://github.com/user-attachments/assets/f0be411a-18a0-4119-9c72-22b9f899f715" />
