### PR TITLE
Fix dark mode in TraceGraph

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.css
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .TraceGraph--graphWrapper {
-  background: #f0f0f0;
+  background: var(--surface-primary);
   bottom: 0;
   cursor: move;
   left: 0;
@@ -24,18 +24,18 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .TraceGraph--graphWrapper.is-uiFind-mode {
-  background: #ddd;
+  background: var(--surface-secondary);
 }
 
 .TraceGraph--sidebar-container {
-  background: #f4f4f4;
+  background: var(--surface-secondary);
   display: flex;
   z-index: 1;
 }
 
 .TraceGraph--menu {
-  border-left: 1px solid #e4e4e4;
-  border-right: 1px solid #e4e4e4;
+  border-left: 1px solid var(--border-default);
+  border-right: 1px solid var(--border-default);
   cursor: pointer;
   padding: 0.8rem;
 }
@@ -71,8 +71,8 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .TraceGraph--miniMap > .plexus-MiniMap--item {
-  border: 1px solid #777;
-  background: #999;
+  border: 1px solid var(--border-default);
+  background: var(--surface-tertiary);
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
   margin-right: 1rem;
   position: relative;
@@ -86,13 +86,13 @@ SPDX-License-Identifier: Apache-2.0
 
 .TraceGraph--miniMap .plexus-MiniMap--mapActive {
   /* dynamic: width, height, transform */
-  background: #ccc;
+  background: var(--surface-secondary);
   position: absolute;
 }
 
 .TraceGraph--miniMap > .plexus-MiniMap--button {
-  background: #ccc;
-  color: #888;
+  background: var(--surface-secondary);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 1.6em;
   line-height: 0;
@@ -100,7 +100,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .TraceGraph--miniMap > .plexus-MiniMap--button:hover {
-  background: #ddd;
+  background: var(--surface-tertiary);
 }
 
 .TraceGraph--menu .ant-btn.active {


### PR DESCRIPTION

## Which problem is this PR solving?
fixes #3333 

## Description of the changes
-The Trace Graph view now properly respects the dark mode theme using design tokens instead of hardcoded colors, ensuring consistency across light and dark themes.
## How was this change tested?
- Before:
<img width="1800" height="1059" alt="Screenshot 2026-01-08 at 1 25 02 AM" src="https://github.com/user-attachments/assets/065c14ac-8669-45a4-a50b-dcc3e30b2bb7" />

- 
-After:
<img width="1796" height="1084" alt="Screenshot 2026-01-08 at 1 24 46 AM" src="https://github.com/user-attachments/assets/271dbcb2-436c-4f31-acb9-ef0573f0db1b" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
