### PR TITLE
Remove sinon dependency, use jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4677,27 +4677,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@sinonjs/samsam": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
-      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -8880,16 +8859,6 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -18393,24 +18362,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sinon": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
-      "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^13.0.5",
-        "@sinonjs/samsam": "^8.0.1",
-        "diff": "^7.0.0",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
     "node_modules/slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -21060,7 +21011,6 @@
         "jest-junit": "^16.0.0",
         "less": "4.4.0",
         "rollup-plugin-visualizer": "^6.0.0",
-        "sinon": "^21.0.0",
         "terser": "^5.31.0",
         "vite": "^7",
         "vite-plugin-imp": "^2.4.0"

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -34,7 +34,6 @@
     "jest-junit": "^16.0.0",
     "less": "4.4.0",
     "rollup-plugin-visualizer": "^6.0.0",
-    "sinon": "^21.0.0",
     "terser": "^5.31.0",
     "vite": "^7",
     "vite-plugin-imp": "^2.4.0"

--- a/packages/jaeger-ui/src/actions/jaeger-api.test.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.test.js
@@ -26,28 +26,34 @@ function isPromise(p) {
   return p !== null && typeof p === 'object' && typeof p.then === 'function' && typeof p.catch === 'function';
 }
 
-import sinon from 'sinon';
 import * as jaegerApiActions from './jaeger-api';
 import JaegerAPI from '../api/jaeger';
