### PR TITLE
[refactor]: Convert ReferenceButton to Functional Component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
@@ -18,7 +18,7 @@ type TReferencesButtonProps = {
 
 // ReferencesButton is displayed as a menu at the span level.
 // Example: https://github.com/jaegertracing/jaeger-ui/assets/94157520/2b29921a-2225-4a01-9018-1a1952f186ef
-const ReferencesButton: React.FC<TReferencesButtonProps> = memo(function ReferencesButton({
+const ReferencesButton: React.FC<TReferencesButtonProps> = memo(function ({
   links,
   children,
   tooltipText,
@@ -71,5 +71,5 @@ const ReferencesButton: React.FC<TReferencesButtonProps> = memo(function Referen
     </Tooltip>
   );
 });
-
+ReferencesButton.displayName = 'ReferencesButton';
 export default ReferencesButton;


### PR DESCRIPTION


## Which problem is this PR solving?
part of: #2610 

## Description of the changes
-changed:
 1. Replaced `class ReferencesButton extends React.PureComponent`  with a functional component wrapped in `memo()`  to maintain the same shallow comparison optimization.
 2. Converted the `linksList` class method to a `useMemo`  hook that memoizes the dropdown items based on `links`  and `focusSpan`  dependencies.
 3. Destructured props directly in the function signature instead of accessing via `this.props`.
 4. Used a named function inside `memo()`  `(memo(function ReferencesButton(...)))`  for better debugging experience in React DevTools.
 5. Moved the `export default`  to the end of the file

-> No behavioral changes - the component functions exactly as before
## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
