### PR TITLE
refactor: convert ReferencesButton to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
@@ -18,7 +18,7 @@ type TReferencesButtonProps = {
 
 // ReferencesButton is displayed as a menu at the span level.
 // Example: https://github.com/jaegertracing/jaeger-ui/assets/94157520/2b29921a-2225-4a01-9018-1a1952f186ef
-export default function ReferencesButton(props: TReferencesButtonProps) {
+export default React.memo(function ReferencesButton(props: TReferencesButtonProps) {
   const { links, children, tooltipText, focusSpan } = props;
 
   const linksList = useCallback(
@@ -71,4 +71,4 @@ export default function ReferencesButton(props: TReferencesButtonProps) {
       </ReferenceLink>
     </Tooltip>
   );
-}
+});


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #2610
## Description of the changes
- Converts `ReferencesButton` from `React.PureComponent` to a functional component using `useCallback`
## How was this change tested?
- `npm run tsc-lint` passes
- `npm test` passes (existing tests)
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully