### PR TITLE
Fix DDG minimap border

### DIFF
--- a/packages/jaeger-ui/src/components/common/utils.css
+++ b/packages/jaeger-ui/src/components/common/utils.css
@@ -104,7 +104,7 @@ SPDX-License-Identifier: Apache-2.0
   left: 0;
   right: 0;
   bottom: 0;
-  outline: 1px solid var(--border-subtle);
+  outline: 1px solid var(--border-strongest);
 }
 
 .u-miniMap > .plexus-MiniMap--map {

--- a/packages/jaeger-ui/src/components/common/vars.css
+++ b/packages/jaeger-ui/src/components/common/vars.css
@@ -46,6 +46,7 @@ SPDX-License-Identifier: Apache-2.0
   --border-default: #e6e6e6;
   --border-subtle: rgba(0, 0, 0, 0.15);
   --border-strong: #d3d3d3;
+  --border-strongest: #777;
 
   /* ============================================
     INTERACTIVE TOKENS (Buttons, Links, Form Controls)


### PR DESCRIPTION
Part of #1911 

The previous change made the minimap border barely visible, this puts it back.