### PR TITLE
test: add missing test coverage for trackStatisticsView and trackTraceSpansView in TracePageHeader.track

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.track.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.track.test.js
@@ -56,6 +56,18 @@ describe('TracePageHeader.track', () => {
       fn: 'trackRawJsonView',
     },
     {
+      action: track.ACTION_STATISTICS,
+      category: track.CATEGORY_ALT_VIEW,
+      msg: 'tracks a GA event for viewing trace statistics',
+      fn: 'trackStatisticsView',
+    },
+    {
+      action: track.ACTION_TRACE_SPANS_VIEW,
+      category: track.CATEGORY_ALT_VIEW,
+      msg: 'tracks a GA event for viewing trace spans table',
+      fn: 'trackTraceSpansView',
+    },
+    {
       action: OPEN,
       arg: false,
       category: track.CATEGORY_SLIM_HEADER,


### PR DESCRIPTION
Added test cases for trackStatisticsView and trackTraceSpansView to ensure full tracking coverage in TracePageHeader.track.test.js.

Before
<img width="832" alt="Screenshot 2025-05-31 at 10 37 30 AM" src="https://github.com/user-attachments/assets/0a4c8d03-6e1d-48e2-9e4a-82ef85bbf496" />

After
<img width="818" alt="Screenshot 2025-05-31 at 10 39 03 AM" src="https://github.com/user-attachments/assets/1fe68279-6df0-4caa-915f-bb352cac3de5" />
