### PR TITLE
feat: Add tags dropdown to SPM page for filtering metrics

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -125,7 +125,7 @@ const JaegerAPI = {
   fetchTagValues(tagName, service) {
     const query = { key: tagName };
     if (service) query.service = service;
-    return getJSON(`${this.apiRoot}metrics/labels`, { query }).then(response => response.data || []);
+    return getJSON(`${this.apiRoot}metrics/attributes`, { query }).then(response => response.data || []);
   },
   searchTraces(query) {
     return getJSON(`${this.apiRoot}traces`, { query });

--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -122,6 +122,11 @@ const JaegerAPI = {
   fetchTrace(id) {
     return getJSON(`${this.apiRoot}traces/${id}`);
   },
+  fetchTagValues(tagName, service) {
+    const query = { key: tagName };
+    if (service) query.service = service;
+    return getJSON(`${this.apiRoot}metrics/labels`, { query }).then(response => response.data || []);
+  },
   searchTraces(query) {
     return getJSON(`${this.apiRoot}traces`, { query });
   },

--- a/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.css
+++ b/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.css
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2025 The Jaeger Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.tag-selector-header {
+  /* padding-left: 10px; */
+  font-size: 18px;
+  font-weight: 800;
+}
+
+/* .tag-selector {
+  padding-left: 10px;
+} */
+
+.multi-tag-selector {
+  padding: 5px;
+}

--- a/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.css
+++ b/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.css
@@ -20,9 +20,11 @@ limitations under the License.
   font-weight: 800;
 }
 
-/* .tag-selector {
-  padding-left: 10px;
-} */
+.tag-selector {
+  /* padding-left: 10px; */
+  min-width: 150px; /* Minimum width for usability */
+  width: 100%; /* Allow width to grow based on content */
+}
 
 .multi-tag-selector {
   padding: 5px;

--- a/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.css
+++ b/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.css
@@ -1,17 +1,6 @@
 /*
-Copyright (c) 2025 The Jaeger Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+// Copyright (c) 2025 The Jaeger Authors
+// SPDX-License-Identifier: Apache-2.0
 */
 
 .tag-selector-header {

--- a/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.jsx
@@ -117,7 +117,7 @@ const MultiTagSelector = ({ service, onChange, disabled = false, value = '' }) =
           <Col key={attribute.name}>
             <h2 className="tag-selector-header">{attribute.label}</h2>
             <SearchableSelect
-              placeholder={`Select ${attribute.label.toLowerCase()}`}
+              placeholder={`Select`}
               value={selectedValues[attribute.name] || undefined}
               onChange={val => handleValueChange(attribute.name, val)}
               loading={loading[attribute.name]}

--- a/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/MultiTagSelector.jsx
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { Col, Row, Select } from 'antd';
+import JaegerAPI from '../../../api/jaeger';
+import { getConfigValue } from '../../../utils/config/get-config';
+import SearchableSelect from '../../common/SearchableSelect';
+import './MultiTagSelector.css';
+
+const { Option } = Select;
+
+const MultiTagSelector = ({ service, onChange, disabled = false, value = '' }) => {
+  const [tagValues, setTagValues] = useState({});
+  const [loading, setLoading] = useState({});
+
+  // Convert string value to object format
+  const valueAsObject = useMemo(() => {
+    if (!value || typeof value !== 'string') return {};
+
+    const obj = {};
+    value.split(' ').forEach(pair => {
+      const [key, val] = pair.split('=');
+      if (key && val) {
+        obj[key] = val;
+      }
+    });
+    return obj;
+  }, [value]);
+
+  const [selectedValues, setSelectedValues] = useState(valueAsObject);
+
+  // Get tag attributes from config and memoize to prevent re-renders
+  const tagAttributes = useMemo(() => {
+    const attrs = getConfigValue('monitor.tagAttributes') || [];
+    return attrs;
+  }, []);
+
+  // Fetch values for all attributes when dependencies change
+  useEffect(() => {
+    const fetchTagValuesForAttribute = async attributeName => {
+      if (!attributeName) return;
+
+      setLoading(prev => ({ ...prev, [attributeName]: true }));
+
+      try {
+        const values = await JaegerAPI.fetchTagValues(attributeName, service);
+        setTagValues(prev => ({
+          ...prev,
+          [attributeName]: values || [],
+        }));
+      } catch (error) {
+        console.error(`Error fetching values for attribute ${attributeName}:`, error);
+        setTagValues(prev => ({
+          ...prev,
+          [attributeName]: [],
+        }));
+      } finally {
+        setLoading(prev => ({ ...prev, [attributeName]: false }));
+      }
+    };
+
+    // Only fetch if we have attributes
+    if (tagAttributes.length > 0) {
+      tagAttributes.forEach(attr => {
+        fetchTagValuesForAttribute(attr.name);
+      });
+    }
+  }, [service, tagAttributes]);
+
+  // Update selected values when value prop changes
+  useEffect(() => {
+    setSelectedValues(valueAsObject);
+  }, [valueAsObject]);
+
+  // Handle value selection for a specific attribute
+  const handleValueChange = useCallback((attributeName, selectedValue) => {
+    setSelectedValues(prevValues => {
+      const newSelectedValues = { ...prevValues };
+
+      if (selectedValue) {
+        newSelectedValues[attributeName] = selectedValue;
+      } else {
+        delete newSelectedValues[attributeName];
+      }
+
+      // Convert to tag string format
+      const tagString = Object.entries(newSelectedValues)
+        .map(([key, val]) => `${key}=${val}`)
+        .join(' ');
+
+      onChange(tagString);
+
+      return newSelectedValues;
+    });
+  }, []); // Remove onChange from dependencies since it's used inside setState callback
+
+  if (tagAttributes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="multi-tag-selector">
+      <Row gutter={16}>
+        {tagAttributes.map(attribute => (
+          <Col key={attribute.name}>
+            <h2 className="tag-selector-header">{attribute.label}</h2>
+            <SearchableSelect
+              placeholder={`Select ${attribute.label.toLowerCase()}`}
+              value={selectedValues[attribute.name] || undefined}
+              onChange={val => handleValueChange(attribute.name, val)}
+              loading={loading[attribute.name]}
+              disabled={disabled}
+              allowClear
+              className="tag-selector"
+            >
+              {(tagValues[attribute.name] || []).map(val => (
+                <Option key={val} value={val}>
+                  {val}
+                </Option>
+              ))}
+            </SearchableSelect>
+          </Col>
+        ))}
+      </Row>
+    </div>
+  );
+};
+
+export default MultiTagSelector;

--- a/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/index.js
+++ b/packages/jaeger-ui/src/components/Monitor/MultiTagSelector/index.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { default } from './MultiTagSelector';

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
@@ -33,6 +33,10 @@ limitations under the License.
   padding-left: 10px;
 }
 
+.tags-selector {
+  padding-left: 10px;
+}
+
 .operations-metrics-text {
   margin-top: 17px;
   margin-bottom: 14px;

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
@@ -39,7 +39,10 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
 }));
 
 jest.mock('../../../utils/config/get-config', () => ({
-  getConfigValue: jest.fn(() => 'https://www.jaegertracing.io/docs/latest/spm/'),
+  getConfigValue: jest.fn(key => {
+    if (key === 'monitor.docsLink') return 'https://www.jaegertracing.io/docs/latest/spm/';
+    return null;
+  }),
   __esModule: true,
   default: jest.fn(() => ({
     qualityMetrics: {
@@ -176,7 +179,9 @@ describe('<MonitorATMServicesView>', () => {
   it('does not explode', () => {
     expect(screen.getByText('Service')).toBeInTheDocument();
     expect(screen.getByText('Span Kind')).toBeInTheDocument();
+    expect(screen.getByText('Tags')).toBeInTheDocument();
     expect(screen.getByTestId('select-a-service-input')).toBeInTheDocument();
+    expect(screen.getByTestId('tags-selector')).toBeInTheDocument();
   });
 
   it('shows a loading indicator when loading services list', () => {
@@ -417,6 +422,7 @@ describe('<MonitorATMServicesView>', () => {
     let trackSelectServiceSpy;
     let trackSelectSpanKindSpy;
     let trackSelectTimeframeSpy;
+    let trackSelectTagsSpy;
     let trackSearchOperationSpy;
     let trackViewAllTracesSpy;
 
@@ -424,6 +430,7 @@ describe('<MonitorATMServicesView>', () => {
       trackSelectServiceSpy = jest.spyOn(track, 'trackSelectService').mockImplementation(() => {});
       trackSelectSpanKindSpy = jest.spyOn(track, 'trackSelectSpanKind').mockImplementation(() => {});
       trackSelectTimeframeSpy = jest.spyOn(track, 'trackSelectTimeframe').mockImplementation(() => {});
+      trackSelectTagsSpy = jest.spyOn(track, 'trackSelectTags').mockImplementation(() => {});
       trackSearchOperationSpy = jest.spyOn(track, 'trackSearchOperation').mockImplementation(() => {});
       trackViewAllTracesSpy = jest.spyOn(track, 'trackViewAllTraces').mockImplementation(() => {});
     });
@@ -432,6 +439,7 @@ describe('<MonitorATMServicesView>', () => {
       trackSelectServiceSpy.mockRestore();
       trackSelectSpanKindSpy.mockRestore();
       trackSelectTimeframeSpy.mockRestore();
+      trackSelectTagsSpy.mockRestore();
       trackSearchOperationSpy.mockRestore();
       trackViewAllTracesSpy.mockRestore();
     });
@@ -494,6 +502,38 @@ describe('<MonitorATMServicesView>', () => {
 
       await waitFor(() => {
         expect(trackSelectSpanKindSpy).toHaveBeenCalledWith('Client');
+      });
+
+      expect(mockFetchAllServiceMetrics).toHaveBeenCalled();
+      expect(mockFetchAggregatedServiceMetrics).toHaveBeenCalled();
+    });
+
+    it('should handle tags change and call tracking', async () => {
+      cleanup();
+      const user = userEvent.setup();
+
+      const tagsProps = {
+        ...props,
+        services: ['apple'],
+        metrics: {
+          ...originInitialState,
+          serviceMetrics,
+          serviceOpsMetrics,
+          loading: false,
+          isATMActivated: true,
+        },
+        fetchServices: mockFetchServices,
+        fetchAllServiceMetrics: mockFetchAllServiceMetrics,
+        fetchAggregatedServiceMetrics: mockFetchAggregatedServiceMetrics,
+      };
+
+      renderWithRouter(<MonitorATMServicesView {...tagsProps} />);
+
+      const tagsSelect = screen.getByTestId('tags-selector');
+      await user.selectOptions(tagsSelect, 'environment:prod');
+
+      await waitFor(() => {
+        expect(trackSelectTagsSpy).toHaveBeenCalledWith('environment:prod');
       });
 
       expect(mockFetchAllServiceMetrics).toHaveBeenCalled();

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.track.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.track.tsx
@@ -20,11 +20,13 @@ export const CATEGORY_VIEW_ALL_TRACES = `${SPM_CATEGORY_BASE}/view-all-traces`;
 export const CATEGORY_SELECT_SERVICE = `${SPM_CATEGORY_BASE}/select-service`;
 export const CATEGORY_SELECT_SPAN_KIND = `${SPM_CATEGORY_BASE}/select-span-kind`;
 export const CATEGORY_SELECT_TIMEFRAME = `${SPM_CATEGORY_BASE}/select-timeframe`;
+export const CATEGORY_SELECT_TAGS = `${SPM_CATEGORY_BASE}/select-tags`;
 export const CATEGORY_SEARCH_OPERATION = `${SPM_CATEGORY_BASE}/search-operation`;
 
 export const trackViewAllTraces = () => trackEvent(CATEGORY_VIEW_ALL_TRACES, 'click');
 export const trackSelectService = (service: string) => trackEvent(CATEGORY_SELECT_SERVICE, service);
 export const trackSelectSpanKind = (spanKind: string) => trackEvent(CATEGORY_SELECT_SPAN_KIND, spanKind);
 export const trackSelectTimeframe = (timeframe: string) => trackEvent(CATEGORY_SELECT_TIMEFRAME, timeframe);
+export const trackSelectTags = (tags: string) => trackEvent(CATEGORY_SELECT_TAGS, tags);
 export const trackSearchOperation = (searchQuery: string) =>
   trackEvent(CATEGORY_SEARCH_OPERATION, searchQuery);

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -209,15 +209,25 @@ export const MonitorATMServicesViewImpl: React.FC<TProps> = props => {
       store.set('lastAtmSearchService', currentService);
       store.set('lastAtmSearchTags', selectedTags);
 
-      const metricQueryPayload = {
+      const metricQueryPayload: MetricsAPIQueryParams = {
         quantile: 0.95,
         endTs: newEndTime,
         lookback: selectedTimeFrame,
         step: 60 * 1000,
         ratePer: 10 * 60 * 1000,
         spanKind: selectedSpanKind,
-        ...(selectedTags && { tag: selectedTags }),
       };
+
+      // Add tags parameter based on format
+      if (selectedTags) {
+        if (selectedTags.startsWith('{') && selectedTags.endsWith('}')) {
+          // It's JSON format, use 'tags' parameter
+          (metricQueryPayload as any).tags = selectedTags;
+        } else {
+          // It's key:value format, use 'tag' parameter
+          (metricQueryPayload as any).tag = selectedTags;
+        }
+      }
 
       fetchAllServiceMetrics(currentService, metricQueryPayload);
       fetchAggregatedServiceMetrics(currentService, metricQueryPayload);

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.css
@@ -48,6 +48,9 @@ limitations under the License.
   vertical-align: middle;
   text-align: center;
   display: table-cell;
+  font-size: 16px;
+  color: #888;
+  font-weight: 500;
 }
 
 .crosshair-value {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.tsx
@@ -95,7 +95,13 @@ export class ServiceGraphImpl extends React.PureComponent<TProps> {
       return [];
     }
 
-    const data = Array.isArray(metricsData) ? metricsData : [metricsData];
+    // Filter out objects with no metric points or empty metric points arrays
+    const data = Array.isArray(metricsData)
+      ? metricsData.filter(m => m && m.metricPoints && m.metricPoints.length > 0)
+      : metricsData && metricsData.metricPoints && metricsData.metricPoints.length > 0
+        ? [metricsData]
+        : [];
+
     return data.sort((a, b) => b.quantile - a.quantile);
   }
 
@@ -252,14 +258,30 @@ export class ServiceGraphImpl extends React.PureComponent<TProps> {
         </Placeholder>
       );
 
-    if (metricsData === null)
+    const data = this.getMetricsData();
+
+    // Check for null data or empty data or data with no valid y values
+    let hasValidData = false;
+    if (data.length > 0) {
+      // Check if any data point has a valid y value
+      for (const point of data) {
+        for (const [key, value] of Object.entries(point)) {
+          if (key !== 'x' && value !== null && value !== undefined && !isNaN(Number(value))) {
+            hasValidData = true;
+            break;
+          }
+        }
+        if (hasValidData) break;
+      }
+    }
+
+    if (metricsData === null || !hasValidData)
       return (
         <Placeholder name={name} marginClassName={marginClassName} width={width} height={this.height}>
-          No Data
+          No data available
         </Placeholder>
       );
 
-    const data = this.getMetricsData();
     const effectiveYDomain = yDomain || this.calculateYDomain(data);
 
     const legendFormatter = (value: string): React.JSX.Element => {

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -105,6 +105,9 @@ const defaultConfig: Config = {
       },
     },
     docsLink: 'https://www.jaegertracing.io/docs/latest/spm/',
+    // Configure tag attributes for filtering metrics in the Monitor tab
+    // Example: [{ name: 'environment', label: 'Environment' }, { name: 'region', label: 'Region' }]
+    // See docs/MONITOR.md for detailed configuration instructions
     tagAttributes: [],
   },
   disableFileUploadControl: false,

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -105,6 +105,12 @@ const defaultConfig: Config = {
       },
     },
     docsLink: 'https://www.jaegertracing.io/docs/latest/spm/',
+    tagFilters: [],
+    tagAttributes: [
+      { name: 'environment', label: 'Environment' },
+      { name: 'http.status_code', label: 'HTTP Status' },
+      { name: 'http.method', label: 'HTTP Method' },
+    ],
   },
   disableFileUploadControl: false,
   disableJsonView: false,

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -105,12 +105,7 @@ const defaultConfig: Config = {
       },
     },
     docsLink: 'https://www.jaegertracing.io/docs/latest/spm/',
-    tagFilters: [],
-    tagAttributes: [
-      { name: 'environment', label: 'Environment' },
-      { name: 'http.status_code', label: 'HTTP Status' },
-      { name: 'http.method', label: 'HTTP Method' },
-    ],
+    tagAttributes: [],
   },
   disableFileUploadControl: false,
   disableJsonView: false,

--- a/packages/jaeger-ui/src/reducers/metrics.tsx
+++ b/packages/jaeger-ui/src/reducers/metrics.tsx
@@ -172,78 +172,73 @@ function fetchOpsMetricsDone(
     payload.forEach((promiseResult, i) => {
       if (promiseResult.status === 'fulfilled') {
         const metric = promiseResult.value;
-        // Add safety check for metric.metrics
-        if (metric && metric.metrics && Array.isArray(metric.metrics)) {
-          metric.metrics.forEach((metricDetails: MetricObject) => {
-            if (opsMetrics === null) {
-              opsMetrics = {};
-            }
+        metric.metrics.forEach((metricDetails: MetricObject) => {
+          if (opsMetrics === null) {
+            opsMetrics = {};
+          }
 
-            let opsName: string | null = null;
-            const avg: {
-              service_operation_latencies: number;
-              service_operation_call_rate: number;
-              service_operation_error_rate: number;
-            } = {
-              service_operation_latencies: 0,
-              service_operation_call_rate: 0,
-              service_operation_error_rate: 0,
-            };
-            const count: {
-              service_operation_latencies: number;
-              service_operation_call_rate: number;
-              service_operation_error_rate: number;
-            } = {
-              service_operation_latencies: 0,
-              service_operation_call_rate: 0,
-              service_operation_error_rate: 0,
-            };
-            metricDetails.labels.forEach((label: { name: string; value: string }) => {
-              if (label.name === 'operation') {
-                opsName = label.value;
-              }
-            });
-
-            if (opsName) {
-              if (opsMetrics[opsName] === undefined) {
-                opsMetrics[opsName] = {
-                  name: opsName,
-                  metricPoints: {
-                    service_operation_latencies: [],
-                    service_operation_call_rate: [],
-                    service_operation_error_rate: [],
-                    avg: {
-                      service_operation_latencies: null,
-                      service_operation_call_rate: null,
-                      service_operation_error_rate: null,
-                    },
-                  },
-                };
-              }
-
-              opsMetrics[opsName].metricPoints[metric.name] = metricDetails.metricPoints.map(p => {
-                let y;
-                try {
-                  y = parseFloat(p.gaugeValue.doubleValue.toFixed(2));
-                  avg[metric.name] += y;
-                  count[metric.name] += 1; // Increment count for non-NaN values
-                } catch (e) {
-                  y = null;
-                }
-
-                return {
-                  x: new Date(p.timestamp).getTime(),
-                  y,
-                };
-              });
-
-              opsMetrics[opsName].metricPoints.avg[metric.name] =
-                count[metric.name] > 0
-                  ? parseFloat((avg[metric.name] / count[metric.name]).toFixed(2))
-                  : null;
+          let opsName: string | null = null;
+          const avg: {
+            service_operation_latencies: number;
+            service_operation_call_rate: number;
+            service_operation_error_rate: number;
+          } = {
+            service_operation_latencies: 0,
+            service_operation_call_rate: 0,
+            service_operation_error_rate: 0,
+          };
+          const count: {
+            service_operation_latencies: number;
+            service_operation_call_rate: number;
+            service_operation_error_rate: number;
+          } = {
+            service_operation_latencies: 0,
+            service_operation_call_rate: 0,
+            service_operation_error_rate: 0,
+          };
+          metricDetails.labels.forEach((label: { name: string; value: string }) => {
+            if (label.name === 'operation') {
+              opsName = label.value;
             }
           });
-        } // Close the safety check
+
+          if (opsName) {
+            if (opsMetrics[opsName] === undefined) {
+              opsMetrics[opsName] = {
+                name: opsName,
+                metricPoints: {
+                  service_operation_latencies: [],
+                  service_operation_call_rate: [],
+                  service_operation_error_rate: [],
+                  avg: {
+                    service_operation_latencies: null,
+                    service_operation_call_rate: null,
+                    service_operation_error_rate: null,
+                  },
+                },
+              };
+            }
+
+            opsMetrics[opsName].metricPoints[metric.name] = metricDetails.metricPoints.map(p => {
+              let y;
+              try {
+                y = parseFloat(p.gaugeValue.doubleValue.toFixed(2));
+                avg[metric.name] += y;
+                count[metric.name] += 1; // Increment count for non-NaN values
+              } catch (e) {
+                y = null;
+              }
+
+              return {
+                x: new Date(p.timestamp).getTime(),
+                y,
+              };
+            });
+
+            opsMetrics[opsName].metricPoints.avg[metric.name] =
+              count[metric.name] > 0 ? parseFloat((avg[metric.name] / count[metric.name]).toFixed(2)) : null;
+          }
+        });
       } else {
         switch (i) {
           case 0:

--- a/packages/jaeger-ui/src/reducers/metrics.tsx
+++ b/packages/jaeger-ui/src/reducers/metrics.tsx
@@ -172,73 +172,78 @@ function fetchOpsMetricsDone(
     payload.forEach((promiseResult, i) => {
       if (promiseResult.status === 'fulfilled') {
         const metric = promiseResult.value;
-        metric.metrics.forEach((metricDetails: MetricObject) => {
-          if (opsMetrics === null) {
-            opsMetrics = {};
-          }
-
-          let opsName: string | null = null;
-          const avg: {
-            service_operation_latencies: number;
-            service_operation_call_rate: number;
-            service_operation_error_rate: number;
-          } = {
-            service_operation_latencies: 0,
-            service_operation_call_rate: 0,
-            service_operation_error_rate: 0,
-          };
-          const count: {
-            service_operation_latencies: number;
-            service_operation_call_rate: number;
-            service_operation_error_rate: number;
-          } = {
-            service_operation_latencies: 0,
-            service_operation_call_rate: 0,
-            service_operation_error_rate: 0,
-          };
-          metricDetails.labels.forEach((label: { name: string; value: string }) => {
-            if (label.name === 'operation') {
-              opsName = label.value;
-            }
-          });
-
-          if (opsName) {
-            if (opsMetrics[opsName] === undefined) {
-              opsMetrics[opsName] = {
-                name: opsName,
-                metricPoints: {
-                  service_operation_latencies: [],
-                  service_operation_call_rate: [],
-                  service_operation_error_rate: [],
-                  avg: {
-                    service_operation_latencies: null,
-                    service_operation_call_rate: null,
-                    service_operation_error_rate: null,
-                  },
-                },
-              };
+        // Add safety check for metric.metrics
+        if (metric && metric.metrics && Array.isArray(metric.metrics)) {
+          metric.metrics.forEach((metricDetails: MetricObject) => {
+            if (opsMetrics === null) {
+              opsMetrics = {};
             }
 
-            opsMetrics[opsName].metricPoints[metric.name] = metricDetails.metricPoints.map(p => {
-              let y;
-              try {
-                y = parseFloat(p.gaugeValue.doubleValue.toFixed(2));
-                avg[metric.name] += y;
-                count[metric.name] += 1; // Increment count for non-NaN values
-              } catch (e) {
-                y = null;
+            let opsName: string | null = null;
+            const avg: {
+              service_operation_latencies: number;
+              service_operation_call_rate: number;
+              service_operation_error_rate: number;
+            } = {
+              service_operation_latencies: 0,
+              service_operation_call_rate: 0,
+              service_operation_error_rate: 0,
+            };
+            const count: {
+              service_operation_latencies: number;
+              service_operation_call_rate: number;
+              service_operation_error_rate: number;
+            } = {
+              service_operation_latencies: 0,
+              service_operation_call_rate: 0,
+              service_operation_error_rate: 0,
+            };
+            metricDetails.labels.forEach((label: { name: string; value: string }) => {
+              if (label.name === 'operation') {
+                opsName = label.value;
               }
-
-              return {
-                x: new Date(p.timestamp).getTime(),
-                y,
-              };
             });
 
-            opsMetrics[opsName].metricPoints.avg[metric.name] =
-              count[metric.name] > 0 ? parseFloat((avg[metric.name] / count[metric.name]).toFixed(2)) : null;
-          }
-        });
+            if (opsName) {
+              if (opsMetrics[opsName] === undefined) {
+                opsMetrics[opsName] = {
+                  name: opsName,
+                  metricPoints: {
+                    service_operation_latencies: [],
+                    service_operation_call_rate: [],
+                    service_operation_error_rate: [],
+                    avg: {
+                      service_operation_latencies: null,
+                      service_operation_call_rate: null,
+                      service_operation_error_rate: null,
+                    },
+                  },
+                };
+              }
+
+              opsMetrics[opsName].metricPoints[metric.name] = metricDetails.metricPoints.map(p => {
+                let y;
+                try {
+                  y = parseFloat(p.gaugeValue.doubleValue.toFixed(2));
+                  avg[metric.name] += y;
+                  count[metric.name] += 1; // Increment count for non-NaN values
+                } catch (e) {
+                  y = null;
+                }
+
+                return {
+                  x: new Date(p.timestamp).getTime(),
+                  y,
+                };
+              });
+
+              opsMetrics[opsName].metricPoints.avg[metric.name] =
+                count[metric.name] > 0
+                  ? parseFloat((avg[metric.name] / count[metric.name]).toFixed(2))
+                  : null;
+            }
+          });
+        } // Close the safety check
       } else {
         switch (i) {
           case 0:

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -74,11 +74,6 @@ export type MonitorConfig = {
   tagAttributes?: readonly TagAttribute[];
 };
 
-export type TagFilter = {
-  label: string;
-  value: string;
-};
-
 export type TagAttribute = {
   name: string;
   label: string;

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -71,7 +71,6 @@ export type MonitorConfig = {
   menuEnabled?: boolean;
   emptyState?: MonitorEmptyStateConfig;
   docsLink?: string;
-  tagFilters?: readonly TagFilter[];
   tagAttributes?: readonly TagAttribute[];
 };
 

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -71,6 +71,18 @@ export type MonitorConfig = {
   menuEnabled?: boolean;
   emptyState?: MonitorEmptyStateConfig;
   docsLink?: string;
+  tagFilters?: readonly TagFilter[];
+  tagAttributes?: readonly TagAttribute[];
+};
+
+export type TagFilter = {
+  label: string;
+  value: string;
+};
+
+export type TagAttribute = {
+  name: string;
+  label: string;
 };
 
 export type TraceGraphConfig = {

--- a/packages/jaeger-ui/src/types/metrics.tsx
+++ b/packages/jaeger-ui/src/types/metrics.tsx
@@ -31,6 +31,7 @@ export type MetricsAPIQueryParams = {
   step: number;
   ratePer: number;
   spanKind: spanKinds;
+  tag?: string;
 };
 
 export type LableObject = {

--- a/packages/jaeger-ui/src/types/metrics.tsx
+++ b/packages/jaeger-ui/src/types/metrics.tsx
@@ -31,7 +31,7 @@ export type MetricsAPIQueryParams = {
   step: number;
   ratePer: number;
   spanKind: spanKinds;
-  tag?: string;
+  tags?: string;
 };
 
 export type LableObject = {


### PR DESCRIPTION
This commit adds functionality to filter metrics by tags in the Service Performance Monitoring (SPM) page.

## Which problem is this PR solving?
- https://github.com/jaegertracing/jaeger/issues/7433

## Description of the changes
This PR introduces configurable tag-based filtering functionality to the Service Performance Monitoring (SPM) tab in Jaeger UI, allowing users to filter metrics by specific tag attributes like environment, region, etc.

- Tags component
The `src/components/Monitor/MultiTagSelector` component would render all the tags that you might have configured in the `tagAttributes` in the monitor section of your jaeger-ui.json configuration file.

An example configuration looks like
```
{
  "monitor": {
    "tagAttributes": [
      { "name": "environment", "label": "Environment" },
      { "name": "region", "label": "Region" },
      { "name": "cluster", "label": "Cluster" }
    ]
  }
}
```
The `label` is used as the title, but `name` is used to fetch the values for that tag from the backend. 

To fetch the values, we use `/metrics/attributes?key=<tag name>` api and then the component is populated.

<img width="2548" height="1203" alt="Screenshot 2025-09-05 at 10 37 04 AM" src="https://github.com/user-attachments/assets/b18f8f30-596b-4d07-97b7-65e7f8135d04" />

- Filter flow
The feature introduced tag filtering in /metrics apis. 
/metrics/latencies, /metrics/errors/, /metrics/calls support one or more tag based filtering.

For example:
```
curl http://localhost:5173/api/metrics/latencies\?service\=mysql\&endTs\=1759230839601\&lookback\=900000\&quantile\=0.5\&ratePer\=600000\&spanKind\=server\&step\=60000\&tags\=%7B%22environment%22%3A%22production%22%7D | jq
``` 
essentially sends tags={environment:production} in url-encoded format to the backend.

The jaeger-ui will use encoded `tags=` json to filter to keep things simple. But if we were to filter only with one tag
`?tag=<key>:<value>` can be used.


## How was this change tested?
- Manually

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