+
+// Mock the JaegerAPI module
+jest.mock('../api/jaeger', () => ({
+  fetchTrace: jest.fn(() => Promise.resolve()),
+  searchTraces: jest.fn(() => Promise.resolve()),
+  archiveTrace: jest.fn(() => Promise.resolve()),
+  fetchServices: jest.fn(() => Promise.resolve()),
+  fetchServiceOperations: jest.fn(() => Promise.resolve()),
+  fetchServiceServerOps: jest.fn(() => Promise.resolve()),
+  fetchDeepDependencyGraph: jest.fn(() => Promise.resolve()),
+  fetchDependencies: jest.fn(() => Promise.resolve()),
+  fetchMetrics: jest.fn(() => Promise.resolve()),
+}));
 
 describe('actions/jaeger-api', () => {
   const query = { param: 'value' };
   const id = 'my-trace-id';
   const ids = [id, id];
-  let mock;
 
   beforeEach(() => {
-    mock = sinon.mock(JaegerAPI);
-  });
-
-  afterEach(() => {
-    mock.restore();
+    jest.clearAllMocks();
   });
 
   it('@JAEGER_API/FETCH_TRACE should fetch the trace by id', () => {
-    mock.expects('fetchTrace').withExactArgs(id);
     jaegerApiActions.fetchTrace(id);
-    expect(() => mock.verify()).not.toThrow();
+    expect(JaegerAPI.fetchTrace).toHaveBeenCalledWith(id);
   });
 
   it('@JAEGER_API/FETCH_TRACE should return the promise', () => {
@@ -61,9 +67,8 @@ describe('actions/jaeger-api', () => {
   });
 
   it('@JAEGER_API/FETCH_MULTIPLE_TRACES should fetch traces by ids', () => {
-    mock.expects('searchTraces').withExactArgs(sinon.match.has('traceID', ids));
     jaegerApiActions.fetchMultipleTraces(ids);
-    expect(() => mock.verify()).not.toThrow();
+    expect(JaegerAPI.searchTraces).toHaveBeenCalledWith(expect.objectContaining({ traceID: ids }));
   });
 
   it('@JAEGER_API/FETCH_MULTIPLE_TRACES should return the promise', () => {
@@ -77,9 +82,8 @@ describe('actions/jaeger-api', () => {
   });
 
   it('@JAEGER_API/ARCHIVE_TRACE should archive the trace by id', () => {
-    mock.expects('archiveTrace').withExactArgs(id);
     jaegerApiActions.archiveTrace(id);
-    expect(() => mock.verify()).not.toThrow();
+    expect(JaegerAPI.archiveTrace).toHaveBeenCalledWith(id);
   });
 
   it('@JAEGER_API/ARCHIVE_TRACE should return the promise', () => {
@@ -93,9 +97,8 @@ describe('actions/jaeger-api', () => {
   });
 
   it('@JAEGER_API/SEARCH_TRACES should fetch the trace by id', () => {
-    mock.expects('searchTraces').withExactArgs(query);
     jaegerApiActions.searchTraces(query);
-    expect(() => mock.verify()).not.toThrow();
+    expect(JaegerAPI.searchTraces).toHaveBeenCalledWith(query);
   });
 
   it('@JAEGER_API/SEARCH_TRACES should return the promise', () => {
@@ -114,21 +117,20 @@ describe('actions/jaeger-api', () => {
   });
 
   it('@JAEGER_API/FETCH_SERVICE_OPERATIONS should call the JaegerAPI', () => {
-    const called = mock.expects('fetchServiceOperations').once().withExactArgs('service');
     jaegerApiActions.fetchServiceOperations('service');
-    expect(called.verify()).toBeTruthy();
+    expect(JaegerAPI.fetchServiceOperations).toHaveBeenCalledTimes(1);
+    expect(JaegerAPI.fetchServiceOperations).toHaveBeenCalledWith('service');
   });
 
   it('@JAEGER_API/FETCH_SERVICE_SERVER_OP should call the JaegerAPI', () => {
-    const called = mock.expects('fetchServiceServerOps').once().withExactArgs('service');
     jaegerApiActions.fetchServiceServerOps('service');
-    expect(called.verify()).toBeTruthy();
+    expect(JaegerAPI.fetchServiceServerOps).toHaveBeenCalledTimes(1);
+    expect(JaegerAPI.fetchServiceServerOps).toHaveBeenCalledWith('service');
   });
 
   it('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should fetch the graph by params', () => {
-    mock.expects('fetchDeepDependencyGraph').withExactArgs(query);
     jaegerApiActions.fetchDeepDependencyGraph(query);
-    expect(() => mock.verify()).not.toThrow();
+    expect(JaegerAPI.fetchDeepDependencyGraph).toHaveBeenCalledWith(query);
   });
 
   it('@JAEGER_API/FETCH_DEEP_DEPENDENCY_GRAPH should return the promise', () => {
@@ -142,9 +144,8 @@ describe('actions/jaeger-api', () => {
   });
 
   it('@JAEGER_API/FETCH_DEPENDENCIES should call the JaegerAPI', () => {
-    const called = mock.expects('fetchDependencies').once();
     jaegerApiActions.fetchDependencies();
-    expect(called.verify()).toBeTruthy();
+    expect(JaegerAPI.fetchDependencies).toHaveBeenCalledTimes(1);
   });
 
   it('@JAEGER_API/FETCH_ALL_SERVICE_METRICS should return the promise', () => {
@@ -153,13 +154,8 @@ describe('actions/jaeger-api', () => {
   });
 
   it('@JAEGER_API/FETCH_ALL_SERVICE_METRICS should fetch service metrics by name', () => {
-    mock.expects('fetchMetrics');
-    mock.expects('fetchMetrics');
-    mock.expects('fetchMetrics');
-    mock.expects('fetchMetrics');
-    mock.expects('fetchMetrics');
     jaegerApiActions.fetchAllServiceMetrics('serviceName', query);
-    expect(() => mock.verify()).not.toThrow();
+    expect(JaegerAPI.fetchMetrics).toHaveBeenCalledTimes(5);
   });
 
   it('@JAEGER_API/FETCH_AGGREGATED_SERVICE_METRICS should return the promise', () => {
@@ -168,10 +164,7 @@ describe('actions/jaeger-api', () => {
   });
 
   it('@JAEGER_API/FETCH_AGGREGATED_SERVICE_METRICS should fetch service metrics by name', () => {
-    mock.expects('fetchMetrics');
-    mock.expects('fetchMetrics');
-    mock.expects('fetchMetrics');
     jaegerApiActions.fetchAggregatedServiceMetrics('serviceName', query);
-    expect(() => mock.verify()).not.toThrow();
+    expect(JaegerAPI.fetchMetrics).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -71,7 +71,6 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import sinon from 'sinon';
 
 import {
   makeShortcutCallbacks,
@@ -383,16 +382,16 @@ describe('<TracePage>', () => {
   });
 
   it('fetches the trace if necessary', () => {
-    const fetchTrace = sinon.spy();
+    const fetchTrace = jest.fn();
     render(<TracePage {...defaultProps} trace={null} fetchTrace={fetchTrace} />);
-    expect(fetchTrace.called).toBeTruthy();
-    expect(fetchTrace.calledWith(trace.traceID)).toBe(true);
+    expect(fetchTrace).toHaveBeenCalled();
+    expect(fetchTrace).toHaveBeenCalledWith(trace.traceID);
   });
 
   it("doesn't fetch the trace if already present", () => {
-    const fetchTrace = sinon.spy();
+    const fetchTrace = jest.fn();
     render(<TracePage {...defaultProps} fetchTrace={fetchTrace} />);
-    expect(fetchTrace.called).toBeFalsy();
+    expect(fetchTrace).not.toHaveBeenCalled();
   });
 
   it('resets the view range when the trace changes', () => {

--- a/packages/jaeger-ui/src/utils/sort.test.js
+++ b/packages/jaeger-ui/src/utils/sort.test.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import sinon from 'sinon';
-
 import * as sortUtils from './sort';
 
 it('localeStringComparator() provides a case-insensitive sort', () => {
@@ -82,7 +80,7 @@ it('createSortClickHandler() should return a function', () => {
   const column = { name: 'alpha' };
   const currentSortKey = 'alpha';
   const currentSortDir = 1;
-  const updateSort = sinon.spy();
+  const updateSort = jest.fn();
 
   expect(typeof sortUtils.createSortClickHandler(column, currentSortKey, currentSortDir, updateSort)).toBe(
     'function'
@@ -94,16 +92,12 @@ it('createSortClickHandler() should call updateSort with the new sort vals', () 
   const prevSort = { key: 'alpha', dir: 1 };
   const currentSortKey = prevSort.key;
   const currentSortDir = prevSort.dir;
-  const updateSort = sinon.spy();
+  const updateSort = jest.fn();
 
   const clickHandler = sortUtils.createSortClickHandler(column, currentSortKey, currentSortDir, updateSort);
 
   clickHandler();
 
-  expect(
-    updateSort.calledWith(
-      sortUtils.getNewSortForClick(prevSort, column).key,
-      sortUtils.getNewSortForClick(prevSort, column).dir
-    )
-  ).toBeTruthy();
+  const newSort = sortUtils.getNewSortForClick(prevSort, column);
+  expect(updateSort).toHaveBeenCalledWith(newSort.key, newSort.dir);
 });


### PR DESCRIPTION
Part of #3147

There was minimal usage of sinon, easily replaced with jest mocks.