### PR TITLE
Convert ServiceGraph to functional component with 100% test coverage across all metrics

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.test.js
@@ -272,11 +272,6 @@ describe('<ServiceGraph>', () => {
     // Test tooltip formatting logic directly
     const formattedValue = serviceGraphUtils.formatYAxisTick(5.123, 'Test Graph');
     expect(formattedValue).toBe('5.12');
-
-    // Test tooltip label formatter
-    const timestamp = 1631271783806;
-    const formattedDate = new Date(timestamp).toLocaleString();
-    expect(formattedDate).toBeTruthy(); // Just verify it returns a string
   });
 
   it('tests tooltip formatter with and without legend', () => {
@@ -530,7 +525,9 @@ describe('ServiceGraphImpl methods', () => {
       // Test createTooltipLabelFormatter
       const labelFormatter = serviceGraphUtils.createTooltipLabelFormatter();
       const timestamp = 1631271783806;
-      expect(labelFormatter(timestamp)).toBeTruthy();
+      const result = labelFormatter(timestamp);
+      expect(typeof result).toBe('string');
+      expect(result).toContain('2021');
 
       // Test createLegendFormatter
       const legendFormatter = serviceGraphUtils.createLegendFormatter(serviceMetrics.service_call_rate);

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.tsx
@@ -167,14 +167,6 @@ export const serviceGraphUtils = {
     return value.toFixed(0);
   },
 
-  calculateNumericTicks: (xDomain: number[]): number[] => {
-    const [start, end] = xDomain;
-    const count = 7;
-    const step = (end - start) / (count - 1);
-
-    return Array.from({ length: count }, (_, i) => start + step * i);
-  },
-
   renderLines: (
     metricsData: ServiceMetricsObject | ServiceMetricsObject[] | null,
     color?: string
@@ -232,6 +224,14 @@ export const serviceGraphUtils = {
     if (foundIdx === -1) return <span>N/A</span>;
     const quantile = dataVal[foundIdx].quantile; // Safe to access since we filtered out nulls
     return <span>{quantile * 100}th</span>;
+  },
+
+  calculateNumericTicks: (xDomain: number[]): number[] => {
+    const [start, end] = xDomain;
+    const count = 7;
+    const step = (end - start) / (count - 1);
+
+    return Array.from({ length: count }, (_, i) => start + step * i);
   },
 
   // Additional functions for testing inline functions


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves part of #2610

- **The tests are trying to instantiate  ServiceGraphImpl as a class, but we converted it to a functional component. so we need to update the tests to work with the functional component.**

### `serviceGraph.tsx` changes
  - Added:  `serviceGraphUtils `object containing all logics
- Functions:
  - `getData()` - Handles metrics data normalization
  - `getMetricsData()` - Processes metric points for chart rendering
  - `calculateYDomain()` - calculates Y-axis domain with padding
  - `calculateYAxisTicks()` - Generates Y-axis tick marks
  - `formatYAxisTick()` - Formats Y-axis tick values
  - `calculateNumericTicks()` - Generates numeric ticks for X-axis
  - `renderLines()` - Renders chart lines with proper colors
  - `generatePlaceholder()` - Creates placeholder components
  - `legendFormatter()` - formats legend values
- Factory functions for testability
  - `createYAxisTickFormatter()` - creates Y-axis tick formatter
  - `createTooltipLabelFormatter()` - creates tooltip label formatter
  - `createTooltipFormatter()` - creates tooltip value formatter
  - `createLegendFormatter()` - creates legend formatter

### `serviceGraph.test.js` changes:

- Factory Functions Tests (NEW)
```
describe('factory functions', () => {
  it('tests createTooltipFormatter', () => { /* Tests both legend scenarios */ })
  it('tests other factory functions', () => { /* Tests all factory functions */ })
})
```
```
 it('handles metrics data with null quantiles', () => {

 });
```

### The Core Problem with ServiceGraphImpl
- Original Issue: Class Component with untestable code
- The original ServiceGraphImpl was a class component with several testing challenges:
- Functional component with utilities:
```
// New tests - can test actual logics
describe('ServiceGraphImpl methods', () => {
  describe('calculateYDomain', () => {
    it('handles empty data', () => {
      expect(serviceGraphUtils.calculateYDomain([])).toEqual([0, 1]);
    });
    
    it('calculates domain with padding', () => {
      const data = [{ x: 1, '0.95': 100 }, { x: 2, '0.95': 200 }];
      const result = serviceGraphUtils.calculateYDomain(data);
      expect(result[0]).toBeLessThan(100); // Has padding
      expect(result[1]).toBeGreaterThan(200); // Has padding
    });
  });
});
```
- Factory Functions for Inline function testing
- The problem:
```
// These were IMPOSSIBLE to test in the original version
<YAxis tickFormatter={(value) => formatYAxisTick(value, name)} />
<Tooltip formatter={(value, uname) => {
  if (!showLegend) return [formatValue(value)];
  return [formatValue(value), `P${Number(uname) * 100}`];
}} />
```
- The solution: 
```
// Factory functions make inline functions testable
createTooltipFormatter: (showLegend, name) => (value, uname) => {
  if (!showLegend) return [formatYAxisTick(value, name)];
  return [formatYAxisTick(value, name), `P${Number(uname) * 100}`];
}

// Now we can test it!
it('tests createTooltipFormatter', () => {
  const formatter = serviceGraphUtils.createTooltipFormatter(true, 'Test');
  const result = formatter(123.456, '0.95');
  expect(result[0]).toBe('123');
  expect(result[1]).toBe('P95');
});
```
### 100% test coverage:
<img width="577" height="107" alt="Screenshot 2025-07-16 183438" src="https://github.com/user-attachments/assets/0ecf11fb-9df5-4d69-808e-a531171dc7a7" />


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
