### PR TITLE
test: Migrate <SpanBarRow> tests from Enzyme to React Testing Library

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
@@ -13,26 +13,50 @@
 // limitations under the License.
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import SpanBarRow from './SpanBarRow';
-import SpanTreeOffset from './SpanTreeOffset';
-import ReferencesButton from './ReferencesButton';
 
-jest.mock('./SpanTreeOffset');
+jest.mock('./SpanTreeOffset', () => ({
+  __esModule: true,
+  default: jest.fn(({ span, childrenVisible, onClick }) => (
+    <div data-testid="span-tree-offset" onClick={onClick}>
+      SpanTreeOffset: {span.spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
+    </div>
+  )),
+}));
+
+jest.mock('./ReferencesButton', () => ({
+  __esModule: true,
+  default: jest.fn(({ tooltipText, references, children }) => (
+    <button
+      data-testid="references-button"
+      data-tooltip={tooltipText}
+      data-references={JSON.stringify(references)}
+    >
+      {children}
+    </button>
+  )),
+}));
+
+jest.mock('./SpanBar', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="span-bar">SpanBar</div>),
+}));
 
 describe('<SpanBarRow>', () => {
   const spanID = 'some-id';
-  const props = {
+  const defaultProps = {
     className: 'a-class-name',
     color: 'color-a',
-    columnDivision: '0.5',
+    criticalPath: [],
+    columnDivision: 0.5,
     isChildrenExpanded: true,
     isDetailExpanded: false,
-    isFilteredOut: false,
+    isMatchingFilter: false,
     onDetailToggled: jest.fn(),
     onChildrenToggled: jest.fn(),
-    operationName: 'op-name',
     numTicks: 5,
     rpc: {
       viewStart: 0.25,
@@ -42,127 +66,138 @@ describe('<SpanBarRow>', () => {
       serviceName: 'rpc-service-name',
     },
     showErrorIcon: false,
-    getViewedBounds: jest
-      .fn()
-      .mockReturnValueOnce({ start: 0.5, end: 0.6 })
-      .mockReturnValue({ start: 0, end: 1 }),
+    getViewedBounds: jest.fn().mockReturnValue({ start: 0.5, end: 0.6 }),
     span: {
       duration: 'test-duration',
       hasChildren: true,
+      operationName: 'op-name',
       process: {
         serviceName: 'service-name',
       },
       spanID,
       logs: [],
+      startTime: 100,
     },
+    traceStartTime: 0,
+    traceDuration: 1000,
+    focusSpan: jest.fn(),
   };
 
-  let wrapper;
-
   beforeEach(() => {
-    props.onDetailToggled.mockReset();
-    props.onChildrenToggled.mockReset();
-    wrapper = mount(<SpanBarRow {...props} />);
+    jest.clearAllMocks();
+    defaultProps.onDetailToggled.mockReset();
+    defaultProps.onChildrenToggled.mockReset();
   });
 
   it('renders without exploding', () => {
-    expect(wrapper).toBeDefined();
+    render(<SpanBarRow {...defaultProps} />);
+
+    expect(screen.getByTestId('span-tree-offset')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeInTheDocument();
   });
 
   it('escalates detail toggling', () => {
-    const { onDetailToggled } = props;
-    expect(onDetailToggled.mock.calls.length).toBe(0);
-    wrapper.find('div.span-view').prop('onClick')();
-    expect(onDetailToggled.mock.calls).toEqual([[spanID]]);
+    const { onDetailToggled } = defaultProps;
+    render(<SpanBarRow {...defaultProps} />);
+
+    const spanView = screen.getByTestId('span-bar').closest('div.span-view');
+    fireEvent.click(spanView);
+
+    expect(onDetailToggled).toHaveBeenCalledWith(spanID);
   });
 
   it('escalates children toggling', () => {
-    const { onChildrenToggled } = props;
-    expect(onChildrenToggled.mock.calls.length).toBe(0);
-    wrapper.find(SpanTreeOffset).prop('onClick')();
-    expect(onChildrenToggled.mock.calls).toEqual([[spanID]]);
+    const { onChildrenToggled } = defaultProps;
+    render(<SpanBarRow {...defaultProps} />);
+
+    const spanTreeOffset = screen.getByTestId('span-tree-offset');
+    fireEvent.click(spanTreeOffset);
+
+    expect(onChildrenToggled).toHaveBeenCalledWith(spanID);
   });
 
   it('render references button', () => {
-    const span = Object.assign(
-      {
-        references: [
-          {
-            refType: 'CHILD_OF',
-            traceID: 'trace1',
+    const span = {
+      ...defaultProps.span,
+      references: [
+        {
+          refType: 'CHILD_OF',
+          traceID: 'trace1',
+          spanID: 'span0',
+          span: {
             spanID: 'span0',
-            span: {
-              spanID: 'span0',
-            },
           },
-          {
-            refType: 'CHILD_OF',
-            traceID: 'otherTrace',
+        },
+        {
+          refType: 'CHILD_OF',
+          traceID: 'otherTrace',
+          spanID: 'span1',
+          span: {
             spanID: 'span1',
-            span: {
-              spanID: 'span1',
-            },
           },
-        ],
-      },
-      props.span
-    );
+        },
+      ],
+    };
 
-    const spanRow = shallow(<SpanBarRow {...props} span={span} />);
-    const refButton = spanRow.find(ReferencesButton);
-    expect(refButton.length).toEqual(1);
-    expect(refButton.at(0).props().tooltipText).toEqual('Contains multiple references');
+    render(<SpanBarRow {...defaultProps} span={span} />);
+
+    const referencesButton = screen.getByTestId('references-button');
+    expect(referencesButton).toBeInTheDocument();
+    expect(referencesButton).toHaveAttribute('data-tooltip', 'Contains multiple references');
   });
 
   it('render referenced to by single span', () => {
-    const span = Object.assign(
-      {
-        subsidiarilyReferencedBy: [
-          {
-            refType: 'CHILD_OF',
-            traceID: 'trace1',
+    const span = {
+      ...defaultProps.span,
+      subsidiarilyReferencedBy: [
+        {
+          refType: 'CHILD_OF',
+          traceID: 'trace1',
+          spanID: 'span0',
+          span: {
             spanID: 'span0',
-            span: {
-              spanID: 'span0',
-            },
           },
-        ],
-      },
-      props.span
-    );
-    const spanRow = shallow(<SpanBarRow {...props} span={span} />);
-    const refButton = spanRow.find(ReferencesButton);
-    expect(refButton.length).toEqual(1);
-    expect(refButton.at(0).props().tooltipText).toEqual('This span is referenced by another span');
+        },
+      ],
+    };
+
+    render(<SpanBarRow {...defaultProps} span={span} />);
+
+    const referencesButton = screen.getByTestId('references-button');
+    expect(referencesButton).toBeInTheDocument();
+    expect(referencesButton).toHaveAttribute('data-tooltip', 'This span is referenced by another span');
   });
 
   it('render referenced to by multiple span', () => {
-    const span = Object.assign(
-      {
-        subsidiarilyReferencedBy: [
-          {
-            refType: 'CHILD_OF',
-            traceID: 'trace1',
+    const span = {
+      ...defaultProps.span,
+      subsidiarilyReferencedBy: [
+        {
+          refType: 'CHILD_OF',
+          traceID: 'trace1',
+          spanID: 'span0',
+          span: {
             spanID: 'span0',
-            span: {
-              spanID: 'span0',
-            },
           },
-          {
-            refType: 'CHILD_OF',
-            traceID: 'trace1',
+        },
+        {
+          refType: 'CHILD_OF',
+          traceID: 'trace1',
+          spanID: 'span1',
+          span: {
             spanID: 'span1',
-            span: {
-              spanID: 'span1',
-            },
           },
-        ],
-      },
-      props.span
+        },
+      ],
+    };
+
+    render(<SpanBarRow {...defaultProps} span={span} />);
+
+    const referencesButton = screen.getByTestId('references-button');
+    expect(referencesButton).toBeInTheDocument();
+    expect(referencesButton).toHaveAttribute(
+      'data-tooltip',
+      'This span is referenced by multiple other spans'
     );
-    const spanRow = shallow(<SpanBarRow {...props} span={span} />);
-    const refButton = spanRow.find(ReferencesButton);
-    expect(refButton.length).toEqual(1);
-    expect(refButton.at(0).props().tooltipText).toEqual('This span is referenced by multiple other spans');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.js
@@ -31,6 +31,7 @@ jest.mock('./ReferencesButton', () => ({
   __esModule: true,
   default: jest.fn(({ tooltipText, references, children }) => (
     <button
+      type="button"
       data-testid="references-button"
       data-tooltip={tooltipText}
       data-references={JSON.stringify(references)}
@@ -89,115 +90,66 @@ describe('<SpanBarRow>', () => {
     defaultProps.onChildrenToggled.mockReset();
   });
 
-  it('renders without exploding', () => {
+  it('renders correctly with essential elements', () => {
     render(<SpanBarRow {...defaultProps} />);
-
-    expect(screen.getByTestId('span-tree-offset')).toBeInTheDocument();
-    expect(screen.getByRole('switch')).toBeInTheDocument();
+    expect(screen.getByTestId('span-tree-offset')).toBeVisible();
+    expect(screen.getByRole('switch')).toBeVisible();
   });
 
-  it('escalates detail toggling', () => {
-    const { onDetailToggled } = defaultProps;
+  it('triggers onDetailToggled when view area is clicked', () => {
     render(<SpanBarRow {...defaultProps} />);
-
     const spanView = screen.getByTestId('span-bar').closest('div.span-view');
     fireEvent.click(spanView);
-
-    expect(onDetailToggled).toHaveBeenCalledWith(spanID);
+    expect(defaultProps.onDetailToggled).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onDetailToggled).toHaveBeenCalledWith(spanID);
   });
 
-  it('escalates children toggling', () => {
-    const { onChildrenToggled } = defaultProps;
+  it('triggers onChildrenToggled when SpanTreeOffset is clicked', () => {
     render(<SpanBarRow {...defaultProps} />);
-
-    const spanTreeOffset = screen.getByTestId('span-tree-offset');
-    fireEvent.click(spanTreeOffset);
-
-    expect(onChildrenToggled).toHaveBeenCalledWith(spanID);
+    const treeOffset = screen.getByTestId('span-tree-offset');
+    fireEvent.click(treeOffset);
+    expect(defaultProps.onChildrenToggled).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onChildrenToggled).toHaveBeenCalledWith(spanID);
   });
 
-  it('render references button', () => {
+  it('shows ReferencesButton when span has multiple references', () => {
     const span = {
       ...defaultProps.span,
       references: [
-        {
-          refType: 'CHILD_OF',
-          traceID: 'trace1',
-          spanID: 'span0',
-          span: {
-            spanID: 'span0',
-          },
-        },
-        {
-          refType: 'CHILD_OF',
-          traceID: 'otherTrace',
-          spanID: 'span1',
-          span: {
-            spanID: 'span1',
-          },
-        },
+        { refType: 'CHILD_OF', traceID: 't1', spanID: 's1', span: { spanID: 's1' } },
+        { refType: 'CHILD_OF', traceID: 't2', spanID: 's2', span: { spanID: 's2' } },
       ],
     };
-
     render(<SpanBarRow {...defaultProps} span={span} />);
-
-    const referencesButton = screen.getByTestId('references-button');
-    expect(referencesButton).toBeInTheDocument();
-    expect(referencesButton).toHaveAttribute('data-tooltip', 'Contains multiple references');
+    const btn = screen.getByTestId('references-button');
+    expect(btn).toBeVisible();
+    expect(btn).toHaveAttribute('data-tooltip', 'Contains multiple references');
   });
 
-  it('render referenced to by single span', () => {
+  it('shows tooltip for a single downstream reference', () => {
     const span = {
       ...defaultProps.span,
       subsidiarilyReferencedBy: [
-        {
-          refType: 'CHILD_OF',
-          traceID: 'trace1',
-          spanID: 'span0',
-          span: {
-            spanID: 'span0',
-          },
-        },
+        { refType: 'CHILD_OF', traceID: 't1', spanID: 's1', span: { spanID: 's1' } },
       ],
     };
-
     render(<SpanBarRow {...defaultProps} span={span} />);
-
-    const referencesButton = screen.getByTestId('references-button');
-    expect(referencesButton).toBeInTheDocument();
-    expect(referencesButton).toHaveAttribute('data-tooltip', 'This span is referenced by another span');
+    const btn = screen.getByTestId('references-button');
+    expect(btn).toBeVisible();
+    expect(btn).toHaveAttribute('data-tooltip', 'This span is referenced by another span');
   });
 
-  it('render referenced to by multiple span', () => {
+  it('shows tooltip for multiple downstream references', () => {
     const span = {
       ...defaultProps.span,
       subsidiarilyReferencedBy: [
-        {
-          refType: 'CHILD_OF',
-          traceID: 'trace1',
-          spanID: 'span0',
-          span: {
-            spanID: 'span0',
-          },
-        },
-        {
-          refType: 'CHILD_OF',
-          traceID: 'trace1',
-          spanID: 'span1',
-          span: {
-            spanID: 'span1',
-          },
-        },
+        { refType: 'CHILD_OF', traceID: 't1', spanID: 's1', span: { spanID: 's1' } },
+        { refType: 'CHILD_OF', traceID: 't2', spanID: 's2', span: { spanID: 's2' } },
       ],
     };
-
     render(<SpanBarRow {...defaultProps} span={span} />);
-
-    const referencesButton = screen.getByTestId('references-button');
-    expect(referencesButton).toBeInTheDocument();
-    expect(referencesButton).toHaveAttribute(
-      'data-tooltip',
-      'This span is referenced by multiple other spans'
-    );
+    const btn = screen.getByTestId('references-button');
+    expect(btn).toBeVisible();
+    expect(btn).toHaveAttribute('data-tooltip', 'This span is referenced by multiple other spans');
   });
 });


### PR DESCRIPTION
Refactored SpanBarRow.test.js to use React Testing Library instead of Enzyme. Improved test coverage, clarified test titles, and added better assertions for interaction and rendering behavior.

Test Coverage

<img width="795" alt="Screenshot 2025-06-18 at 4 56 17 PM" src="https://github.com/user-attachments/assets/ba025a66-828c-4eba-9109-6ccbf8a5b610" />
