### PR TITLE
Fix in-trace search

### DIFF
--- a/packages/jaeger-ui/src/index.tsx
+++ b/packages/jaeger-ui/src/index.tsx
@@ -7,12 +7,13 @@
 import './site-prefix';
 
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import { CompatRouter } from 'react-router-dom-v5-compat';
 import { createRoot } from 'react-dom/client';
 
 import JaegerUIApp from './components/App';
 import { context as trackingContext } from './utils/tracking';
+import { history } from './utils/configure-store';
 
 // these need to go after the App import
 
@@ -34,19 +35,19 @@ const root = createRoot(rootElement);
 if (typeof trackingContext === 'object' && trackingContext !== null) {
   (trackingContext as any).context(() => {
     root.render(
-      <BrowserRouter>
+      <Router history={history}>
         <CompatRouter>
           <JaegerUIApp />
         </CompatRouter>
-      </BrowserRouter>
+      </Router>
     );
   });
 } else {
   root.render(
-    <BrowserRouter>
+    <Router history={history}>
       <CompatRouter>
         <JaegerUIApp />
       </CompatRouter>
-    </BrowserRouter>
+    </Router>
   );
 }


### PR DESCRIPTION
Attempt to resolve #3249, AI-generated.

Fix the search functionality regression by unifying the history management in index.tsx.

The issue was caused by a mismatch between the history instance used by the Redux store and the one used by BrowserRouter. By switching to a plain Router with the shared history object, all URL updates are now correctly synchronized.

<img width="1168" height="641" alt="image" src="https://github.com/user-attachments/assets/52bd0ce7-952b-40fa-8354-6b88c91d164f" />
