### PR TITLE
test: achieve 100% test coverage for src/utils

### DIFF
--- a/packages/jaeger-ui/src/utils/color-generator.test.js
+++ b/packages/jaeger-ui/src/utils/color-generator.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import colorGenerator from './color-generator';
+import colorGenerator, { strToRgb } from './color-generator';
 
 it('gives the same color for the same key', () => {
   colorGenerator.clear();
@@ -34,4 +34,10 @@ it('should clear cache', () => {
   colorGenerator.clear();
   const colorTwo = colorGenerator.getColorByKey('serviceB');
   expect(colorOne).toBe(colorTwo);
+});
+
+it('returns [0,0,0] if invalid color string is passed to strToRgb', () => {
+  expect(strToRgb('#FFF')).toEqual([0, 0, 0]);
+  expect(strToRgb('')).toEqual([0, 0, 0]);
+  expect(strToRgb('#1234567')).toEqual([0, 0, 0]);
 });

--- a/packages/jaeger-ui/src/utils/color-generator.tsx
+++ b/packages/jaeger-ui/src/utils/color-generator.tsx
@@ -36,7 +36,7 @@ const COLORS_HEX = [
 ];
 
 // TS needs the precise return type
-function strToRgb(s: string): [number, number, number] {
+export function strToRgb(s: string): [number, number, number] {
   if (s.length !== 7) {
     return [0, 0, 0];
   }

--- a/packages/jaeger-ui/src/utils/constants.test.js
+++ b/packages/jaeger-ui/src/utils/constants.test.js
@@ -1,11 +1,11 @@
 // Copyright (c) 2025 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getAppEnvironment, getVersionInfo, shouldDebugGoogleAnalytics } from './constants';
+
 global.__APP_ENVIRONMENT__ = 'test';
 global.__REACT_APP_VSN_STATE__ = '{"version":"1.2.3"}';
 global.__REACT_APP_GA_DEBUG__ = 'true';
-
-import { getAppEnvironment, getVersionInfo, shouldDebugGoogleAnalytics } from './constants';
 
 describe('constants real implementation', () => {
   it('should return correct app environment', () => {

--- a/packages/jaeger-ui/src/utils/constants.test.js
+++ b/packages/jaeger-ui/src/utils/constants.test.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+global.__APP_ENVIRONMENT__ = 'test';
+global.__REACT_APP_VSN_STATE__ = '{"version":"1.2.3"}';
+global.__REACT_APP_GA_DEBUG__ = 'true';
+
+import { getAppEnvironment, getVersionInfo, shouldDebugGoogleAnalytics } from './constants';
+
+describe('constants real implementation', () => {
+  it('should return correct app environment', () => {
+    expect(getAppEnvironment()).toBe('test');
+  });
+
+  it('should return version info string', () => {
+    expect(getVersionInfo()).toBe('{"version":"1.2.3"}');
+  });
+
+  it('should return GA debug flag', () => {
+    expect(shouldDebugGoogleAnalytics()).toBe('true');
+  });
+});

--- a/packages/jaeger-ui/src/utils/embedded-url.test.js
+++ b/packages/jaeger-ui/src/utils/embedded-url.test.js
@@ -66,18 +66,18 @@ describe('stripEmbeddedState()', () => {
     });
   });
 
-it('does not strip anything except uiEmbed when version is not v0', () => {
-  const input = {
-    uiEmbed: 'v1',
-    uiSearchHideGraph: '1',
-    uiTimelineCollapseTitle: '1',
-  };
+  it('does not strip anything except uiEmbed when version is not v0', () => {
+    const input = {
+      uiEmbed: 'v1',
+      uiSearchHideGraph: '1',
+      uiTimelineCollapseTitle: '1',
+    };
 
-  expect(stripEmbeddedState(input)).toEqual({
-    uiSearchHideGraph: '1',
-    uiTimelineCollapseTitle: '1',
+    expect(stripEmbeddedState(input)).toEqual({
+      uiSearchHideGraph: '1',
+      uiTimelineCollapseTitle: '1',
+    });
   });
-});
 
   it('works when uiEmbed is undefined', () => {
     const input = {

--- a/packages/jaeger-ui/src/utils/embedded-url.test.js
+++ b/packages/jaeger-ui/src/utils/embedded-url.test.js
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getEmbeddedState, stripEmbeddedState } from './embedded-url.tsx';
+
+describe('getEmbeddedState()', () => {
+  it('returns null if uiEmbed is not v0', () => {
+    const search = 'uiEmbed=v1&uiSearchHideGraph=1';
+    expect(getEmbeddedState(search)).toBeNull();
+  });
+
+  it('parses full v0 state correctly', () => {
+    const search =
+      'uiEmbed=v0&uiSearchHideGraph=1&uiTimelineCollapseTitle=1&uiTimelineHideMinimap=1&uiTimelineHideSummary=1';
+    expect(getEmbeddedState(search)).toEqual({
+      version: 'v0',
+      searchHideGraph: true,
+      timeline: {
+        collapseTitle: true,
+        hideMinimap: true,
+        hideSummary: true,
+      },
+    });
+  });
+
+  it('returns false for missing flags', () => {
+    const search = 'uiEmbed=v0';
+    expect(getEmbeddedState(search)).toEqual({
+      version: 'v0',
+      searchHideGraph: false,
+      timeline: {
+        collapseTitle: false,
+        hideMinimap: false,
+        hideSummary: false,
+      },
+    });
+  });
+
+  it('handles mixed values correctly', () => {
+    const search = 'uiEmbed=v0&uiSearchHideGraph=1&uiTimelineHideSummary=1';
+    expect(getEmbeddedState(search)).toEqual({
+      version: 'v0',
+      searchHideGraph: true,
+      timeline: {
+        collapseTitle: false,
+        hideMinimap: false,
+        hideSummary: true,
+      },
+    });
+  });
+});
+
+describe('stripEmbeddedState()', () => {
+  it('removes v0 embedded keys', () => {
+    const input = {
+      uiEmbed: 'v0',
+      uiSearchHideGraph: '1',
+      uiTimelineCollapseTitle: '1',
+      uiTimelineHideMinimap: '1',
+      uiTimelineHideSummary: '1',
+      unrelatedKey: 'hello',
+    };
+
+    expect(stripEmbeddedState(input)).toEqual({
+      unrelatedKey: 'hello',
+    });
+  });
+
+it('does not strip anything except uiEmbed when version is not v0', () => {
+  const input = {
+    uiEmbed: 'v1',
+    uiSearchHideGraph: '1',
+    uiTimelineCollapseTitle: '1',
+  };
+
+  expect(stripEmbeddedState(input)).toEqual({
+    uiSearchHideGraph: '1',
+    uiTimelineCollapseTitle: '1',
+  });
+});
+
+  it('works when uiEmbed is undefined', () => {
+    const input = {
+      uiSearchHideGraph: '1',
+      uiTimelineHideSummary: '1',
+    };
+
+    expect(stripEmbeddedState(input)).toEqual({
+      uiSearchHideGraph: '1',
+      uiTimelineHideSummary: '1',
+    });
+  });
+});

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -97,4 +97,40 @@ describe('fileReader.readJsonFile', () => {
     const p = readJsonFile({ file });
     return expect(p).resolves.toMatchObject(expectedOutput);
   });
+
+  it('handles FileReader error', () => {
+    const file = new File([''], 'error.json');
+    const mockReader = { readAsText: jest.fn(), onerror: null, error: new Error('Read error') };
+
+    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+    const promise = readJsonFile({ file });
+
+    mockReader.onerror();
+
+    return expect(promise).rejects.toThrow(/Read error/);
+  });
+
+  it('handles FileReader abort', () => {
+    const file = new File([''], 'abort.json');
+    const mockReader = { readAsText: jest.fn(), onabort: null };
+
+    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+    const promise = readJsonFile({ file });
+
+    mockReader.onabort();
+
+    return expect(promise).rejects.toThrow(/aborted/);
+  });
+
+  it('rejects if FileReader result is not a string', () => {
+    const file = new File(['{ "test": true }'], 'dummy.json');
+    const mockReader = { readAsText: jest.fn(), onload: null, result: {} };
+
+    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+    const promise = readJsonFile({ file });
+
+    mockReader.onload();
+
+    return expect(promise).rejects.toThrow(/Invalid result type/);
+  });
 });


### PR DESCRIPTION
Improved and added tests to fully cover edge cases in src/utils, achieving complete coverage.

Before
<img width="752" alt="Screenshot 2025-06-02 at 6 37 14 PM" src="https://github.com/user-attachments/assets/e466b50f-12ff-410d-8a20-b7424a05f786" />

After
<img width="726" alt="Screenshot 2025-06-02 at 6 33 39 PM" src="https://github.com/user-attachments/assets/4fc8b6c6-4e67-4508-954c-6ae699d22978" />
