### PR TITLE
Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ build
 
 # reports
 coverage
-.nyc_output
 junit.xml
 
 # misc
@@ -18,8 +17,8 @@ junit.xml
 npm-debug.log
 .vscode
 .idea
-yarn-error.log
 .eslintcache
+.envrc
 .vscode
 
 # scripts


### PR DESCRIPTION
allows using `direnv` to set up correct Node version
```
$ cat .envrc
# Source nvm.sh to make the 'nvm' function available
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm

nvm use
```