### PR TITLE
fix: add missing error handling for fetchServiceOperations

### DIFF
--- a/packages/jaeger-ui/src/reducers/services.test.js
+++ b/packages/jaeger-ui/src/reducers/services.test.js
@@ -126,6 +126,20 @@ describe('reducers/services', () => {
     expect(state).toEqual(expected);
   });
 
+  it('should handle a failed operations for a service fetch', () => {
+    const error = new Error('some-message');
+    const state = serviceReducer(initialState, {
+      type: `${fetchServiceOperations}_REJECTED`,
+      meta: { serviceName },
+      payload: error,
+    });
+    const expected = {
+      ...initialState,
+      error,
+    };
+    expect(state).toEqual(expected);
+  });
+
   it('should handle a successful server operations for a service fetch', () => {
     const state = serviceReducer(initialState, {
       type: `${fetchServiceServerOps}_FULFILLED`,

--- a/packages/jaeger-ui/src/reducers/services.ts
+++ b/packages/jaeger-ui/src/reducers/services.ts
@@ -96,7 +96,9 @@ function fetchOpsDone(state: ServicesState, { meta, payload }: any): ServicesSta
   return { ...state, operationsForService };
 }
 
-// TODO(joe): fetchOpsErred
+function fetchOpsErred(state: ServicesState, { payload: error }: any): ServicesState {
+  return { ...state, error };
+}
 
 export default handleActions(
   {
@@ -109,6 +111,7 @@ export default handleActions(
 
     [`${fetchOps}_PENDING`]: fetchOpsStarted,
     [`${fetchOps}_FULFILLED`]: fetchOpsDone,
+    [`${fetchOps}_REJECTED`]: fetchOpsErred,
   },
   initialState
 );


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #3353 

## Description of the changes
- Implemented the [fetchOpsErred](cci:1://file:///Users/aadishah/Jagerui/jaeger-ui/packages/jaeger-ui/src/reducers/services.ts:98:0-100:1) reducer function in [packages/jaeger-ui/src/reducers/services.ts](cci:7://file:///Users/aadishah/Jagerui/jaeger-ui/packages/jaeger-ui/src/reducers/services.ts:0:0-0:0) to properly handle the `_REJECTED` action type, ensuring application stability when API calls fail.
- Added a unit test in [packages/jaeger-ui/src/reducers/services.test.js](cci:7://file:///Users/aadishah/Jagerui/jaeger-ui/packages/jaeger-ui/src/reducers/services.test.js:0:0-0:0) to verify that the application state is correctly updated with an error when fetching service operations fails.
- Addressed the long-standing TODO comment: `// TODO(joe): fetchOpsErred`.

## How was this change tested?
- Added a specific unit test `should handle a failed operations for a service fetch` in [services.test.js](cci:7://file:///Users/aadishah/Jagerui/jaeger-ui/packages/jaeger-ui/src/reducers/services.test.js:0:0-0:0).
- Ran the tests locally using `npm test packages/jaeger-ui/src/reducers/services.test.js` and confirmed they passed successfully.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`