### PR TITLE
test: Migrate SpanTreeOffset Tests from Enzyme to React Testing Library

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { shallow } from 'enzyme';
 import React from 'react';
-import { IoChevronForward, IoChevronDown } from 'react-icons/io5';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
 import spanAncestorIdsSpy from '../../../utils/span-ancestor-ids';
@@ -27,10 +27,8 @@ describe('SpanTreeOffset', () => {
   const rootSpanID = 'rootSpanID';
   const specialRootID = 'root';
   let props;
-  let wrapper;
 
   beforeEach(() => {
-    // Mock implementation instead of Mock return value so that each call returns a new array (like normal)
     spanAncestorIdsSpy.mockImplementation(() => [parentSpanID, rootSpanID]);
     props = {
       addHoverIndentGuideId: jest.fn(),
@@ -41,101 +39,148 @@ describe('SpanTreeOffset', () => {
         spanID: ownSpanID,
       },
     };
-    wrapper = shallow(<UnconnectedSpanTreeOffset {...props} />);
   });
 
   describe('.SpanTreeOffset--indentGuide', () => {
     it('renders only one .SpanTreeOffset--indentGuide for entire trace if span has no ancestors', () => {
       spanAncestorIdsSpy.mockReturnValue([]);
-      wrapper = shallow(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuides = wrapper.find('.SpanTreeOffset--indentGuide');
-      expect(indentGuides.length).toBe(1);
-      expect(indentGuides.prop('data-ancestor-id')).toBe(specialRootID);
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const indentGuides = screen.getAllByTestId(/indent-guide/);
+      expect(indentGuides).toHaveLength(1);
+      expect(indentGuides[0]).toHaveAttribute('data-ancestor-id', specialRootID);
     });
 
     it('renders one .SpanTreeOffset--indentGuide per ancestor span, plus one for entire trace', () => {
-      const indentGuides = wrapper.find('.SpanTreeOffset--indentGuide');
-      expect(indentGuides.length).toBe(3);
-      expect(indentGuides.at(0).prop('data-ancestor-id')).toBe(specialRootID);
-      expect(indentGuides.at(1).prop('data-ancestor-id')).toBe(rootSpanID);
-      expect(indentGuides.at(2).prop('data-ancestor-id')).toBe(parentSpanID);
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const indentGuides = screen.getAllByTestId(/indent-guide/);
+      expect(indentGuides).toHaveLength(3);
+      expect(indentGuides[0]).toHaveAttribute('data-ancestor-id', specialRootID);
+      expect(indentGuides[1]).toHaveAttribute('data-ancestor-id', rootSpanID);
+      expect(indentGuides[2]).toHaveAttribute('data-ancestor-id', parentSpanID);
     });
 
     it('adds .is-active to correct indentGuide', () => {
-      props.hoverIndentGuideIds = new Set([parentSpanID]);
-      wrapper = shallow(<UnconnectedSpanTreeOffset {...props} />);
-      const activeIndentGuide = wrapper.find('.is-active');
-      expect(activeIndentGuide.length).toBe(1);
-      expect(activeIndentGuide.prop('data-ancestor-id')).toBe(parentSpanID);
+      const propsWithHover = {
+        ...props,
+        hoverIndentGuideIds: new Set([parentSpanID]),
+      };
+      render(<UnconnectedSpanTreeOffset {...propsWithHover} />);
+
+      const activeIndentGuide = screen.getByTestId(`indent-guide-${parentSpanID}`);
+      expect(activeIndentGuide).toHaveClass('is-active');
     });
 
     it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseenter', {});
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const indentGuide = screen.getByTestId(`indent-guide-${parentSpanID}`);
+      fireEvent.mouseEnter(indentGuide);
+
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
     });
 
     it('does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId', () => {
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
       const relatedTarget = document.createElement('span');
       relatedTarget.dataset.ancestorId = parentSpanID;
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseenter', {
+
+      const indentGuide = screen.getByTestId(`indent-guide-${parentSpanID}`);
+
+      const mouseEnterEvent = new MouseEvent('mouseenter', {
+        bubbles: true,
         relatedTarget,
       });
+
+      fireEvent(indentGuide, mouseEnterEvent);
+
       expect(props.addHoverIndentGuideId).not.toHaveBeenCalled();
     });
 
     it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseleave', {});
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const indentGuide = screen.getByTestId(`indent-guide-${parentSpanID}`);
+      fireEvent.mouseLeave(indentGuide);
+
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
     });
 
     it('does not call props.removeHoverIndentGuideId on mouse leave if mouse leaves to a indentGuide with the same ancestorId', () => {
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
       const relatedTarget = document.createElement('span');
       relatedTarget.dataset.ancestorId = parentSpanID;
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseleave', {
+
+      const indentGuide = screen.getByTestId(`indent-guide-${parentSpanID}`);
+
+      const mouseLeaveEvent = new MouseEvent('mouseleave', {
+        bubbles: true,
         relatedTarget,
       });
+
+      fireEvent(indentGuide, mouseLeaveEvent);
+
       expect(props.removeHoverIndentGuideId).not.toHaveBeenCalled();
     });
   });
 
   describe('icon', () => {
     beforeEach(() => {
-      wrapper.setProps({ span: { ...props.span, hasChildren: true } });
+      props.span = { ...props.span, hasChildren: true };
     });
 
     it('does not render icon if props.span.hasChildren is false', () => {
-      wrapper.setProps({ span: { ...props.span, hasChildren: false } });
-      expect(wrapper.find(IoChevronForward).length).toBe(0);
-      expect(wrapper.find(IoChevronDown).length).toBe(0);
+      props.span = { ...props.span, hasChildren: false };
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      expect(screen.queryByTestId('icon-wrapper')).not.toBeInTheDocument();
     });
 
     it('does not render icon if props.span.hasChildren is true and showChildrenIcon is false', () => {
-      wrapper.setProps({ showChildrenIcon: false });
-      expect(wrapper.find(IoChevronForward).length).toBe(0);
-      expect(wrapper.find(IoChevronDown).length).toBe(0);
+      props.showChildrenIcon = false;
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      expect(screen.queryByTestId('icon-wrapper')).not.toBeInTheDocument();
     });
 
     it('renders IoChevronRight if props.span.hasChildren is true and props.childrenVisible is false', () => {
-      expect(wrapper.find(IoChevronForward).length).toBe(1);
-      expect(wrapper.find(IoChevronDown).length).toBe(0);
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const iconWrapper = screen.getByTestId('icon-wrapper');
+      expect(iconWrapper).toBeInTheDocument();
+      expect(iconWrapper.querySelector('svg')).toBeInTheDocument();
     });
 
     it('renders IoIosArrowDown if props.span.hasChildren is true and props.childrenVisible is true', () => {
-      wrapper.setProps({ childrenVisible: true });
-      expect(wrapper.find(IoChevronForward).length).toBe(0);
-      expect(wrapper.find(IoChevronDown).length).toBe(1);
+      props.childrenVisible = true;
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const iconWrapper = screen.getByTestId('icon-wrapper');
+      expect(iconWrapper).toBeInTheDocument();
+      expect(iconWrapper.querySelector('svg')).toBeInTheDocument();
     });
 
     it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      wrapper.find('.SpanTreeOffset--iconWrapper').simulate('mouseenter', {});
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const iconWrapper = screen.getByTestId('icon-wrapper');
+      fireEvent.mouseEnter(iconWrapper);
+
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
     });
 
     it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      wrapper.find('.SpanTreeOffset--iconWrapper').simulate('mouseleave', {});
