### PR TITLE
Enable theme selector by default

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.css
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   padding-top: 0.3%;
   padding-bottom: 0.3%;
   padding-left: 0.4%;
-  background: rgb(236, 236, 236);
+  background: var(--surface-tertiary);
   margin-bottom: 0%;
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.css
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   padding-top: 0.3%;
   padding-bottom: 0.3%;
   padding-left: 0.4%;
-  background: rgb(236, 236, 236);
+  background: var(--surface-tertiary);
   margin-bottom: 0%;
 }
 
@@ -19,10 +19,10 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .MainTableData--TraceStatistics {
-  border-top: 1px solid rgb(255, 255, 255);
+  border-top: 1px solid var(--border-strong);
 }
 
 .MainTableData--TraceStatistics:hover {
-  background: rgb(250, 250, 250);
-  color: rgb(0, 0, 0);
+  background: var(--surface-component-background-hover);
+  color: var(--text-primary);
 }

--- a/packages/jaeger-ui/src/constants/default-config.tsx
+++ b/packages/jaeger-ui/src/constants/default-config.tsx
@@ -114,7 +114,7 @@ const defaultConfig: Config = {
     helpLink: 'https://medium.com/jaegertracing/trace-comparisons-arrive-in-jaeger-1-7-a97ad5e2d05d',
   },
   themes: {
-    enabled: false,
+    enabled: true,
   },
 };
 


### PR DESCRIPTION
There can be future improvements but overall the dark theme looks usable now, so we can enable the theme selector by default.