### PR TITLE
Convert SeachResults{ResultItem, ResultItemTitle} to functional components

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -44,102 +44,94 @@ type Props = {
   disableComparision: boolean;
 };
 
-type State = {
-  erroredServices: Set<string>;
-  numSpans: number;
-  numErredSpans: number;
-  timeStr: string;
-  fromNow: string | boolean;
-};
-
 const isErrorTag = ({ key, value }: KeyValuePair<boolean | string>) =>
   key === 'error' && (value === true || value === 'true');
 const trackTraceConversions = () => trackConversions(EAltViewActions.Traces);
 
-export default class ResultItem extends React.PureComponent<Props, State> {
-  constructor(props: Props, state: State) {
-    super(props, state);
-    const { startTime, spans } = props.trace;
+export default function ResultItem({
+  durationPercent,
+  isInDiffCohort,
+  linkTo,
+  toggleComparison,
+  trace,
+  disableComparision,
+}: Props) {
+  const { duration, services = [], startTime, traceName, traceID, spans = [] } = trace;
 
+  // Initialize state values
+  const [erroredServices, setErroredServices] = React.useState<Set<string>>(new Set());
+  const [numSpans] = React.useState(spans.length);
+  const [numErredSpans, setNumErredSpans] = React.useState(0);
+  const [timeStr, setTimeStr] = React.useState('');
+  const [fromNow, setFromNow] = React.useState<string | boolean>('');
+
+  React.useEffect(() => {
     const startTimeDayjs = dayjs(startTime / 1000);
+    setTimeStr(startTimeDayjs.format('h:mm:ss a'));
+    setFromNow(startTimeDayjs.fromNow());
 
-    const erroredServices: Set<string> = new Set<string>();
-
-    const numErredSpans = spans.filter(sp => {
+    const errored = new Set<string>();
+    const erredCount = spans.filter(sp => {
       const hasError = sp.tags.some(isErrorTag);
-      if (hasError) {
-        erroredServices.add(sp.process.serviceName);
-      }
+      if (hasError) errored.add(sp.process.serviceName);
       return hasError;
     }).length;
 
-    this.state = {
-      numSpans: spans.length,
-      timeStr: startTimeDayjs.format('h:mm:ss a'),
-      fromNow: startTimeDayjs.fromNow(),
-      numErredSpans,
-      erroredServices,
-    };
-  }
+    setErroredServices(errored);
+    setNumErredSpans(erredCount);
+  }, [startTime, spans]);
 
-  render() {
-    const { disableComparision, durationPercent, isInDiffCohort, linkTo, toggleComparison, trace } =
-      this.props;
-    const { duration, services, startTime, traceName, traceID } = trace;
-    return (
-      <div className="ResultItem" onClick={trackTraceConversions} role="button">
-        <ResultItemTitle
-          duration={duration}
-          durationPercent={durationPercent}
-          isInDiffCohort={isInDiffCohort}
-          linkTo={linkTo}
-          toggleComparison={toggleComparison}
-          traceID={traceID}
-          traceName={traceName}
-          disableComparision={disableComparision}
-        />
-        <Link to={linkTo}>
-          <Row>
-            <Col span={4} className="ub-p2">
-              <Tag className="ub-m1" data-testid={markers.NUM_SPANS}>
-                {this.state.numSpans} Span{this.state.numSpans > 1 && 's'}
+  return (
+    <div className="ResultItem" onClick={trackTraceConversions} role="button">
+      <ResultItemTitle
+        duration={duration}
+        durationPercent={durationPercent}
+        isInDiffCohort={isInDiffCohort}
+        linkTo={linkTo}
+        toggleComparison={toggleComparison}
+        traceID={traceID}
+        traceName={traceName}
+        disableComparision={disableComparision}
+      />
+      <Link to={linkTo}>
+        <Row>
+          <Col span={4} className="ub-p2">
+            <Tag className="ub-m1" data-testid={markers.NUM_SPANS}>
+              {numSpans} Span{numSpans > 1 && 's'}
+            </Tag>
+            {Boolean(numErredSpans) && (
+              <Tag className="ub-m1" color="red">
+                {numErredSpans} Error{numErredSpans > 1 && 's'}
               </Tag>
-              {Boolean(this.state.numErredSpans) && (
-                <Tag className="ub-m1" color="red">
-                  {this.state.numErredSpans} Error{this.state.numErredSpans > 1 && 's'}
-                </Tag>
-              )}
-            </Col>
-            <Col span={16} className="ub-p2">
-              <ul className="ub-list-reset" data-testid={markers.SERVICE_TAGS}>
-                {_sortBy(services, s => s.name).map(service => {
-                  const { name, numberOfSpans: count } = service;
-                  return (
-                    <li key={name} className="ub-inline-block ub-m1">
-                      <Tag
-                        className="ResultItem--serviceTag"
-                        style={{ borderLeftColor: colorGenerator.getColorByKey(name) }}
-                      >
-                        {this.state.erroredServices.has(name) && (
-                          <IoAlert className="ResultItem--errorIcon" />
-                        )}
-                        {name} ({count})
-                      </Tag>
-                    </li>
-                  );
-                })}
-              </ul>
-            </Col>
-            <Col span={4} className="ub-p3 ub-tx-right-align">
-              {formatRelativeDate(startTime / 1000)}
-              <Divider type="vertical" />
-              {this.state.timeStr.slice(0, -3)}&nbsp;{this.state.timeStr.slice(-2)}
-              <br />
-              <small>{this.state.fromNow}</small>
-            </Col>
-          </Row>
-        </Link>
-      </div>
-    );
-  }
+            )}
+          </Col>
+          <Col span={16} className="ub-p2">
+            <ul className="ub-list-reset" data-testid={markers.SERVICE_TAGS}>
+              {_sortBy(services, s => s.name).map(service => {
+                const { name, numberOfSpans: count } = service;
+                return (
+                  <li key={name} className="ub-inline-block ub-m1">
+                    <Tag
+                      className="ResultItem--serviceTag"
+                      style={{ borderLeftColor: colorGenerator.getColorByKey(name) }}
+                    >
+                      {erroredServices.has(name) && <IoAlert className="ResultItem--errorIcon" />}
+                      {name} ({count})
+                    </Tag>
+                  </li>
+                );
+              })}
+            </ul>
+          </Col>
+          <Col span={4} className="ub-p3 ub-tx-right-align">
+            {formatRelativeDate(startTime / 1000)}
+            <Divider type="vertical" />
+            {timeStr.slice(0, -3)}&nbsp;{timeStr.slice(-2)}
+            <br />
+            <small>{fromNow}</small>
+          </Col>
+        </Row>
+      </Link>
+    </div>
+  );
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
@@ -63,6 +63,7 @@ export default function ResultItemTitle({
     toggleComparison(traceID, isInDiffCohort);
   }, [toggleComparison, traceID, isInDiffCohort]);
 
+  // Use a div when the ResultItemTitle doesn't link to anything
   let WrapperComponent: string | typeof Link = 'div';
   const wrapperProps: Record<string, any> = {
     className: 'ResultItemTitle--item ub-flex-auto',

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
@@ -46,72 +46,58 @@ const DEFAULT_DURATION_PERCENT = 0;
 
 const stopCheckboxPropagation = (evt: React.MouseEvent) => evt.stopPropagation();
 
-export default class ResultItemTitle extends React.PureComponent<Props> {
-  static defaultProps: Partial<Props> = {
-    disableComparision: false,
-    durationPercent: DEFAULT_DURATION_PERCENT,
-    error: undefined,
-    state: undefined,
-    targetBlank: false,
-  };
-
-  toggleComparison = () => {
-    const { isInDiffCohort, toggleComparison, traceID } = this.props;
+export default function ResultItemTitle({
+  duration,
+  durationPercent = DEFAULT_DURATION_PERCENT,
+  error,
+  isInDiffCohort,
+  linkTo,
+  state,
+  targetBlank = false,
+  toggleComparison,
+  traceID,
+  traceName,
+  disableComparision = false,
+}: Props) {
+  const onToggleComparison = React.useCallback(() => {
     toggleComparison(traceID, isInDiffCohort);
+  }, [toggleComparison, traceID, isInDiffCohort]);
+
+  let WrapperComponent: string | typeof Link = 'div';
+  const wrapperProps: Record<string, any> = {
+    className: 'ResultItemTitle--item ub-flex-auto',
+  };
+  if (linkTo) {
+    WrapperComponent = Link;
+    wrapperProps.to = linkTo;
+    if (targetBlank) {
+      wrapperProps.target = getTargetEmptyOrBlank();
+      wrapperProps.rel = 'noopener noreferrer';
+    }
+  }
+
+  const isErred = state === fetchedState.ERROR;
+  // Separate propagation management and toggle manegement due to ant-design#16400
+  const checkboxProps = {
+    className: 'ResultItemTitle--item ub-flex-none',
+    checked: !isErred && isInDiffCohort,
+    disabled: isErred,
+    onChange: onToggleComparison,
+    onClick: stopCheckboxPropagation,
   };
 
-  render() {
-    const {
-      disableComparision,
-      duration,
-      durationPercent,
-      error,
-      isInDiffCohort,
-      linkTo,
-      state,
-      targetBlank,
-      traceID,
-      traceName,
-    } = this.props;
-    // Use a div when the ResultItemTitle doesn't link to anything
-    let WrapperComponent: string | typeof Link = 'div';
-    const wrapperProps: Record<string, string | LocationDescriptor> = {
-      className: 'ResultItemTitle--item ub-flex-auto',
-    };
-    if (linkTo) {
-      wrapperProps.to = linkTo;
-      WrapperComponent = Link;
-      if (targetBlank) {
-        wrapperProps.target = getTargetEmptyOrBlank();
-        wrapperProps.rel = 'noopener noreferrer';
-      }
-    }
-    const isErred = state === fetchedState.ERROR;
-    // Separate propagation management and toggle manegement due to ant-design#16400
-    const checkboxProps = {
-      className: 'ResultItemTitle--item ub-flex-none',
-      checked: !isErred && isInDiffCohort,
-      disabled: isErred,
-      onChange: this.toggleComparison,
-      onClick: stopCheckboxPropagation,
-    };
-
-    return (
-      <div className="ResultItemTitle">
-        {!disableComparision && <Checkbox {...checkboxProps} />}
-        {/* TODO: Shouldn't need cast */}
-        <WrapperComponent {...(wrapperProps as any)}>
-          <span
-            className="ResultItemTitle--durationBar"
-            style={{ width: `${durationPercent || DEFAULT_DURATION_PERCENT}%` }}
-          />
-          {duration != null && <span className="ub-right ub-relative">{formatDuration(duration)}</span>}
-          <h3 className="ResultItemTitle--title">
-            <TraceName error={error} state={state} traceName={traceName} />
-            <TraceId traceId={traceID} className="ResultItemTitle--idExcerpt" />
-          </h3>
-        </WrapperComponent>
-      </div>
-    );
-  }
+  return (
+    <div className="ResultItemTitle">
+      {!disableComparision && <Checkbox {...checkboxProps} />}
+      {/* TODO: Shouldn't need cast */}
+      <WrapperComponent {...(wrapperProps as any)}>
+        <span className="ResultItemTitle--durationBar" style={{ width: `${durationPercent}%` }} />
+        {duration != null && <span className="ub-right ub-relative">{formatDuration(duration)}</span>}
+        <h3 className="ResultItemTitle--title">
+          <TraceName error={error} state={state} traceName={traceName} />
+          <TraceId traceId={traceID} className="ResultItemTitle--idExcerpt" />
+        </h3>
+      </WrapperComponent>
+    </div>
+  );
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolved https://github.com/jaegertracing/jaeger-ui/issues/2610 <!-- Example: Resolves #123 -->

## Description of the changes
- convert `packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx` and `packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx` from class to functional

## How was this change tested?
- Ensured there is no break in the functionality in UI
- Ran the test suite using npm run test to ensure all test cases pass.


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
