### PR TITLE
refactor: convert TraceStatisticsHeader to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Checkbox, Select } from 'antd';
-import React, { Component } from 'react';
+import type { CheckboxChangeEvent } from 'antd/es/checkbox';
+import React, { useState, useEffect, useCallback } from 'react';
 import { IOtelTrace } from '../../../types/otel';
 import { ITableSpan } from './types';
 import { generateDropdownValue, generateSecondDropdownValue } from './generateDropdownValue';
@@ -24,14 +25,6 @@ type Props = {
   useOtelTerms: boolean;
 };
 
-type State = {
-  valueNameSelector1: string;
-  valueNameSelector2: string | null;
-  valueNameSelector3: string;
-
-  checkboxStatus: boolean;
-};
-
 const optionsNameSelector3 = new Map([
   ['Count', 'count'],
   ['Total', 'total'],
@@ -45,220 +38,188 @@ const optionsNameSelector3 = new Map([
   ['ST in Duration', 'percent'],
 ]);
 
-export default class TraceStatisticsHeader extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    const serviceName = getServiceName();
-    this.props.handler(
-      getColumnValues(serviceName, this.props.trace, this.props.useOtelTerms),
-      getColumnValues(serviceName, this.props.trace, this.props.useOtelTerms),
-      serviceName,
-      null
-    );
+export default function TraceStatisticsHeader(props: Props) {
+  const { trace, tableValue, wholeTable, handler, useOtelTerms } = props;
 
-    this.state = {
-      valueNameSelector1: serviceName,
-      valueNameSelector2: null,
-      valueNameSelector3: 'Count',
-      checkboxStatus: false,
-    };
-    this.setValueNameSelector1 = this.setValueNameSelector1.bind(this);
-    this.setValueNameSelector2 = this.setValueNameSelector2.bind(this);
-    this.setValueNameSelector3 = this.setValueNameSelector3.bind(this);
-    this.checkboxButton = this.checkboxButton.bind(this);
-    this.clearValue = this.clearValue.bind(this);
-  }
+  const [valueNameSelector1, setValueNameSelector1State] = useState<string>(getServiceName());
+  const [valueNameSelector2, setValueNameSelector2State] = useState<string | null>(null);
+  const [valueNameSelector3, setValueNameSelector3State] = useState<string>('Count');
+  const [checkboxStatus, setCheckboxStatus] = useState<boolean>(false);
 
   /**
    * Returns the value of optionsNameSelector3.
    */
-  getValue() {
-    let toColor = optionsNameSelector3.get(this.state.valueNameSelector3);
+  const getValue = useCallback(() => {
+    let toColor = optionsNameSelector3.get(valueNameSelector3);
     if (toColor === undefined) {
       toColor = '';
     }
     return toColor;
-  }
+  }, [valueNameSelector3]);
+
+  useEffect(() => {
+    const serviceName = getServiceName();
+    handler(
+      getColumnValues(serviceName, trace, useOtelTerms),
+      getColumnValues(serviceName, trace, useOtelTerms),
+      serviceName,
+      null
+    );
+  }, []);
 
   /**
    * Is called after a value from the first dropdown is selected.
    */
-  setValueNameSelector1(value: string) {
-    this.setState({
-      valueNameSelector1: value,
-      valueNameSelector2: null,
-    });
-    const newTableValue = generateColor(
-      getColumnValues(value, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
-    );
-    const newWohleTable = generateColor(
-      getColumnValues(value, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
-    );
-    this.props.handler(newTableValue, newWohleTable, value, null);
-  }
+  const setValueNameSelector1 = useCallback(
+    (value: string) => {
+      setValueNameSelector1State(value);
+      setValueNameSelector2State(null);
+      const newTableValue = generateColor(
+        getColumnValues(value, trace, useOtelTerms),
+        getValue(),
+        checkboxStatus
+      );
+      const newWholeTable = generateColor(
+        getColumnValues(value, trace, useOtelTerms),
+        getValue(),
+        checkboxStatus
+      );
+      handler(newTableValue, newWholeTable, value, null);
+    },
+    [trace, useOtelTerms, getValue, checkboxStatus, handler]
+  );
 
   /**
    * Is called after a value from the second dropdown is selected.
    */
-  setValueNameSelector2(value: string) {
-    this.setState({
-      valueNameSelector2: value,
-    });
-    const newTableValue = generateColor(
-      getColumnValuesSecondDropdown(
-        this.props.tableValue,
-        this.state.valueNameSelector1,
-        value,
-        this.props.trace,
-        this.props.useOtelTerms
-      ),
-      this.getValue(),
-      this.state.checkboxStatus
-    );
-    const newWohleTable = generateColor(
-      getColumnValuesSecondDropdown(
-        this.props.wholeTable,
-        this.state.valueNameSelector1,
-        value,
-        this.props.trace,
-        this.props.useOtelTerms
-      ),
-      this.getValue(),
-      this.state.checkboxStatus
-    );
-    this.props.handler(newTableValue, newWohleTable, this.state.valueNameSelector1, value);
-  }
+  const setValueNameSelector2 = useCallback(
+    (value: string) => {
+      setValueNameSelector2State(value);
+      const newTableValue = generateColor(
+        getColumnValuesSecondDropdown(tableValue, valueNameSelector1, value, trace, useOtelTerms),
+        getValue(),
+        checkboxStatus
+      );
+      const newWholeTable = generateColor(
+        getColumnValuesSecondDropdown(wholeTable, valueNameSelector1, value, trace, useOtelTerms),
+        getValue(),
+        checkboxStatus
+      );
+      handler(newTableValue, newWholeTable, valueNameSelector1, value);
+    },
+    [tableValue, wholeTable, valueNameSelector1, trace, useOtelTerms, getValue, checkboxStatus, handler]
+  );
 
   /**
    * Is called after a value from the third dropdown is selected.
    */
-  setValueNameSelector3(value: string) {
-    this.setState({
-      valueNameSelector3: value,
-    });
+  const setValueNameSelector3 = useCallback(
+    (value: string) => {
+      setValueNameSelector3State(value);
 
-    let toColor = optionsNameSelector3.get(value);
-    if (toColor === undefined) {
-      toColor = '';
-    }
-    const newTableValue = generateColor(this.props.tableValue, toColor, this.state.checkboxStatus);
-    const newWohleTable = generateColor(this.props.wholeTable, toColor, this.state.checkboxStatus);
-    this.props.handler(
-      newTableValue,
-      newWohleTable,
-      this.state.valueNameSelector1,
-      this.state.valueNameSelector2
-    );
-  }
+      let toColor = optionsNameSelector3.get(value);
+      if (toColor === undefined) {
+        toColor = '';
+      }
+      const newTableValue = generateColor(tableValue, toColor, checkboxStatus);
+      const newWholeTable = generateColor(wholeTable, toColor, checkboxStatus);
+      handler(newTableValue, newWholeTable, valueNameSelector1, valueNameSelector2);
+    },
+    [tableValue, wholeTable, checkboxStatus, handler, valueNameSelector1, valueNameSelector2]
+  );
 
   /**
    * Is called after the checkbox changes its status.
    */
-  checkboxButton(e: any) {
-    this.setState({
-      checkboxStatus: e.target.checked,
-    });
+  const checkboxButton = useCallback(
+    (e: CheckboxChangeEvent) => {
+      setCheckboxStatus(e.target.checked);
 
-    const newTableValue = generateColor(this.props.tableValue, this.getValue(), e.target.checked);
-    const newWholeTable = generateColor(this.props.wholeTable, this.getValue(), e.target.checked);
-    this.props.handler(
-      newTableValue,
-      newWholeTable,
-      this.state.valueNameSelector1,
-      this.state.valueNameSelector2
-    );
-  }
+      const newTableValue = generateColor(tableValue, getValue(), e.target.checked);
+      const newWholeTable = generateColor(wholeTable, getValue(), e.target.checked);
+      handler(newTableValue, newWholeTable, valueNameSelector1, valueNameSelector2);
+    },
+    [tableValue, wholeTable, getValue, handler, valueNameSelector1, valueNameSelector2]
+  );
 
   /**
    * Sets the second dropdown to "No Item selected" and sets the table to the values after the first dropdown.
    */
-  clearValue() {
-    this.setState({
-      valueNameSelector2: null,
-    });
+  const clearValue = useCallback(() => {
+    setValueNameSelector2State(null);
 
     const newTableValue = generateColor(
-      getColumnValues(this.state.valueNameSelector1, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValues(valueNameSelector1, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
     const newWholeTable = generateColor(
-      getColumnValues(this.state.valueNameSelector1, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValues(valueNameSelector1, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
-    this.props.handler(newTableValue, newWholeTable, this.state.valueNameSelector1, null);
-  }
+    handler(newTableValue, newWholeTable, valueNameSelector1, null);
+  }, [valueNameSelector1, trace, useOtelTerms, getValue, checkboxStatus, handler]);
 
-  render() {
-    const optionsNameSelector1 = generateDropdownValue(this.props.trace, this.props.useOtelTerms);
-    const optionsNameSelector2 = generateSecondDropdownValue(
-      this.props.trace,
-      this.state.valueNameSelector1,
-      this.props.useOtelTerms
-    );
+  const optionsNameSelector1 = generateDropdownValue(trace, useOtelTerms);
+  const optionsNameSelector2 = generateSecondDropdownValue(trace, valueNameSelector1, useOtelTerms);
 
-    return (
-      <div className="TraceStatisticsHeader">
+  return (
+    <div className="TraceStatisticsHeader">
+      <label className="TraceStatisticsHeader--label">
+        <span className="TraceStatisticsHeader--labelText">Group By:</span>
+        <SearchableSelect
+          className="TraceStatisticsHeader--select"
+          value={valueNameSelector1}
+          onChange={setValueNameSelector1}
+          popupMatchSelectWidth={false}
+          fuzzy
+        >
+          {optionsNameSelector1.map(opt => (
+            <Select.Option key={opt} value={opt}>
+              {opt}
+            </Select.Option>
+          ))}
+        </SearchableSelect>
+      </label>
+      <label className="TraceStatisticsHeader--label">
+        <span className="TraceStatisticsHeader--labelText">Sub-Group:</span>
+        <SearchableSelect
+          className="TraceStatisticsHeader--select"
+          value={valueNameSelector2}
+          onChange={setValueNameSelector2}
+          allowClear
+          onClear={clearValue}
+          placeholder="No item selected"
+          popupMatchSelectWidth={false}
+          fuzzy
+        >
+          {optionsNameSelector2.map(opt => (
+            <Select.Option key={opt} value={opt}>
+              {opt}
+            </Select.Option>
+          ))}
+        </SearchableSelect>
+      </label>
+      <div className="TraceStatisticsHeader--colorByWrapper">
+        <Checkbox className="TraceStatisticsHeader--checkbox" onChange={checkboxButton} />
         <label className="TraceStatisticsHeader--label">
-          <span className="TraceStatisticsHeader--labelText">Group By:</span>
+          <span className="TraceStatisticsHeader--labelText">Color by:</span>
           <SearchableSelect
             className="TraceStatisticsHeader--select"
-            value={this.state.valueNameSelector1}
-            onChange={this.setValueNameSelector1}
+            value={valueNameSelector3}
+            onChange={setValueNameSelector3}
             popupMatchSelectWidth={false}
             fuzzy
           >
-            {optionsNameSelector1.map(opt => (
+            {Array.from(optionsNameSelector3.keys()).map(opt => (
               <Select.Option key={opt} value={opt}>
                 {opt}
               </Select.Option>
             ))}
           </SearchableSelect>
         </label>
-        <label className="TraceStatisticsHeader--label">
-          <span className="TraceStatisticsHeader--labelText">Sub-Group:</span>
-          <SearchableSelect
-            className="TraceStatisticsHeader--select"
-            value={this.state.valueNameSelector2}
-            onChange={this.setValueNameSelector2}
-            allowClear
-            onClear={this.clearValue}
-            placeholder="No item selected"
-            popupMatchSelectWidth={false}
-            fuzzy
-          >
-            {optionsNameSelector2.map(opt => (
-              <Select.Option key={opt} value={opt}>
-                {opt}
-              </Select.Option>
-            ))}
-          </SearchableSelect>
-        </label>
-        <div className="TraceStatisticsHeader--colorByWrapper">
-          <Checkbox className="TraceStatisticsHeader--checkbox" onChange={this.checkboxButton} />
-          <label className="TraceStatisticsHeader--label">
-            <span className="TraceStatisticsHeader--labelText">Color by:</span>
-            <SearchableSelect
-              className="TraceStatisticsHeader--select"
-              value={this.state.valueNameSelector3}
-              onChange={this.setValueNameSelector3}
-              popupMatchSelectWidth={false}
-              fuzzy
-            >
-              {Array.from(optionsNameSelector3.keys()).map(opt => (
-                <Select.Option key={opt} value={opt}>
-                  {opt}
-                </Select.Option>
-              ))}
-            </SearchableSelect>
-          </label>
-        </div>
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -59,12 +59,8 @@ export default function TraceStatisticsHeader(props: Props) {
 
   useEffect(() => {
     const serviceName = getServiceName();
-    handler(
-      getColumnValues(serviceName, trace, useOtelTerms),
-      getColumnValues(serviceName, trace, useOtelTerms),
-      serviceName,
-      null
-    );
+    const columnValues = getColumnValues(serviceName, trace, useOtelTerms);
+    handler(columnValues, columnValues, serviceName, null);
   }, [handler, trace, useOtelTerms]);
 
   /**
@@ -74,17 +70,9 @@ export default function TraceStatisticsHeader(props: Props) {
     (value: string) => {
       setValueNameSelector1State(value);
       setValueNameSelector2State(null);
-      const newTableValue = generateColor(
-        getColumnValues(value, trace, useOtelTerms),
-        getValue(),
-        checkboxStatus
-      );
-      const newWholeTable = generateColor(
-        getColumnValues(value, trace, useOtelTerms),
-        getValue(),
-        checkboxStatus
-      );
-      handler(newTableValue, newWholeTable, value, null);
+      const columnValues = getColumnValues(value, trace, useOtelTerms);
+      const colored = generateColor(columnValues, getValue(), checkboxStatus);
+      handler(colored, colored, value, null);
     },
     [trace, useOtelTerms, getValue, checkboxStatus, handler]
   );
@@ -148,17 +136,9 @@ export default function TraceStatisticsHeader(props: Props) {
   const clearValue = useCallback(() => {
     setValueNameSelector2State(null);
 
-    const newTableValue = generateColor(
-      getColumnValues(valueNameSelector1, trace, useOtelTerms),
-      getValue(),
-      checkboxStatus
-    );
-    const newWholeTable = generateColor(
-      getColumnValues(valueNameSelector1, trace, useOtelTerms),
-      getValue(),
-      checkboxStatus
-    );
-    handler(newTableValue, newWholeTable, valueNameSelector1, null);
+    const columnValues = getColumnValues(valueNameSelector1, trace, useOtelTerms);
+    const colored = generateColor(columnValues, getValue(), checkboxStatus);
+    handler(colored, colored, valueNameSelector1, null);
   }, [valueNameSelector1, trace, useOtelTerms, getValue, checkboxStatus, handler]);
 
   const optionsNameSelector1 = generateDropdownValue(trace, useOtelTerms);

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -65,7 +65,7 @@ export default function TraceStatisticsHeader(props: Props) {
       serviceName,
       null
     );
-  }, []);
+  }, [handler, trace, useOtelTerms]);
 
   /**
    * Is called after a value from the first dropdown is selected.


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #2610
## Description of the changes
- Converts `TraceStatisticsHeader` from a class component to a functional component using React hooks (`useState`, `useEffect`, `useCallback`)
## How was this change tested?
- `npm run tsc-lint` passes
- `npm test` passes (existing tests)
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully