### PR TITLE
test: migrate <TracePageSearchBar> tests from Enzyme to React Testing Library

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.test.js
@@ -148,6 +148,7 @@ describe('<DefaultTracePageSearchBar>', () => {
 
   it('forwardsRef correctly', () => {
     render(<DefaultTracePageSearchBar {...propsWithoutRef} ref={ref} />);
+    expect(ref.current).not.toBeNull();
 
     const uiFindInput = screen.getByTestId('ui-find-input');
     expect(uiFindInput).toBeInTheDocument();


### PR DESCRIPTION
Replaced Enzyme-based tests with React Testing Library for <TracePageSearchBar> and its default export.