### PR TITLE
Fix top bar tab order

### DIFF
--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -144,7 +144,14 @@ export function TopNavImpl(props: Props) {
           NAV_LINKS.map(({ matches, to, text }) => {
             const url = typeof to === 'string' ? to : to(props);
             const key = matches(pathname) ? pathname : url;
-            return { key, label: <Link to={url}>{text}</Link> };
+            return {
+              key,
+              label: (
+                <Link style={{ outline: 'revert' }} to={url}>
+                  {text}
+                </Link>
+              ),
+            };
           })
         )}
         className="Menu--item"


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes accessibility issues with topbar's tab navigation experience.

- The tab order was starting from the search box on the right half of the topbar and subsequently jumping left to the nav items.
- There was no focus ring on the topbar nav menu items

## Description of the changes
- Tab navigation ordering in top bar now flows left to right as expected
- Tabbing into the topbar nav now shows focus ring

Screenshot of focus ring:
<img width="483" height="107" alt="image" src="https://github.com/user-attachments/assets/4043f41d-23fa-405c-8eea-43198481de29" />

Large screen:
<img width="1259" height="381" alt="image" src="https://github.com/user-attachments/assets/6dd5de0e-df5f-4b94-bcd3-e7124440a9f8" />

Small screen:
<img width="605" height="205" alt="image" src="https://github.com/user-attachments/assets/93fe2b10-6e74-4a99-bb75-22ded6cb542e" />



## How was this change tested?
- Tested various screen sizes for visual regressions in responsive behavior
- Tested with keyboard navigation and programmatically triggering focus ring

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
