### PR TITLE
Fix bug when calculate GroupByOperation metrics

### DIFF
--- a/packages/jaeger-ui/src/reducers/metrics.mock.js
+++ b/packages/jaeger-ui/src/reducers/metrics.mock.js
@@ -985,7 +985,7 @@ const serviceOpsMetricsWithNull = [
     dataPoints: {
       avg: {
         service_operation_call_rate: 0.02,
-        service_operation_error_rate: 0,
+        service_operation_error_rate: null,
         service_operation_latencies: 2,
       },
       service_operation_call_rate: [
@@ -1031,7 +1031,7 @@ const serviceOpsMetricsWithNull = [
       avg: {
         service_operation_call_rate: 0.01,
         service_operation_error_rate: 1,
-        service_operation_latencies: 0,
+        service_operation_latencies: null,
       },
       service_operation_call_rate: [
         {
@@ -1077,7 +1077,7 @@ const serviceOpsMetricsZeroDivision = [
     dataPoints: {
       avg: {
         service_operation_call_rate: 0.02,
-        service_operation_error_rate: 0,
+        service_operation_error_rate: null,
         service_operation_latencies: 0,
       },
       service_operation_call_rate: [
@@ -1123,7 +1123,7 @@ const serviceOpsMetricsZeroDivision = [
       avg: {
         service_operation_call_rate: 0.01,
         service_operation_error_rate: 1,
-        service_operation_latencies: 0,
+        service_operation_latencies: null,
       },
       service_operation_call_rate: [
         {

--- a/packages/jaeger-ui/src/reducers/metrics.tsx
+++ b/packages/jaeger-ui/src/reducers/metrics.tsx
@@ -191,6 +191,15 @@ function fetchOpsMetricsDone(
             service_operation_call_rate: 0,
             service_operation_error_rate: 0,
           };
+          const count: {
+            service_operation_latencies: number;
+            service_operation_call_rate: number;
+            service_operation_error_rate: number;
+          } = {
+            service_operation_latencies: 0,
+            service_operation_call_rate: 0,
+            service_operation_error_rate: 0,
+          };
           metricDetails.labels.forEach((label: { name: string; value: string }) => {
             if (label.name === 'operation') {
               opsName = label.value;
@@ -219,6 +228,7 @@ function fetchOpsMetricsDone(
               try {
                 y = parseFloat(p.gaugeValue.doubleValue.toFixed(2));
                 avg[metric.name] += y;
+                count[metric.name] += 1; // Increment count for non-NaN values
               } catch (e) {
                 y = null;
               }
@@ -230,8 +240,8 @@ function fetchOpsMetricsDone(
             });
 
             opsMetrics[opsName].metricPoints.avg[metric.name] =
-              metricDetails.metricPoints.length > 0
-                ? parseFloat((avg[metric.name] / metricDetails.metricPoints.length).toFixed(2))
+              count[metric.name] > 0
+                ? parseFloat((avg[metric.name] / count[metric.name]).toFixed(2))
                 : null;
           }
         });

--- a/packages/jaeger-ui/src/reducers/metrics.tsx
+++ b/packages/jaeger-ui/src/reducers/metrics.tsx
@@ -240,9 +240,7 @@ function fetchOpsMetricsDone(
             });
 
             opsMetrics[opsName].metricPoints.avg[metric.name] =
-              count[metric.name] > 0
-                ? parseFloat((avg[metric.name] / count[metric.name]).toFixed(2))
-                : null;
+              count[metric.name] > 0 ? parseFloat((avg[metric.name] / count[metric.name]).toFixed(2)) : null;
           }
         });
       } else {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger-ui/issues/2922

## Description of the changes
- Exclude count for NaN-value when calculate mean for operation 

## How was this change tested?
- npm run lin
- npm run test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
