### PR TITLE
A11y topbar 2

### DIFF
--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -139,6 +139,7 @@ export function TopNavImpl(props: Props) {
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between' }}>
       <Menu
+        tabIndex={-1}
         theme="dark"
         items={itemsGlobalLeft?.concat(
           NAV_LINKS.map(({ matches, to, text }) => {
@@ -161,6 +162,7 @@ export function TopNavImpl(props: Props) {
         style={{ flex: '1 1 0', minWidth: 0 }}
       />
       <Menu
+        tabIndex={-1}
         theme="dark"
         items={itemsGlobalRight}
         className="Menu--item"


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes two a11y issues. Logo/ home link in leftmost position in top bar does not show a focus ring. Additionally, the two menus have their own focus which is not actionable, this should be skipped since the menus' items are already focusable.

## Description of the changes
- Revert the outline css applied globally by ant design that breaks proper focus ring support on the Logo/home link
- Manually set tabindex to -1 on both topbar menus so they are removed from taborder

## How was this change tested?
- Tabbed through the page to verify correct order

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
