### PR TITLE
Expand the logs automatically

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
@@ -18,6 +18,8 @@ limitations under the License.
   border: 1px solid #d8d8d8;
   position: relative;
   margin-bottom: 0.25rem;
+  overflow: visible;
+  z-index: auto;
 }
 
 .AccordianLogs--header {
@@ -47,4 +49,18 @@ limitations under the License.
 
 .AccordianLogs--footer {
   color: #999;
+}
+
+.AccordianLogs--showMore {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  text-align: left;
+  clear: both;
+  display: block;
+}
+
+.AccordianLogs--toggle {
+  font-weight: bold;
+  font-style: normal;
+  padding: 0.25rem 0.5rem;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
@@ -68,6 +68,8 @@ describe('<AccordianLogs>', () => {
   ];
 
   const defaultTotalCount = logs.length;
+  const defaultInRangeLogs = [logs[0]];
+  const defaultInRangeLogsCount = defaultInRangeLogs.length;
   const defaultProps = {
     logs,
     isOpen: false,
@@ -98,7 +100,7 @@ describe('<AccordianLogs>', () => {
   it('shows log items when expanded', () => {
     render(<AccordianLogs {...defaultProps} isOpen />);
     const items = screen.getAllByTestId('log-item');
-    expect(items.length).toBe(3); // Shows first 3 logs by default
+    expect(items.length).toBe(defaultInRangeLogsCount);
   });
 
   it('calls onItemToggle when a log item is toggled', () => {
@@ -107,14 +109,16 @@ describe('<AccordianLogs>', () => {
 
     items.forEach((item, index) => {
       fireEvent.click(item);
-      expect(defaultProps.onItemToggle).toHaveBeenCalledWith(logs[index]); // First 3 logs
+      expect(defaultProps.onItemToggle).toHaveBeenCalledWith(defaultInRangeLogs[index]);
     });
   });
 
   it('propagates isOpen to log items correctly', () => {
     render(<AccordianLogs {...defaultProps} isOpen />);
-    expect(mockAccordianKeyValues).toHaveBeenCalledTimes(3); // First 3 logs
-    expect(mockAccordianKeyValues.mock.calls[0][0].isOpen).toBe(defaultProps.openedItems.has(logs[0]));
+    expect(mockAccordianKeyValues).toHaveBeenCalledTimes(defaultInRangeLogsCount);
+    expect(mockAccordianKeyValues.mock.calls[0][0].isOpen).toBe(
+      defaultProps.openedItems.has(defaultInRangeLogs[0])
+    );
   });
 
   it('calls onToggle when the header is clicked', () => {
@@ -131,7 +135,7 @@ describe('<AccordianLogs>', () => {
     expect(header).toBeInTheDocument();
     fireEvent.click(header);
     expect(propsWithoutInteractive.onToggle).toHaveBeenCalledTimes(1);
-    expect(mockAccordianKeyValues).toHaveBeenCalledTimes(3); // First 3 logs
+    expect(mockAccordianKeyValues).toHaveBeenCalledTimes(defaultInRangeLogsCount);
 
     mockAccordianKeyValues.mock.calls.forEach(callArgs => {
       const childProps = callArgs[0];

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.test.js
@@ -67,9 +67,9 @@ describe('<AccordianLogs>', () => {
     },
   ];
 
-  const defaultTotalCount = logs.length;
   const defaultInRangeLogs = [logs[0]];
   const defaultInRangeLogsCount = defaultInRangeLogs.length;
+  const defaultTotalCount = logs.length;
   const defaultProps = {
     logs,
     isOpen: false,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
@@ -72,12 +72,11 @@ export default function AccordianLogs({
   const logsToDisplay = expandedOnce ? inRangeLogs : inRangeLogs.slice(0, autoExpandCount);
 
   const totalCount = logs.length;
-  const hasMoreLogs = inRangeLogs.length > autoExpandCount && !expandedOnce;
 
   const title = `Logs (${totalCount})`;
   let showMoreLink: React.ReactNode = null;
 
-  if (hasMoreLogs) {
+  if (inRangeLogs.length > autoExpandCount && !expandedOnce) {
     showMoreLink = (
       <button
         type="button"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
@@ -46,6 +46,8 @@ export default function AccordianLogs({
   onItemToggle,
   onToggle,
   timestamp,
+  currentViewRangeTime,
+  traceDuration,
 }: AccordianLogsProps) {
   let arrow: React.ReactNode | null = null;
   let HeaderComponent: 'span' | 'a' = 'span';
@@ -60,11 +62,17 @@ export default function AccordianLogs({
     }
   }, [hasAutoOpened, isOpen, logs, onToggle]);
 
+  const inRangeLogs = React.useMemo(() => {
+    const viewStartAbsolute = timestamp + currentViewRangeTime[0] * traceDuration;
+    const viewEndAbsolute = timestamp + currentViewRangeTime[1] * traceDuration;
+    return logs.filter(log => log.timestamp >= viewStartAbsolute && log.timestamp <= viewEndAbsolute);
+  }, [logs, timestamp, currentViewRangeTime, traceDuration]);
+
   const autoExpandCount = 3;
-  const logsToDisplay = expandedOnce ? logs : logs.slice(0, autoExpandCount);
+  const logsToDisplay = expandedOnce ? inRangeLogs : inRangeLogs.slice(0, autoExpandCount);
 
   const totalCount = logs.length;
-  const hasMoreLogs = logs.length > autoExpandCount && !expandedOnce;
+  const hasMoreLogs = inRangeLogs.length > autoExpandCount && !expandedOnce;
 
   const title = `Logs (${totalCount})`;
   let showMoreLink: React.ReactNode = null;


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #144 
- Logs section auto-opens and show first 3 logs
<img width="1851" height="577" alt="Screenshot 2025-07-14 192021" src="https://github.com/user-attachments/assets/e681f538-756d-4a1a-a036-f82afdebfede" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
