### PR TITLE
Move theme vars back to root

### DIFF
--- a/packages/jaeger-ui/src/components/App/ThemeProvider.test.tsx
+++ b/packages/jaeger-ui/src/components/App/ThemeProvider.test.tsx
@@ -5,10 +5,8 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 
-import AppThemeProvider, { __themeTestInternals, useThemeMode } from './ThemeProvider';
-
-const THEME_STORAGE_KEY = 'jaeger-ui-theme';
-
+import AppThemeProvider, { useThemeMode } from './ThemeProvider';
+import { THEME_STORAGE_KEY } from './ThemeStorage';
 import { getConfigValue } from '../../utils/config/get-config';
 
 jest.mock('../../utils/config/get-config', () => ({
@@ -228,51 +226,6 @@ describe('AppThemeProvider', () => {
     const context = observer.mock.calls[0][0];
     expect(context.setMode('dark')).toBeUndefined();
     expect(context.toggleMode()).toBeUndefined();
-  });
-
-  it('short-circuits storage helpers when no window is available', () => {
-    expect(__themeTestInternals.readStoredTheme(null)).toBeNull();
-    expect(() => __themeTestInternals.writeStoredTheme('dark', null)).not.toThrow();
-  });
-
-  it('honors injected window overrides when reading and writing storage', () => {
-    const getItem = jest.fn(() => 'dark');
-    const setItem = jest.fn();
-    const fakeWindow = {
-      localStorage: { getItem, setItem },
-    } as unknown as Window;
-
-    expect(__themeTestInternals.readStoredTheme(fakeWindow)).toBe('dark');
-    __themeTestInternals.writeStoredTheme('light', fakeWindow);
-
-    expect(getItem).toHaveBeenCalledWith('jaeger-ui-theme');
-    expect(setItem).toHaveBeenCalledWith('jaeger-ui-theme', 'light');
-  });
-
-  it('uses the global window when no override is provided', () => {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
-    expect(__themeTestInternals.readStoredTheme()).toBe('dark');
-    expect(__themeTestInternals.readStoredTheme(undefined)).toBe('dark');
-
-    const setItem = jest.spyOn(Storage.prototype, 'setItem');
-    try {
-      __themeTestInternals.writeStoredTheme('light');
-      expect(setItem).toHaveBeenCalledWith(THEME_STORAGE_KEY, 'light');
-    } finally {
-      setItem.mockRestore();
-    }
-  });
-
-  it('falls back gracefully when the global window is unavailable', () => {
-    const originalWindow = window;
-    (global as typeof global & { window?: Window }).window = undefined;
-
-    try {
-      expect(__themeTestInternals.readStoredTheme()).toBeNull();
-      expect(() => __themeTestInternals.writeStoredTheme('dark')).not.toThrow();
-    } finally {
-      (global as typeof global & { window?: Window }).window = originalWindow;
-    }
   });
 
   it('skips updating document body when document is undefined', () => {

--- a/packages/jaeger-ui/src/components/App/ThemeStorage.test.ts
+++ b/packages/jaeger-ui/src/components/App/ThemeStorage.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { THEME_STORAGE_KEY, readStoredTheme, writeStoredTheme, getInitialTheme } from './ThemeStorage';
+import { getConfigValue } from '../../utils/config/get-config';
+
+jest.mock('../../utils/config/get-config', () => ({
+  getConfigValue: jest.fn(),
+}));
+
+function setupMatchMedia(matches = false) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
+
+describe('ThemeStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    setupMatchMedia(false);
+    (getConfigValue as jest.Mock).mockImplementation(key => {
+      if (key === 'themes.enabled') {
+        return true;
+      }
+      return undefined;
+    });
+  });
+
+  describe('readStoredTheme', () => {
+    it('returns stored theme when present and valid', () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+      expect(readStoredTheme()).toBe('dark');
+    });
+
+    it('returns null when stored theme is invalid', () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, 'invalid');
+      expect(readStoredTheme()).toBeNull();
+    });
+
+    it('returns null when no theme is stored', () => {
+      expect(readStoredTheme()).toBeNull();
+    });
+
+    it('returns null and suppresses error when global window is blocked/unavailable', () => {
+      const originalGetItem = window.localStorage.getItem;
+      window.localStorage.getItem = jest.fn(() => {
+        throw new Error('blocked');
+      });
+
+      try {
+        expect(readStoredTheme()).toBeNull();
+      } finally {
+        window.localStorage.getItem = originalGetItem;
+      }
+    });
+
+    it('honors injected window override', () => {
+      const getItem = jest.fn(() => 'dark');
+      const fakeWindow = {
+        localStorage: { getItem },
+      } as unknown as Window;
+
+      expect(readStoredTheme(fakeWindow)).toBe('dark');
+      expect(getItem).toHaveBeenCalledWith(THEME_STORAGE_KEY);
+    });
+
+    it('short-circuits when null window is provided', () => {
+      expect(readStoredTheme(null)).toBeNull();
+    });
+
+    it('falls back gracefully when the global window is unavailable', () => {
+      const originalWindow = window;
+      (global as typeof global & { window?: Window }).window = undefined;
+
+      try {
+        expect(readStoredTheme()).toBeNull();
+      } finally {
+        (global as typeof global & { window?: Window }).window = originalWindow;
+      }
+    });
+  });
+
+  describe('writeStoredTheme', () => {
+    it('writes theme to localStorage', () => {
+      writeStoredTheme('dark');
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    });
+
+    it('suppresses errors when localStorage is full or blocked', () => {
+      const originalSetItem = window.localStorage.setItem;
+      window.localStorage.setItem = jest.fn(() => {
+        throw new Error('quota exceeded');
+      });
+
+      try {
+        expect(() => writeStoredTheme('dark')).not.toThrow();
+      } finally {
+        window.localStorage.setItem = originalSetItem;
+      }
+    });
+
+    it('honors injected window override', () => {
+      const setItem = jest.fn();
+      const fakeWindow = {
+        localStorage: { setItem },
+      } as unknown as Window;
+
+      writeStoredTheme('light', fakeWindow);
+      expect(setItem).toHaveBeenCalledWith(THEME_STORAGE_KEY, 'light');
+    });
+
+    it('short-circuits when null window is provided', () => {
+      expect(() => writeStoredTheme('dark', null)).not.toThrow();
+    });
+
+    it('falls back gracefully when the global window is unavailable', () => {
+      const originalWindow = window;
+      (global as typeof global & { window?: Window }).window = undefined;
+
+      try {
+        expect(() => writeStoredTheme('dark')).not.toThrow();
+      } finally {
+        (global as typeof global & { window?: Window }).window = originalWindow;
+      }
+    });
+  });
+
+  describe('getInitialTheme', () => {
+    it('returns default mode when themes are disabled', () => {
+      (getConfigValue as jest.Mock).mockReturnValue(false);
+      window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+      expect(getInitialTheme()).toBe('light');
+    });
+
+    it('prefers stored theme when present', () => {
+      window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+      expect(getInitialTheme()).toBe('dark');
+    });
+
+    it('prefers system preference when no stored theme', () => {
+      setupMatchMedia(true);
+      expect(getInitialTheme()).toBe('dark');
+    });
+
+    it('falls back to default mode when no preference or stored theme', () => {
+      expect(getInitialTheme()).toBe('light');
+    });
+  });
+});

