### PR TITLE
feat: Filter logs based on the selected time range

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.tsx
@@ -44,6 +44,7 @@ type TCommonProps = {
   span: Span;
   longLabel: string;
   shortLabel: string;
+  traceDuration: number;
 };
 
 function toPercent(value: number) {
@@ -106,6 +107,7 @@ function SpanBar(props: TCommonProps) {
     span,
     shortLabel,
     longLabel,
+    traceDuration,
   } = props;
   // group logs based on timestamps
   const logGroups = _groupBy(span.logs, log => {
@@ -156,6 +158,8 @@ function SpanBar(props: TCommonProps) {
                 isOpen
                 logs={logGroups[positionKey]}
                 timestamp={traceStartTime}
+                currentViewRangeTime={[0, 1]}
+                traceDuration={traceDuration}
               />
             }
           >

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -57,6 +57,7 @@ type SpanBarRowProps = {
   traceStartTime: number;
   span: Span;
   focusSpan: (spanID: string) => void;
+  traceDuration: number;
 };
 
 /**
@@ -98,6 +99,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
       traceStartTime,
       span,
       focusSpan,
+      traceDuration,
     } = this.props;
     const {
       duration,
@@ -211,6 +213,7 @@ export default class SpanBarRow extends React.PureComponent<SpanBarRowProps> {
             hintSide={hintSide}
             traceStartTime={traceStartTime}
             span={span}
+            traceDuration={traceDuration}
           />
         </TimelineRow.Cell>
       </TimelineRow>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
@@ -31,6 +31,14 @@ limitations under the License.
   background: #dadada;
 }
 
+.AccordianLogs--toggle {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-style: italic;
+  text-decoration: underline;
+}
+
 .AccordianLogs--content {
   background: #f0f0f0;
   border-top: 1px solid #d8d8d8;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
@@ -127,4 +127,21 @@ describe('<AccordianLogs>', () => {
     expect(items.length).toBe(defaultInRangeLogsCount);
     expect(screen.getByRole('button', { name: /show all/i })).toBeInTheDocument();
   });
+
+  it('is interactive by default', () => {
+    const { interactive, ...propsWithoutInteractive } = defaultProps;
+    render(<AccordianLogs {...propsWithoutInteractive} isOpen />);
+
+    const header = screen.getByRole('switch');
+    expect(header).toBeInTheDocument();
+    fireEvent.click(header);
+    expect(propsWithoutInteractive.onToggle).toHaveBeenCalledTimes(1);
+    expect(mockAccordianKeyValues).toHaveBeenCalledTimes(defaultInRangeLogsCount);
+
+    mockAccordianKeyValues.mock.calls.forEach(callArgs => {
+      const childProps = callArgs[0];
+      expect(childProps.interactive).toBe(true);
+      expect(childProps.onToggle).toBeInstanceOf(Function);
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
@@ -53,6 +53,8 @@ describe('<AccordianLogs>', () => {
     onToggle: jest.fn(),
     openedItems: new Set([logs[1]]),
     timestamp: 5,
+    traceDuration: 100,
+    currentViewRangeTime: [0.0, 0.12],
   };
 
   beforeEach(() => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -42,6 +42,8 @@ type SpanDetailProps = {
   warningsToggle: (spanID: string) => void;
   referencesToggle: (spanID: string) => void;
   focusSpan: (uiFind: string) => void;
+  currentViewRangeTime: [number, number];
+  traceDuration: number;
 };
 
 export default function SpanDetail(props: SpanDetailProps) {
@@ -57,6 +59,8 @@ export default function SpanDetail(props: SpanDetailProps) {
     warningsToggle,
     referencesToggle,
     focusSpan,
+    currentViewRangeTime,
+    traceDuration,
   } = props;
   const { isTagsOpen, isProcessOpen, logs: logsState, isWarningsOpen, isReferencesOpen } = detailState;
   const { operationName, process, duration, relativeStartTime, spanID, logs, tags, warnings, references } =
@@ -120,6 +124,8 @@ export default function SpanDetail(props: SpanDetailProps) {
             onToggle={() => logsToggle(spanID)}
             onItemToggle={logItem => logItemToggle(spanID, logItem)}
             timestamp={traceStartTime}
+            currentViewRangeTime={currentViewRangeTime}
+            traceDuration={traceDuration}
           />
         )}
         {warnings && warnings.length > 0 && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -38,6 +38,8 @@ type SpanDetailRowProps = {
   tagsToggle: (spanID: string) => void;
   traceStartTime: number;
   focusSpan: (uiFind: string) => void;
+  currentViewRangeTime: [number, number];
+  traceDuration: number;
 };
 
 const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
@@ -63,6 +65,8 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
     tagsToggle,
     traceStartTime,
     focusSpan,
+    currentViewRangeTime,
+    traceDuration,
   } = props;
   return (
     <TimelineRow className="detail-row">
@@ -92,6 +96,8 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
             tagsToggle={tagsToggle}
             traceStartTime={traceStartTime}
             focusSpan={focusSpan}
+            currentViewRangeTime={currentViewRangeTime}
+            traceDuration={traceDuration}
           />
         </div>
       </TimelineRow.Cell>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -482,6 +482,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       detailToggle,
       spanNameColumnWidth,
       trace,
+      currentViewRangeTime,
     } = this.props;
     const detailState = detailStates.get(spanID);
     if (!trace || !detailState) {
@@ -505,6 +506,8 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           tagsToggle={detailTagsToggle}
           traceStartTime={trace.startTime}
           focusSpan={this.focusSpan}
+          currentViewRangeTime={currentViewRangeTime}
+          traceDuration={trace.duration}
         />
       </div>
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -463,6 +463,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           traceStartTime={trace.startTime}
           span={span}
           focusSpan={this.focusSpan}
+          traceDuration={trace.duration}
         />
       </div>
     );


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2002 

## Description of the changes
- Adds the ability to show only in-range logs when a time range is selected. 
- A button is added to toggle this functionality to either see all logs or logs within the selected zoom level.


https://github.com/user-attachments/assets/437945de-e4f1-491a-b89d-03c900e4d98e



## How was this change tested?
- Added additional test cases to test the new functionality of `AccordianLogs`
- Tested keyboard shortcuts for zoom levels as seen in the later half of the video.
- Ran `npm run test` and `npm run lint`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
