### PR TITLE
test: improve coverage for TraceDiffGraph directory

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.test.js
@@ -168,4 +168,29 @@ describe('TraceDiffGraph', () => {
     wrapper.unmount();
     expect(layoutManager).toHaveBeenCalledTimes(1);
   });
+
+  it('displays match count when uiFind matches span data', () => {
+    const span = {
+      spanID: 'abc123',
+      operationName: 'GET /api',
+      process: { serviceName: 'svc' },
+      tags: [],
+      logs: [],
+    };
+
+    const baseTrace = {
+      data: { spans: [span], traceID: 't-id' },
+      error: null,
+      id: 't-id',
+      state: fetchedState.DONE,
+    };
+
+    const wrapper = shallow(
+      <TraceDiffGraph a={baseTrace} b={baseTrace} uiFind="GET" />
+    );
+
+    expect(wrapper.find(UiFindInput).prop('inputProps')).toMatchObject({
+      suffix: '1',
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.js
@@ -15,7 +15,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import renderNode, { DiffNode } from './renderNode';
+import renderNode, { DiffNode, getNodeEmphasisRenderer } from './renderNode';
+import EmphasizedNode from '../../common/EmphasizedNode';
 
 describe('drawNode', () => {
   const operation = 'operationName';
@@ -86,6 +87,25 @@ describe('drawNode', () => {
       expect(node.props.b).toBe(lenB);
       expect(node.props.operation).toBe(operation);
       expect(node.props.service).toBe(service);
+    });
+  });
+
+  describe('getNodeEmphasisRenderer', () => {
+    const key = 'match-key';
+    const renderer = getNodeEmphasisRenderer(new Set([key]));
+
+    it('returns EmphasizedNode when key matches', () => {
+      const lv = { height: 100, width: 200, vertex: { key } };
+      const result = renderer(lv);
+      expect(result.type).toBe(EmphasizedNode);
+      expect(result.props.height).toBe(100);
+      expect(result.props.width).toBe(200);
+    });
+
+    it('returns null when key does not match', () => {
+      const lv = { height: 100, width: 200, vertex: { key: 'no-match' } };
+      const result = renderer(lv);
+      expect(result).toBeNull();
     });
   });
 });


### PR DESCRIPTION
This PR improves test coverage for renderNode, and traceDiffGraphUtils by adding tests that cover previously untested branches. These additions help achieve full coverage.

Before
<img width="1440" alt="Screenshot 2025-05-21 at 11 09 59 PM" src="https://github.com/user-attachments/assets/17ebbe4e-caa4-40c0-8150-dc3c3338f702" />

After
<img width="1439" alt="Screenshot 2025-05-21 at 11 08 07 PM" src="https://github.com/user-attachments/assets/6454e471-2b58-40fe-a03a-4ec8ea88b9cb" />
