### PR TITLE
test: improve test coverage for dropdown value generation

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.ts
@@ -39,4 +39,11 @@ describe(' generateDropdownValue', () => {
     const values = generateSecondDropdownValue(transformedTrace, 'span.kind');
     expect(values).toEqual(expectValues);
   });
+
+  it('check generateSecondDropdownValue when Operation Name is selected', () => {
+    const expectValues = ['Service Name', 'span.kind', 'error', 'db.type'];
+    const values = generateSecondDropdownValue(transformedTrace, 'Operation Name');
+
+    expect(values).toEqual(expectValues);
+  });
 });


### PR DESCRIPTION
This PR adds a new test case to improve overall test coverage for the dropdown value generation logic.

Before
<img width="815" alt="Screenshot 2025-05-25 at 11 15 05 PM" src="https://github.com/user-attachments/assets/0bfe14a2-f13a-4b17-84c9-e4ded9d549a4" />

After
<img width="814" alt="Screenshot 2025-05-25 at 11 16 01 PM" src="https://github.com/user-attachments/assets/113cb7c5-530a-4003-8ebb-b3bf4eb38968" />