--- a/packages/jaeger-ui/src/components/App/ThemeStorage.ts
+++ b/packages/jaeger-ui/src/components/App/ThemeStorage.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getConfigValue } from '../../utils/config/get-config';
+
+export type ThemeMode = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'jaeger-ui-theme';
+export const DEFAULT_MODE: ThemeMode = 'light';
+
+export function readStoredTheme(targetWindow?: Window | null): ThemeMode | null {
+  const activeWindow =
+    targetWindow !== undefined
+      ? (targetWindow ?? undefined)
+      : typeof window !== 'undefined'
+        ? window
+        : undefined;
+  if (!activeWindow) {
+    return null;
+  }
+
+  try {
+    const stored = activeWindow.localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode | null;
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+  } catch (err) {
+    // Local storage may be blocked; ignore and fallback below.
+  }
+
+  return null;
+}
+
+export function writeStoredTheme(mode: ThemeMode, targetWindow?: Window | null) {
+  const activeWindow =
+    targetWindow !== undefined
+      ? (targetWindow ?? undefined)
+      : typeof window !== 'undefined'
+        ? window
+        : undefined;
+  if (!activeWindow) {
+    return;
+  }
+
+  try {
+    activeWindow.localStorage.setItem(THEME_STORAGE_KEY, mode);
+  } catch (err) {
+    // Ignore storage errors (e.g., Safari in private mode).
+  }
+}
+
+export function getInitialTheme(): ThemeMode {
+  if (!getConfigValue('themes.enabled')) {
+    return DEFAULT_MODE;
+  }
+  const stored = readStoredTheme();
+  if (stored) {
+    return stored;
+  }
+
+  if (
+    typeof window !== 'undefined' &&
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  ) {
+    return 'dark';
+  }
+
+  return DEFAULT_MODE;
+}

