### PR TITLE
test: Migrate DAG tests to React Testing Library

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.js
@@ -329,14 +329,16 @@ describe('<DAG>', () => {
 
     let renderNodeFn;
 
+    const originalMockImplementation = Digraph.mockImplementation;
     Digraph.mockImplementation(props => {
       renderNodeFn = props.layers?.find(l => l.key === 'nodes')?.renderNode;
       return <div data-testid="digraph-mock" />;
     });
-
     render(
       <DAG data={data} selectedLayout="dot" selectedDepth={1} selectedService="test-node" uiFind="test" />
     );
+
+    Digraph.mockImplementation = originalMockImplementation;
 
     expect(typeof renderNodeFn).toBe('function');
 

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -130,7 +130,7 @@ export const createMenuItems = (
 
 const { classNameIsSmall } = Digraph.propsFactories;
 
-const DAGMenu = ({
+export const DAGMenu = ({
   menuPosition,
   hoveredNode,
   isMenuVisible,


### PR DESCRIPTION
Replaced all usage of react-test-renderer/shallow with React Testing Library to modernize the test suite, improve coverage clarity, and ensure real DOM interaction behavior is validated.