### PR TITLE
Resolves #3175 - Nav-highlight not working

### DIFF
--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -21,9 +21,9 @@ import { getConfigValue } from '../../utils/config/get-config';
 import prefixUrl from '../../utils/prefix-url';
 
 import './TopNav.css';
-import withRouteProps from '../../utils/withRouteProps';
+import withRouteProps, { IWithRouteProps } from '../../utils/withRouteProps';
 
-type Props = ReduxState;
+type Props = ReduxState & IWithRouteProps;
 
 const NAV_LINKS = [
   {
@@ -108,8 +108,7 @@ const itemsGlobalLeft: MenuProps['items'] = [
 ];
 
 export function TopNavImpl(props: Props) {
-  const { config, router } = props;
-  const { pathname } = router.location;
+  const { config, pathname } = props;
   const menuItems = Array.isArray(config.menu) ? config.menu : [];
 
   const itemsGlobalRight: MenuProps['items'] = [


### PR DESCRIPTION
## Which problem is this PR solving?
The highlighting of the current tab in the main nav bar is broken

## Description of the changes
- Destructure pathname from props to get the updated pathname passed down from withRouteProps rather than Redux.
- Update Props type to include IWithRouteProps as well as ReduxState.

## How was this change tested?
With ```npm test -- --coverage```
*Test Suites: 205 passed, 205 total
*Tests:       2263 passed, 2263 total
*Snapshots:   3 passed, 3 total
*Time:        51.924 s, estimated 71 s
Ran all test suites.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