--- a/packages/jaeger-ui/src/components/App/ThemeTokenSync.test.tsx
+++ b/packages/jaeger-ui/src/components/App/ThemeTokenSync.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { theme } from 'antd';
+import { ThemeTokenSync } from './ThemeTokenSync';
+
+jest.mock('antd', () => ({
+  theme: {
+    useToken: jest.fn(),
+  },
+}));
+
+describe('ThemeTokenSync', () => {
+  let setPropertySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setPropertySpy = jest.spyOn(document.documentElement.style, 'setProperty');
+  });
+
+  afterEach(() => {
+    setPropertySpy.mockRestore();
+  });
+
+  it('syncs design tokens to CSS variables on :root', () => {
+    const mockTokens = {
+      colorBgContainer: '#ffffff',
+      colorPrimary: '#1890ff',
+      fontSize: 14,
+      borderRadius: 4,
+    };
+
+    (theme.useToken as jest.Mock).mockReturnValue({ token: mockTokens });
+
+    render(<ThemeTokenSync />);
+
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-color-bg-container', '#ffffff');
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-color-primary', '#1890ff');
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-font-size', '14');
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-border-radius', '4');
+    expect(setPropertySpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('handles camelCase to kebab-case conversion correctly', () => {
+    const mockTokens = {
+      someLongCamelCaseToken: 'value',
+    };
+
+    (theme.useToken as jest.Mock).mockReturnValue({ token: mockTokens });
+
+    render(<ThemeTokenSync />);
+
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-some-long-camel-case-token', 'value');
+  });
+
+  it('ignores nested objects and only syncs strings and numbers', () => {
+    const mockTokens = {
+      validString: 'hello',
+      validNumber: 123,
+      invalidObject: { some: 'nested' },
+      invalidArray: [1, 2, 3],
+      invalidNull: null,
+      invalidUndefined: undefined,
+    };
+
+    (theme.useToken as jest.Mock).mockReturnValue({ token: mockTokens });
+
+    render(<ThemeTokenSync />);
+
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-valid-string', 'hello');
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-valid-number', '123');
+    // Only 2 should be called (string and number)
+    expect(setPropertySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates CSS variables when tokens change', () => {
+    const { rerender } = render(<ThemeTokenSync />);
+
+    const tokens1 = { colorPrimary: 'blue' };
+    (theme.useToken as jest.Mock).mockReturnValue({ token: tokens1 });
+    rerender(<ThemeTokenSync />);
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-color-primary', 'blue');
+
+    setPropertySpy.mockClear();
+
+    const tokens2 = { colorPrimary: 'red' };
+    (theme.useToken as jest.Mock).mockReturnValue({ token: tokens2 });
+    rerender(<ThemeTokenSync />);
+    expect(setPropertySpy).toHaveBeenCalledWith('--ant-color-primary', 'red');
+  });
+});

--- a/packages/jaeger-ui/src/components/App/ThemeTokenSync.tsx
+++ b/packages/jaeger-ui/src/components/App/ThemeTokenSync.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { theme } from 'antd';
+import { useEffect } from 'react';
+
+/**
+ * ThemeTokenSync acts as a bridge between Ant Design's CSS-in-JS design tokens
+ * and global CSS variables.
+ *
+ * ### Why is this needed?
+ *
+ * Ant Design v6 injects design tokens into a local scope (usually the `.ant-layout` container).
+ * Elements rendered via Portals (Modals, Tooltips, Drawers) or those with `position: fixed`
+ * often live outside this scope in the DOM tree, causing `--ant-` variables to be undefined.
+ *
+ * ### What it does:
+ *
+ * 1. Hooks into the current AntD theme context via `theme.useToken()`.
+ * 2. Iterates through all tokens (e.g., `colorBgContainer`).
+ * 3. Converts them to kebab-case CSS variables (e.g., `--ant-color-bg-container`).
+ * 4. Injects them into the `:root` (`<html>`) element, making them globally accessible
+ *    to custom CSS variables like `--surface-primary: var(--ant-color-bg-container)`.
+ *
+ * @example
+ *   <ConfigProvider theme={...}>
+ *     <ThemeTokenSync />
+ *     <App />
+ *   </ConfigProvider>
+ */
+export function ThemeTokenSync(): null {
+  const { token } = theme.useToken();
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    // Helper to convert camelCase to kebab-case
+    const toKebabCase = (str: string) => str.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
+
+    // Map every design token to a CSS variable
+    Object.entries(token).forEach(([key, value]) => {
+      // We prefix with --ant to match your existing custom vars
+      // and check if the value is a string or number (avoiding nested objects)
+      if (typeof value === 'string' || typeof value === 'number') {
+        root.style.setProperty(`--ant-${toKebabCase(key)}`, String(value));
+      }
+    });
+  }, [token]);
+
+  return null;
+}

