### PR TITLE
test: Fix CI timeout in <TraceTagOverview> test

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import TraceStatistics from './index';
 import transformTraceData from '../../../model/transform-trace-data';
@@ -86,14 +86,6 @@ describe('<TraceTagOverview>', () => {
 
     render(<TestWrapper />);
 
-    // Wait for component to be ready
-    await waitFor(
-      () => {
-        expect(componentRef.current).toBeDefined();
-      },
-      { timeout: 3000 }
-    );
-
     let tableValue = getColumnValues('Service Name', transformedTrace);
     tableValue = getColumnValuesSecondDropdown(
       tableValue,
@@ -102,22 +94,19 @@ describe('<TraceTagOverview>', () => {
       transformedTrace
     );
 
-    // Call handler and wait for state update
-    act(() => {
-      componentRef.current.handler(tableValue, tableValue, 'Service Name', 'Operation Name');
+    await waitFor(() => {
+      if (componentRef.current) {
+        componentRef.current.handler(tableValue, tableValue, 'Service Name', 'Operation Name');
+      }
     });
 
-    // Wait for the table to update with new data
-    await waitFor(
-      () => {
-        const rows = screen.getAllByRole('row');
-        expect(rows.length).toBeGreaterThan(1);
-        const cells = screen.getAllByRole('cell');
-        expect(cells.length).toBeGreaterThan(0);
-      },
-      { timeout: 8000 }
-    );
-  }, 15000);
+    await waitFor(() => {
+      const rows = screen.getAllByRole('row');
+      expect(rows.length).toBeGreaterThan(1);
+      const cells = screen.getAllByRole('cell');
+      expect(cells.length).toBeGreaterThan(0);
+    });
+  });
 
   it('check togglePopup', async () => {
     let componentRef;

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
@@ -74,6 +74,7 @@ describe('<TraceTagOverview>', () => {
   });
 
   it('check handler', async () => {
+    jest.setTimeout(10000);
     let componentRef;
     const TestWrapper = () => {
       const ref = React.useRef();

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import TraceStatistics from './index';
 import transformTraceData from '../../../model/transform-trace-data';
@@ -86,6 +86,11 @@ describe('<TraceTagOverview>', () => {
 
     render(<TestWrapper />);
 
+    // Wait for component to be ready
+    await waitFor(() => {
+      expect(componentRef.current).toBeDefined();
+    }, { timeout: 3000 });
+
     let tableValue = getColumnValues('Service Name', transformedTrace);
     tableValue = getColumnValuesSecondDropdown(
       tableValue,
@@ -94,19 +99,19 @@ describe('<TraceTagOverview>', () => {
       transformedTrace
     );
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        componentRef.current.handler(tableValue, tableValue, 'Service Name', 'Operation Name');
-      }
+    // Call handler and wait for state update
+    act(() => {
+      componentRef.current.handler(tableValue, tableValue, 'Service Name', 'Operation Name');
     });
 
+    // Wait for the table to update with new data
     await waitFor(() => {
       const rows = screen.getAllByRole('row');
       expect(rows.length).toBeGreaterThan(1);
       const cells = screen.getAllByRole('cell');
       expect(cells.length).toBeGreaterThan(0);
-    });
-  });
+    }, { timeout: 8000 });
+  }, 15000);
 
   it('check togglePopup', async () => {
     let componentRef;

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
@@ -26,9 +26,6 @@ const transformedTrace = transformTraceData(testTrace);
 describe('<TraceTagOverview>', () => {
   let defaultProps;
 
-  // FIXME Increase timeout for this test suite due to slow Enzyme/React 18 mounting
-  jest.setTimeout(10000);
-
   beforeEach(() => {
     defaultProps = {
       trace: transformedTrace,

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.js
@@ -87,9 +87,12 @@ describe('<TraceTagOverview>', () => {
     render(<TestWrapper />);
 
     // Wait for component to be ready
-    await waitFor(() => {
-      expect(componentRef.current).toBeDefined();
-    }, { timeout: 3000 });
+    await waitFor(
+      () => {
+        expect(componentRef.current).toBeDefined();
+      },
+      { timeout: 3000 }
+    );
 
     let tableValue = getColumnValues('Service Name', transformedTrace);
     tableValue = getColumnValuesSecondDropdown(
@@ -105,12 +108,15 @@ describe('<TraceTagOverview>', () => {
     });
 
     // Wait for the table to update with new data
-    await waitFor(() => {
-      const rows = screen.getAllByRole('row');
-      expect(rows.length).toBeGreaterThan(1);
-      const cells = screen.getAllByRole('cell');
-      expect(cells.length).toBeGreaterThan(0);
-    }, { timeout: 8000 });
+    await waitFor(
+      () => {
+        const rows = screen.getAllByRole('row');
+        expect(rows.length).toBeGreaterThan(1);
+        const cells = screen.getAllByRole('cell');
+        expect(cells.length).toBeGreaterThan(0);
+      },
+      { timeout: 8000 }
+    );
   }, 15000);
 
   it('check togglePopup', async () => {


### PR DESCRIPTION
Increased test timeout to handle longer execution in CI environment. Ensures <TraceTagOverview> handler test passes reliably across environments.