### PR TITLE
fixes dark mode trace search buttons and text visibility

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.css
@@ -72,6 +72,8 @@ SPDX-License-Identifier: Apache-2.0
 .ant-input-group.ant-input-group-compact .TracePageSearchBar--ButtonClose {
   display: flex;
   align-items: center;
+  color: var(--text-secondary);
+  border-color: var(--border-default);
 }
 
 .ant-input-group.ant-input-group-compact .TracePageSearchBar--locateBtn svg,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianKeyValues.css
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianKeyValues--header:hover {
-  background: #e8e8e8;
+  background: var(--surface-tertiary);
 }
 
 .AccordianKeyValues--header.is-empty {
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianKeyValues--header.is-high-contrast:not(.is-empty):hover {
-  background: #ddd;
+  background: var(--surface-tertiary);
 }
 
 .AccordianKeyValues--emptyIcon {
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
   display: inline;
   margin-left: 0.7em;
   padding-right: 0.5rem;
-  border-right: 1px solid #ddd;
+  border-right: 1px solid var(--border-strong);
 }
 
 .AccordianKeyValues--summaryItem:last-child {
@@ -47,10 +47,10 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianKeyValues--summaryLabel {
-  color: #777;
+  color: var(--text-secondary);
 }
 
 .AccordianKeyValues--summaryDelim {
-  color: #bbb;
+  color: var(--text-muted);
   padding: 0 0.2em;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordianLogs.css
@@ -10,14 +10,14 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianLogs--header {
-  background: #e4e4e4;
+  background: var(--surface-primary);
   color: inherit;
   display: block;
   padding: 0.25rem 0.5rem;
 }
 
 .AccordianLogs--header:hover {
-  background: #dadada;
+  background: var(--surface-tertiary);
 }
 
 .AccordianLogs--toggle {
@@ -29,7 +29,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .AccordianLogs--content {
-  background: #f0f0f0;
+  background: var(--surface-primary);
   border-top: 1px solid #d8d8d8;
   padding: 0.5rem 0.5rem 0.25rem 0.5rem;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/KeyValuesTable.css
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 .KeyValueTable {
   background: var(--surface-primary);
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-strong);
   margin-bottom: 0.7em;
   max-height: 450px;
   overflow: auto;
@@ -20,11 +20,11 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .KeyValueTable--row:nth-child(2n) > td {
-  background: #f5f5f5;
+  background: var(--surface-primary);
 }
 
 .KeyValueTable--keyColumn {
-  color: #888;
+  color: var(--text-secondary);
   white-space: pre;
   width: 125px;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.css
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .detail-info-wrapper {
-  background: #f5f5f5;
+  background: var(--surface-primary);
   border: 1px solid #d3d3d3;
   border-top: 3px solid;
   padding: 0.75rem;


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3282 

## Description of the changes
- Replaced the hardcoded colors with the tokens defined in `packages/jaeger-ui/src/components/common/vars.css`, this made the text visible
- Applied the same with search bar buttons in `packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.css`, to fix the low contrast icons and borders

## How was this change tested?
- Verified the above mentioned in both dark mode and light mode (including the hover states)
- Both text and icons were readable and visible 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
