### PR TITLE
Fix UI bug of convertServiceErrorRateToPercentages

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
@@ -175,6 +175,44 @@ describe('<MonitorATMServicesView>', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('handles null error rate values in metrics', () => {
+    const testMetrics = {
+      ...originInitialState,
+      serviceMetrics: {
+        service_latencies: serviceMetrics.service_latencies,
+        service_error_rate: {
+          metricPoints: [
+            { x: 1, y: null },
+            { x: 2, y: 0.25 },
+          ],
+          quantile: 0.5,
+          serviceName: 'cartservice',
+        },
+        service_call_rate: serviceMetrics.service_call_rate,
+      },
+      serviceOpsMetrics,
+      loading: false,
+      isATMActivated: true,
+    };
+
+    wrapper.setProps({
+      services: ['s1'],
+      selectedService: 's1',
+      metrics: testMetrics,
+    });
+
+    // Verify the error rate data transformation
+    const errorRateGraph = wrapper.find(ServiceGraph).find({ name: 'Error rate (%)' });
+    expect(errorRateGraph.prop('metricsData')).toEqual({
+      metricPoints: [
+        { x: 1, y: null },
+        { x: 2, y: 25 },
+      ],
+      quantile: 0.5,
+      serviceName: 'cartservice',
+    });
+  });
+
   it('render one service latency', () => {
     wrapper.setProps({
       metrics: {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -134,7 +134,13 @@ const convertServiceErrorRateToPercentages = (serviceErrorRate: null | ServiceMe
   if (!serviceErrorRate) return null;
 
   const convertedMetricsPoints = serviceErrorRate.metricPoints.map((metricPoint: Points) => {
-    return { ...metricPoint, y: metricPoint.y! * 100 };
+    const y = metricPoint.y;
+
+    if (y === null || y === undefined || Number.isNaN(y)) {
+      return { ...metricPoint, y: null };
+    }
+
+    return { ...metricPoint, y: y * 100 };
   });
 
   return { ...serviceErrorRate, metricPoints: convertedMetricsPoints };


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves bug where y is math.NaN or null returning 0. Specifically doing `return { ...metricPoint, y: metricPoint.y! * 100 };` will return 0 for y = null or math.NaN

## Description of the changes
- Add explicit check to prevent this bugs

## How was this change tested?
- npm run test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
