### PR TITLE
Clean-up package-lock.json

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,6 +25,8 @@ jobs:
           cache: npm
           node-version: '22'
       - run: npm ci
+      - run: node -v
+      - run: npm -v
       - run: npm ls --all
       - run: npm run coverage
       - name: Upload coverage to codecov.io

--- a/package-lock.json
+++ b/package-lock.json
@@ -20548,21 +20548,6 @@
         "vite": ">= 2.0.0-beta.5"
       }
     },
-    "packages/jaeger-ui/node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "packages/plexus": {
       "name": "@jaegertracing/plexus",
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20548,6 +20548,21 @@
         "vite": ">= 2.0.0-beta.5"
       }
     },
+    "packages/jaeger-ui/node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "packages/plexus": {
       "name": "@jaegertracing/plexus",
       "version": "0.2.0",


### PR DESCRIPTION
Clean-up `package-lock.json` by running:
```
$ npm ci
$ npm install
```

Doing so removes `registry.npmjs.org/yaml/-/yaml-2.7.0.tgz` which was causing issues in subsequent upgrades.