### PR TITLE
refactor: convert AccordionLinks to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -58,29 +58,15 @@ export function References(props: ReferenceItemProps) {
   );
 }
 
-type AccordionLinksDefaultProps = {
-  highContrast: boolean;
-  interactive: boolean;
-  onToggle: null | (() => void);
-};
-
-const defaultProps: AccordionLinksDefaultProps = {
-  highContrast: false,
-  interactive: true,
-  onToggle: null,
-};
-
-export default function AccordionLinks(props: AccordionLinksProps) {
-  const {
-    data,
-    highContrast = defaultProps.highContrast,
-    interactive = defaultProps.interactive,
-    isOpen,
-    onToggle = defaultProps.onToggle,
-    focusSpan,
-    useOtelTerms,
-  } = props;
-
+export default React.memo(function AccordionLinks({
+  data,
+  highContrast = false,
+  interactive = true,
+  isOpen,
+  onToggle = null,
+  focusSpan,
+  useOtelTerms,
+}: AccordionLinksProps) {
   const isEmpty = !Array.isArray(data) || !data.length;
   const iconCls = cx('u-align-icon', { 'AccordianKReferences--emptyIcon': isEmpty });
   let arrow: React.ReactNode | null = null;
@@ -114,4 +100,4 @@ export default function AccordionLinks(props: AccordionLinksProps) {
       {isOpen && <References data={data} focusSpan={focusSpan} />}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #2610
## Description of the changes
- Converts `AccordionLinks` from `React.PureComponent` to a functional component with default props
## How was this change tested?
- `npm run tsc-lint` passes
- `npm test` passes (existing tests)
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully