### PR TITLE
Sync Node versions in CI

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           cache: npm
-          node-version: '22'
+          node-version-file: '.nvmrc'
       - run: npm ci
       - name: Run depcheck
         run: npm run depcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           cache: npm
-          node-version: '22'
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           cache: npm
-          node-version: '22'
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm ls --all
       - run: npm run coverage


### PR DESCRIPTION
## Which problem is this PR solving?
- Renovate bot can update Node version in .nvmrc (#3144) and in the workflows (#3141) independently, causing inconsistencies

## Description of the changes
- Make the workflows read the version from `.nvmrc` file

## How was this change tested?
- CI
