### PR TITLE
Add new test file for BreakableText

### DIFF
--- a/packages/jaeger-ui/src/components/common/BreakableText.test.js
+++ b/packages/jaeger-ui/src/components/common/BreakableText.test.js
@@ -1,16 +1,5 @@
-// Copyright (c) 2025 Uber Technologies, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Description of the changes
- There was no test file found for `/src/components/common/BreakableText.js`. Added a new test file `BreakableText.test.js` to cover the test cases.

## How was this change tested?
-  Ran the test suite using npm run test to ensure all test cases pass.
<img width="1595" height="947" alt="image" src="https://github.com/user-attachments/assets/14e4f203-5963-44a4-9009-34c51cdada60" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
