### PR TITLE
fix: [Bug]: Clicking on Services dropdown's icon opens and closes it immediately

### DIFF
--- a/packages/jaeger-ui/src/components/common/SearchableSelect.tsx
+++ b/packages/jaeger-ui/src/components/common/SearchableSelect.tsx
@@ -58,7 +58,43 @@ export type SearchableSelectProps = SelectProps & {
  */
 const SearchableSelect: FunctionComponent<SearchableSelectProps> = ({ fuzzy, ...props }) => {
   const filterOption = fuzzy ? filterOptionsFuzzy : filterOptionsByLabel;
-  return <Select showSearch filterOption={filterOption} {...props} />;
+
+  // Handle the specific arrow click issue in Ant Design v6
+  const handleMouseDown = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+
+    // Check if the click is on the arrow icon specifically
+    // We need to be precise here to avoid interfering with option clicks
+    const isArrowIcon = target.classList.contains('ant-select-arrow') ||
+                       (target.closest('.ant-select-arrow') !== null &&
+                        !target.closest('.ant-select-dropdown'));
+
+    if (isArrowIcon) {
+      // Prevent the default mousedown behavior on the arrow which can cause
+      // the dropdown to close immediately after opening
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Manually trigger the click to open the dropdown by simulating a click
+      // on the selector area instead of the arrow
+      const selectElement = target.closest('.ant-select') as HTMLElement;
+      if (selectElement) {
+        const selector = selectElement.querySelector('.ant-select-selector') as HTMLElement;
+        if (selector) {
+          selector.click();
+        }
+      }
+    }
+  };
+
+  return (
+    <Select
+      showSearch
+      filterOption={filterOption}
+      onMouseDown={handleMouseDown}
+      {...props}
+    />
+  );
 };
 
 export default SearchableSelect;


### PR DESCRIPTION
## Summary

Fixes the dropdown arrow click behavior in the Services and Operations comboboxes on the Search page.

## Root Cause

In Ant Design v6, clicking on the dropdown arrow icon (`.ant-select-arrow`) triggers a `mousedown` event that causes the dropdown to immediately close after opening. This happens because the arrow icon's default mousedown behavior conflicts with the dropdown's open/close state management.

## Solution

Added a `handleMouseDown` event handler to `SearchableSelect` that:
1. Detects clicks specifically on the arrow icon element
2. Prevents the default mousedown behavior using `e.preventDefault()` and `e.stopPropagation()`
3. Manually triggers a click on the selector area (`.ant-select-selector`) instead, which properly opens and keeps the dropdown open

This approach targets only the arrow icon clicks without interfering with normal dropdown option selection.

## Testing

- Clicking on the dropdown arrow now opens and keeps the dropdown open
- Clicking on the main body of the dropdown still works as expected
- Selecting options from the dropdown works correctly

---
🤖 Changes prepared with assistance from OSS-Agent