### PR TITLE
ui: recognize otel.status_code=ERROR as error span

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
@@ -58,6 +58,7 @@ describe('TraceTimelineViewer/utils', () => {
       { fn: isServerSpan, name: 'isServerSpan', key: 'span.kind', value: 'server' },
       { fn: isErrorSpan, name: 'isErrorSpan', key: 'error', value: true },
       { fn: isErrorSpan, name: 'isErrorSpan', key: 'error', value: 'true' },
+      { fn: isErrorSpan, name: 'isErrorSpan', key: 'otel.status_code', value: 'ERROR' },
     ];
 
     spanTypeTestCases.forEach(testCase => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.tsx
@@ -63,7 +63,9 @@ export const isServerSpan = spanHasTag.bind(null, 'span.kind', 'server');
 
 const isErrorBool = spanHasTag.bind(null, 'error', true);
 const isErrorStr = spanHasTag.bind(null, 'error', 'true');
-export const isErrorSpan = (span: Span) => isErrorBool(span) || isErrorStr(span);
+const isOtelError = (span: Span) =>
+  span.tags?.some(({ key, value }) => key === 'otel.status_code' && String(value).toUpperCase() === 'ERROR');
+export const isErrorSpan = (span: Span) => isErrorBool(span) || isErrorStr(span) || isOtelError(span);
 
 /**
  * Returns `true` if at least one of the descendants of the `parentSpanIndex`


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves jaegertracing/jaeger#7696

## Description of the changes
- Treat spans with `otel.status_code=ERROR` as error spans in the Jaeger UI.
- This ensures error highlighting and filtering work correctly for OpenTelemetry-generated traces.

## How was this change tested?
- Updated unit tests in `TraceTimelineViewer/utils.test.js`
- Ran `npm run test` locally and verified all tests pass.

## Checklist
- [x] I have read the contributing guidelines
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
