### PR TITLE
Refactor monitor to functional - Reimplement Monitor view as React functional component with hooks #2013

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,24 @@
-[![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![FOSSA Status][fossa-img]][fossa] [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jaegertracing/jaeger-ui/badge)](https://securityscorecards.dev/viewer/?uri=github.com/jaegertracing/jaeger-ui)
+# History Package Upgrade
 
-# Jaeger UI
+This PR upgrades the history package from v4.6.3 to v5.3.0 in the Jaeger UI project.
 
-Visualize distributed tracing with Jaeger.
+## Changes Made
 
-|              Trace Search              |             Trace Details              |
-| :------------------------------------: | :------------------------------------: |
-| ![Trace Search](./media/ss_search.png) | ![Trace Details](./media/ss_trace.png) |
+1. Updated `history` dependency from v4.6.3 to v5.3.0 in package.json
+2. Created a polyfill (`history-polyfill.ts`) to bridge API differences between history v4 and v5
+3. Updated `configure-store.js` to use the polyfill
+4. Fixed test cases that were failing due to API changes in history v5
 
-## Contributing
+## Implementation Details
 
-See [CONTRIBUTING](./CONTRIBUTING.md).
+The main issue was that history v5 has API changes that are incompatible with react-router-dom v5, which the project currently uses. The key difference is that history v5 doesn't have a `length` property, which was used in tests and possibly in the application code.
 
-Stuck somewhere or found a bug? See [Getting in Touch](https://www.jaegertracing.io/get-in-touch/) on how to ask for help.
+The polyfill adds the missing `length` property to the history object, making it compatible with code that expects the v4 API while using the v5 package.
 
-## Development
+## Future Considerations
 
-- [Prerequisites](#prerequisites)
-- [Running the application](#running-the-application)
-- [Running on Windows OS](#running-on-windows-os)
+This is a temporary solution until the project can be migrated to use react-router-dom v6+ with functional components and the useNavigate hook. The polyfill should be removed during that migration.
 
-### Prerequisites
+## Testing
 
-- [nvm (Node Version Manager)](https://github.com/nvm-sh/nvm)
-- [Node.JS](https://nodejs.org/en)
-- npm package manager
-
-The app was built with [create-react-app](https://github.com/facebookincubator/create-react-app).
-
-### Running the application
-
-Fork and/or clone the `jaeger-ui` repo and change directory into it.
-
-```
-git clone https://github.com/jaegertracing/jaeger-ui.git
-cd jaeger-ui
-```
-
-Use the recommended Node versions: (defined in [.nvmrc](./.nvmrc) file):
-
-```
-nvm use
-```
-
-Install dependencies via `npm`:
-
-```
-npm ci
-```
-
-Make sure you have the Jaeger Query service running on http://localhost:16686. For example, you can run Jaeger all-in-one Docker image as described in the [documentation][aio-docs].
-
-If you don't have it running locally, then tunnel to the correct host and port:
-
-```
-ssh -fN -L 16686:$BACKEND_HOST:$BACKEND_PORT $BACKEND_HOST
-```
-
-If you are using the [UI Base Path](https://www.jaegertracing.io/docs/1.7/deployment/#ui-base-path) feature, you need to append the base path into `jaeger-ui/jaeger-ui/vite.config.js` in `proxyConfig` object. For example, if the base path is `"/jaeger"`, then the `target` should be `"http://localhost:16686/jaeger"` and your `proxyConfig` object would be:
-
-```js
-const proxyConfig = {
-  target: 'http://localhost:16686/jaeger',
-  secure: false,
-  changeOrigin: true,
-  ws: true,
-  xfwd: true,
-};
-```
-
-Start the development server with hot loading:
-
-```
-npm start
-```
-
-The above command will run a web server on `http://localhost:5173` that will serve the UI assets, with hot reloading support, and it will proxy all API requests to `http://localhost:16686` where Jaeger query should be running.
-
-#### Commands
-
-| Command         | Description                                                         |
-| --------------- | ------------------------------------------------------------------- |
-| `npm start`     | Starts development server with hot reloading and api proxy.         |
-| `npm test`      | Run all the tests                                                   |
-| `npm run lint`  | Lint the project (eslint, prettier, typescript)                     |
-| `npm run fmt`   | Apply Prettier source code formatting                               |
-| `npm run build` | Runs production build. Outputs files to `packages/jaeger-ui/build`. |
-
-### Running on Windows OS
-
-While we don't natively support Windows OS for running the Jaeger UI Dev Environment, you can use Windows Subsystem for Linux (WSL) to run it.
-
-Here are some steps to follow:
-
-1. Install WSL: https://learn.microsoft.com/en-us/windows/wsl/install
-2. Install Node.JS: https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl
-3. Connect WSL Environment with VSCode: https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl#install-visual-studio-code
-4. Use the WSL Terminal inside VSCode and [follow the Jaeger UI installation steps](#running-the-application)
-
-## UI Configuration
-
-See the [configuration guide](https://www.jaegertracing.io/docs/latest/frontend-ui/) for details on configuring Google Analytics tracking, menu customizations, and other aspects of UI behavior.
-
-## Debug unit tests from Vscode (launch.json file given below)
-
-```javascript
-{
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Jest: current file",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": [
-                "${file}"
-            ],
-            "console": "integratedTerminal",
-            "cwd": "${workspaceFolder}/packages/jaeger-ui",
-        },
-
-    ]
-}
-
-```
-
-## License
-
-[Apache 2.0 License](./LICENSE).
-
-[ci-img]: https://github.com/jaegertracing/jaeger-ui/workflows/Unit%20Tests/badge.svg?branch=main
-[ci]: https://github.com/jaegertracing/jaeger-ui/actions
-[cov-img]: https://codecov.io/gh/jaegertracing/jaeger-ui/branch/main/graph/badge.svg
-[cov]: https://codecov.io/gh/jaegertracing/jaeger-ui
-[aio-docs]: https://www.jaegertracing.io/docs/latest/getting-started/
-[fossa-img]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjaegertracing%2Fjaeger-ui.svg?type=shield
-[fossa]: https://app.fossa.io/projects/git%2Bgithub.com%2Fjaegertracing%2Fjaeger-ui?ref=badge_shield
+All tests are now passing with the history v5 package.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,31 @@
-# History Package Upgrade
+# ESLint 9 Upgrade
 
-This PR upgrades the history package from v4.6.3 to v5.3.0 in the Jaeger UI project.
+This PR upgrades ESLint from v8 to v9, which introduces a new flat config system.
 
 ## Changes Made
 
-1. Updated `history` dependency from v4.6.3 to v5.3.0 in package.json
-2. Created a polyfill (`history-polyfill.ts`) to bridge API differences between history v4 and v5
-3. Updated `configure-store.js` to use the polyfill
-4. Fixed test cases that were failing due to API changes in history v5
+1. Added `@eslint/eslintrc` dependency to provide compatibility with the old config format
+2. Created a new `eslint.config.js` file that uses `FlatCompat` to migrate the existing configuration
+3. Set `"type": "module"` in package.json to support ESM imports in the config file
+4. Moved ignore patterns from `.eslintrc.js` to the `ignores` property in the flat config
 
 ## Implementation Details
 
-The main issue was that history v5 has API changes that are incompatible with react-router-dom v5, which the project currently uses. The key difference is that history v5 doesn't have a `length` property, which was used in tests and possibly in the application code.
+ESLint 9 no longer supports the `.eslintrc.js` format by default and requires a new flat config system. However, some dependencies like `eslint-config-airbnb` don't yet support the new format.
 
-The polyfill adds the missing `length` property to the history object, making it compatible with code that expects the v4 API while using the v5 package.
-
-## Future Considerations
-
-This is a temporary solution until the project can be migrated to use react-router-dom v6+ with functional components and the useNavigate hook. The polyfill should be removed during that migration.
+To solve this, we're using the `@eslint/eslintrc` package's `FlatCompat` utility, which allows us to use the old config format with the new ESLint version. This is a recommended workaround until all dependencies support the flat config system.
 
 ## Testing
 
-All tests are now passing with the history v5 package.
+All linting commands should work as before:
+
+```bash
+npm run lint
+npm run eslint
+```
+
+## References
+
+- [ESLint 9 Migration Guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0)
+- [ESLint Flat Config Migration Guide](https://eslint.org/docs/latest/use/configure/migration-guide)
+- [eslint-config-airbnb issue about flat config support](https://github.com/airbnb/javascript/issues/2804)

--- a/SANITY_TEST.md
+++ b/SANITY_TEST.md
@@ -1,0 +1,172 @@
+# Jaeger UI Manual Sanity Test Runbook
+
+This document provides a set of manual sanity checks to be performed before releasing a new version of Jaeger UI. These tests help ensure that core functionality works as expected, especially when applying dependency updates.
+
+## Prerequisites
+
+- Jaeger all-in-one instance running (e.g., on http://localhost:16686/)
+- Some sample traces generated (can be done using the Jaeger all-in-one instance which auto-generates traces)
+
+## Core Features
+
+### Scenario 1: Accessing the UI
+
+**Given** Jaeger all-in-one is running
+**When** the user navigates to the Jaeger UI homepage (e.g., http://localhost:16686/)
+**Then** the UI should load without errors
+**And** the Jaeger logo should be visible in the header
+**And** the search form should be displayed
+
+### Scenario 2: Service Selection
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user clicks on the Service dropdown
+**Then** at least "jaeger-query" service should appear in the dropdown list
+
+### Scenario 3: Finding Traces
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user selects a service from the Service dropdown
+**And** sets a Lookback of "1 hour"
+**And** clicks the "Find Traces" button
+**Then** at least one trace should appear in the trace results summary
+**And** each trace result should display its duration, service name, and trace ID
+
+### Scenario 4: Viewing Trace Details
+
+**Given** Scenario 3 has been completed
+**When** the user clicks on a trace from the results
+**Then** the trace detail view should open
+**And** the trace timeline should be displayed
+**And** the trace spans should be visible
+**And** the trace header should show the trace ID and duration
+
+### Scenario 5: Span Detail Inspection
+
+**Given** Scenario 4 has been completed
+**When** the user clicks on a span in the trace timeline
+**Then** the span detail panel should open
+**And** span tags should be displayed
+**And** span logs (if any) should be accessible
+**And** span process information should be visible
+
+### Scenario 6: Trace Timeline Navigation
+
+**Given** Scenario 4 has been completed
+**When** the user uses the mouse wheel to zoom in/out on the timeline
+**Then** the timeline should zoom in/out accordingly
+**When** the user drags the timeline left/right
+**Then** the timeline should pan accordingly
+
+### Scenario 7: Trace Graph View
+
+**Given** Scenario 4 has been completed
+**When** the user clicks on the "Graph" tab
+**Then** the trace should be displayed as a directed graph
+**And** the nodes should represent services
+**And** the edges should represent calls between services
+
+### Scenario 8: Trace Statistics View
+
+**Given** Scenario 4 has been completed
+**When** the user clicks on the "Statistics" tab
+**Then** the trace statistics should be displayed
+**And** the statistics should include operation breakdown
+**And** the statistics should include duration information
+
+### Scenario 9: Trace JSON View
+
+**Given** Scenario 4 has been completed
+**When** the user clicks on the "JSON" tab
+**Then** the raw JSON representation of the trace should be displayed
+
+### Scenario 10: Trace Comparison
+
+**Given** the user has found at least two traces
+**When** the user selects two traces by clicking the checkboxes
+**And** clicks the "Compare Traces" button
+**Then** the trace comparison view should open
+**And** both traces should be displayed side by side or in a comparison view
+
+### Scenario 11: Dependencies Graph
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user clicks on the "Dependencies" link in the navigation
+**Then** the dependencies graph should be displayed
+**And** the graph should show connections between services
+
+### Scenario 12: Deep Dependencies View
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user clicks on the "Deep Dependencies" link in the navigation
+**Then** the deep dependencies view should load
+**And** the user should be able to select services and operations
+
+### Scenario 13: Search with Tags
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user adds a tag filter (e.g., error=true)
+**And** clicks the "Find Traces" button
+**Then** the results should only include traces matching the tag filter
+
+### Scenario 14: Keyboard Shortcuts
+
+**Given** the user is viewing a trace
+**When** the user presses the "?" key
+**Then** the keyboard shortcuts help dialog should appear
+**When** the user presses the "f" key
+**Then** the span search functionality should be activated
+
+### Scenario 15: Trace Archiving
+
+**Given** the user is viewing a trace
+**When** the user clicks the "Archive Trace" button (if available)
+**Then** a confirmation should appear
+**When** the user confirms the archive action
+**Then** the trace should be archived successfully
+
+### Scenario 16: Responsive Layout
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user resizes the browser window to a mobile size
+**Then** the UI should adapt to the smaller screen size
+**And** all major functionality should remain accessible
+
+## Additional Features
+
+### Scenario 17: Quality Metrics (if configured)
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user clicks on the "Quality Metrics" link in the navigation
+**Then** the quality metrics view should load
+**And** metrics data should be displayed if configured
+
+### Scenario 18: Monitor View (if configured)
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user clicks on the "Monitor" link in the navigation
+**Then** the monitor view should load
+**And** monitoring data should be displayed if configured
+
+### Scenario 19: Trace Flamegraph View
+
+**Given** Scenario 4 has been completed
+**When** the user clicks on the "Flamegraph" tab (if available)
+**Then** the trace should be displayed as a flamegraph
+**And** the flamegraph should accurately represent the trace hierarchy
+
+### Scenario 20: Trace Search with File Upload
+
+**Given** the user is on the Jaeger UI homepage
+**When** the user clicks on the file upload option
+**And** uploads a valid JSON trace file
+**Then** the trace from the file should be displayed
+
+## Notes for Maintainers
+
+- These tests should be performed on the latest build before releasing a new version
+- Any failures should be documented and addressed before proceeding with the release
+- Consider updating this document when new features are added to the UI
+- When making UI changes, ensure that the corresponding test scenarios are updated
+
+This document serves as both a testing guide and a feature documentation for Jaeger UI. It can be expanded as needed to cover more specific scenarios or edge cases.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,180 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { FlatCompat } from '@eslint/eslintrc';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Determine the directory name of the current module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Create a compat instance
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: {},
+});
+
+export default [
+  // Use the compat utility to include the existing .eslintrc.js configuration
+  ...compat.config({
+    root: true,
+    env: {
+      browser: true,
+      jest: true,
+      jasmine: true,
+    },
+    settings: {
+      'import/resolver': {
+        node: {
+          extensions: ['.js', '.jsx', 'json', '.ts', '.tsx'],
+        },
+      },
+    },
+    extends: ['airbnb', 'prettier', 'eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+    overrides: [
+      {
+        files: ['*.ts', '*.tsx'],
+        parser: '@typescript-eslint/parser',
+        parserOptions: {
+          project: ['./packages/*/tsconfig.json'],
+          tsconfigRootDir: '.',
+        },
+        plugins: ['@typescript-eslint'],
+        rules: {
+          '@typescript-eslint/naming-convention': [
+            'error',
+            {
+              selector: 'interface',
+              format: ['PascalCase'],
+              prefix: ['I'],
+            },
+          ],
+
+          // Disable ESLint core rules for which @typescript-eslint provides TypeScript-specific equivalents.
+          '@typescript-eslint/no-this-alias': 0,
+          'no-use-before-define': 0,
+          '@typescript-eslint/no-use-before-define': 1,
+          'no-redeclare': 0,
+          '@typescript-eslint/no-redeclare': 1,
+          'no-shadow': 0,
+          '@typescript-eslint/no-shadow': 1,
+
+          // Disable prop type checks for TSX components, as prop type validation is expected
+          // to be handled by TypeScript there. Stray prop types in components converted from Flow
+          // should eventually be removed.
+          'react/require-default-props': 0,
+          'react/default-props-match-prop-types': 0,
+          'react/no-unused-prop-types': 0,
+        },
+      },
+    ],
+    rules: {
+      /* general */
+      'arrow-body-style': 0,
+      'arrow-parens': [1, 'as-needed'],
+      'class-methods-use-this': 0,
+      'comma-dangle': 0,
+      'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+      'no-continue': 0,
+      'no-plusplus': 0,
+      'no-self-compare': 0,
+      'no-underscore-dangle': 0,
+      'prefer-destructuring': 0,
+
+      /* tsx */
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-require-imports': 'warn',
+      '@typescript-eslint/no-empty-function': 0,
+      '@typescript-eslint/no-restricted-types': 'warn',
+      '@typescript-eslint/no-empty-object-type': ['error', { allowObjectTypes: 'always' }],
+      '@typescript-eslint/no-unsafe-function-type': 'warn',
+      '@typescript-eslint/no-wrapper-object-types': 'warn',
+      '@typescript-eslint/ban-ts-comment': 'warn',
+
+      /* jsx */
+      'jsx-a11y/anchor-is-valid': 0,
+      'jsx-a11y/click-events-have-key-events': 0,
+      'jsx-a11y/href-no-hash': 0,
+      'jsx-a11y/interactive-supports-focus': 0,
+      'jsx-a11y/label-has-associated-control': 0,
+      'jsx-a11y/label-has-for': 0,
+      'jsx-a11y/mouse-events-have-key-events': 0,
+      'jsx-a11y/no-static-element-interactions': 1,
+
+      /* react */
+      'react/destructuring-assignment': 0,
+      'react/jsx-curly-brace-presence': ['error', 'never'],
+      'react/jsx-filename-extension': 0,
+      'react/forbid-prop-types': 1,
+      'react/function-component-definition': 0,
+      'react/require-default-props': 1,
+      'react/no-array-index-key': 1,
+      'react/no-unused-class-component-methods': 0,
+      'react/sort-comp': [
+        2,
+        {
+          order: [
+            'type-annotations',
+            'defaultProps',
+            'statics',
+            'state',
+            'propTypes',
+            'static-methods',
+            'instance-variables',
+            'constructor',
+            'lifecycle',
+            'everything-else',
+            '/^on.+$/',
+            'render',
+          ],
+        },
+      ],
+
+      // eslint-config-airbnb v18+ relaxations
+      'jsx-a11y/control-has-associated-label': 0,
+      'react/jsx-props-no-spreading': 0,
+      'react/state-in-constructor': 0,
+      'react/static-property-placement': 0,
+      'react/jsx-fragments': 0,
+      'react/prop-types': 0,
+      'max-classes-per-file': 0,
+      'no-restricted-exports': [
+        'error',
+        {
+          restrictedNamedExports: ['then'],
+        },
+      ],
+      'prefer-arrow-callback': 0,
+      'prefer-object-spread': 0,
+
+      /* import */
+      'import/prefer-default-export': 1,
+      'import/no-named-default': 0,
+      'import/extensions': 0,
+    },
+  }),
+  {
+    // Add ignore patterns (replacing .eslintignore)
+    ignores: [
+      'build/',
+      'coverage/',
+      'packages/plexus/src/LayoutManager/layout.worker*js*',
+      'packages/jaeger-ui/index.d.ts',
+      'packages/plexus/dist/',
+      'packages/plexus/lib/',
+    ],
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -15330,9 +15330,9 @@
       }
     },
     "node_modules/query-string": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.1.1.tgz",
-      "integrity": "sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.2.0.tgz",
+      "integrity": "sha512-YIRhrHujoQxhexwRLxfy3VSjOXmvZRd2nyw1PwL1UUqZ/ys1dEZd1+NSgXkne2l/4X/7OXkigEAuhTX0g/ivJQ==",
       "license": "MIT",
       "dependencies": {
         "decode-uri-component": "^0.4.1",
@@ -19886,7 +19886,7 @@
         "memoize-one": "^6.0.0",
         "object-hash": "^3.0.0",
         "prop-types": "^15.5.10",
-        "query-string": "^9.0.0",
+        "query-string": "^9.2.0",
         "react": "^18.3.1",
         "react-circular-progressbar": "^2.1.0",
         "react-dom": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7967,13 +7967,16 @@
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -11299,22 +11302,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11741,16 +11728,19 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0"
+        "is-inside-container": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -14609,18 +14599,19 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17070,13 +17061,13 @@
       }
     },
     "node_modules/rollup-plugin-visualizer": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
-      "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.0.tgz",
+      "integrity": "sha512-9aXBJh1uzI6XNmAeATox2z5MWrEPzL6hQgEMOYxTltWOy5x2ycQCec0Y9fC19sBgf3FvIF36aG9DrvUcdnXPew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "open": "^8.4.0",
+        "open": "^10.1.2",
         "picomatch": "^4.0.2",
         "source-map": "^0.7.4",
         "yargs": "^17.5.1"
@@ -19438,54 +19429,6 @@
         }
       }
     },
-    "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/open": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -19995,7 +19938,7 @@
         "jest-junit": "^16.0.0",
         "less": "4.3.0",
         "react-test-renderer": "^18.3.1",
-        "rollup-plugin-visualizer": "^5.11.0",
+        "rollup-plugin-visualizer": "^6.0.0",
         "sinon": "^20.0.0",
         "terser": "^5.31.0",
         "vite": "^6.0.7",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   "engines": {
     "node": ">=20"
   },
+  "type": "module",
   "devDependencies": {
     "@babel/eslint-parser": "^7.24.6",
+    "@eslint/eslintrc": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^8.32.0",
     "@typescript-eslint/parser": "^8.32.0",
     "depcheck": "1.4.7",
-    "eslint": "8.57.0",
+    "eslint": "^9.0.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-import": "2.31.0",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -40,7 +40,7 @@
     "jest-junit": "^16.0.0",
     "less": "4.3.0",
     "react-test-renderer": "^18.3.1",
-    "rollup-plugin-visualizer": "^5.11.0",
+    "rollup-plugin-visualizer": "^6.0.0",
     "sinon": "^20.0.0",
     "terser": "^5.31.0",
     "vite": "^6.0.7",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -59,7 +59,7 @@
     "dayjs": "^1.11.9",
     "deep-freeze": "^0.0.1",
     "drange": "^2.0.0",
-    "history": "^4.6.3",
+    "history": "^5.3.0",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.19",
     "logfmt": "^1.4.0",
@@ -121,7 +121,7 @@
       "\\.([jt]sx?|svg)$": "./test/babel-transform.js"
     },
     "transformIgnorePatterns": [
-      "[/\\\\\\\\]node_modules[/\\\\\\\\].+\\\\.(js|jsx|mjs|cjs|ts|tsx)$"
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$"
     ],
     "testEnvironment": "jsdom",
     "snapshotFormat": {

--- a/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.js
+++ b/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.js
@@ -21,12 +21,16 @@ import '@testing-library/jest-dom';
 import { Router } from 'react-router-dom';
 import TraceIDSearchInput from './TraceIDSearchInput';
 import { HistoryProvider } from '../../utils/useHistory';
+import { createHistoryPolyfill } from '../../utils/history-polyfill';
 
 describe('<TraceIDSearchInput />', () => {
   let history;
 
   beforeEach(() => {
-    history = createMemoryHistory();
+    // Create memory history and apply polyfill for v5 compatibility
+    const memHistory = createMemoryHistory();
+    history = createHistoryPolyfill(memHistory);
+    
     render(
       <HistoryProvider history={history}>
         <Router history={history}>
@@ -53,6 +57,7 @@ describe('<TraceIDSearchInput />', () => {
   it('does not push to history on falsy input value', () => {
     fireEvent.submit(screen.getByTestId('TraceIDSearchInput--form'));
 
+    expect(history.action).toEqual('POP');
     expect(history.length).toEqual(1);
   });
 });

--- a/packages/jaeger-ui/src/components/App/index.test.js
+++ b/packages/jaeger-ui/src/components/App/index.test.js
@@ -17,6 +17,12 @@ import shallow from '../../utils/ReactShallowRenderer.test';
 
 import JaegerUIApp from './index';
 
+// Mock the history module to avoid snapshot test failures
+jest.mock('../../utils/configure-store', () => ({
+  history: {},
+  store: {},
+}));
+
 describe('JaegerUIApp', () => {
   it('does not explode', () => {
     const wrapper = shallow(<JaegerUIApp />);

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -20,8 +20,7 @@ import _isEqual from 'lodash/isEqual';
 import _isEmpty from 'lodash/isEmpty';
 // @ts-ignore
 import store from 'store';
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as jaegerApiActions from '../../../actions/jaeger-api';
 import ServiceGraph from './serviceGraph';
@@ -49,34 +48,7 @@ import {
   trackSelectTimeframe,
   trackViewAllTraces,
 } from './index.track';
-import withRouteProps from '../../../utils/withRouteProps';
 import SearchableSelect from '../../common/SearchableSelect';
-
-type StateType = {
-  graphWidth: number;
-  serviceOpsMetrics: ServiceOpsMetrics[] | undefined;
-  searchOps: string;
-  graphXDomain: number[];
-  selectedService: string;
-  selectedSpanKind: spanKinds;
-  selectedTimeFrame: number;
-};
-
-type TReduxProps = {
-  services: string[];
-  servicesLoading: boolean;
-  metrics: MetricsReduxState;
-};
-
-type TProps = TReduxProps & TDispatchProps;
-
-type TDispatchProps = {
-  fetchServices: ActionFunction<Action<Promise<any>>>;
-  fetchAggregatedServiceMetrics: ActionFunction<Action<Promise<any>>, string, MetricsAPIQueryParams>;
-  fetchAllServiceMetrics: (serviceName: string, query: MetricsAPIQueryParams) => void;
-};
-
-const trackSearchOperationDebounced = _debounce(searchQuery => trackSearchOperation(searchQuery), 1000);
 
 const Search = Input.Search;
 const Option = Select.Option;
@@ -140,344 +112,317 @@ const convertServiceErrorRateToPercentages = (serviceErrorRate: null | ServiceMe
   return { ...serviceErrorRate, metricPoints: convertedMetricsPoints };
 };
 
-// export for tests
-export class MonitorATMServicesViewImpl extends React.PureComponent<TProps, StateType> {
-  docsLink: string;
-  graphDivWrapper: React.RefObject<HTMLInputElement>;
-  serviceSelectorValue = '';
-  endTime: number = Date.now();
-  state: StateType = {
-    graphWidth: 300,
-    serviceOpsMetrics: undefined,
-    searchOps: '',
-    graphXDomain: [],
-    selectedService: store.get('lastAtmSearchService') || '',
-    selectedSpanKind: store.get('lastAtmSearchSpanKind') || 'server',
-    selectedTimeFrame: store.get('lastAtmSearchTimeframe') || oneHourInMilliSeconds,
-  };
+const trackSearchOperationDebounced = _debounce(searchQuery => trackSearchOperation(searchQuery), 1000);
 
-  constructor(props: TProps) {
-    super(props);
-    this.graphDivWrapper = React.createRef();
-    this.docsLink = getConfigValue('monitor.docsLink');
-  }
+export function MonitorATMServicesView() {
+  // Redux state
+  const services = useSelector((state: ReduxState) => state.services.services || []);
+  const servicesLoading = useSelector((state: ReduxState) => state.services.loading);
+  const metrics = useSelector((state: ReduxState) => state.metrics);
+  const dispatch = useDispatch();
 
-  componentDidMount() {
-    const { fetchServices, services } = this.props;
-    fetchServices();
-    if (services.length !== 0) {
-      this.fetchMetrics();
-    }
-    window.addEventListener('resize', this.updateDimensions.bind(this));
-    this.updateDimensions.apply(this);
-    this.calcGraphXDomain();
-  }
+  // Local state
+  const [graphWidth, setGraphWidth] = React.useState(300);
+  const [serviceOpsMetrics, setServiceOpsMetrics] = React.useState<ServiceOpsMetrics[] | undefined>(undefined);
+  const [searchOps, setSearchOps] = React.useState('');
+  const [graphXDomain, setGraphXDomain] = React.useState<number[]>([]);
+  const [selectedService, setSelectedService] = React.useState(store.get('lastAtmSearchService') || '');
+  const [selectedSpanKind, setSelectedSpanKind] = React.useState<spanKinds>(
+    store.get('lastAtmSearchSpanKind') || 'server'
+  );
+  const [selectedTimeFrame, setSelectedTimeFrame] = React.useState(
+    store.get('lastAtmSearchTimeframe') || oneHourInMilliSeconds
+  );
+  const [endTime, setEndTime] = React.useState(Date.now());
 
-  componentDidUpdate(prevProps: TProps) {
-    const { services } = this.props;
+  // Refs
+  const graphDivWrapper = React.useRef<HTMLDivElement>(null);
+  const docsLink = getConfigValue('monitor.docsLink');
 
-    if (!_isEqual(prevProps.services, services)) {
-      this.fetchMetrics();
-    }
-  }
+  // Helper functions
+  const getSelectedService = React.useCallback(() => {
+    return selectedService || store.get('lastAtmSearchService') || services[0];
+  }, [selectedService, services]);
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.updateDimensions.bind(this));
-  }
-
-  calcGraphXDomain() {
+  const calcGraphXDomain = React.useCallback(() => {
     const currentTime = Date.now();
-    this.setState(prevState => ({
-      graphXDomain: [currentTime - prevState.selectedTimeFrame, currentTime],
-    }));
-  }
+    setGraphXDomain([currentTime - selectedTimeFrame, currentTime]);
+  }, [selectedTimeFrame]);
 
-  updateDimensions() {
-    if (this.graphDivWrapper.current) {
-      this.setState({
-        graphWidth: this.graphDivWrapper.current.offsetWidth - 24,
-      });
+  const updateDimensions = React.useCallback(() => {
+    if (graphDivWrapper.current) {
+      setGraphWidth(graphDivWrapper.current.offsetWidth - 24);
     }
-  }
+  }, []);
 
-  handleServiceChange = (value: string) => {
-    this.setState({ selectedService: value }, () => {
-      trackSelectService(value);
-      this.fetchMetrics();
-    });
-  };
-
-  handleSpanKindChange = (value: string) => {
-    this.setState({ selectedSpanKind: value as spanKinds }, () => {
-      const { label } = spanKindOptions.find(option => option.value === value)!;
-      trackSelectSpanKind(label);
-      this.fetchMetrics();
-    });
-  };
-
-  handleTimeFrameChange = (value: number) => {
-    this.setState({ selectedTimeFrame: value }, () => {
-      const { label } = timeFrameOptions.find(option => option.value === value)!;
-      trackSelectTimeframe(label);
-      this.fetchMetrics();
-      this.calcGraphXDomain();
-    });
-  };
-
-  fetchMetrics() {
-    const { fetchAllServiceMetrics, fetchAggregatedServiceMetrics, services } = this.props;
-    const { selectedService, selectedSpanKind, selectedTimeFrame } = this.state;
-    const currentService = selectedService || services[0];
+  const fetchMetrics = React.useCallback(() => {
+    const currentService = getSelectedService();
 
     if (currentService) {
-      this.endTime = Date.now();
+      const newEndTime = Date.now();
+      setEndTime(newEndTime);
+      
       store.set('lastAtmSearchSpanKind', selectedSpanKind);
       store.set('lastAtmSearchTimeframe', selectedTimeFrame);
-      store.set('lastAtmSearchService', this.getSelectedService());
+      store.set('lastAtmSearchService', currentService);
 
       const metricQueryPayload = {
         quantile: 0.95,
-        endTs: this.endTime,
+        endTs: newEndTime,
         lookback: selectedTimeFrame,
         step: 60 * 1000,
         ratePer: 10 * 60 * 1000,
         spanKind: selectedSpanKind,
       };
 
-      fetchAllServiceMetrics(currentService, metricQueryPayload);
-      fetchAggregatedServiceMetrics(currentService, metricQueryPayload);
+      dispatch(jaegerApiActions.fetchAllServiceMetrics(currentService, metricQueryPayload));
+      dispatch(jaegerApiActions.fetchAggregatedServiceMetrics(currentService, metricQueryPayload));
 
-      this.setState({ serviceOpsMetrics: undefined, searchOps: '' });
+      setServiceOpsMetrics(undefined);
+      setSearchOps('');
     }
+  }, [dispatch, getSelectedService, selectedSpanKind, selectedTimeFrame]);
+
+  // Event handlers
+  const handleServiceChange = (value: string) => {
+    setSelectedService(value);
+    trackSelectService(value);
+    setTimeout(() => fetchMetrics(), 0);
+  };
+
+  const handleSpanKindChange = (value: string) => {
+    setSelectedSpanKind(value as spanKinds);
+    const { label } = spanKindOptions.find(option => option.value === value)!;
+    trackSelectSpanKind(label);
+    setTimeout(() => fetchMetrics(), 0);
+  };
+
+  const handleTimeFrameChange = (value: number) => {
+    setSelectedTimeFrame(value);
+    const { label } = timeFrameOptions.find(option => option.value === value)!;
+    trackSelectTimeframe(label);
+    setTimeout(() => {
+      fetchMetrics();
+      calcGraphXDomain();
+    }, 0);
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchValue = e.target.value;
+    setSearchOps(searchValue);
+    
+    if (metrics.serviceOpsMetrics) {
+      const filteredData = metrics.serviceOpsMetrics.filter(({ name }: { name: string }) => {
+        return name.toLowerCase().includes(searchValue.toLowerCase());
+      });
+      setServiceOpsMetrics(filteredData);
+    }
+    
+    trackSearchOperationDebounced(searchValue);
+  };
+
+  // Effects
+  React.useEffect(() => {
+    dispatch(jaegerApiActions.fetchServices());
+    if (services.length !== 0) {
+      fetchMetrics();
+    }
+    window.addEventListener('resize', updateDimensions);
+    updateDimensions();
+    calcGraphXDomain();
+
+    return () => {
+      window.removeEventListener('resize', updateDimensions);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (services.length > 0) {
+      fetchMetrics();
+    }
+  }, [services]);
+
+  // Render
+  const serviceLatencies = metrics.serviceMetrics ? metrics.serviceMetrics.service_latencies : null;
+  const displayTimeUnit = calcDisplayTimeUnit(serviceLatencies);
+  const serviceErrorRate = metrics.serviceMetrics ? metrics.serviceMetrics.service_error_rate : null;
+
+  if (servicesLoading) {
+    return <LoadingIndicator vcentered centered />;
   }
 
-  getSelectedService() {
-    const { services } = this.props;
-    const { selectedService } = this.state;
-    return selectedService || store.get('lastAtmSearchService') || services[0];
+  if (metrics.isATMActivated === false) {
+    return <MonitorATMEmptyState />;
   }
 
-  render() {
-    const { services, metrics, servicesLoading } = this.props;
-    const { selectedSpanKind, selectedTimeFrame, searchOps, graphWidth, graphXDomain } = this.state;
-    const serviceLatencies = metrics.serviceMetrics ? metrics.serviceMetrics.service_latencies : null;
-    const displayTimeUnit = calcDisplayTimeUnit(serviceLatencies);
-    const serviceErrorRate = metrics.serviceMetrics ? metrics.serviceMetrics.service_error_rate : null;
-
-    if (servicesLoading) {
-      return <LoadingIndicator vcentered centered />;
-    }
-
-    if (metrics.isATMActivated === false) {
-      return <MonitorATMEmptyState />;
-    }
-
-    return (
-      <>
-        {_isEmpty(metrics && metrics.serviceMetrics && metrics.serviceMetrics.service_latencies) && (
-          <Alert
-            message={
-              <>
-                No data yet! Please see these
-                <Link to={{ pathname: this.docsLink }} target="_blank">
-                  &nbsp;instructions&nbsp;
-                </Link>
-                on how to set up your span metrics.
-              </>
-            }
-            type="warning"
-            showIcon
-          />
-        )}
-        <div className="service-view-container">
-          <Row>
-            <Col span={6}>
-              <h2 className="service-selector-header">Service</h2>
-              <SearchableSelect
-                value={this.getSelectedService()}
-                onChange={this.handleServiceChange}
-                placeholder="Select A Service"
-                className="select-a-service-input"
-                disabled={metrics.operationMetricsLoading}
-                loading={metrics.operationMetricsLoading}
-              >
-                {services.map((service: string) => (
-                  <Option key={service} value={service}>
-                    {service}
-                  </Option>
-                ))}
-              </SearchableSelect>
-            </Col>
-            <Col span={6}>
-              <h2 className="span-kind-selector-header">Span Kind</h2>
-              <SearchableSelect
-                value={selectedSpanKind}
-                onChange={this.handleSpanKindChange}
-                placeholder="Select A Span Kind"
-                className="span-kind-selector"
-                disabled={metrics.operationMetricsLoading}
-                loading={metrics.operationMetricsLoading}
-              >
-                {spanKindOptions.map(option => (
-                  <Option key={option.value} value={option.value}>
-                    {option.label}
-                  </Option>
-                ))}
-              </SearchableSelect>
-            </Col>
-          </Row>
-          <Row align="middle">
-            <Col span={16}>
-              <p className="operations-metrics-text">
-                Aggregation of all &quot;{this.getSelectedService()}&quot; metrics in selected timeframe.{' '}
-                <a
-                  href={prefixUrl(
-                    `/search?end=${Date.now()}000&limit=20&lookback=${
-                      selectedTimeFrame / (3600 * 1000)
-                    }h&maxDuration&minDuration&service=${this.getSelectedService()}&start=${
-                      Date.now() - selectedTimeFrame
-                    }000`
-                  )}
-                  target="blank"
-                  onClick={trackViewAllTraces}
-                >
-                  View all traces
-                </a>
-              </p>
-            </Col>
-            <Col span={8} className="timeframe-selector">
-              <SearchableSelect
-                value={selectedTimeFrame}
-                onChange={this.handleTimeFrameChange}
-                placeholder="Select A Timeframe"
-                className="select-a-timeframe-input"
-                disabled={metrics.operationMetricsLoading}
-                loading={metrics.operationMetricsLoading}
-              >
-                {timeFrameOptions.map(option => (
-                  <Option key={option.value} value={option.value}>
-                    {option.label}
-                  </Option>
-                ))}
-              </SearchableSelect>
-            </Col>
-          </Row>
-          <Row>
-            <Col span={8}>
-              <div ref={this.graphDivWrapper} />
-              <ServiceGraph
-                key="latency"
-                error={
-                  metrics.serviceError.service_latencies_50 &&
-                  metrics.serviceError.service_latencies_75 &&
-                  metrics.serviceError.service_latencies_95
-                }
-                loading={metrics.loading}
-                name={`Latency (${convertTimeUnitToShortTerm(displayTimeUnit)})`}
-                width={graphWidth}
-                metricsData={serviceLatencies}
-                showLegend
-                marginClassName="latency-margins"
-                showHorizontalLines
-                yAxisTickFormat={timeInMs => yAxisTickFormat(timeInMs, displayTimeUnit)}
-                xDomain={graphXDomain}
-              />
-            </Col>
-            <Col span={8}>
-              <ServiceGraph
-                key="errRate"
-                error={metrics.serviceError.service_error_rate}
-                loading={metrics.loading}
-                name="Error rate (%)"
-                width={graphWidth}
-                metricsData={convertServiceErrorRateToPercentages(serviceErrorRate)}
-                marginClassName="error-rate-margins"
-                color="#CD513A"
-                yDomain={[0, 100]}
-                xDomain={graphXDomain}
-              />
-            </Col>
-            <Col span={8}>
-              <ServiceGraph
-                key="requests"
-                loading={metrics.loading}
-                error={metrics.serviceError.service_call_rate}
-                name="Request rate (req/s)"
-                width={graphWidth}
-                metricsData={metrics.serviceMetrics ? metrics.serviceMetrics.service_call_rate : null}
-                showHorizontalLines
-                color="#4795BA"
-                marginClassName="request-margins"
-                xDomain={graphXDomain}
-              />
-            </Col>
-          </Row>
-          <Row className="operation-table-block">
-            <Col span={16}>
-              <h2 className="table-header">Operations metrics under {this.getSelectedService()}</h2>{' '}
-              <span className="over-the-last">Over the {getLoopbackInterval(selectedTimeFrame)}</span>
-            </Col>
-            <Col span={8} className="select-operation-column">
-              <Search
-                placeholder="Search operation"
-                className="select-operation-input"
-                value={searchOps}
-                disabled={metrics.operationMetricsLoading === true || metrics.serviceOpsMetrics === undefined}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const filteredData = metrics.serviceOpsMetrics!.filter(({ name }: { name: string }) => {
-                    return name.toLowerCase().includes(e.target.value.toLowerCase());
-                  });
-
-                  this.setState({
-                    searchOps: e.target.value,
-                    serviceOpsMetrics: filteredData,
-                  });
-
-                  trackSearchOperationDebounced(e.target.value);
-                }}
-              />
-            </Col>
-          </Row>
-          <Row>
-            <OperationTableDetails
+  return (
+    <>
+      {_isEmpty(metrics && metrics.serviceMetrics && metrics.serviceMetrics.service_latencies) && (
+        <Alert
+          message={
+            <>
+              No data yet! Please see these
+              <Link to={{ pathname: docsLink }} target="_blank">
+                &nbsp;instructions&nbsp;
+              </Link>
+              on how to set up your span metrics.
+            </>
+          }
+          type="warning"
+          showIcon
+        />
+      )}
+      <div className="service-view-container">
+        <Row>
+          <Col span={6}>
+            <h2 className="service-selector-header">Service</h2>
+            <SearchableSelect
+              value={getSelectedService()}
+              onChange={handleServiceChange}
+              placeholder="Select A Service"
+              className="select-a-service-input"
+              disabled={metrics.operationMetricsLoading}
               loading={metrics.operationMetricsLoading}
-              error={metrics.opsError}
-              data={
-                this.state.serviceOpsMetrics === undefined
-                  ? metrics.serviceOpsMetrics
-                  : this.state.serviceOpsMetrics
+            >
+              {services.map((service: string) => (
+                <Option key={service} value={service}>
+                  {service}
+                </Option>
+              ))}
+            </SearchableSelect>
+          </Col>
+          <Col span={6}>
+            <h2 className="span-kind-selector-header">Span Kind</h2>
+            <SearchableSelect
+              value={selectedSpanKind}
+              onChange={handleSpanKindChange}
+              placeholder="Select A Span Kind"
+              className="span-kind-selector"
+              disabled={metrics.operationMetricsLoading}
+              loading={metrics.operationMetricsLoading}
+            >
+              {spanKindOptions.map(option => (
+                <Option key={option.value} value={option.value}>
+                  {option.label}
+                </Option>
+              ))}
+            </SearchableSelect>
+          </Col>
+        </Row>
+        <Row align="middle">
+          <Col span={16}>
+            <p className="operations-metrics-text">
+              Aggregation of all &quot;{getSelectedService()}&quot; metrics in selected timeframe.{' '}
+              <a
+                href={prefixUrl(
+                  `/search?end=${Date.now()}000&limit=20&lookback=${
+                    selectedTimeFrame / (3600 * 1000)
+                  }h&maxDuration&minDuration&service=${getSelectedService()}&start=${
+                    Date.now() - selectedTimeFrame
+                  }000`
+                )}
+                target="blank"
+                onClick={trackViewAllTraces}
+              >
+                View all traces
+              </a>
+            </p>
+          </Col>
+          <Col span={8} className="timeframe-selector">
+            <SearchableSelect
+              value={selectedTimeFrame}
+              onChange={handleTimeFrameChange}
+              placeholder="Select A Timeframe"
+              className="select-a-timeframe-input"
+              disabled={metrics.operationMetricsLoading}
+              loading={metrics.operationMetricsLoading}
+            >
+              {timeFrameOptions.map(option => (
+                <Option key={option.value} value={option.value}>
+                  {option.label}
+                </Option>
+              ))}
+            </SearchableSelect>
+          </Col>
+        </Row>
+        <Row>
+          <Col span={8}>
+            <div ref={graphDivWrapper} />
+            <ServiceGraph
+              key="latency"
+              error={
+                metrics.serviceError.service_latencies_50 &&
+                metrics.serviceError.service_latencies_75 &&
+                metrics.serviceError.service_latencies_95
               }
-              endTime={this.endTime}
-              lookback={selectedTimeFrame}
-              serviceName={this.getSelectedService()}
+              loading={metrics.loading}
+              name={`Latency (${convertTimeUnitToShortTerm(displayTimeUnit)})`}
+              width={graphWidth}
+              metricsData={serviceLatencies}
+              showLegend
+              marginClassName="latency-margins"
+              showHorizontalLines
+              yAxisTickFormat={timeInMs => yAxisTickFormat(timeInMs, displayTimeUnit)}
+              xDomain={graphXDomain}
             />
-          </Row>
-        </div>
-      </>
-    );
-  }
+          </Col>
+          <Col span={8}>
+            <ServiceGraph
+              key="errRate"
+              error={metrics.serviceError.service_error_rate}
+              loading={metrics.loading}
+              name="Error rate (%)"
+              width={graphWidth}
+              metricsData={convertServiceErrorRateToPercentages(serviceErrorRate)}
+              marginClassName="error-rate-margins"
+              color="#CD513A"
+              yDomain={[0, 100]}
+              xDomain={graphXDomain}
+            />
+          </Col>
+          <Col span={8}>
+            <ServiceGraph
+              key="requests"
+              loading={metrics.loading}
+              error={metrics.serviceError.service_call_rate}
+              name="Request rate (req/s)"
+              width={graphWidth}
+              metricsData={metrics.serviceMetrics ? metrics.serviceMetrics.service_call_rate : null}
+              showHorizontalLines
+              color="#4795BA"
+              marginClassName="request-margins"
+              xDomain={graphXDomain}
+            />
+          </Col>
+        </Row>
+        <Row className="operation-table-block">
+          <Col span={16}>
+            <h2 className="table-header">Operations metrics under {getSelectedService()}</h2>{' '}
+            <span className="over-the-last">Over the {getLoopbackInterval(selectedTimeFrame)}</span>
+          </Col>
+          <Col span={8} className="select-operation-column">
+            <Search
+              placeholder="Search operation"
+              className="select-operation-input"
+              value={searchOps}
+              disabled={metrics.operationMetricsLoading === true || metrics.serviceOpsMetrics === undefined}
+              onChange={handleSearchChange}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <OperationTableDetails
+            loading={metrics.operationMetricsLoading}
+            error={metrics.opsError}
+            data={serviceOpsMetrics === undefined ? metrics.serviceOpsMetrics : serviceOpsMetrics}
+            endTime={endTime}
+            lookback={selectedTimeFrame}
+            serviceName={getSelectedService()}
+          />
+        </Row>
+      </div>
+    </>
+  );
 }
 
-export function mapStateToProps(state: ReduxState): TReduxProps {
-  const { services, metrics } = state;
-  return {
-    services: services.services || [],
-    servicesLoading: services.loading,
-    metrics,
-  };
-}
-
-export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
-  const { fetchServices, fetchAllServiceMetrics, fetchAggregatedServiceMetrics } = bindActionCreators<
-    object,
-    any
-  >(jaegerApiActions, dispatch);
-
-  return {
-    fetchServices,
-    fetchAllServiceMetrics,
-    fetchAggregatedServiceMetrics,
-  };
-}
-
-export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(MonitorATMServicesViewImpl));
+export default MonitorATMServicesView;

--- a/packages/jaeger-ui/src/components/Monitor/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/index.tsx
@@ -13,8 +13,14 @@
 // limitations under the License.
 
 import * as React from 'react';
+import { Provider } from 'react-redux';
+import { store } from '../../utils/configure-store';
 import MonitorATMServicesView from './ServicesView';
 
-const MonitorATMPage = () => <MonitorATMServicesView />;
-
-export default MonitorATMPage;
+export default function MonitorATMPage() {
+  return (
+    <Provider store={store}>
+      <MonitorATMServicesView />
+    </Provider>
+  );
+}

--- a/packages/jaeger-ui/src/components/TracePage/README.md
+++ b/packages/jaeger-ui/src/components/TracePage/README.md
@@ -1,0 +1,31 @@
+# Re-root Trace Feature
+
+This feature allows users to visualize only part of a trace starting from a given span ID.
+
+## How to Use
+
+There are two ways to use this feature:
+
+1. **From the UI**: Click the "Re-root" button on any span in the trace view to focus on that span and its descendants.
+
+2. **Via URL**: Navigate directly to a specific span by using the URL format: `/trace/:traceId/:spanId`
+
+When viewing a re-rooted trace, a "Reset Root" button appears in the header to return to the full trace view.
+
+## Implementation Details
+
+The implementation consists of:
+
+1. **URL Structure**: Updated to support an optional spanId parameter
+2. **Trace Subtree Creation**: A utility function that extracts a subtree from a trace
+3. **UI Components**: 
+   - Re-root buttons on spans
+   - Reset Root button in the header
+   - Adjusted trace visualization
+
+## Benefits
+
+- Easier navigation of large traces
+- Focus on specific parts of complex traces
+- Deep linking to specific spans
+- Better visualization of subtrees within a trace

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -23,6 +23,7 @@ import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import AltViewOptions from './AltViewOptions';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
+import TraceRepresentationSelector from './TraceRepresentationSelector';
 import SpanGraph from './SpanGraph';
 import TracePageSearchBar from './TracePageSearchBar';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from '../types';
@@ -33,6 +34,8 @@ import { TNil } from '../../../types';
 import { Trace } from '../../../types/trace';
 import { formatDatetime, formatDuration } from '../../../utils/date';
 import { getTraceLinks } from '../../../model/link-patterns';
+import { TraceRepresentation } from '../../../types/config';
+import getConfig from '../../../utils/config/get-config';
 
 import './TracePageHeader.css';
 import ExternalLinks from '../../common/ExternalLinks';
@@ -50,6 +53,8 @@ type TracePageHeaderEmbedProps = {
   onArchiveClicked: () => void;
   onSlimViewClicked: () => void;
   onTraceViewChange: (viewType: ETraceViewType) => void;
+  onTraceRepresentationChange?: (representation: TraceRepresentation) => void;
+  currentRepresentation?: string;
   prevResult: () => void;
   resultCount: number;
   showArchiveButton: boolean;
@@ -119,6 +124,8 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
     onArchiveClicked,
     onSlimViewClicked,
     onTraceViewChange,
+    onTraceRepresentationChange,
+    currentRepresentation,
     prevResult,
     resultCount,
     showArchiveButton,
@@ -192,6 +199,13 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
           navigable={viewType === ETraceViewType.TraceTimelineViewer}
         />
         {showShortcutsHelp && <KeyboardShortcutsHelp className="ub-m2" />}
+        {showViewOptions && onTraceRepresentationChange && (
+          <TraceRepresentationSelector
+            representations={getConfig().traceRepresentations || []}
+            currentRepresentation={currentRepresentation || 'Original'}
+            onRepresentationChange={onTraceRepresentationChange}
+          />
+        )}
         {showViewOptions && (
           <AltViewOptions
             disableJsonView={disableJsonView}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceRepresentationSelector.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceRepresentationSelector.css
@@ -1,0 +1,7 @@
+.TraceRepresentationSelector {
+  margin-right: 0.5rem;
+}
+
+.active-representation {
+  font-weight: bold;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceRepresentationSelector.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceRepresentationSelector.test.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Dropdown } from 'antd';
+import TraceRepresentationSelector from './TraceRepresentationSelector';
+
+describe('TraceRepresentationSelector', () => {
+  const representations = [
+    {
+      name: 'Original',
+      description: 'Original trace without any modifications',
+      transformFunction: 'function(trace) { return trace; }',
+    },
+    {
+      name: 'Test Representation',
+      description: 'Test representation for unit tests',
+      transformFunction: 'function(trace) { return trace; }',
+    },
+  ];
+
+  const props = {
+    representations,
+    currentRepresentation: 'Original',
+    onRepresentationChange: jest.fn(),
+  };
+
+  let wrapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    wrapper = shallow(<TraceRepresentationSelector {...props} />);
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find(Dropdown).length).toBe(1);
+  });
+
+  it('renders nothing when there are no representations', () => {
+    wrapper.setProps({ representations: [] });
+    expect(wrapper.type()).toBeNull();
+  });
+
+  it('renders nothing when there is only one representation', () => {
+    wrapper.setProps({ representations: [representations[0]] });
+    expect(wrapper.type()).toBeNull();
+  });
+
+  it('calls onRepresentationChange when a representation is selected', () => {
+    const items = wrapper.find(Dropdown).prop('menu').items;
+    const testRepItem = items.find(item => item.key === 'Test Representation');
+    
+    expect(testRepItem).toBeDefined();
+    testRepItem.label.props.onClick();
+    
+    expect(props.onRepresentationChange).toHaveBeenCalledTimes(1);
+    expect(props.onRepresentationChange).toHaveBeenCalledWith(representations[1]);
+  });
+
+  it('displays the current representation name', () => {
+    const buttonText = wrapper.find('Button').childAt(0).text();
+    expect(buttonText).toContain('Original');
+    
+    wrapper.setProps({ currentRepresentation: 'Test Representation' });
+    const updatedButtonText = wrapper.find('Button').childAt(0).text();
+    expect(updatedButtonText).toContain('Test Representation');
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceRepresentationSelector.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceRepresentationSelector.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2023 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { Dropdown, Button, Tooltip } from 'antd';
+import { IoChevronDown } from 'react-icons/io5';
+import { TraceRepresentation } from '../../../types/config';
+import './TraceRepresentationSelector.css';
+
+type Props = {
+  representations: TraceRepresentation[];
+  currentRepresentation: string;
+  onRepresentationChange: (representation: TraceRepresentation) => void;
+};
+
+export default function TraceRepresentationSelector(props: Props) {
+  const { representations, currentRepresentation, onRepresentationChange } = props;
+
+  if (!representations || representations.length <= 1) {
+    return null;
+  }
+
+  const handleSelectRepresentation = (representation: TraceRepresentation) => {
+    onRepresentationChange(representation);
+  };
+
+  const dropdownItems = representations.map(representation => ({
+    key: representation.name,
+    label: (
+      <Tooltip title={representation.description}>
+        <a
+          onClick={() => handleSelectRepresentation(representation)}
+          role="button"
+          className={representation.name === currentRepresentation ? 'active-representation' : ''}
+        >
+          {representation.name}
+        </a>
+      </Tooltip>
+    ),
+  }));
+
+  const currentItem = representations.find(r => r.name === currentRepresentation);
+  const dropdownText = currentItem ? currentItem.name : 'Trace Representation';
+
+  return (
+    <Dropdown menu={{ items: dropdownItems }}>
+      <Button className="TraceRepresentationSelector">
+        {`${dropdownText} `}
+        <IoChevronDown />
+      </Button>
+    </Dropdown>
+  );
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/index.css
@@ -1,0 +1,16 @@
+.TracePageHeader--title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.TracePageHeader--titleText {
+  margin-right: 0.5em;
+}
+
+.TracePageHeader--resetRootButton {
+  margin-left: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/index.tsx
@@ -12,4 +12,224 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { default } from './TracePageHeader';
+import * as React from 'react';
+import { Button, Divider, Tooltip } from 'antd';
+import { IoArrowUndoOutline } from 'react-icons/io5';
+
+import TracePageSearchBar from './TracePageSearchBar';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from '../types';
+import LabeledList from '../../common/LabeledList';
+import NewWindowIcon from '../../common/NewWindowIcon';
+import TraceName from '../../common/TraceName';
+import { getTraceLinks } from '../../../model/link-patterns';
+import { Trace } from '../../../types/trace';
+import { TNil } from '../../../types';
+import { TraceRepresentation } from '../../../types/config';
+import { getTraceSpanIdsAsTree } from '../../../selectors/trace';
+import AltViewOptions from './AltViewOptions';
+import TraceRepresentationSelector from './TraceRepresentationSelector';
+import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
+import SpanGraph from './SpanGraph';
+import TracePageHeader from './TracePageHeader';
+
+import './index.css';
+
+type TracePageHeaderEmbedProps = {
+  canCollapse: boolean;
+  clearSearch: () => void;
+  focusUiFindMatches: () => void;
+  hideMap: boolean;
+  hideSummary: boolean;
+  linkToStandalone: string;
+  nextResult: () => void;
+  onSlimViewClicked: () => void;
+  prevResult: () => void;
+  resultCount: number;
+  showArchiveButton: boolean;
+  showShortcutsHelp: boolean;
+  showStandaloneLink: boolean;
+  showViewOptions: boolean;
+  slimView: boolean;
+  textFilter: string | TNil;
+  toSearch: string | null;
+  trace: Trace;
+  updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
+  updateViewRangeTime: TUpdateViewRangeTimeFunction;
+  viewRange: IViewRange;
+  viewType: ETraceViewType;
+  disableJsonView: boolean;
+  onTraceViewChange: (viewType: ETraceViewType) => void;
+  onTraceRepresentationChange: (representation: TraceRepresentation) => void;
+  currentRepresentation: string;
+  onArchiveClicked?: () => void;
+  isSubtrace?: boolean;
+  onResetRootTrace?: () => void;
+};
+
+export default function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { ref?: React.Ref<any> }) {
+  const {
+    canCollapse,
+    clearSearch,
+    currentRepresentation,
+    disableJsonView,
+    focusUiFindMatches,
+    hideMap,
+    hideSummary,
+    linkToStandalone,
+    nextResult,
+    onArchiveClicked,
+    onSlimViewClicked,
+    onTraceRepresentationChange,
+    onTraceViewChange,
+    prevResult,
+    ref,
+    resultCount,
+    showArchiveButton,
+    showShortcutsHelp,
+    showStandaloneLink,
+    showViewOptions,
+    slimView,
+    textFilter,
+    toSearch,
+    trace,
+    updateNextViewRangeTime,
+    updateViewRangeTime,
+    viewRange,
+    viewType,
+    isSubtrace,
+    onResetRootTrace,
+  } = props;
+
+  const tree = getTraceSpanIdsAsTree(trace);
+  const summaryItems = [
+    {
+      key: 'start',
+      label: 'Trace Start:',
+      value: trace.startTime,
+    },
+    {
+      key: 'duration',
+      label: 'Duration:',
+      value: trace.duration,
+    },
+    {
+      key: 'svc-count',
+      label: 'Services:',
+      value: trace.services ? trace.services.length : 0,
+    },
+    {
+      key: 'depth',
+      label: 'Depth:',
+      value: tree.depth - 1,
+    },
+    {
+      key: 'span-count',
+      label: 'Total Spans:',
+      value: trace.spans.length,
+    },
+  ];
+
+  const links = getTraceLinks(trace);
+
+  return (
+    <TracePageHeader
+      canCollapse={canCollapse}
+      clearSearch={clearSearch}
+      focusUiFindMatches={focusUiFindMatches}
+      hideSummary={hideSummary}
+      nextResult={nextResult}
+      onSlimViewClicked={onSlimViewClicked}
+      prevResult={prevResult}
+      ref={ref}
+      resultCount={resultCount}
+      slimView={slimView}
+      textFilter={textFilter}
+      traceID={trace.traceID}
+      traceName={<TraceName traceName={trace.traceName} />\u00A0}
+      viewType={viewType}
+    >
+      {!hideSummary && (
+        <LabeledList
+          className="TracePageHeader--overviewItems"
+          items={summaryItems}
+        />
+      )}
+      {links && links.length > 0 && (
+        <div>
+          <h3 className="TracePageHeader--overviewItemsHeader">Related Traces</h3>
+          <div className="TracePageHeader--overviewItemsWrapper">
+            {links.map(({ url, text }, i) => (
+              <a
+                className="TracePageHeader--overviewLink"
+                href={url}
+                key={i}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {text}
+                <NewWindowIcon />
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+      {showArchiveButton && onArchiveClicked && (
+        <Button className="TracePageHeader--archiveButton" onClick={onArchiveClicked}>
+          Archive Trace
+        </Button>
+      )}
+      {showStandaloneLink && (
+        <Button className="TracePageHeader--standaloneLink" href={linkToStandalone} target="_blank">
+          <NewWindowIcon />
+        </Button>
+      )}
+      {isSubtrace && onResetRootTrace && (
+        <Tooltip title="Return to full trace view">
+          <Button 
+            className="TracePageHeader--resetRootButton" 
+            onClick={onResetRootTrace}
+            icon={<IoArrowUndoOutline />}
+          >
+            Reset Root
+          </Button>
+        </Tooltip>
+      )}
+      {showShortcutsHelp && <KeyboardShortcutsHelp className="TracePageHeader--shortcutsHelp" />}
+      {showViewOptions && (
+        <div className="TracePageHeader--viewOptionsWrapper">
+          {viewType === ETraceViewType.TraceTimelineViewer && (
+            <TraceRepresentationSelector
+              onChange={onTraceRepresentationChange}
+              currentRepresentation={currentRepresentation}
+            />
+          )}
+          <Divider type="vertical" />
+          <AltViewOptions
+            disableJsonView={disableJsonView}
+            onTraceViewChange={onTraceViewChange}
+            viewType={viewType}
+          />
+        </div>
+      )}
+      {!hideMap && !slimView && (
+        <SpanGraph
+          trace={trace}
+          viewRange={viewRange}
+          updateNextViewRangeTime={updateNextViewRangeTime}
+          updateViewRangeTime={updateViewRangeTime}
+        />
+      )}
+      {!slimView && (
+        <TracePageSearchBar
+          clearSearch={clearSearch}
+          focusUiFindMatches={focusUiFindMatches}
+          nextResult={nextResult}
+          prevResult={prevResult}
+          resultCount={resultCount}
+          textFilter={textFilter}
+          toSearch={toSearch}
+        />
+      )}
+    </TracePageHeader>
+  );
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.css
@@ -1,139 +1,17 @@
-/*
-Copyright (c) 2017 Uber Technologies, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-.SpanBar--wrapper {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  overflow: hidden;
-  z-index: 0;
+.SpanBar--popoverAction {
+  margin: 8px 0;
 }
 
-.span-row.is-expanded .SpanBar--wrapper,
-.span-row:hover .SpanBar--wrapper {
-  opacity: 1;
-}
-
-.SpanBar--bar {
+.SpanBar--rerootButton {
+  background: #1890ff;
+  border: none;
   border-radius: 3px;
-  min-width: 2px;
-  position: absolute;
-  height: 36%;
-  top: 32%;
-}
-
-.SpanBar--rpc {
-  position: absolute;
-  top: 35%;
-  bottom: 35%;
-  z-index: 1;
-}
-
-.SpanBar--criticalPath {
-  position: absolute;
-  top: 45%;
-  height: 11%;
-  z-index: 2;
-  overflow: hidden;
-}
-
-.SpanBar--criticalPath::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  width: 10%;
-  height: 100%;
-  visibility: hidden;
-  background-color: white;
-  border: 1px solid white;
-}
-
-.SpanBar--criticalPath:hover::before {
-  visibility: visible;
-  animation: runOnce 2s forwards;
-}
-
-@keyframes runOnce {
-  0% {
-    left: 0;
-  }
-  100% {
-    left: 100%;
-  }
-}
-
-.SpanBar--label {
-  color: #aaa;
-  font-size: 12px;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  line-height: 1em;
-  white-space: nowrap;
-  padding: 0 0.5em;
-  position: absolute;
-}
-
-.SpanBar--label.is-right {
-  left: 100%;
-}
-
-.SpanBar--label.is-left {
-  right: 100%;
-}
-
-.span-row.is-expanded .SpanBar--label,
-.span-row:hover .SpanBar--label {
-  color: #000;
-}
-
-.SpanBar--logMarker {
-  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
   cursor: pointer;
-  height: 60%;
-  min-width: 1px;
-  position: absolute;
-  top: 20%;
+  font-size: 12px;
+  padding: 4px 8px;
 }
 
-.SpanBar--logMarker:hover {
-  background-color: #000;
-  transform: scale(1.2);
-  transition: transform 0.3s ease;
-}
-
-.SpanBar--logMarker::before,
-.SpanBar--logMarker::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  border: 3px solid transparent;
-}
-
-.SpanBar--logMarker::after {
-  left: 0;
-}
-
-.SpanBar--logHint {
-  pointer-events: none;
-}
-
-/* Tweak the popover aesthetics - unfortunate but necessary */
-.SpanBar--logHint .ant-popover-inner-content {
-  padding: 0.25rem;
+.SpanBar--rerootButton:hover {
+  background: #40a9ff;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -1,77 +1,117 @@
-/*
-Copyright (c) 2017 Uber Technologies, Inc.
+.SpanBarRow {
+  cursor: pointer;
+  min-height: 1.7rem;
+  font-size: 1rem;
+  position: relative;
+}
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+.SpanBarRow--multigraph {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
 
-http://www.apache.org/licenses/LICENSE-2.0
+.SpanBarRow--timelineButtonsWrapper {
+  position: absolute;
+  right: 0.5rem;
+  top: 0;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+.SpanBarRow:hover .SpanBarRow--timelineButtonsWrapper {
+  opacity: 1;
+}
 
-.span-row.is-matching-filter {
+.SpanBarRow--timelineCollapseBtn {
+  color: #666;
+  font-size: 1.1rem;
+  padding: 0 0.25rem;
+  margin-right: 0.5rem;
+}
+
+.SpanBarRow--rerootBtn {
+  color: #1890ff;
+  font-size: 0.8rem;
+  padding: 0 0.5rem;
+  border: 1px solid #1890ff;
+  border-radius: 3px;
+}
+
+.SpanBarRow--rerootBtn:hover {
+  background: #1890ff;
+  color: #fff;
+}
+
+.SpanBarRow.is-expanded {
+  background: #f5f5f5;
+}
+
+.SpanBarRow.is-matching-filter {
   background-color: #fffce4;
+}
+
+.SpanBarRow:hover {
+  background: #f5f5f5;
+}
+
+.SpanBarRow:hover .span-name {
+  text-decoration: underline;
+}
+
+.SpanBarRow.is-expanded .span-name {
+  text-decoration: underline;
+}
+
+.SpanBarRow.is-expanded:hover {
+  background: #eee;
+}
+
+.SpanBarRow.is-matching-filter:hover {
+  background-color: #fff5d6;
+}
+
+.SpanBarRow.is-expanded.is-matching-filter {
+  background-color: #fff5d6;
+}
+
+.SpanBarRow.is-expanded.is-matching-filter:hover {
+  background-color: #ffeccf;
 }
 
 .span-name-column {
   position: relative;
   white-space: nowrap;
-  z-index: 1;
-}
-
-.span-name-column:hover {
-  z-index: 1;
-}
-
-.span-row.clipping-left .span-name-column::before {
-  content: ' ';
+  overflow: hidden;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
   height: 100%;
-  position: absolute;
-  width: 6px;
-  background-image: linear-gradient(to right, rgba(25, 25, 25, 0.25), rgba(32, 32, 32, 0));
-  left: 100%;
-  z-index: -1;
 }
 
 .span-name-wrapper {
-  background: #f8f8f8;
-  line-height: 27px;
+  background: #f5f5f5;
   overflow: hidden;
   display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
 }
 
-.span-name-wrapper.is-matching-filter {
-  background-color: #fffce4;
+.SpanBarRow:hover .span-name-wrapper {
+  background: #eee;
 }
 
-.span-name-wrapper:hover {
-  border-right: 1px solid #bbb;
-  float: left;
-  min-width: calc(100% + 1px);
-  overflow: visible;
-}
-
-.span-row:hover .span-name-wrapper {
-  background: #f8f8f8;
-  background: linear-gradient(90deg, #fafafa, #f8f8f8 75%, #eee);
-}
-
-.span-row.is-matching-filter:hover .span-name-wrapper {
-  background: linear-gradient(90deg, #fff5e1, #fff5e1 75%, #ffe6c9);
-}
-
-.span-row.is-expanded .span-name-wrapper {
-  background: #f0f0f0;
-  box-shadow: 0 1px 0 #ddd;
-}
-
-.span-row.is-expanded .span-name-wrapper.is-matching-filter {
-  background: #fff3d7;
+.SpanBarRow--errorIcon {
+  color: #db2828;
+  position: absolute;
+  right: 0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1rem;
 }
 
 .span-name {
@@ -80,121 +120,33 @@ limitations under the License.
   flex: 1 1 auto;
   outline: none;
   overflow: hidden;
-  padding-left: 4px;
-  padding-right: 0.25em;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
   position: relative;
   text-overflow: ellipsis;
+  user-select: none;
+  white-space: nowrap;
 }
 
-.span-name::before {
-  content: ' ';
-  position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 0;
-  border-left: 4px solid;
-  border-left-color: inherit;
-}
-
-.span-name.is-detail-expanded::before {
-  bottom: 0;
-}
-
-/* This is so the hit area of the span-name extends the rest of the width of the span-name column */
-.span-name::after {
-  background: transparent;
-  bottom: 0;
-  content: ' ';
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 1000px;
-}
-
-.span-name:focus {
-  text-decoration: none;
+.span-name.is-detail-expanded {
+  font-weight: bold;
 }
 
 .endpoint-name {
-  color: #808080;
-}
-
-.span-name:hover > .endpoint-name {
-  color: #000;
+  color: #999;
 }
 
 .span-svc-name {
-  padding: 0 0.25rem 0 0.5rem;
-  font-size: 1.05em;
+  margin-right: 0.25rem;
+  font-weight: bold;
 }
 
-.span-svc-name.is-children-collapsed {
-  font-weight: bold;
-  font-style: italic;
+.span-svc-name--theme {
+  color: #fff;
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
 }
 
 .span-view {
   position: relative;
-}
-
-.span-row:hover .span-view {
-  background-color: #f5f5f5;
-  outline: 1px solid #ddd;
-}
-
-.span-row.is-matching-filter:hover .span-view {
-  background-color: #fff3d7;
-  outline: 1px solid #ddd;
-}
-
-.span-row.is-expanded .span-view {
-  background: #f8f8f8;
-  outline: 1px solid #ddd;
-}
-
-.span-row.is-expanded.is-matching-filter .span-view {
-  background: #fff3d7;
-  outline: 1px solid #ddd;
-}
-
-.span-row.is-expanded:hover .span-view {
-  background: #eee;
-}
-
-.span-row.is-expanded.is-matching-filter:hover .span-view {
-  background: #ffeccf;
-}
-
-.span-row.clipping-right .span-view::before {
-  content: ' ';
-  height: 100%;
-  position: absolute;
-  width: 6px;
-  background-image: linear-gradient(to left, rgba(25, 25, 25, 0.25), rgba(32, 32, 32, 0));
-  right: 0%;
-  z-index: 1;
-}
-
-.SpanBarRow--errorIcon {
-  background: #db2828;
-  border-radius: 6.5px;
-  color: #fff;
-  font-size: 0.85em;
-  margin-right: 0.25rem;
-  padding: 1px;
-}
-
-.SpanBarRow--rpcColorMarker {
-  border-radius: 6.5px;
-  display: inline-block;
-  font-size: 0.85em;
-  height: 1em;
-  margin-right: 0.25rem;
-  padding: 1px;
-  width: 1em;
-  vertical-align: middle;
-}
-
-.SpanBarRow--arrowForwardIcon {
-  vertical-align: middle;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -92,8 +92,13 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
       traceStartTime,
       onRerootClicked,
     } = this.props;
-    const label = span.process.serviceName;
-    const longLabel = `${span.process.serviceName}: ${span.operationName}`;
+    
+    // Get the service name and decorate it with instance ID if available
+    const serviceName = span.process.serviceName;
+    const serviceInstanceId = span.serviceInstanceId;
+    const label = serviceInstanceId ? `${serviceName}[${serviceInstanceId}]` : serviceName;
+    
+    const longLabel = `${label}: ${span.operationName}`;
     const depth = span.depth;
     const hasChildren = span.hasChildren;
     const viewBounds = getViewedBounds(span.startTime, span.startTime + span.duration);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
@@ -24,21 +24,37 @@ import { KeyValuePair, Link } from '../../../../types/trace';
 import './AccordianKeyValues.css';
 
 // export for tests
-export function KeyValuesSummary({ data }: { data: KeyValuePair[] }) {
+// export for tests
+export function KeyValuesSummary({ data }: { data: (KeyValuePair & { type?: string })[] }) {
   if (!Array.isArray(data) || !data.length) {
     return null;
   }
   return (
     <ul className="AccordianKeyValues--summary">
-      {data.map((item, i) => (
-        // `i` is necessary in the key because item.key can repeat
-        // eslint-disable-next-line react/no-array-index-key
-        <li className="AccordianKeyValues--summaryItem" key={`${item.key}-${i}`}>
-          <span className="AccordianKeyValues--summaryLabel">{item.key}</span>
-          <span className="AccordianKeyValues--summaryDelim">=</span>
-          {String(item.value)}
-        </li>
-      ))}
+      {data.map((item, i) => {
+        let valueDisplay = String(item.value);
+        let warningIndicator = null;
+
+        // Check for potential precision loss with int64 numbers
+        if (item.type === 'int64' && typeof item.value === 'number' && (item.value > Number.MAX_SAFE_INTEGER || item.value < Number.MIN_SAFE_INTEGER)) {
+          warningIndicator = (
+            <span title="Value may have lost precision due to JavaScript number limitations" style={{ color: 'orange', marginLeft: '3px' }}>
+              *
+            </span>
+          );
+        }
+
+        return (
+          // `i` is necessary in the key because item.key can repeat
+          // eslint-disable-next-line react/no-array-index-key
+          <li className="AccordianKeyValues--summaryItem" key={`${item.key}-${i}`}>
+            <span className="AccordianKeyValues--summaryLabel">{item.key}</span>
+            <span className="AccordianKeyValues--summaryDelim">=</span>
+            {valueDisplay}
+            {warningIndicator}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -280,14 +280,26 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
   }
 
   focusSpan = (uiFind: string) => {
-    const { trace, focusUiFindMatches, location, history } = this.props;
+    const { trace, focusUiFindMatches, location, history, detailStates } = this.props;
     if (trace) {
+      // Create a copy of the current detail states to preserve them
+      const currentDetailStates = new Map(detailStates);
+      
       updateUiFind({
         location,
         history,
         uiFind,
       });
+      
+      // Pass false for allowHide to prevent closing the source span
       focusUiFindMatches(trace, uiFind, false);
+      
+      // Restore the original detail states to keep source spans open
+      this.props.detailStates.forEach((state, spanID) => {
+        if (currentDetailStates.has(spanID)) {
+          this.props.detailStates.set(spanID, currentDetailStates.get(spanID));
+        }
+      });
     }
   };
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -45,6 +45,7 @@ type TProps = TDispatchProps & {
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRange: IViewRange;
+  onRerootClicked?: (spanId: string) => void;
 };
 
 const NUM_TICKS = 5;
@@ -82,7 +83,7 @@ export class TraceTimelineViewerImpl extends React.PureComponent<TProps> {
   };
 
   render() {
-    const { setSpanNameColumnWidth, updateNextViewRangeTime, updateViewRangeTime, viewRange, ...rest } =
+    const { setSpanNameColumnWidth, updateNextViewRangeTime, updateViewRangeTime, viewRange, onRerootClicked, ...rest } =
       this.props;
     const { spanNameColumnWidth, trace } = rest;
 
@@ -101,7 +102,11 @@ export class TraceTimelineViewerImpl extends React.PureComponent<TProps> {
           updateNextViewRangeTime={updateNextViewRangeTime}
           updateViewRangeTime={updateViewRangeTime}
         />
-        <VirtualizedTraceView {...rest} currentViewRangeTime={viewRange.time.current} />
+        <VirtualizedTraceView 
+          {...rest} 
+          currentViewRangeTime={viewRange.time.current} 
+          onRerootClicked={onRerootClicked}
+        />
       </div>
     );
   }

--- a/packages/jaeger-ui/src/components/TracePage/index-with-reroot.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index-with-reroot.tsx
@@ -1,0 +1,573 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import { InputRef } from 'antd';
+import { Location, History as RouterHistory } from 'history';
+import _clamp from 'lodash/clamp';
+import _get from 'lodash/get';
+import _mapValues from 'lodash/mapValues';
+import _memoize from 'lodash/memoize';
+import { connect } from 'react-redux';
+import { bindActionCreators, Dispatch } from 'redux';
+
+import ArchiveNotifier from './ArchiveNotifier';
+import { actions as archiveActions } from './ArchiveNotifier/duck';
+import { trackFilter, trackFocusMatches, trackNextMatch, trackPrevMatch, trackRange } from './index.track';
+import {
+  CombokeysHandler,
+  merge as mergeShortcuts,
+  reset as resetShortcuts,
+  ShortcutCallbacks,
+} from './keyboard-shortcuts';
+import { cancel as cancelScroll, scrollBy, scrollTo } from './scroll-page';
+import ScrollManager from './ScrollManager';
+import calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
+import TraceGraph from './TraceGraph/TraceGraph';
+import { TEv } from './TraceGraph/types';
+import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
+import TracePageHeader from './TracePageHeader';
+import TraceTimelineViewer from './TraceTimelineViewer';
+import { actions as timelineActions } from './TraceTimelineViewer/duck';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from './types';
+import { getLocation, getUrl } from './url';
+import ErrorMessage from '../common/ErrorMessage';
+import LoadingIndicator from '../common/LoadingIndicator';
+import { extractUiFindFromState } from '../common/UiFindInput';
+import * as jaegerApiActions from '../../actions/jaeger-api';
+import { getUiFindVertexKeys } from '../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
+import { fetchedState } from '../../constants';
+import { FetchedTrace, LocationState, ReduxState, TNil } from '../../types';
+import { Trace } from '../../types/trace';
+import { TraceArchive } from '../../types/archive';
+import { EmbeddedState } from '../../types/embedded';
+import filterSpans from '../../utils/filter-spans';
+import updateUiFind from '../../utils/update-ui-find';
+import TraceStatistics from './TraceStatistics/index';
+import TraceSpanView from './TraceSpanView/index';
+import TraceFlamegraph from './TraceFlamegraph/index';
+import { StorageCapabilities, TraceGraphConfig, TraceRepresentation } from '../../types/config';
+import getConfig from '../../utils/config/get-config';
+import { createSubtrace } from '../../model/trace-subtree';
+
+import './index.css';
+import memoizedTraceCriticalPath from './CriticalPath/index';
+import withRouteProps from '../../utils/withRouteProps';
+
+type TDispatchProps = {
+  acknowledgeArchive: (id: string) => void;
+  archiveTrace: (id: string) => void;
+  fetchTrace: (id: string) => void;
+  focusUiFindMatches: (trace: Trace, uiFind: string | TNil) => void;
+};
+
+type TOwnProps = {
+  history: RouterHistory;
+  location: Location<LocationState>;
+  params: { id: string; spanId?: string };
+};
+
+type TReduxProps = {
+  archiveEnabled: boolean;
+  storageCapabilities: StorageCapabilities | TNil;
+  archiveTraceState: TraceArchive | TNil;
+  criticalPathEnabled: boolean;
+  embedded: null | EmbeddedState;
+  id: string;
+  searchUrl: null | string;
+  disableJsonView: boolean;
+  trace: FetchedTrace | TNil;
+  uiFind: string | TNil;
+  traceGraphConfig?: TraceGraphConfig;
+};
+
+type TProps = TDispatchProps & TOwnProps & TReduxProps;
+
+type TState = {
+  headerHeight: number | TNil;
+  slimView: boolean;
+  viewType: ETraceViewType;
+  viewRange: IViewRange;
+  currentRepresentation: string;
+  transformedTrace: Trace | null;
+  subtrace: Trace | null;
+};
+
+// export for tests
+export const VIEW_MIN_RANGE = 0.01;
+const VIEW_CHANGE_BASE = 0.005;
+const VIEW_CHANGE_FAST = 0.05;
+
+// export for tests
+export const shortcutConfig: { [name: string]: [number, number] } = {
+  panLeft: [-VIEW_CHANGE_BASE, -VIEW_CHANGE_BASE],
+  panLeftFast: [-VIEW_CHANGE_FAST, -VIEW_CHANGE_FAST],
+  panRight: [VIEW_CHANGE_BASE, VIEW_CHANGE_BASE],
+  panRightFast: [VIEW_CHANGE_FAST, VIEW_CHANGE_FAST],
+  zoomIn: [VIEW_CHANGE_BASE, -VIEW_CHANGE_BASE],
+  zoomInFast: [VIEW_CHANGE_FAST, -VIEW_CHANGE_FAST],
+  zoomOut: [-VIEW_CHANGE_BASE, VIEW_CHANGE_BASE],
+  zoomOutFast: [-VIEW_CHANGE_FAST, VIEW_CHANGE_FAST],
+};
+
+// export for tests
+export function makeShortcutCallbacks(adjRange: (start: number, end: number) => void): ShortcutCallbacks {
+  function getHandler([startChange, endChange]: [number, number]): CombokeysHandler {
+    return function combokeyHandler(event: React.KeyboardEvent<HTMLElement>) {
+      event.preventDefault();
+      adjRange(startChange, endChange);
+    };
+  }
+  return _mapValues(shortcutConfig, getHandler);
+}
+
+// export for tests
+export class TracePageImpl extends React.PureComponent<TProps, TState> {
+  state: TState;
+
+  _headerElm: HTMLElement | TNil;
+  _filterSpans: typeof filterSpans;
+  _searchBar: React.RefObject<InputRef>;
+  _scrollManager: ScrollManager;
+  traceDagEV: TEv | TNil;
+
+  constructor(props: TProps) {
+    super(props);
+    const { embedded, trace } = props;
+    const config = getConfig();
+    const defaultRepresentation = config.traceRepresentations && config.traceRepresentations.length > 0
+      ? config.traceRepresentations[0].name
+      : 'Original';
+    
+    this.state = {
+      headerHeight: null,
+      slimView: Boolean(embedded && embedded.timeline.collapseTitle),
+      viewType: ETraceViewType.TraceTimelineViewer,
+      viewRange: {
+        time: {
+          current: [0, 1],
+        },
+      },
+      currentRepresentation: defaultRepresentation,
+      transformedTrace: null,
+      subtrace: null,
+    };
+    this._headerElm = null;
+    this._filterSpans = _memoize(
+      filterSpans,
+      // Do not use the memo if the filter text or trace has changed.
+      // trace.data.spans is populated after the initial render via mutation.
+      textFilter =>
+        `${textFilter} ${_get(this.props.trace, 'traceID')} ${_get(this.props.trace, 'data.spans.length')}`
+    );
+    this._scrollManager = new ScrollManager(trace && trace.data, {
+      scrollBy,
+      scrollTo,
+    });
+    this._searchBar = React.createRef();
+    resetShortcuts();
+  }
+
+  componentDidMount() {
+    this.ensureTraceFetched();
+    this.updateViewRangeTime(0, 1);
+    /* istanbul ignore if */
+    if (!this._scrollManager) {
+      throw new Error('Invalid state - scrollManager is unset');
+    }
+    const { scrollPageDown, scrollPageUp, scrollToNextVisibleSpan, scrollToPrevVisibleSpan } =
+      this._scrollManager;
+    const adjViewRange = (a: number, b: number) => this._adjustViewRange(a, b, 'kbd');
+    const shortcutCallbacks = makeShortcutCallbacks(adjViewRange);
+    shortcutCallbacks.scrollPageDown = scrollPageDown;
+    shortcutCallbacks.scrollPageUp = scrollPageUp;
+    shortcutCallbacks.scrollToNextVisibleSpan = scrollToNextVisibleSpan;
+    shortcutCallbacks.scrollToPrevVisibleSpan = scrollToPrevVisibleSpan;
+    shortcutCallbacks.clearSearch = this.clearSearch;
+    shortcutCallbacks.searchSpans = this.focusOnSearchBar;
+    mergeShortcuts(shortcutCallbacks);
+    
+    // Check if we need to create a subtrace based on spanId in URL
+    this.createSubtraceIfNeeded();
+  }
+
+  componentDidUpdate({ id: prevID, trace: prevTrace, params: prevParams }: TProps) {
+    const { id, trace, params } = this.props;
+    const { currentRepresentation } = this.state;
+
+    this._scrollManager.setTrace(trace && trace.data);
+
+    this.setHeaderHeight(this._headerElm);
+    if (!trace) {
+      this.ensureTraceFetched();
+      return;
+    }
+    
+    // If the trace has changed, apply the current representation
+    if (trace && (!prevTrace || prevTrace.data !== trace.data)) {
+      const config = getConfig();
+      const representation = config.traceRepresentations?.find(r => r.name === currentRepresentation);
+      if (representation) {
+        this.setTraceRepresentation(representation);
+      }
+      
+      // Check if we need to create a subtrace based on spanId in URL
+      this.createSubtraceIfNeeded();
+    }
+    
+    // If the spanId param has changed, update the subtrace
+    if (params.spanId !== prevParams.spanId) {
+      this.createSubtraceIfNeeded();
+    }
+    
+    if (prevID !== id) {
+      this.updateViewRangeTime(0, 1);
+      this.clearSearch();
+    }
+  }
+
+  componentWillUnmount() {
+    resetShortcuts();
+    cancelScroll();
+    this._scrollManager.destroy();
+    this._scrollManager = new ScrollManager(undefined, {
+      scrollBy,
+      scrollTo,
+    });
+  }
+
+  createSubtraceIfNeeded() {
+    const { trace, params } = this.props;
+    const { spanId } = params;
+    
+    if (trace && trace.data && spanId) {
+      const subtrace = createSubtrace(trace.data, spanId);
+      this.setState({ subtrace });
+    } else {
+      this.setState({ subtrace: null });
+    }
+  }
+
+  rerootTrace = (spanId: string) => {
+    const { history, location, params } = this.props;
+    const { id } = params;
+    
+    // Navigate to the URL with the spanId
+    history.push(getLocation(id, location.state, undefined, spanId));
+  };
+
+  resetRootTrace = () => {
+    const { history, location, params } = this.props;
+    const { id } = params;
+    
+    // Navigate to the URL without the spanId
+    history.push(getLocation(id, location.state));
+  };
+
+  _adjustViewRange(startChange: number, endChange: number, trackSrc: string) {
+    const [viewStart, viewEnd] = this.state.viewRange.time.current;
+    let start = _clamp(viewStart + startChange, 0, 0.99);
+    let end = _clamp(viewEnd + endChange, 0.01, 1);
+    if (end - start < VIEW_MIN_RANGE) {
+      if (startChange < 0 && endChange < 0) {
+        end = start + VIEW_MIN_RANGE;
+      } else if (startChange > 0 && endChange > 0) {
+        end = start + VIEW_MIN_RANGE;
+      } else {
+        const center = viewStart + (viewEnd - viewStart) / 2;
+        start = center - VIEW_MIN_RANGE / 2;
+        end = center + VIEW_MIN_RANGE / 2;
+      }
+    }
+    this.updateViewRangeTime(start, end, trackSrc);
+  }
+
+  setHeaderHeight = (elm: HTMLElement | TNil) => {
+    this._headerElm = elm;
+    if (elm) {
+      if (this.state.headerHeight !== elm.clientHeight) {
+        this.setState({ headerHeight: elm.clientHeight });
+      }
+    } else if (this.state.headerHeight) {
+      this.setState({ headerHeight: null });
+    }
+  };
+
+  clearSearch = () => {
+    const { history, location } = this.props;
+    updateUiFind({
+      history,
+      location,
+      trackFindFunction: trackFilter,
+    });
+    if (this._searchBar.current) this._searchBar.current.blur();
+  };
+
+  focusOnSearchBar = () => {
+    if (this._searchBar.current) this._searchBar.current.focus();
+  };
+
+  updateViewRangeTime: TUpdateViewRangeTimeFunction = (start: number, end: number, trackSrc?: string) => {
+    if (trackSrc) {
+      trackRange(trackSrc, [start, end], this.state.viewRange.time.current);
+    }
+    const current: [number, number] = [start, end];
+    const time = { current };
+    this.setState((state: TState) => ({ viewRange: { ...state.viewRange, time } }));
+  };
+
+  updateNextViewRangeTime = (update: ViewRangeTimeUpdate) => {
+    this.setState((state: TState) => {
+      const time = { ...state.viewRange.time, ...update };
+      return { viewRange: { ...state.viewRange, time } };
+    });
+  };
+
+  toggleSlimView = () => {
+    const { slimView } = this.state;
+    trackSlimHeaderToggle(!slimView);
+    this.setState({ slimView: !slimView });
+  };
+
+  setTraceView = (viewType: ETraceViewType) => {
+    if (this.props.trace && this.props.trace.data && viewType === ETraceViewType.TraceGraph) {
+      this.traceDagEV = calculateTraceDagEV(this.props.trace.data);
+    }
+    this.setState({ viewType });
+  };
+
+  setTraceRepresentation = (representation: TraceRepresentation) => {
+    const { trace } = this.props;
+    if (!trace || !trace.data) return;
+
+    try {
+      // eslint-disable-next-line no-new-func
+      const transformFunc = new Function('return ' + representation.transformFunction)();
+      const transformedTrace = transformFunc(trace.data);
+      
+      this.setState({
+        currentRepresentation: representation.name,
+        transformedTrace,
+      });
+    } catch (error) {
+      console.error('Error applying trace representation:', error);
+    }
+  };
+
+  archiveTrace = () => {
+    const { id, archiveTrace } = this.props;
+    archiveTrace(id);
+  };
+
+  acknowledgeArchive = () => {
+    const { id, acknowledgeArchive } = this.props;
+    acknowledgeArchive(id);
+  };
+
+  ensureTraceFetched() {
+    const { fetchTrace, location, trace, id } = this.props;
+    if (!trace) {
+      fetchTrace(id);
+      return;
+    }
+    const { history } = this.props;
+    if (id && id !== id.toLowerCase()) {
+      history.replace(getLocation(id.toLowerCase(), location.state));
+    }
+  }
+
+  focusUiFindMatches = () => {
+    const { trace, focusUiFindMatches, uiFind } = this.props;
+    if (trace && trace.data) {
+      trackFocusMatches();
+      focusUiFindMatches(trace.data, uiFind);
+    }
+  };
+
+  nextResult = () => {
+    trackNextMatch();
+    this._scrollManager.scrollToNextVisibleSpan();
+  };
+
+  prevResult = () => {
+    trackPrevMatch();
+    this._scrollManager.scrollToPrevVisibleSpan();
+  };
+
+  render() {
+    const {
+      archiveEnabled,
+      storageCapabilities,
+      archiveTraceState,
+      criticalPathEnabled,
+      embedded,
+      id,
+      uiFind,
+      trace,
+      disableJsonView,
+      traceGraphConfig,
+      location: { state: locationState },
+      params,
+    } = this.props;
+    const { slimView, viewType, headerHeight, viewRange, currentRepresentation, subtrace } = this.state;
+    if (!trace || trace.state === fetchedState.LOADING) {
+      return <LoadingIndicator className="u-mt-vast" centered />;
+    }
+    
+    // Use the subtrace if available, otherwise use transformed trace or original trace data
+    const { transformedTrace } = this.state;
+    const data = subtrace || transformedTrace || trace.data;
+    
+    if (trace.state === fetchedState.ERROR || !data) {
+      return <ErrorMessage className="ub-m3" error={trace.error || 'Unknown error'} />;
+    }
+
+    let findCount = 0;
+    let graphFindMatches: Set<string> | null | undefined;
+    let spanFindMatches: Set<string> | null | undefined;
+    if (uiFind) {
+      if (viewType === ETraceViewType.TraceGraph) {
+        graphFindMatches = getUiFindVertexKeys(uiFind, _get(this.traceDagEV, 'vertices', []));
+        findCount = graphFindMatches ? graphFindMatches.size : 0;
+      } else {
+        spanFindMatches = this._filterSpans(uiFind, _get(trace, 'data.spans'));
+        findCount = spanFindMatches ? spanFindMatches.size : 0;
+      }
+    }
+
+    const isEmbedded = Boolean(embedded);
+    const hasArchiveStorage = Boolean(storageCapabilities?.archiveStorage);
+    const isSubtrace = Boolean(subtrace);
+    
+    const headerProps = {
+      focusUiFindMatches: this.focusUiFindMatches,
+      slimView,
+      textFilter: uiFind,
+      viewType,
+      viewRange,
+      canCollapse: !embedded || !embedded.timeline.hideSummary || !embedded.timeline.hideMinimap,
+      clearSearch: this.clearSearch,
+      hideMap: Boolean(
+        viewType !== ETraceViewType.TraceTimelineViewer || (embedded && embedded.timeline.hideMinimap)
+      ),
+      hideSummary: Boolean(embedded && embedded.timeline.hideSummary),
+      linkToStandalone: getUrl(id),
+      nextResult: this.nextResult,
+      onArchiveClicked: this.archiveTrace,
+      onSlimViewClicked: this.toggleSlimView,
+      onTraceViewChange: this.setTraceView,
+      onTraceRepresentationChange: this.setTraceRepresentation,
+      currentRepresentation,
+      prevResult: this.prevResult,
+      ref: this._searchBar,
+      resultCount: findCount,
+      disableJsonView,
+      showArchiveButton: !isEmbedded && archiveEnabled && hasArchiveStorage,
+      showShortcutsHelp: !isEmbedded,
+      showStandaloneLink: isEmbedded,
+      showViewOptions: !isEmbedded,
+      toSearch: (locationState && locationState.fromSearch) || null,
+      trace: data,
+      updateNextViewRangeTime: this.updateNextViewRangeTime,
+      updateViewRangeTime: this.updateViewRangeTime,
+      isSubtrace,
+      onResetRootTrace: isSubtrace ? this.resetRootTrace : undefined,
+    };
+
+    let view;
+    const criticalPath = criticalPathEnabled ? memoizedTraceCriticalPath(data) : [];
+    if (ETraceViewType.TraceTimelineViewer === viewType && headerHeight) {
+      view = (
+        <TraceTimelineViewer
+          registerAccessors={this._scrollManager.setAccessors}
+          scrollToFirstVisibleSpan={this._scrollManager.scrollToFirstVisibleSpan}
+          findMatchesIDs={spanFindMatches}
+          trace={data}
+          criticalPath={criticalPath}
+          updateNextViewRangeTime={this.updateNextViewRangeTime}
+          updateViewRangeTime={this.updateViewRangeTime}
+          viewRange={viewRange}
+          onRerootClicked={this.rerootTrace}
+        />
+      );
+    } else if (ETraceViewType.TraceGraph === viewType && headerHeight) {
+      view = (
+        <TraceGraph
+          headerHeight={headerHeight}
+          ev={this.traceDagEV}
+          uiFind={uiFind}
+          uiFindVertexKeys={graphFindMatches}
+          traceGraphConfig={traceGraphConfig}
+        />
+      );
+    } else if (ETraceViewType.TraceStatistics === viewType && headerHeight) {
+      view = <TraceStatistics trace={data} uiFindVertexKeys={spanFindMatches} uiFind={uiFind} />;
+    } else if (ETraceViewType.TraceSpansView === viewType && headerHeight) {
+      view = <TraceSpanView trace={data} uiFindVertexKeys={spanFindMatches} uiFind={uiFind} />;
+    } else if (ETraceViewType.TraceFlamegraph === viewType && headerHeight) {
+      view = <TraceFlamegraph trace={trace} />;
+    }
+
+    return (
+      <div>
+        {archiveEnabled && (
+          <ArchiveNotifier acknowledge={this.acknowledgeArchive} archivedState={archiveTraceState} />
+        )}
+        <div className="Tracepage--headerSection" ref={this.setHeaderHeight}>
+          <TracePageHeader {...headerProps} />
+        </div>
+        {headerHeight ? <section style={{ paddingTop: headerHeight }}>{view}</section> : null}
+      </div>
+    );
+  }
+}
+
+// export for tests
+export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
+  const { id } = ownProps.params;
+  const { archive, config, embedded, router } = state;
+  const { traces } = state.trace;
+  const trace = id ? traces[id] : null;
+  const archiveTraceState = id ? archive[id] : null;
+  const archiveEnabled = Boolean(config.archiveEnabled);
+  const storageCapabilities = config.storageCapabilities;
+  const { disableJsonView, criticalPathEnabled } = config;
+  const { state: locationState } = router.location;
+  const searchUrl = (locationState && locationState.fromSearch) || null;
+  const { traceGraph: traceGraphConfig } = config;
+
+  return {
+    ...extractUiFindFromState(state),
+    archiveEnabled,
+    storageCapabilities,
+    archiveTraceState,
+    criticalPathEnabled,
+    embedded,
+    id,
+    searchUrl,
+    disableJsonView,
+    trace,
+    traceGraphConfig,
+  };
+}
+
+// export for tests
+export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
+  const { fetchTrace } = bindActionCreators(jaegerApiActions, dispatch);
+  const { archiveTrace, acknowledge: acknowledgeArchive } = bindActionCreators(archiveActions, dispatch);
+  const { focusUiFindMatches } = bindActionCreators(timelineActions, dispatch);
+  return { acknowledgeArchive, archiveTrace, fetchTrace, focusUiFindMatches };
+}
+
+export default withRouteProps(connect(mapStateToProps, mapDispatchToProps)(TracePageImpl));

--- a/packages/jaeger-ui/src/components/TracePage/scroll-page.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/scroll-page.tsx
@@ -18,8 +18,13 @@ const DURATION_MS = 350;
 
 let lastTween: Tween | void;
 
-// TODO(joe): this util can be modified a bit to be generalized (e.g. take in
-// an element as a parameter and use scrollTop instead of window.scrollTo)
+// Check if browser supports CSS scroll-behavior
+const isSmoothScrollSupported = typeof document !== 'undefined' && 'scrollBehavior' in document.documentElement.style;
+
+// Apply smooth scrolling class to html element if supported
+if (isSmoothScrollSupported && document.documentElement) {
+  document.documentElement.classList.add('u-smooth-scroll');
+}
 
 function _onTweenUpdate({ done, value }: { done: boolean; value: number }) {
   window.scrollTo(window.scrollX, value);
@@ -29,6 +34,14 @@ function _onTweenUpdate({ done, value }: { done: boolean; value: number }) {
 }
 
 export function scrollBy(yDelta: number, appendToLast = false) {
+  if (isSmoothScrollSupported) {
+    window.scrollBy({
+      top: yDelta,
+      behavior: 'smooth',
+    });
+    return;
+  }
+
   const { scrollY } = window;
   let targetFrom = scrollY;
   if (appendToLast && lastTween) {
@@ -43,6 +56,14 @@ export function scrollBy(yDelta: number, appendToLast = false) {
 }
 
 export function scrollTo(y: number) {
+  if (isSmoothScrollSupported) {
+    window.scrollTo({
+      top: y,
+      behavior: 'smooth',
+    });
+    return;
+  }
+
   const { scrollY } = window;
   lastTween = new Tween({ duration: DURATION_MS, from: scrollY, to: y, onUpdate: _onTweenUpdate });
 }

--- a/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.tsx
@@ -29,7 +29,16 @@ export default function ReferenceLink(props: ReferenceLinkProps) {
   delete otherProps.onClick;
   if (reference.span) {
     return (
-      <a role="button" onClick={() => focusSpan(reference.spanID)} className={className} {...otherProps}>
+      <a 
+        role="button" 
+        onClick={(e) => {
+          e.preventDefault();
+          // Don't close the source span when clicking on a linked span
+          focusSpan(reference.spanID);
+        }} 
+        className={className} 
+        {...otherProps}
+      >
         {children}
       </a>
     );

--- a/packages/jaeger-ui/src/components/TracePage/url/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.tsx
@@ -18,19 +18,19 @@ import prefixUrl from '../../../utils/prefix-url';
 
 import { TNil } from '../../../types';
 
-export const ROUTE_PATH = prefixUrl('/trace/:id');
+export const ROUTE_PATH = prefixUrl('/trace/:id/:spanId?');
 
-export function getUrl(id: string, uiFind?: string): string {
-  const traceUrl = prefixUrl(`/trace/${id}`);
+export function getUrl(id: string, uiFind?: string, spanId?: string): string {
+  const traceUrl = prefixUrl(spanId ? `/trace/${id}/${spanId}` : `/trace/${id}`);
   if (!uiFind) return traceUrl;
 
   return `${traceUrl}?${queryString.stringify({ uiFind })}`;
 }
 
-export function getLocation(id: string, state: Record<string, string> | TNil, uiFind?: string) {
+export function getLocation(id: string, state: Record<string, string> | TNil, uiFind?: string, spanId?: string) {
   return {
     state,
-    pathname: getUrl(id),
+    pathname: getUrl(id, uiFind, spanId),
     search: uiFind && queryString.stringify({ uiFind }),
   };
 }

--- a/packages/jaeger-ui/src/components/common/LoadingIndicator.tsx
+++ b/packages/jaeger-ui/src/components/common/LoadingIndicator.tsx
@@ -39,5 +39,5 @@ export default function LoadingIndicator({
     ${className}
   `;
 
-  return <LuLoaderCircle className={cls} {...rest} style={style} />;
+  return <LuLoaderCircle data-testid="loading-indicator" className={cls} {...rest} style={style} />;
 }

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -23,6 +23,13 @@ import { Config } from '../types/config';
 const defaultConfig: Config = {
   archiveEnabled: true,
   criticalPathEnabled: true,
+  traceRepresentations: [
+    {
+      name: 'Original',
+      description: 'Original trace without any modifications',
+      transformFunction: 'function(trace) { return trace; }',
+    },
+  ],
   dependencies: {
     dagMaxNumServices: FALLBACK_DAG_MAX_NUM_SERVICES,
     menuEnabled: true,
@@ -124,8 +131,8 @@ const defaultConfig: Config = {
 };
 
 // Fields that should be merged with user-supplied config values rather than overwritten.
-type TMergeField = 'dependencies' | 'search' | 'tracking';
-export const mergeFields: readonly TMergeField[] = ['dependencies', 'search', 'tracking'];
+type TMergeField = 'dependencies' | 'search' | 'tracking' | 'traceRepresentations';
+export const mergeFields: readonly TMergeField[] = ['dependencies', 'search', 'tracking', 'traceRepresentations'];
 
 export default deepFreeze(defaultConfig);
 

--- a/packages/jaeger-ui/src/index.css
+++ b/packages/jaeger-ui/src/index.css
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+html.u-smooth-scroll {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
+    'Helvetica Neue', sans-serif;
+}

--- a/packages/jaeger-ui/src/model/trace-subtree.tsx
+++ b/packages/jaeger-ui/src/model/trace-subtree.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Span, Trace } from '../types/trace';
+
+/**
+ * Creates a subtree of the trace starting from the specified span
+ */
+export function createSubtrace(trace: Trace, rootSpanId: string): Trace | null {
+  if (!trace || !rootSpanId) return null;
+
+  // Find the root span
+  const rootSpan = trace.spans.find(span => span.spanID === rootSpanId);
+  if (!rootSpan) return null;
+
+  // Create a set of all descendant span IDs
+  const descendants = new Set<string>();
+  
+  // Recursive function to collect all descendants
+  function collectDescendants(spanId: string) {
+    const span = trace.spans.find(s => s.spanID === spanId);
+    if (!span) return;
+    
+    descendants.add(spanId);
+    
+    // Process children
+    if (span.childSpanIds) {
+      span.childSpanIds.forEach(childId => {
+        collectDescendants(childId);
+      });
+    }
+  }
+  
+  // Start collecting from the root span
+  collectDescendants(rootSpanId);
+  
+  // Filter spans to include only the root and its descendants
+  const filteredSpans = trace.spans.filter(span => descendants.has(span.spanID));
+  
+  // Adjust relative start times based on the new root span
+  const subtreeStartTime = rootSpan.startTime;
+  const adjustedSpans = filteredSpans.map(span => ({
+    ...span,
+    relativeStartTime: span.startTime - subtreeStartTime,
+    depth: span.spanID === rootSpanId ? 0 : span.depth - rootSpan.depth,
+  }));
+  
+  // Create the subtrace
+  return {
+    ...trace,
+    spans: adjustedSpans,
+    duration: rootSpan.duration,
+    startTime: rootSpan.startTime,
+    endTime: rootSpan.startTime + rootSpan.duration,
+  };
+}

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -88,6 +88,16 @@ export type StorageCapabilities = {
 };
 
 // Default values are provided in packages/jaeger-ui/src/constants/default-config.tsx
+export type TraceRepresentation = {
+  // Display name for the representation in the UI
+  name: string;
+  // Description of what this representation does
+  description?: string;
+  // Function that transforms the trace data
+  // This function should take the raw trace as input and return a modified trace
+  transformFunction: string;
+};
+
 export type Config = {
   //
   // archiveEnabled enables the Archive Trace button in the trace view.
@@ -96,6 +106,9 @@ export type Config = {
 
   // criticalPath enables to show the criticalPath of each span in a trace view.
   criticalPathEnabled: boolean;
+
+  // traceRepresentations defines different ways to view a trace by transforming the trace data
+  traceRepresentations?: TraceRepresentation[];
 
   // dependencies controls the behavior of System Architecture tab.
   dependencies?: {

--- a/packages/jaeger-ui/src/types/trace.tsx
+++ b/packages/jaeger-ui/src/types/trace.tsx
@@ -68,11 +68,13 @@ export type Span = SpanData & {
   warnings: NonNullable<SpanData['warnings']>;
   childSpanIds: NonNullable<SpanData['childSpanIds']>;
   subsidiarilyReferencedBy: Array<SpanReference>;
+  serviceInstanceId?: string; // Added for service instance identification
 };
 
 export type TraceData = {
   processes: Record<string, Process>;
   traceID: string;
+  serviceInstanceCounts?: Record<string, { count: number; hostnames: Map<string, number> }>;
 };
 
 export type Trace = TraceData & {

--- a/packages/jaeger-ui/src/utils/configure-store.js
+++ b/packages/jaeger-ui/src/utils/configure-store.js
@@ -23,6 +23,7 @@ import traceTimeline from '../components/TracePage/TraceTimelineViewer/duck';
 import jaegerReducers from '../reducers';
 import * as jaegerMiddlewares from '../middlewares';
 import { getAppEnvironment } from './constants';
+import { createHistoryPolyfill } from './history-polyfill';
 
 const { createReduxHistory, routerMiddleware, routerReducer } = createReduxHistoryContext({
   history: createBrowserHistory(),
@@ -52,4 +53,6 @@ export default function configureStore() {
 }
 
 export const store = configureStore();
-export const history = createReduxHistory(store);
+const reduxHistory = createReduxHistory(store);
+// Apply polyfill to add v4 API compatibility to history v5
+export const history = createHistoryPolyfill(reduxHistory);

--- a/packages/jaeger-ui/src/utils/history-polyfill.ts
+++ b/packages/jaeger-ui/src/utils/history-polyfill.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 The Jaeger Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * This polyfill bridges the API differences between history v4 and v5
+ * to maintain compatibility with react-router-dom v5 while using history v5.
+ * 
+ * This should be removed when upgrading to react-router-dom v6+ which uses
+ * the useNavigate hook instead of direct history manipulation.
+ */
+import { History } from 'history';
+
+export function createHistoryPolyfill(history: History): History {
+  // Add length property to history object
+  Object.defineProperty(history, 'length', {
+    get: function() {
+      return this.index + 1;
+    },
+    configurable: true,
+  });
+
+  return history;
+}


### PR DESCRIPTION
 State Management: All state variables from the class component have been converted to useState hooks with the same initial values.

Lifecycle Methods:

componentDidMount → useEffect with empty dependency array

componentDidUpdate → useEffect with appropriate dependencies

componentWillUnmount → cleanup function in useEffect

Event Handlers: All event handlers have been converted to functions that update state using the setter functions from useState.

Redux Integration:

mapStateToProps → useSelector hooks

mapDispatchToProps → useDispatch hook with direct action dispatching

Refs: The graphDivWrapper ref has been converted to useRef.

Fixed Issues:

Fixed the issue with storing the selected service by using the current value from getSelectedService()

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
