### PR TITLE
fix: enable CodeQL scan on main to resolve configuration missing error

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,10 @@
 name: "CodeQL"
 
-
 on:
   workflow_dispatch:
   merge_group:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
-
   push:
     branches: [main]
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #2649 

## Description of the changes
- This PR updates the `.github/workflows/codeql.yml` to ensure the CodeQL analysis job runs on both:
- `push` to `main` (baseline scan required by GitHub)
- `pull_request` to `main`

Previously, the job was restricted to only pull requests, which caused the error:
> "1 configuration not found on refs/heads/main"

With this update, GitHub Advanced Security will be able to run CodeQL on `main`, allowing proper diff analysis for PRs.

## How was this change tested?
- Raised this PR to verify that the CodeQL job triggers correctly on pull request
- After merging, will push a trivial commit to `main` to confirm baseline scan runs as expected

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