+      render(<UnconnectedSpanTreeOffset {...props} />);
+
+      const iconWrapper = screen.getByTestId('icon-wrapper');
+      fireEvent.mouseLeave(iconWrapper);
+
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
     });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -108,6 +108,7 @@ export class UnconnectedSpanTreeOffset extends React.PureComponent<TProps> {
               'is-active': this.props.hoverIndentGuideIds.has(ancestorId),
             })}
             data-ancestor-id={ancestorId}
+            data-testid={`indent-guide-${ancestorId}`}
             onMouseEnter={event => this.handleMouseEnter(event, ancestorId)}
             onMouseLeave={event => this.handleMouseLeave(event, ancestorId)}
           />
@@ -115,6 +116,7 @@ export class UnconnectedSpanTreeOffset extends React.PureComponent<TProps> {
         {icon && (
           <span
             className="SpanTreeOffset--iconWrapper"
+            data-testid="icon-wrapper"
             onMouseEnter={event => this.handleMouseEnter(event, spanID)}
             onMouseLeave={event => this.handleMouseLeave(event, spanID)}
           >


### PR DESCRIPTION
Rewrote tests for the SpanTreeOffset component using React Testing Library, replacing Enzyme APIs. Improved test clarity, enhanced assertions, and preserved original test coverage.

Test Coverage
<img width="783" alt="Screenshot 2025-06-18 at 4 39 47 PM" src="https://github.com/user-attachments/assets/3b572f90-9065-4323-a8d5-f12fe74dba96" />
