### PR TITLE
Enhance TraceStatistics styles for improved theming and hover effects

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.css
@@ -16,13 +16,38 @@ SPDX-License-Identifier: Apache-2.0
   color: rgb(153, 153, 153);
   font-style: italic;
   cursor: default;
+  background-color: transparent !important;
 }
 
 .MainTableData--TraceStatistics {
   border-top: 1px solid var(--border-strong);
+  background-color: var(--bg-2) !important;
 }
 
 .MainTableData--TraceStatistics:hover {
-  background: var(--surface-component-background-hover);
+  background-color: var(--bg-3) !important;
   color: var(--text-primary);
+}
+
+/* For table cells */
+.span-table .ant-table-cell {
+  background-color: inherit !important;
+}
+
+/* Default row background that adapts to theme */
+.span-table .ant-table-row {
+  background-color: var(--bg-1);
+}
+
+.span-table .ant-table-row:hover {
+  background-color: var(--bg-2);
+}
+
+/* Expanded rows */
+.span-table .ant-table-row-level-0 {
+  background-color: var(--bg-1);
+}
+
+.span-table .ant-table-row-level-1 {
+  background-color: var(--bg-2);
 }


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolve #3322 

## Description of the changes
- Now change the dark mode visibility.
-  In this PR, we fix the dark mode visibility issue in the tracks statistics section on this page.
- The issue occurred when switching to dark mode: the table rows did not change their theme and remained in light mode.
- This PR ensures that the table rows now properly adapt to the selected theme—dark mode applies dark styling, and light mode applies light styling.

## How was this change tested?
- npm run prettier
- npm run lint
- npm test
- npm run build

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`


## Befour

<img width="1819" height="874" alt="Screenshot From 2026-01-07 09-40-32" src="https://github.com/user-attachments/assets/3fb4575b-2fd1-444f-a1a1-c007358d4fe1" />

##  After

<img width="1819" height="874" alt="Screenshot From 2026-01-07 09-40-41" src="https://github.com/user-attachments/assets/37fbd1e8-606a-405d-ad2d-0767e2e464ea" />