--- a/packages/jaeger-ui/src/components/App/index.tsx
+++ b/packages/jaeger-ui/src/components/App/index.tsx
@@ -30,7 +30,7 @@ import '../common/utils.css';
 import 'antd/dist/reset.css';
 import './index.css';
 import { store } from '../../utils/configure-store';
-import AppThemeProvider from './ThemeProvider';
+import ThemeProvider from './ThemeProvider';
 
 export default class JaegerUIApp extends Component<{}> {
   constructor(props: {}) {
@@ -41,7 +41,7 @@ export default class JaegerUIApp extends Component<{}> {
 
   render() {
     return (
-      <AppThemeProvider>
+      <ThemeProvider>
         <Provider store={store as any}>
           {
             // the Page component is a connected component (wrapped by Redux's connect HOC)
@@ -90,7 +90,7 @@ export default class JaegerUIApp extends Component<{}> {
             </Switch>
           </Page>
         </Provider>
-      </AppThemeProvider>
+      </ThemeProvider>
     );
   }
 }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
@@ -27,7 +27,7 @@ SPDX-License-Identifier: Apache-2.0
 .TracePageHeader--back {
   align-items: center;
   align-self: stretch;
-  background-color: #fafafa;
+  background-color: var(--surface-secondary);
   border-bottom: 1px solid #ddd;
   border-right: 1px solid #ddd;
   color: inherit;

--- a/packages/jaeger-ui/src/components/common/vars.css
+++ b/packages/jaeger-ui/src/components/common/vars.css
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
  * New naming scheme follows semantic conventions for better maintainability.
  */
 
-.ant-layout {
+:root {
   /* ============================================
     SURFACE TOKENS (Backgrounds)
     Based on audit of background/background-color properties
@@ -113,7 +113,7 @@ SPDX-License-Identifier: Apache-2.0
   --trace-emphasis-highlight: #fff3d7;
 }
 
-[data-theme='dark'] .ant-layout {
+:root[data-theme='dark'] {
   /* ============================================
     SURFACE TOKENS (Backgrounds)
     ============================================ */


### PR DESCRIPTION
As raised in https://github.com/jaegertracing/jaeger-ui/pull/3246#issuecomment-3693078955, some of the "portals" like tooltips, dropdowns, etc. are not attached to the div that has the `.ant-layout` class, so our custom theme variables were not visible to those components.

This changes moves the definition of our custom variables back to `:root`, but also adds a manual sync of AntD variables retrieved via `theme.useToken` into the same root node (the new ThemeTokenSync component).

Additional refactoring - the utility functions for saving/loading theme setting into local storage are moved into a separate ThemeStorage module.