### PR TITLE
Allow json logs to occupy entire available width

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -40,12 +40,17 @@ limitations under the License.
   width: 125px;
 }
 
-.KeyValueTable--copyColumn {
-  white-space: nowrap;
-  text-align: right;
+.KeyValueTable--valueColumn {
+  position: relative;
 }
 
-.KeyValueTable--row:not(:hover) > .KeyValueTable--copyColumn > .KeyValueTable--copyIcon {
+.KeyValueTable--copyContainer {
+  float: right;
+  margin-left: 8px;
+  white-space: nowrap;
+}
+
+.KeyValueTable--row:not(:hover) .KeyValueTable--copyContainer .KeyValueTable--copyIcon {
   visibility: hidden;
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -24,6 +24,7 @@ import { TNil } from '../../../../types';
 import { KeyValuePair, Link } from '../../../../types/trace';
 
 import './KeyValuesTable.css';
+import { consoleIntegration } from '@sentry/core';
 
 const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 
@@ -178,21 +179,23 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
               // eslint-disable-next-line react/no-array-index-key
               <tr className="KeyValueTable--row" key={`${row.key}-${i}`}>
                 <td className="KeyValueTable--keyColumn">{row.key}</td>
-                <td>{valueMarkup}</td>
-                <td className="KeyValueTable--copyColumn">
-                  <CopyIcon
-                    className="KeyValueTable--copyIcon"
-                    copyText={row.value}
-                    tooltipTitle="Copy value"
-                    buttonText="Copy"
-                  />
-                  <CopyIcon
-                    className="KeyValueTable--copyIcon"
-                    icon={<IoCopyOutline />}
-                    copyText={JSON.stringify(row, null, 2)}
-                    tooltipTitle="Copy JSON"
-                    buttonText="JSON"
-                  />
+                <td className="KeyValueTable--valueColumn">
+                  <div className="KeyValueTable--copyContainer">
+                    <CopyIcon
+                      className="KeyValueTable--copyIcon"
+                      copyText={row.value}
+                      tooltipTitle="Copy value"
+                      buttonText="Copy"
+                    />
+                    <CopyIcon
+                      className="KeyValueTable--copyIcon"
+                      icon={<IoCopyOutline />}
+                      copyText={JSON.stringify(row, null, 2)}
+                      tooltipTitle="Copy JSON"
+                      buttonText="JSON"
+                    />
+                  </div>
+                  {valueMarkup}
                 </td>
               </tr>
             );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -24,7 +24,6 @@ import { TNil } from '../../../../types';
 import { KeyValuePair, Link } from '../../../../types/trace';
 
 import './KeyValuesTable.css';
-import { consoleIntegration } from '@sentry/core';
 
 const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -83,7 +83,8 @@ limitations under the License.
 }
 
 .json-markup-child {
-  margin: 0.25rem 2.5rem;
+  margin: 0.25rem;
+  width: 100%;
   padding: 0;
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2477  

## Description of the changes
- Displayed the copy actions in a floating container instead of a separate column, making the table simpler with only 2 columns
- Minimized the margin on the right
- This allowed the `valueMarkup` to take up the remaining space within the table

*Before:* 
![Screenshot From 2025-05-24 23-05-46](https://github.com/user-attachments/assets/15bb5460-3cd8-4a1b-9e1a-19025f4fc24f)

*After:*
![Screenshot From 2025-05-24 23-04-46](https://github.com/user-attachments/assets/aea6a629-4cb1-49a2-94a4-e314b85ab493)


## How was this change tested?
- Tested the changes across different browser sizes
- Ran `npm run lint` and `npm run test`

![Screenshot From 2025-05-24 22-57-13](https://github.com/user-attachments/assets/10317bcc-24b6-435f-a0c4-46857efd6893)
![Screenshot From 2025-05-24 22-58-25](https://github.com/user-attachments/assets/e38c1d98-96f3-4d95-9cb2-2ac7ba12b5d5)


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
