### PR TITLE
test: Migrate <ViewingLayer> Tests from Enzyme to React Testing Library

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/ViewingLayer.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/ViewingLayer.test.js
@@ -12,30 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { shallow } from 'enzyme';
 import React from 'react';
-
-import GraphTicks from './GraphTicks';
-import Scrubber from './Scrubber';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import ViewingLayer, { dragTypes } from './ViewingLayer';
 import { EUpdateTypes } from '../../../../utils/DraggableManager';
-import { polyfill as polyfillAnimationFrame } from '../../../../utils/test/requestAnimationFrame';
+
+jest.mock('./Scrubber', () => props => <div data-testid="scrubber" {...props} />);
 
 function getViewRange(viewStart, viewEnd) {
-  return {
-    time: {
-      current: [viewStart, viewEnd],
-    },
-  };
+  return { time: { current: [viewStart, viewEnd] } };
 }
 
 describe('<SpanGraph>', () => {
-  polyfillAnimationFrame(window);
-
   let props;
-  let wrapper;
+  let ref;
+  let container;
+  let rerender;
 
   beforeEach(() => {
+    ref = React.createRef();
     props = {
       height: 60,
       numTicks: 5,
@@ -43,29 +39,23 @@ describe('<SpanGraph>', () => {
       updateViewRangeTime: jest.fn(),
       viewRange: getViewRange(0, 1),
     };
-    wrapper = shallow(<ViewingLayer {...props} />);
+    ({ container, rerender } = render(<ViewingLayer ref={ref} {...props} />));
   });
 
   describe('_getDraggingBounds()', () => {
     beforeEach(() => {
-      props = { ...props, viewRange: getViewRange(0.1, 0.9) };
-      wrapper = shallow(<ViewingLayer {...props} />);
-      wrapper.instance()._setRoot({
-        getBoundingClientRect() {
-          return { left: 10, width: 100 };
-        },
-      });
+      ref.current._setRoot({ getBoundingClientRect: () => ({ left: 10, width: 100 }) });
+      props.viewRange = getViewRange(0.1, 0.9);
+      rerender(<ViewingLayer ref={ref} {...props} />);
     });
 
     it('throws if _root is not set', () => {
-      const instance = wrapper.instance();
-      instance._root = null;
-      expect(() => instance._getDraggingBounds(dragTypes.REFRAME)).toThrow();
+      ref.current._root = null;
+      expect(() => ref.current._getDraggingBounds(dragTypes.REFRAME)).toThrow();
     });
 
     it('returns the correct bounds for reframe', () => {
-      const bounds = wrapper.instance()._getDraggingBounds(dragTypes.REFRAME);
-      expect(bounds).toEqual({
+      expect(ref.current._getDraggingBounds(dragTypes.REFRAME)).toEqual({
         clientXLeft: 10,
         width: 100,
         maxValue: 1,
@@ -74,8 +64,7 @@ describe('<SpanGraph>', () => {
     });
 
     it('returns the correct bounds for shiftStart', () => {
-      const bounds = wrapper.instance()._getDraggingBounds(dragTypes.SHIFT_START);
-      expect(bounds).toEqual({
+      expect(ref.current._getDraggingBounds(dragTypes.SHIFT_START)).toEqual({
         clientXLeft: 10,
         width: 100,
         maxValue: 0.9,
@@ -84,245 +73,210 @@ describe('<SpanGraph>', () => {
     });
 
     it('returns the correct bounds for shiftEnd', () => {
-      const bounds = wrapper.instance()._getDraggingBounds(dragTypes.SHIFT_END);
-      expect(bounds).toEqual({
+      expect(ref.current._getDraggingBounds(dragTypes.SHIFT_END)).toEqual({
         clientXLeft: 10,
         width: 100,
         maxValue: 1,
         minValue: 0.1,
       });
     });
+
+    it('calls getNextViewLayout via _getMarkers (from < to)', () => {
+      expect(ref.current._getMarkers(0.1, 0.9, false)).toBeInstanceOf(Array);
+    });
+
+    it('calls getNextViewLayout via _getMarkers (from > to)', () => {
+      expect(ref.current._getMarkers(0.9, 0.1, false)).toBeInstanceOf(Array);
+    });
+
+    it('calls getNextViewLayout via _getMarkers (from == to)', () => {
+      expect(ref.current._getMarkers(0.5, 0.5, false)).toBeInstanceOf(Array);
+    });
+
+    it('throws in _handleScrubberDragEnd for unknown tag', () => {
+      expect(() =>
+        ref.current._handleScrubberDragEnd({ manager: { resetBounds: jest.fn() }, tag: 'random', value: 0.5 })
+      ).toThrow('bad state');
+    });
+
+    it('renders the cursor guide when cursor is present and not prevented', () => {
+      props.viewRange = {
+        time: {
+          current: [0, 1],
+          cursor: 0.5,
+        },
+      };
+      rerender(<ViewingLayer ref={ref} {...props} />);
+      const guide = container.querySelector('.ViewingLayer--cursorGuide');
+      expect(guide).toBeInTheDocument();
+      expect(guide.getAttribute('x1')).toBe('50%');
+    });
   });
 
   describe('DraggableManager callbacks', () => {
     describe('reframe', () => {
       it('handles mousemove', () => {
-        const value = 0.5;
-        wrapper.instance()._handleReframeMouseMove({ value });
-        const calls = props.updateNextViewRangeTime.mock.calls;
-        expect(calls).toEqual([[{ cursor: value }]]);
+        ref.current._handleReframeMouseMove({ value: 0.5 });
+        expect(props.updateNextViewRangeTime).toHaveBeenLastCalledWith({ cursor: 0.5 });
       });
 
       it('handles mouseleave', () => {
-        wrapper.instance()._handleReframeMouseLeave();
-        const calls = props.updateNextViewRangeTime.mock.calls;
-        expect(calls).toEqual([[{ cursor: null }]]);
+        ref.current._handleReframeMouseLeave();
+        expect(props.updateNextViewRangeTime).toHaveBeenLastCalledWith({ cursor: null });
       });
 
       describe('drag update', () => {
         it('handles sans anchor', () => {
-          const value = 0.5;
-          wrapper.instance()._handleReframeDragUpdate({ value });
-          const calls = props.updateNextViewRangeTime.mock.calls;
-          expect(calls).toEqual([[{ reframe: { anchor: value, shift: value } }]]);
+          ref.current._handleReframeDragUpdate({ value: 0.5 });
+          expect(props.updateNextViewRangeTime).toHaveBeenLastCalledWith({
+            reframe: { anchor: 0.5, shift: 0.5 },
+          });
         });
 
         it('handles the existing anchor', () => {
-          const value = 0.5;
-          const anchor = 0.1;
-          const time = { ...props.viewRange.time, reframe: { anchor } };
-          props = { ...props, viewRange: { time } };
-          wrapper = shallow(<ViewingLayer {...props} />);
-          wrapper.instance()._handleReframeDragUpdate({ value });
-          const calls = props.updateNextViewRangeTime.mock.calls;
-          expect(calls).toEqual([[{ reframe: { anchor, shift: value } }]]);
+          props.viewRange.time.reframe = { anchor: 0.1 };
+          rerender(<ViewingLayer ref={ref} {...props} />);
+          ref.current._handleReframeDragUpdate({ value: 0.5 });
+          expect(props.updateNextViewRangeTime).toHaveBeenLastCalledWith({
+            reframe: { anchor: 0.1, shift: 0.5 },
+          });
         });
       });
 
       describe('drag end', () => {
         let manager;
-
         beforeEach(() => {
           manager = { resetBounds: jest.fn() };
         });
 
         it('handles sans anchor', () => {
-          const value = 0.5;
-          wrapper.instance()._handleReframeDragEnd({ manager, value });
-          expect(manager.resetBounds.mock.calls).toEqual([[]]);
-          const calls = props.updateViewRangeTime.mock.calls;
-          expect(calls).toEqual([[value, value, 'minimap']]);
+          ref.current._handleReframeDragEnd({ manager, value: 0.5 });
+          expect(manager.resetBounds).toHaveBeenCalled();
+          expect(props.updateViewRangeTime).toHaveBeenLastCalledWith(0.5, 0.5, 'minimap');
         });
 
         it('handles dragged left (anchor is greater)', () => {
-          const value = 0.5;
-          const anchor = 0.6;
-          const time = { ...props.viewRange.time, reframe: { anchor } };
-          props = { ...props, viewRange: { time } };
-          wrapper = shallow(<ViewingLayer {...props} />);
-          wrapper.instance()._handleReframeDragEnd({ manager, value });
-
-          expect(manager.resetBounds.mock.calls).toEqual([[]]);
-          const calls = props.updateViewRangeTime.mock.calls;
-          expect(calls).toEqual([[value, anchor, 'minimap']]);
+          props.viewRange.time.reframe = { anchor: 0.6 };
+          rerender(<ViewingLayer ref={ref} {...props} />);
+          ref.current._handleReframeDragEnd({ manager, value: 0.5 });
+          expect(props.updateViewRangeTime).toHaveBeenLastCalledWith(0.5, 0.6, 'minimap');
         });
 
         it('handles dragged right (anchor is less)', () => {
-          const value = 0.5;
-          const anchor = 0.4;
-          const time = { ...props.viewRange.time, reframe: { anchor } };
-          props = { ...props, viewRange: { time } };
-          wrapper = shallow(<ViewingLayer {...props} />);
-          wrapper.instance()._handleReframeDragEnd({ manager, value });
-
-          expect(manager.resetBounds.mock.calls).toEqual([[]]);
-          const calls = props.updateViewRangeTime.mock.calls;
-          expect(calls).toEqual([[anchor, value, 'minimap']]);
+          props.viewRange.time.reframe = { anchor: 0.4 };
+          rerender(<ViewingLayer ref={ref} {...props} />);
+          ref.current._handleReframeDragEnd({ manager, value: 0.5 });
+          expect(props.updateViewRangeTime).toHaveBeenLastCalledWith(0.4, 0.5, 'minimap');
         });
       });
     });
 
     describe('scrubber', () => {
       it('prevents the cursor from being drawn on scrubber mouseover', () => {
-        wrapper.instance()._handleScrubberEnterLeave({ type: EUpdateTypes.MouseEnter });
-        expect(wrapper.state('preventCursorLine')).toBe(true);
+        fireEvent.mouseEnter(container.querySelectorAll('[data-testid="scrubber"]')[0]);
+        expect(ref.current.state.preventCursorLine).toBe(true);
       });
 
       it('prevents the cursor from being drawn on scrubber mouseleave', () => {
-        wrapper.instance()._handleScrubberEnterLeave({ type: EUpdateTypes.MouseLeave });
-        expect(wrapper.state('preventCursorLine')).toBe(false);
+        fireEvent.mouseLeave(container.querySelectorAll('[data-testid="scrubber"]')[0]);
+        expect(ref.current.state.preventCursorLine).toBe(false);
       });
 
       describe('drag start and update', () => {
         it('stops propagation on drag start', () => {
           const stopPropagation = jest.fn();
-          const update = {
+          ref.current._handleScrubberDragUpdate({
             event: { stopPropagation },
             type: EUpdateTypes.DragStart,
-          };
-          wrapper.instance()._handleScrubberDragUpdate(update);
-          expect(stopPropagation.mock.calls).toEqual([[]]);
+          });
+          expect(stopPropagation).toHaveBeenCalled();
         });
 
         it('updates the viewRange for shiftStart and shiftEnd', () => {
-          const instance = wrapper.instance();
-          const value = 0.5;
-          const cases = [
-            {
-              dragUpdate: {
-                value,
-                tag: dragTypes.SHIFT_START,
-                type: EUpdateTypes.DragMove,
-              },
-              viewRangeUpdate: { shiftStart: value },
-            },
-            {
-              dragUpdate: {
-                value,
-                tag: dragTypes.SHIFT_END,
-                type: EUpdateTypes.DragMove,
-              },
-              viewRangeUpdate: { shiftEnd: value },
-            },
+          const moves = [
+            { value: 0.5, tag: dragTypes.SHIFT_START },
+            { value: 0.5, tag: dragTypes.SHIFT_END },
           ];
-          cases.forEach(_case => {
-            instance._handleScrubberDragUpdate(_case.dragUpdate);
-            expect(props.updateNextViewRangeTime).lastCalledWith(_case.viewRangeUpdate);
+          moves.forEach(({ value, tag }) => {
+            ref.current._handleScrubberDragUpdate({ value, tag, type: EUpdateTypes.DragMove });
+            expect(props.updateNextViewRangeTime).toHaveBeenLastCalledWith(
+              tag === dragTypes.SHIFT_START ? { shiftStart: 0.5 } : { shiftEnd: 0.5 }
+            );
           });
         });
       });
 
       it('updates the view on drag end', () => {
-        const instance = wrapper.instance();
-        const [viewStart, viewEnd] = props.viewRange.time.current;
-        const value = 0.5;
+        const [start, end] = props.viewRange.time.current;
         const cases = [
           {
-            dragUpdate: {
-              value,
-              manager: { resetBounds: jest.fn() },
-              tag: dragTypes.SHIFT_START,
-            },
-            viewRangeUpdate: [value, viewEnd],
+            update: { value: 0.5, tag: dragTypes.SHIFT_START, manager: { resetBounds: jest.fn() } },
+            expectArgs: [0.5, end, 'minimap'],
           },
           {
-            dragUpdate: {
-              value,
-              manager: { resetBounds: jest.fn() },
-              tag: dragTypes.SHIFT_END,
-            },
-            viewRangeUpdate: [viewStart, value],
+            update: { value: 0.5, tag: dragTypes.SHIFT_END, manager: { resetBounds: jest.fn() } },
+            expectArgs: [start, 0.5, 'minimap'],
           },
         ];
-        cases.forEach(_case => {
-          const { manager } = _case.dragUpdate;
-          wrapper.setState({ preventCursorLine: true });
-          expect(wrapper.state('preventCursorLine')).toBe(true);
-          instance._handleScrubberDragEnd(_case.dragUpdate);
-          expect(wrapper.state('preventCursorLine')).toBe(false);
-          expect(manager.resetBounds.mock.calls).toEqual([[]]);
-          expect(props.updateViewRangeTime).lastCalledWith(..._case.viewRangeUpdate, 'minimap');
+        cases.forEach(({ update, expectArgs }) => {
+          ref.current.setState({ preventCursorLine: true });
+          ref.current._handleScrubberDragEnd(update);
+          expect(ref.current.state.preventCursorLine).toBe(false);
+          expect(update.manager.resetBounds).toHaveBeenCalled();
+          expect(props.updateViewRangeTime).toHaveBeenLastCalledWith(...expectArgs);
         });
       });
     });
+  });
 
-    describe('.ViewingLayer--resetZoom', () => {
-      it('should not render .ViewingLayer--resetZoom if props.viewRange.time.current = [0,1]', () => {
-        expect(wrapper.find('.ViewingLayer--resetZoom').length).toBe(0);
-        wrapper.setProps({ viewRange: { time: { current: [0, 1] } } });
-        expect(wrapper.find('.ViewingLayer--resetZoom').length).toBe(0);
-      });
+  describe('.ViewingLayer--resetZoom', () => {
+    it('should not render .ViewingLayer--resetZoom if props.viewRange.time.current = [0,1]', () => {
+      expect(container.querySelector('.ViewingLayer--resetZoom')).toBeNull();
+    });
 
-      it('should render ViewingLayer--resetZoom if props.viewRange.time.current[0] !== 0', () => {
-        // If the test fails on the following expect statement, this may be a false negative
-        expect(wrapper.find('.ViewingLayer--resetZoom').length).toBe(0);
-        wrapper.setProps({ viewRange: { time: { current: [0.1, 1] } } });
-        expect(wrapper.find('.ViewingLayer--resetZoom').length).toBe(1);
-      });
+    it('should render ViewingLayer--resetZoom if props.viewRange.time.current[0] !== 0', () => {
+      props.viewRange = getViewRange(0.1, 1);
+      rerender(<ViewingLayer ref={ref} {...props} />);
+      expect(container.querySelector('.ViewingLayer--resetZoom')).toBeInTheDocument();
+    });
 
-      it('should render ViewingLayer--resetZoom if props.viewRange.time.current[1] !== 1', () => {
-        // If the test fails on the following expect statement, this may be a false negative
-        expect(wrapper.find('.ViewingLayer--resetZoom').length).toBe(0);
-        wrapper.setProps({ viewRange: { time: { current: [0, 0.9] } } });
-        expect(wrapper.find('.ViewingLayer--resetZoom').length).toBe(1);
-      });
+    it('should render ViewingLayer--resetZoom if props.viewRange.time.current[1] !== 1', () => {
+      props.viewRange = getViewRange(0, 0.9);
+      rerender(<ViewingLayer ref={ref} {...props} />);
+      expect(container.querySelector('.ViewingLayer--resetZoom')).toBeInTheDocument();
+    });
 
-      it('should call props.updateViewRangeTime when clicked', () => {
-        wrapper.setProps({ viewRange: { time: { current: [0.1, 0.9] } } });
-        const resetZoomButton = wrapper.find('.ViewingLayer--resetZoom');
-        // If the test fails on the following expect statement, this may be a false negative caused
-        // by a regression to rendering.
-        expect(resetZoomButton.length).toBe(1);
-
-        resetZoomButton.simulate('click');
-        expect(props.updateViewRangeTime).lastCalledWith(0, 1);
-      });
+    it('should call props.updateViewRangeTime when clicked', () => {
+      props.viewRange = getViewRange(0.1, 0.9);
+      rerender(<ViewingLayer ref={ref} {...props} />);
+      fireEvent.click(container.querySelector('.ViewingLayer--resetZoom'));
+      expect(props.updateViewRangeTime).toHaveBeenLastCalledWith(0, 1);
     });
   });
 
   it('renders a <GraphTicks />', () => {
-    expect(wrapper.find(GraphTicks).length).toBe(1);
+    expect(container.querySelector('svg g')).toBeInTheDocument();
   });
 
   it('renders a filtering box if leftBound exists', () => {
-    const _props = { ...props, viewRange: getViewRange(0.2, 1) };
-    wrapper = shallow(<ViewingLayer {..._props} />);
-
-    const leftBox = wrapper.find('.ViewingLayer--inactive');
-    expect(leftBox.length).toBe(1);
-    const width = Number(leftBox.prop('width').slice(0, -1));
-    const x = leftBox.prop('x');
-    expect(Math.round(width)).toBe(20);
-    expect(x).toBe(0);
+    props.viewRange = getViewRange(0.2, 1);
+    rerender(<ViewingLayer ref={ref} {...props} />);
+    const box = container.querySelectorAll('.ViewingLayer--inactive')[0];
+    expect(box).toBeInTheDocument();
+    expect(Math.round(parseFloat(box.getAttribute('width')))).toBe(20);
+    expect(box.getAttribute('x')).toBe('0');
   });
 
   it('renders a filtering box if rightBound exists', () => {
-    const _props = { ...props, viewRange: getViewRange(0, 0.8) };
-    wrapper = shallow(<ViewingLayer {..._props} />);
-
-    const rightBox = wrapper.find('.ViewingLayer--inactive');
-    expect(rightBox.length).toBe(1);
-    const width = Number(rightBox.prop('width').slice(0, -1));
-    const x = Number(rightBox.prop('x').slice(0, -1));
-    expect(Math.round(width)).toBe(20);
-    expect(x).toBe(80);
+    props.viewRange = getViewRange(0, 0.8);
+    rerender(<ViewingLayer ref={ref} {...props} />);
+    const box = container.querySelectorAll('.ViewingLayer--inactive')[0];
+    expect(box).toBeInTheDocument();
+    expect(Math.round(parseFloat(box.getAttribute('width')))).toBe(20);
+    expect(Math.round(parseFloat(box.getAttribute('x')))).toBe(80);
   });
 
   it('renders handles for the timeRangeFilter', () => {
-    const [viewStart, viewEnd] = props.viewRange.time.current;
-    let scrubber = <Scrubber position={viewStart} />;
-    expect(wrapper.containsMatchingElement(scrubber)).toBeTruthy();
-    scrubber = <Scrubber position={viewEnd} />;
-    expect(wrapper.containsMatchingElement(scrubber)).toBeTruthy();
+    expect(container.querySelectorAll('[data-testid="scrubber"]').length).toBe(2);
   });
 });


### PR DESCRIPTION
Rewrote the ViewingLayer component test suite to use React Testing Library instead of Enzyme.