### PR TITLE
refactor: SpanDetailRow to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.js
@@ -73,19 +73,17 @@ describe('<SpanDetailRow>', () => {
   });
 
   it('renders the SpanDetail', () => {
-    const spanDetail = (
-      <SpanDetail
-        detailState={props.detailState}
-        linksGetter={wrapper.instance()._linksGetter}
-        logItemToggle={props.logItemToggle}
-        logsToggle={props.logsToggle}
-        processToggle={props.processToggle}
-        span={props.span}
-        tagsToggle={props.tagsToggle}
-        traceStartTime={props.traceStartTime}
-      />
-    );
-    expect(wrapper.contains(spanDetail)).toBe(true);
+    const spanDetailNode = wrapper.find(SpanDetail);
+    expect(spanDetailNode.exists()).toBe(true);
+
+    expect(spanDetailNode.prop('detailState')).toBe(props.detailState);
+    expect(spanDetailNode.prop('linksGetter')).toEqual(expect.any(Function));
+    expect(spanDetailNode.prop('logItemToggle')).toBe(props.logItemToggle);
+    expect(spanDetailNode.prop('logsToggle')).toBe(props.logsToggle);
+    expect(spanDetailNode.prop('processToggle')).toBe(props.processToggle);
+    expect(spanDetailNode.prop('span')).toBe(props.span);
+    expect(spanDetailNode.prop('tagsToggle')).toBe(props.tagsToggle);
+    expect(spanDetailNode.prop('traceStartTime')).toBe(props.traceStartTime);
   });
 
   it('adds span when calling linksGetter', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -40,63 +40,63 @@ type SpanDetailRowProps = {
   focusSpan: (uiFind: string) => void;
 };
 
-export default class SpanDetailRow extends React.PureComponent<SpanDetailRowProps> {
-  _detailToggle = () => {
-    this.props.onDetailToggled(this.props.span.spanID);
+const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
+  const _detailToggle = () => {
+    props.onDetailToggled(props.span.spanID);
   };
 
-  _linksGetter = (items: KeyValuePair[], itemIndex: number) => {
-    const { linksGetter, span } = this.props;
+  const _linksGetter = (items: KeyValuePair[], itemIndex: number) => {
+    const { linksGetter, span } = props;
     return linksGetter(span, items, itemIndex);
   };
 
-  render() {
-    const {
-      color,
-      columnDivision,
-      detailState,
-      logItemToggle,
-      logsToggle,
-      processToggle,
-      referencesToggle,
-      warningsToggle,
-      span,
-      tagsToggle,
-      traceStartTime,
-      focusSpan,
-    } = this.props;
-    return (
-      <TimelineRow className="detail-row">
-        <TimelineRow.Cell width={columnDivision}>
-          <SpanTreeOffset span={span} showChildrenIcon={false} />
-          <span>
-            <span
-              className="detail-row-expanded-accent"
-              aria-checked="true"
-              onClick={this._detailToggle}
-              role="switch"
-              style={{ borderColor: color }}
-            />
-          </span>
-        </TimelineRow.Cell>
-        <TimelineRow.Cell width={1 - columnDivision}>
-          <div className="detail-info-wrapper" style={{ borderTopColor: color }}>
-            <SpanDetail
-              detailState={detailState}
-              linksGetter={this._linksGetter}
-              logItemToggle={logItemToggle}
-              logsToggle={logsToggle}
-              processToggle={processToggle}
-              referencesToggle={referencesToggle}
-              warningsToggle={warningsToggle}
-              span={span}
-              tagsToggle={tagsToggle}
-              traceStartTime={traceStartTime}
-              focusSpan={focusSpan}
-            />
-          </div>
-        </TimelineRow.Cell>
-      </TimelineRow>
-    );
-  }
-}
+  const {
+    color,
+    columnDivision,
+    detailState,
+    logItemToggle,
+    logsToggle,
+    processToggle,
+    referencesToggle,
+    warningsToggle,
+    span,
+    tagsToggle,
+    traceStartTime,
+    focusSpan,
+  } = props;
+  return (
+    <TimelineRow className="detail-row">
+      <TimelineRow.Cell width={columnDivision}>
+        <SpanTreeOffset span={span} showChildrenIcon={false} />
+        <span>
+          <span
+            className="detail-row-expanded-accent"
+            aria-checked="true"
+            onClick={_detailToggle}
+            role="switch"
+            style={{ borderColor: color }}
+          />
+        </span>
+      </TimelineRow.Cell>
+      <TimelineRow.Cell width={1 - columnDivision}>
+        <div className="detail-info-wrapper" style={{ borderTopColor: color }}>
+          <SpanDetail
+            detailState={detailState}
+            linksGetter={_linksGetter}
+            logItemToggle={logItemToggle}
+            logsToggle={logsToggle}
+            processToggle={processToggle}
+            referencesToggle={referencesToggle}
+            warningsToggle={warningsToggle}
+            span={span}
+            tagsToggle={tagsToggle}
+            traceStartTime={traceStartTime}
+            focusSpan={focusSpan}
+          />
+        </div>
+      </TimelineRow.Cell>
+    </TimelineRow>
+  );
+});
+
+export default SpanDetailRow;


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #2610 

## Description of the changes
- Refactored the SpanDetailRow into a functional component 
- Modified the `renders the SpanDetail` test by removing the `wrapper.instance()` method and instead added tests to check the props.
- The `renders the SpanDetail` test now checks if the `SpanDetail` component receives a function as a prop, and the `adds span when calling linksGetter` test confirms this function is working as expected.

## How was this change tested?
- Checked the UI is working as expected on the web.
- Ran `npm run test` and `npm run lint`

![image](https://github.com/user-attachments/assets/1308d7e0-b902-4070-aef8-661f3d85aecd)
![image](https://github.com/user-attachments/assets/2d9eed2e-fe89-4764-a145-85cffde857b9)


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
