### PR TITLE
Fix span detail panel in dark theme

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.css
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianKeyValues--header:hover {
-  background: #e8e8e8;
+  background: var(--surface-tertiary);
 }
 
 .AccordianKeyValues--header.is-empty {
@@ -21,11 +21,11 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianKeyValues--header.is-high-contrast:not(.is-empty):hover {
-  background: #ddd;
+  background: var(--surface-tertiary);
 }
 
 .AccordianKeyValues--emptyIcon {
-  color: #aaa;
+  color: var(--text-muted);
 }
 
 .AccordianKeyValues--summary {
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
   display: inline;
   margin-left: 0.7em;
   padding-right: 0.5rem;
-  border-right: 1px solid #ddd;
+  border-right: 1px solid var(--border-default);
 }
 
 .AccordianKeyValues--summaryItem:last-child {
@@ -47,10 +47,10 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianKeyValues--summaryLabel {
-  color: #777;
+  color: var(--text-secondary);
 }
 
 .AccordianKeyValues--summaryDelim {
-  color: #bbb;
+  color: var(--text-muted);
   padding: 0 0.2em;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
@@ -4,20 +4,20 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 .AccordianLogs {
-  border: 1px solid #d8d8d8;
+  border: 1px solid var(--border-default);
   position: relative;
   margin-bottom: 0.25rem;
 }
 
 .AccordianLogs--header {
-  background: #e4e4e4;
+  background: var(--surface-secondary);
   color: inherit;
   display: block;
   padding: 0.25rem 0.5rem;
 }
 
 .AccordianLogs--header:hover {
-  background: #dadada;
+  background: var(--surface-tertiary);
 }
 
 .AccordianLogs--toggle {
@@ -29,11 +29,11 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianLogs--content {
-  background: #f0f0f0;
-  border-top: 1px solid #d8d8d8;
+  background: var(--surface-primary);
+  border-top: 1px solid var(--border-default);
   padding: 0.5rem 0.5rem 0.25rem 0.5rem;
 }
 
 .AccordianLogs--footer {
-  color: #999;
+  color: var(--text-secondary);
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianReferences.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianReferences.css
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0
   margin: 0;
   background: var(--surface-primary);
 }
+
 .ReferencesList {
   background: var(--surface-primary);
   border: 1px solid var(--border-default);
@@ -40,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .SpanReference--debugLabel::before {
-  color: #bbb;
+  color: var(--text-muted);
   content: attr(data-label);
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 .KeyValueTable {
   background: var(--surface-primary);
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-default);
   margin-bottom: 0.7em;
   max-height: 450px;
   overflow: auto;
@@ -20,11 +20,11 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .KeyValueTable--row:nth-child(2n) > td {
-  background: #f5f5f5;
+  background: var(--surface-secondary);
 }
 
 .KeyValueTable--keyColumn {
-  color: #888;
+  color: var(--text-secondary);
   white-space: pre;
   width: 125px;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
@@ -29,24 +29,26 @@ SPDX-License-Identifier: Apache-2.0
 .SpanDetail--debugValue:hover {
   color: var(--text-primary);
 }
+
 .AccordianWarnings {
   background: var(--surface-tertiary);
   border: 1px solid var(--border-default);
   margin-bottom: 0.25rem;
 }
+
 .AccordianWarnings--header {
-  background: #fff7e6;
+  background: var(--ant-color-warning-bg);
   padding: 0.25rem 0.5rem;
 }
 
 .AccordianWarnings--header:hover {
-  background: #ffe7ba;
+  background: var(--ant-color-warning-bg-hover);
 }
 
 .AccordianWarnings--header.is-open {
-  border-bottom: 1px solid #e8e8e8;
+  border-bottom: 1px solid var(--border-default);
 }
 
 .AccordianWarnings--label {
-  color: #d36c08;
+  color: var(--feedback-warning);
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.css
@@ -38,8 +38,8 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .detail-info-wrapper {
-  background: #f5f5f5;
-  border: 1px solid #d3d3d3;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-strong);
   border-top: 3px solid;
   padding: 0.75rem;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -24,20 +24,20 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .json-markup-bool {
-  color: firebrick;
+  color: var(--syntax-bool);
 }
 
 .json-markup-string {
-  color: teal;
+  color: var(--syntax-string);
 }
 
 .json-markup-null,
 .json-markup-undefined {
-  color: gray;
+  color: var(--syntax-null);
 }
 
 .json-markup-number {
-  color: blue;
+  color: var(--syntax-number);
 }
 
 .json-markup-other {
@@ -50,7 +50,7 @@ SPDX-License-Identifier: Apache-2.0
 
 .json-markup-icon-expand::after {
   content: '\25B6';
-  color: black;
+  color: var(--text-primary);
   font-size: 12px;
 }
 
@@ -60,13 +60,13 @@ SPDX-License-Identifier: Apache-2.0
 
 .json-markup-icon-collapse::after {
   content: '\25BC';
-  color: black;
+  color: var(--text-primary);
   font-size: 12px;
 }
 
 .json-markup-collapse-content::after {
   content: '\2026';
-  color: black;
+  color: var(--text-primary);
   font-size: 18px;
   margin-right: 4px;
 }

--- a/packages/jaeger-ui/src/components/common/vars.css
+++ b/packages/jaeger-ui/src/components/common/vars.css
@@ -122,6 +122,15 @@ SPDX-License-Identifier: Apache-2.0
 
   /* Minimap / SpanGraph */
   --span-graph-inactive: rgba(216, 216, 216, 0.5);
+
+  /* ============================================
+    SYNTAX HIGHLIGHTING TOKENS
+    Used for JSON/KeyValue displays
+    ============================================ */
+  --syntax-string: #22863a;
+  --syntax-number: #005cc5;
+  --syntax-bool: #d73a49;
+  --syntax-null: #6a737d;
 }
 
 :root[data-theme='dark'] {
@@ -171,4 +180,12 @@ SPDX-License-Identifier: Apache-2.0
 
   /* Minimap / SpanGraph - dark mode needs visible inactive region */
   --span-graph-inactive: rgba(200, 200, 200, 0.25);
+
+  /* ============================================
+    SYNTAX HIGHLIGHTING TOKENS - Dark Mode
+    ============================================ */
+  --syntax-string: #79c0ff;
+  --syntax-number: #d2a8ff;
+  --syntax-bool: #ff7b72;
+  --syntax-null: #8b949e;
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #3282
- Addresses the readability of expanded span detail

## Description of the changes
- Updated the syntax highlighting in the KeyValueTable to use theme-aware CSS variables instead of hardcoded colors (like the brand teal for strings). This should make the values look more appropriate and improve readability in dark theme. Also updated the JSON expand/collapse icons to follow the theme.

## How was this change tested?
<img width="1140" height="388" alt="image" src="https://github.com/user-attachments/assets/1d8c5743-525e-46e5-acce-926d13285624" />
