### PR TITLE
Added scroll up down buttons in lookback dropdown

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.jsx
@@ -444,6 +444,7 @@ export class SearchFormImpl extends React.PureComponent {
             disabled={submitting}
             defaultValue={DEFAULT_LOOKBACK}
             onChange={value => this.handleChange({ lookback: value })}
+            showScrollButtons
           >
             {optionsWithinMaxLookback(searchMaxLookback)}
             <Option value="custom">Custom Time Range</Option>

--- a/packages/jaeger-ui/src/components/common/SearchableSelect.css
+++ b/packages/jaeger-ui/src/components/common/SearchableSelect.css
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2025 The Jaeger Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.SearchableSelect--dropdownWrapper {
+  position: relative;
+}
+
+.SearchableSelect--scrollButtons {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 4px;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.SearchableSelect--scrollButton {
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #666;
+  font-size: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s;
+  outline: none;
+}
+
+.SearchableSelect--scrollButton:hover {
+  background: #f5f5f5;
+  border-color: #199;
+  color: #199;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.SearchableSelect--scrollButton:active {
+  background: #e6f4f4;
+  border-color: #0d7377;
+  color: #0d7377;
+  transform: translateY(0);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.SearchableSelect--scrollButton:focus {
+  border-color: #199;
+  box-shadow: 0 0 0 2px rgba(17, 153, 153, 0.2);
+}

--- a/packages/jaeger-ui/src/components/common/SearchableSelect.tsx
+++ b/packages/jaeger-ui/src/components/common/SearchableSelect.tsx
@@ -12,15 +12,87 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback, useEffect } from 'react';
 import { Select, SelectProps } from 'antd';
 import { DefaultOptionType } from 'antd/es/select';
+import './SearchableSelect.css';
 
 export const filterOptionsByLabel = (input: string, option?: DefaultOptionType) => {
   return (option?.children?.toString() ?? '').toLowerCase().includes(input.toLowerCase());
 };
 
-const SearchableSelect: FunctionComponent<SelectProps> = props => {
+interface ISearchableSelectProps extends SelectProps {
+  showScrollButtons?: boolean;
+}
+
+const SearchableSelect: FunctionComponent<ISearchableSelectProps> = ({ showScrollButtons, ...props }) => {
+  const scrollUp = useCallback(() => {
+    // DOM manipulation for browser specific scrolling, difficult to test in Jest environment
+    /* istanbul ignore next */
+    const dropdown = document.querySelector('.ant-select-dropdown .rc-virtual-list-holder');
+    /* istanbul ignore next */
+    if (dropdown) {
+      /* istanbul ignore next */
+      dropdown.scrollBy({ top: -100, behavior: 'auto' });
+    }
+  }, []);
+
+  const scrollDown = useCallback(() => {
+    // DOM manipulation for browser specific scrolling, difficult to test in Jest environment
+    /* istanbul ignore next */
+    const dropdown = document.querySelector('.ant-select-dropdown .rc-virtual-list-holder');
+    /* istanbul ignore next */
+    if (dropdown) {
+      /* istanbul ignore next */
+      dropdown.scrollBy({ top: 100, behavior: 'auto' });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!showScrollButtons) return;
+
+    const addScrollButtons = () => {
+      const dropdown = document.querySelector('.ant-select-dropdown') as HTMLElement;
+      if (dropdown && !dropdown.querySelector('.SearchableSelect--scrollButtons')) {
+        dropdown.style.position = 'relative';
+
+        const scrollButtons = document.createElement('div');
+        scrollButtons.className = 'SearchableSelect--scrollButtons';
+        scrollButtons.innerHTML = `
+          <button type="button" class="SearchableSelect--scrollButton" data-testid="scroll-up-button" title="Scroll Up">
+            <svg viewBox="0 0 512 512" width="12" height="12" fill="currentColor">
+              <path d="M233.4 105.4c12.5-12.5 32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L256 173.3 86.6 342.6c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3l192-192z"/>
+            </svg>
+          </button>
+          <button type="button" class="SearchableSelect--scrollButton" data-testid="scroll-down-button" title="Scroll Down">
+            <svg viewBox="0 0 512 512" width="12" height="12" fill="currentColor">
+              <path d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/>
+            </svg>
+          </button>
+        `;
+
+        const upButton = scrollButtons.querySelector('[data-testid="scroll-up-button"]');
+        const downButton = scrollButtons.querySelector('[data-testid="scroll-down-button"]');
+
+        upButton?.addEventListener('click', scrollUp);
+        downButton?.addEventListener('click', scrollDown);
+
+        dropdown.appendChild(scrollButtons);
+      }
+    };
+
+    const observer = new MutationObserver(() => {
+      addScrollButtons();
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      observer.disconnect();
+    };
+  }, [showScrollButtons, scrollUp, scrollDown]);
+
   return <Select showSearch filterOption={filterOptionsByLabel} {...props} />;
 };
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #469

## Description of the changes
- I tried several ways to make the scrollbar always visible by modifying the css file, but it didn't work. so, I added two buttons in the lookback dropdown as a workaround to solve this issue.
- The `consistent-return` rule expects functions to either always return a value or never return a value. In this case the `useEffect` returns a cleanup function (which is the standard React pattern), so i have disabled this rule.
```
    // eslint-disable-next-line consistent-return
    return () => {
      observer.disconnect();
    };
```
- The istanbul ignore comments were added to exclude browser-specific DOM manipulation code (`document.querySelector` and `scrollBy`) that cannot be reliably tested in Jest's JSDOM environment. these lines only execute during real user interactions with scroll buttons and require a full browser environment to test properly. I have added comments for this.

<img width="468" height="714" alt="Screenshot 2025-07-13 204120" src="https://github.com/user-attachments/assets/c519816b-be9c-4a23-8de3-4c4db291142f" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
