### PR TITLE
test: improve test coverage for generateColor

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
@@ -116,4 +116,17 @@ describe('generateColor', () => {
     expect(tableValue2[1].total).toBe(390);
     expect(tableValue2[1].colorToPercent).toBe('rgb(248,248,248)');
   });
+
+it('covers percent attribute with colorToPercent=true', () => {
+  const input = [
+    { isDetail: false, percent: 75 },
+    { isDetail: false, percent: 25 },
+  ];
+
+  const output = generateColor(input, 'percent', true);
+
+  expect(output[0].colorToPercent).toBe('rgb(248,111.5,111.5)');
+  expect(output[1].colorToPercent).toBe('rgb(248,194.5,194.5)');
+});
+
 });


### PR DESCRIPTION
This PR adds a new test case to improve overall test coverage for the generateColor.

Before
<img width="719" alt="Screenshot 2025-05-25 at 10 54 36 PM" src="https://github.com/user-attachments/assets/dd11d261-9cd0-457b-89cb-92c970e661f5" />

After
<img width="714" alt="Screenshot 2025-05-25 at 11 03 40 PM" src="https://github.com/user-attachments/assets/90e5ce4a-0af6-4644-a72b-6cfc8d659a56" />
