### PR TITLE
Highlight active mode button in TraceGraph

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
@@ -113,3 +113,9 @@ limitations under the License.
 .TraceGraph--miniMap > .plexus-MiniMap--button:hover {
   background: #ddd;
 }
+
+.TraceGraph--menu .ant-btn.active {
+  background-color: #1890ff;
+  color: white;
+  border-color: #1890ff;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -61,7 +61,7 @@ const HELP_CONTENT = (
         <tbody>
           <tr>
             <td>
-              <Button htmlType="button" shape="circle" size="small">
+              <Button htmlType="button" shape="circle" size="small" className="active">
                 S
               </Button>
             </td>
@@ -218,7 +218,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
             <li>
               <Tooltip placement="left" title="Service">
                 <Button
-                  className="TraceGraph--btn-service"
+                  className={cx('TraceGraph--btn-service', { active: mode === MODE_SERVICE })}
                   htmlType="button"
                   shape="circle"
                   size="small"
@@ -231,7 +231,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
             <li>
               <Tooltip placement="left" title="Time">
                 <Button
-                  className="TraceGraph--btn-time"
+                  className={cx('TraceGraph--btn-time', { active: mode === MODE_TIME })}
                   htmlType="button"
                   shape="circle"
                   size="small"
@@ -244,7 +244,7 @@ export default class TraceGraph extends React.PureComponent<Props, State> {
             <li>
               <Tooltip placement="left" title="Selftime">
                 <Button
-                  className="TraceGraph--btn-selftime"
+                  className={cx('TraceGraph--btn-selftime', { active: mode === MODE_SELFTIME })}
                   htmlType="button"
                   shape="circle"
                   size="small"


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #2572

## Description of the changes
- 
     ## Problem
     The TraceGraph mode buttons don’t show which mode is active (issue #XXX).  
     ## Solution
     - Added `active` class to highlight the selected button.
     - Styled it with Ant Design’s primary color.
     ## Testing 
     Verified all modes (Service/Time/Selftime) highlight correctly.


## How was this change tested?
**Manual verification:**
1. Confirmed all mode buttons (S/T/ST) properly highlight when selected
2. Verified graph rendering matches each mode:
   - Service colors (S)
   - Time gradients (T) 
   - Selftime highlights (ST)

## Checklist
- [ done ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ done  ] I have signed all commits
- [ done  ] I have added unit tests for the new functionality
- [ done ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
