### PR TITLE
Use outlined tags for contrast

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -85,11 +85,11 @@ export default function ResultItem({
       <Link to={linkTo}>
         <Row>
           <Col span={4} className="ub-p2">
-            <Tag className="ub-m1" data-testid={markers.NUM_SPANS}>
+            <Tag className="ub-m1" data-testid={markers.NUM_SPANS} variant="outlined">
               {numSpans} Span{numSpans > 1 && 's'}
             </Tag>
             {Boolean(numErredSpans) && (
-              <Tag className="ub-m1" color="red">
+              <Tag className="ub-m1" color="red" variant="outlined">
                 {numErredSpans} Error{numErredSpans > 1 && 's'}
               </Tag>
             )}
@@ -103,6 +103,7 @@ export default function ResultItem({
                     <Tag
                       className="ResultItem--serviceTag"
                       style={{ borderLeftColor: colorGenerator.getColorByKey(name) }}
+                      variant="outlined"
                     >
                       {erroredServices.has(name) && <IoAlert className="ResultItem--errorIcon" />}
                       {name} ({count})


### PR DESCRIPTION
See: https://github.com/jaegertracing/jaeger-ui/pull/3193#issuecomment-3610048456

Before:

<img width="720" height="254" alt="image" src="https://github.com/user-attachments/assets/046bb76a-cd7b-4a6c-91cf-ba810ea14e57" />

After:

<img width="696" height="246" alt="image" src="https://github.com/user-attachments/assets/30b1eb74-e042-4d09-bbd4-3a4dc6cb29a9" />