### PR TITLE
Make Deep Dependencies API endpoint configurable

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -81,7 +81,7 @@ function getJSON(url, options = {}) {
 }
 
 export const DEFAULT_API_ROOT = prefixUrl('/api/');
-export const ANALYTICS_ROOT = prefixUrl('/analytics/');
+export const DEEP_DEPENDENCIES_ROOT = prefixUrl(getConfig().deepDependencies.apiEndpoint);
 export const QUALITY_METRICS_ROOT = prefixUrl(getConfig().qualityMetrics.apiEndpoint);
 export const DEFAULT_DEPENDENCY_LOOKBACK = dayjs.duration(1, 'weeks').asMilliseconds();
 
@@ -94,7 +94,7 @@ const JaegerAPI = {
     return getJSON(url);
   },
   fetchDeepDependencyGraph(query) {
-    return getJSON(`${ANALYTICS_ROOT}v1/dependencies`, { query });
+    return getJSON(DEEP_DEPENDENCIES_ROOT, { query });
   },
   fetchDependencies(endTs = new Date().getTime(), lookback = DEFAULT_DEPENDENCY_LOOKBACK) {
     return getJSON(`${this.apiRoot}dependencies`, { query: { endTs, lookback } });

--- a/packages/jaeger-ui/src/api/jaeger.test.js
+++ b/packages/jaeger-ui/src/api/jaeger.test.js
@@ -30,7 +30,7 @@ import JaegerAPI, {
   getMessageFromError,
   DEFAULT_API_ROOT,
   DEFAULT_DEPENDENCY_LOOKBACK,
-  ANALYTICS_ROOT,
+  DEEP_DEPENDENCIES_ROOT,
 } from './jaeger';
 
 const defaultOptions = {
@@ -60,7 +60,7 @@ describe('fetchDeepDependencyGraph', () => {
     const query = { service: 'serviceName', start: 400, end: 800 };
     JaegerAPI.fetchDeepDependencyGraph(query);
     expect(fetchMock).toHaveBeenLastCalledWith(
-      `${ANALYTICS_ROOT}v1/dependencies?${queryString.stringify(query)}`,
+      `${DEEP_DEPENDENCIES_ROOT}?${queryString.stringify(query)}`,
       defaultOptions
     );
   });

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -115,6 +115,8 @@ const defaultConfig: Config = {
 
   deepDependencies: {
     menuEnabled: false,
+    menuLabel: 'Deep Dependencies',
+    apiEndpoint: '/api/deep-dependencies',
   },
   qualityMetrics: {
     menuEnabled: false,

--- a/packages/jaeger-ui/src/types/config.tsx
+++ b/packages/jaeger-ui/src/types/config.tsx
@@ -193,8 +193,10 @@ export type Config = {
 
   // The following features are experimental / undocumented.
 
-  deepDependencies?: {
-    menuEnabled?: boolean;
+  deepDependencies: {
+    menuEnabled: boolean;
+    menuLabel: string;
+    apiEndpoint: string;
   };
   pathAgnosticDecorations?: readonly TPathAgnosticDecorationSchema[];
   qualityMetrics?: {


### PR DESCRIPTION
## Which problem is this PR solving?
- Implements the UI changes needed for the merged backend issue `jaegertracing/jaeger#7399` (originally `jaegertracing/jaeger#6606`).
- This supersedes the stale pull request #3058.
- Part of https://github.com/jaegertracing/jaeger/issues/6606

## Description of the changes
- Updates the `fetchDeepDependencyGraph` API function to use the new `DEEP_DEPENDENCIES_ROOT` (pointing to `/api/deep-dependencies`).
- Removes the now-unused `ANALYTICS_ROOT` constant.
- Addresses maintainer feedback  from #3058 by updating `packages/jaeger-ui/src/types/config.tsx`:
    - The `deepDependencies` config object and its properties (`menuEnabled`, `menuLabel`, `apiEndpoint`) are now **required** (non-optional).
- As a result, `packages/jaeger-ui/src/api/jaeger.js` was updated to remove the optional chaining (`?.`), making the config access safer.
- Updates `packages/jaeger-ui/src/api/jaeger.test.js` to reflect these changes.

## How was this change tested?
- Updated existing unit tests in `jaeger.test.js`.
- All local checks pass:
  - `npm run lint`
  - `npm run test`

## Checklist
- [x] I have read [https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md](https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md)
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
