### PR TITLE
Remove history from TraceDiff component

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.js
@@ -18,12 +18,19 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import queryString from 'query-string';
 import * as redux from 'redux';
+import { BrowserRouter } from 'react-router-dom-v5-compat';
 
 import { mapStateToProps, mapDispatchToProps, TraceDiffImpl } from './TraceDiff';
 import * as TraceDiffUrl from './url';
 import { actions as diffActions } from './duck';
 import * as jaegerApiActions from '../../actions/jaeger-api';
 import { fetchedState, TOP_NAV_HEIGHT } from '../../constants';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useNavigate: () => mockNavigate,
+}));
 
 /* 
 With v5+, redux no longer supports `bindActionCreators` to be configured.
@@ -65,22 +72,23 @@ describe('TraceDiff', () => {
   const defaultCohort = [defaultA, defaultB, ...defaultCohortIds];
   const fetchMultipleTracesMock = jest.fn();
   const forceStateMock = jest.fn();
-  const historyPushMock = jest.fn();
   const defaultProps = {
     a: defaultA,
     b: defaultB,
     cohort: defaultCohort,
     fetchMultipleTraces: fetchMultipleTracesMock,
     forceState: forceStateMock,
-    history: {
-      push: historyPushMock,
-    },
     tracesData: new Map(defaultCohort.map(id => [id, { id, state: fetchedState.DONE }])),
     traceDiffState: {
       a: defaultA,
       b: defaultB,
       cohort: defaultCohort,
     },
+  };
+
+  // Helper function to render with router context
+  const renderWithRouter = component => {
+    return render(<BrowserRouter>{component}</BrowserRouter>);
   };
   const newAValue = 'newAValue';
   const newBValue = 'newBValue';
@@ -96,12 +104,12 @@ describe('TraceDiff', () => {
     fetchMultipleTracesMock.mockClear();
     forceStateMock.mockClear();
     getUrlSpy.mockClear();
-    historyPushMock.mockClear();
+    mockNavigate.mockClear();
   });
 
   describe('syncStates', () => {
     it('forces state if a is inconsistent between url and reduxState', () => {
-      render(<TraceDiffImpl {...defaultProps} a={newAValue} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} a={newAValue} />);
 
       expect(forceStateMock).toHaveBeenLastCalledWith({
         a: newAValue,
@@ -111,7 +119,7 @@ describe('TraceDiff', () => {
     });
 
     it('forces state if b is inconsistent between url and reduxState', () => {
-      render(<TraceDiffImpl {...defaultProps} b={newBValue} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} b={newBValue} />);
 
       expect(forceStateMock).toHaveBeenLastCalledWith({
         a: defaultProps.a,
@@ -122,7 +130,7 @@ describe('TraceDiff', () => {
 
     it('forces state if cohort size has changed', () => {
       const newCohort = [...defaultProps.cohort, nonDefaultCohortId];
-      render(<TraceDiffImpl {...defaultProps} cohort={newCohort} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} cohort={newCohort} />);
 
       expect(forceStateMock).toHaveBeenLastCalledWith({
         a: defaultProps.a,
@@ -132,7 +140,7 @@ describe('TraceDiff', () => {
 
       forceStateMock.mockClear();
 
-      render(
+      renderWithRouter(
         <TraceDiffImpl {...defaultProps} traceDiffState={{ ...defaultProps.traceDiffState, cohort: null }} />
       );
 
@@ -145,7 +153,7 @@ describe('TraceDiff', () => {
 
     it('forces state if cohort entry has changed', () => {
       const newCohort = [...defaultProps.cohort.slice(1), nonDefaultCohortId];
-      render(<TraceDiffImpl {...defaultProps} cohort={newCohort} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} cohort={newCohort} />);
 
       expect(forceStateMock).toHaveBeenLastCalledWith({
         a: defaultProps.a,
@@ -155,7 +163,7 @@ describe('TraceDiff', () => {
     });
 
     it('does not force state if cohorts have same values in differing orders', () => {
-      render(
+      renderWithRouter(
         <TraceDiffImpl
           {...defaultProps}
           traceDiffState={{
@@ -174,7 +182,7 @@ describe('TraceDiff', () => {
     const newId1 = 'new-id-1';
     expect(fetchMultipleTracesMock).toHaveBeenCalledTimes(0);
 
-    render(<TraceDiffImpl {...defaultProps} cohort={[...defaultProps.cohort, newId0, newId1]} />);
+    renderWithRouter(<TraceDiffImpl {...defaultProps} cohort={[...defaultProps.cohort, newId0, newId1]} />);
 
     expect(fetchMultipleTracesMock).toHaveBeenCalledWith([newId0, newId1]);
     expect(fetchMultipleTracesMock).toHaveBeenCalledTimes(1);
@@ -190,14 +198,14 @@ describe('TraceDiff', () => {
     tracesData.set(newId0, { id: newId0, state: fetchedState.ERROR });
     tracesData.set(newId1, { id: newId1, state: fetchedState.LOADING });
 
-    render(<TraceDiffImpl {...defaultProps} cohort={cohort} tracesData={tracesData} />);
+    renderWithRouter(<TraceDiffImpl {...defaultProps} cohort={cohort} tracesData={tracesData} />);
 
     expect(fetchMultipleTracesMock).not.toHaveBeenCalled();
   });
 
   it('updates url when TraceDiffHeader sets a or b', async () => {
     const user = userEvent.setup();
-    render(<TraceDiffImpl {...defaultProps} />);
+    renderWithRouter(<TraceDiffImpl {...defaultProps} />);
 
     await user.click(screen.getByTestId('diff-set-a-btn'));
     expect(getUrlSpy).toHaveBeenLastCalledWith({
@@ -227,12 +235,12 @@ describe('TraceDiff', () => {
       cohort: defaultProps.cohort,
     });
 
-    expect(historyPushMock).toHaveBeenCalledTimes(4);
+    expect(mockNavigate).toHaveBeenCalledTimes(4);
   });
 
   describe('render', () => {
     it('renders both header and graph components', () => {
-      render(<TraceDiffImpl {...defaultProps} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} />);
 
       expect(screen.getByTestId('trace-diff-header')).toBeInTheDocument();
       expect(screen.getByTestId('trace-diff-graph')).toBeInTheDocument();
@@ -243,14 +251,14 @@ describe('TraceDiff', () => {
       tracesData.delete(defaultA);
       tracesData.delete(defaultB);
 
-      render(<TraceDiffImpl {...defaultProps} tracesData={tracesData} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} tracesData={tracesData} />);
 
       expect(screen.getByTestId('trace-diff-header')).toBeInTheDocument();
       expect(screen.getByTestId('trace-diff-graph')).toBeInTheDocument();
     });
 
     it('handles absent a and b', () => {
-      render(<TraceDiffImpl {...defaultProps} a={null} b={null} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} a={null} b={null} />);
 
       expect(screen.getByTestId('trace-diff-header')).toBeInTheDocument();
       expect(screen.getByTestId('trace-diff-graph')).toBeInTheDocument();
@@ -278,7 +286,7 @@ describe('TraceDiff', () => {
         return originalGetBoundingClientRect.call(this);
       });
 
-      render(<TraceDiffImpl {...defaultProps} />);
+      renderWithRouter(<TraceDiffImpl {...defaultProps} />);
 
       const graphWrapper = document.querySelector('.TraceDiff--graphWrapper');
       expect(graphWrapper).toHaveStyle(`top: ${TOP_NAV_HEIGHT}px`);
@@ -289,7 +297,7 @@ describe('TraceDiff', () => {
     it('calls setGraphTopOffset and updates graphTopOffset state on header ref change', () => {
       // This test verifies the component structure and initial behavior
       // The actual height calculation is tested by the component's useEffect which runs when the ref is set during mount
-      const { container } = render(<TraceDiffImpl {...defaultProps} />);
+      const { container } = renderWithRouter(<TraceDiffImpl {...defaultProps} />);
       const headerWrapper = container.querySelector('[data-testid="trace-diff-header"]').parentElement;
       const graphWrapper = container.querySelector('.TraceDiff--graphWrapper');
       expect(headerWrapper).toBeInTheDocument();
@@ -307,7 +315,7 @@ describe('TraceDiff', () => {
         value: mockHeight,
       });
 
-      const { container, rerender } = render(<TraceDiffImpl {...defaultProps} />);
+      const { container, rerender } = renderWithRouter(<TraceDiffImpl {...defaultProps} />);
       rerender(<TraceDiffImpl {...defaultProps} />);
 
       const graphWrapper = container.querySelector('.TraceDiff--graphWrapper');
@@ -325,7 +333,7 @@ describe('TraceDiff', () => {
         value: undefined,
       });
 
-      const { container } = render(<TraceDiffImpl {...defaultProps} />);
+      const { container } = renderWithRouter(<TraceDiffImpl {...defaultProps} />);
       const graphWrapper = container.querySelector('.TraceDiff--graphWrapper');
       expect(graphWrapper).toHaveStyle(`top: ${TOP_NAV_HEIGHT}px`);
 

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { History as RouterHistory } from 'history';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -45,7 +45,6 @@ type TDispatchProps = {
 };
 
 type TOwnProps = {
-  history: RouterHistory;
   params: TDiffRouteParams;
 };
 
@@ -80,8 +79,8 @@ export function TraceDiffImpl({
   traceDiffState,
   fetchMultipleTraces,
   forceState,
-  history,
 }: TStateProps & TDispatchProps & TOwnProps) {
+  const navigate = useNavigate();
   const [graphTopOffset, setGraphTopOffset] = React.useState(TOP_NAV_HEIGHT);
   const headerWrapperElmRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -112,9 +111,9 @@ export function TraceDiffImpl({
     (change: { newA?: string | TNil; newB?: string | TNil }) => {
       const { newA, newB } = change;
       const url = getUrl({ a: newA || a, b: newB || b, cohort });
-      history.push(url);
+      navigate(url);
     },
-    [a, b, cohort, history]
+    [a, b, cohort, navigate]
   );
 
   const diffSetA = React.useCallback(


### PR DESCRIPTION
## Which problem is this PR solving?
- Work towards #2531 

## Description of the changes
- It's safe to remove the `history` prop because the component was already router-dependent (it needed to be wrapped in router context to receive the history prop). Now actually, `history.push(url)` and `navigate(url)` do exactly the same thing. The component still gets router context through the `withRouteProps`, so `useNavigate()` works perfectly.

## How was this change tested?
- unit tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
