### PR TITLE
feat(ui): add configurable 12h/24h time format

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -225,15 +225,17 @@ export function convertQueryParamsToFormDates({ start, end }: QueryParams): Form
   let queryStartDateTime: string | undefined;
   let queryEndDate: string | undefined;
   let queryEndDateTime: string | undefined;
+  const searchTimeFormat = 'HH:mm';
+  const ONE_MILLISECOND = 1000 * 1;
   if (end) {
     const endUnixNs = parseInt(end, 10);
     queryEndDate = formatDate(endUnixNs);
-    queryEndDateTime = formatTime(endUnixNs);
+    queryEndDateTime = dayjs(endUnixNs / ONE_MILLISECOND).format(searchTimeFormat);
   }
   if (start) {
     const startUnixNs = parseInt(start, 10);
     queryStartDate = formatDate(startUnixNs);
-    queryStartDateTime = formatTime(startUnixNs);
+    queryStartDateTime = dayjs(startUnixNs / ONE_MILLISECOND).format(searchTimeFormat);
   }
 
   return {
@@ -757,7 +759,8 @@ export function mapStateToProps(state: ReduxState) {
 
   const nowInMicroseconds = dayjs().valueOf() * 1000;
   const today = formatDate(nowInMicroseconds);
-  const currentTime = formatTime(nowInMicroseconds);
+  const ONE_MILLISECOND = 1000 * 1;
+  const currentTime = dayjs(nowInMicroseconds / ONE_MILLISECOND).format('HH:mm');
   const lastSearch = store.get('lastSearch') as { service?: string; operation?: string } | undefined;
   let lastSearchService: string | undefined;
   let lastSearchOperation: string | undefined;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -126,6 +126,9 @@ export default function ResultItem({
           <Col span={4} className="ub-p3 ub-tx-right-align">
             {formatRelativeDate(startTime / 1000)}
             <Divider vertical />
+            {/* For 12h format: slice off the trailing " am"/" pm" (including the preceding space),
+            keep only the suffix ("am"/"pm"), and re-join with &nbsp; for non-breaking layout.
+            For 24h: no suffix exists → use full timeStr without slicing to avoid corruption. */}
             {is24h ? timeStr : `${timeStr.slice(0, -3)}&nbsp;${timeStr.slice(-2)}`}
             <br />
             <small>{fromNow}</small>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -126,7 +126,7 @@ export default function ResultItem({
           <Col span={4} className="ub-p3 ub-tx-right-align">
             {formatRelativeDate(startTime / 1000)}
             <Divider vertical />
-            {is24h ? timeStr : `${timeStr.slice(0, -3)}&nbsp;${timeStr.slice(-3)}`}
+            {is24h ? timeStr : `${timeStr.slice(0, -3)}&nbsp;${timeStr.slice(-2)}`}
             <br />
             <small>{fromNow}</small>
           </Col>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -20,6 +20,8 @@ import { formatRelativeDate } from '../../../utils/date';
 import { IOtelTrace, StatusCode } from '../../../types/otel';
 
 import './ResultItem.css';
+import { getTimeFormat } from '../../../utils/time-format';
+import { getConfigValue } from '../../../utils/config/get-config';
 
 dayjs.extend(relativeTime);
 
@@ -50,10 +52,11 @@ export default function ResultItem({
   const [numErredSpans, setNumErredSpans] = React.useState(0);
   const [timeStr, setTimeStr] = React.useState('');
   const [fromNow, setFromNow] = React.useState<string | boolean>('');
+  const is24h = getConfigValue('timeFormat') === '24h';
 
   React.useEffect(() => {
     const startTimeDayjs = dayjs(startTime / 1000);
-    setTimeStr(startTimeDayjs.format('h:mm:ss a'));
+    setTimeStr(startTimeDayjs.format(getTimeFormat(true)));
     setFromNow(startTimeDayjs.fromNow());
 
     const errored = new Set<string>();
@@ -123,7 +126,7 @@ export default function ResultItem({
           <Col span={4} className="ub-p3 ub-tx-right-align">
             {formatRelativeDate(startTime / 1000)}
             <Divider vertical />
-            {timeStr.slice(0, -3)}&nbsp;{timeStr.slice(-2)}
+            {timeStr}
             <br />
             <small>{fromNow}</small>
           </Col>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -20,7 +20,7 @@ import { formatRelativeDate } from '../../../utils/date';
 import { IOtelTrace, StatusCode } from '../../../types/otel';
 
 import './ResultItem.css';
-import { getTimeFormat } from '../../../utils/time-format';
+import { getTimeFormatWithSeconds } from '../../../utils/time-format';
 import { getConfigValue } from '../../../utils/config/get-config';
 
 dayjs.extend(relativeTime);
@@ -56,7 +56,7 @@ export default function ResultItem({
 
   React.useEffect(() => {
     const startTimeDayjs = dayjs(startTime / 1000);
-    setTimeStr(startTimeDayjs.format(getTimeFormat(true)));
+    setTimeStr(startTimeDayjs.format(getTimeFormatWithSeconds()));
     setFromNow(startTimeDayjs.fromNow());
 
     const errored = new Set<string>();
@@ -126,7 +126,7 @@ export default function ResultItem({
           <Col span={4} className="ub-p3 ub-tx-right-align">
             {formatRelativeDate(startTime / 1000)}
             <Divider vertical />
-            {timeStr}
+            {is24h ? timeStr : `${timeStr.slice(0, -3)}&nbsp;${timeStr.slice(-3)}`}
             <br />
             <small>{fromNow}</small>
           </Col>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
@@ -19,6 +19,7 @@ import { FALLBACK_TRACE_NAME } from '../../../constants';
 import { ONE_MILLISECOND, formatDuration } from '../../../utils/date';
 
 import './ScatterPlot.css';
+import { getTimeFormat } from '../../../utils/time-format';
 
 export type TScatterPlotPoint = {
   x: number;
@@ -155,7 +156,7 @@ export default function ScatterPlot({
               name="Time"
               domain={[xMin, xMax]}
               ticks={generateUniqueTicks(xMin, xMax, 10)}
-              tickFormatter={t => dayjs(t / ONE_MILLISECOND).format('hh:mm:ss a')}
+              tickFormatter={t => dayjs(t / ONE_MILLISECOND).format(getTimeFormat(true))}
               tick={{ fontSize: 11, dy: 5 }}
               axisLine={{ stroke: '#e6e6e9', strokeWidth: 2 }}
               tickLine={{ stroke: '#e6e6e9', strokeWidth: 1 }}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
@@ -19,7 +19,7 @@ import { FALLBACK_TRACE_NAME } from '../../../constants';
 import { ONE_MILLISECOND, formatDuration } from '../../../utils/date';
 
 import './ScatterPlot.css';
-import { getTimeFormat } from '../../../utils/time-format';
+import { getTimeFormatWithSeconds } from '../../../utils/time-format';
 
 export type TScatterPlotPoint = {
   x: number;
@@ -156,7 +156,7 @@ export default function ScatterPlot({
               name="Time"
               domain={[xMin, xMax]}
               ticks={generateUniqueTicks(xMin, xMax, 10)}
-              tickFormatter={t => dayjs(t / ONE_MILLISECOND).format(getTimeFormat(true))}
+              tickFormatter={t => dayjs(t / ONE_MILLISECOND).format(getTimeFormatWithSeconds())}
               tick={{ fontSize: 11, dy: 5 }}
               axisLine={{ stroke: '#e6e6e9', strokeWidth: 2 }}
               tickLine={{ stroke: '#e6e6e9', strokeWidth: 1 }}

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceHeader.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceHeader.test.js
@@ -8,6 +8,13 @@ import '@testing-library/jest-dom';
 import TraceHeader, { Attrs, EmptyAttrs } from './TraceHeader';
 import { fetchedState } from '../../../constants';
 
+jest.mock('../../../utils/config/get-config', () => ({
+  getConfigValue: key => {
+    if (key === 'timeFormat') return '12h';
+    return undefined;
+  },
+}));
+
 describe('TraceHeader', () => {
   const renderWithProps = (passedProps = {}) => {
     const originalProps = {

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -8,11 +8,10 @@ import { ColumnProps } from 'antd/es/table';
 import './index.css';
 import { TNil } from '../../../types';
 import { IOtelSpan, IOtelTrace } from '../../../types/otel';
-import { formatDuration, formatDurationCompact } from '../../../utils/date';
+import { formatDuration, formatDurationCompact, formatDatetime } from '../../../utils/date';
 import prefixUrl from '../../../utils/prefix-url';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 import SearchableSelect from '../../common/SearchableSelect';
-import { getTimeFormat } from '../../../utils/time-format';
 
 type FilterType = 'serviceName' | 'operationName';
 
@@ -222,9 +221,7 @@ export default class TraceSpanView extends Component<Props, State> {
           const compactValue = formatDurationCompact(span.relativeStartTime);
 
           return (
-            <Tooltip
-              title={`${dayjs(span.startTime / 1000).format(`DD MMM YYYY ${getTimeFormat(true)}`)} (${preciseValue})`}
-            >
+            <Tooltip title={`${formatDatetime(span.startTime)} (${preciseValue})`}>
               <span
                 style={{ fontFamily: 'monospace', fontSize: '12px', display: 'block', textAlign: 'right' }}
               >

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -12,6 +12,7 @@ import { formatDuration, formatDurationCompact } from '../../../utils/date';
 import prefixUrl from '../../../utils/prefix-url';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 import SearchableSelect from '../../common/SearchableSelect';
+import { getTimeFormat } from '../../../utils/time-format';
 
 type FilterType = 'serviceName' | 'operationName';
 
@@ -222,7 +223,7 @@ export default class TraceSpanView extends Component<Props, State> {
 
           return (
             <Tooltip
-              title={`${dayjs(span.startTime / 1000).format('DD MMM YYYY hh:mm:ss A')} (${preciseValue})`}
+              title={`${dayjs(span.startTime / 1000).format(`DD MMM YYYY ${getTimeFormat(true)}`)} (${preciseValue})`}
             >
               <span
                 style={{ fontFamily: 'monospace', fontSize: '12px', display: 'block', textAlign: 'right' }}

--- a/packages/jaeger-ui/src/components/common/RelativeDate.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeDate.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 
 import { formatRelativeDate } from '../../utils/date';
+import { getTimeFormat } from '../../utils/time-format';
 
 type Props = {
   fullMonthName: boolean | undefined | null;
@@ -18,6 +19,6 @@ export default function RelativeDate(props: Props): React.JSX.Element {
   const { value, includeTime, fullMonthName } = props;
   const m = dayjs.isDayjs(value) ? value : dayjs(value);
   const dateStr = formatRelativeDate(m, Boolean(fullMonthName));
-  const timeStr = includeTime ? `, ${m.format('h:mm:ss a')}` : '';
+  const timeStr = includeTime ? `, ${m.format(getTimeFormat(true))}` : '';
   return <span>{`${dateStr}${timeStr}`}</span>;
 }

--- a/packages/jaeger-ui/src/components/common/RelativeDate.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeDate.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 
 import { formatRelativeDate } from '../../utils/date';
-import { getTimeFormat } from '../../utils/time-format';
+import { getTimeFormatWithSeconds } from '../../utils/time-format';
 
 type Props = {
   fullMonthName: boolean | undefined | null;
@@ -19,6 +19,6 @@ export default function RelativeDate(props: Props): React.JSX.Element {
   const { value, includeTime, fullMonthName } = props;
   const m = dayjs.isDayjs(value) ? value : dayjs(value);
   const dateStr = formatRelativeDate(m, Boolean(fullMonthName));
-  const timeStr = includeTime ? `, ${m.format(getTimeFormat(true))}` : '';
+  const timeStr = includeTime ? `, ${m.format(getTimeFormatWithSeconds())}` : '';
   return <span>{`${dateStr}${timeStr}`}</span>;
 }

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -116,6 +116,7 @@ const defaultConfig: Config = {
   themes: {
     enabled: true,
   },
+  timeFormat: '24h',
   useOpenTelemetryTerms: false,
 };
 

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -116,7 +116,7 @@ const defaultConfig: Config = {
   themes: {
     enabled: true,
   },
-  timeFormat: '24h',
+  timeFormat: '12h',
   useOpenTelemetryTerms: false,
 };
 

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -204,6 +204,7 @@ export type Config = {
   themes: {
     enabled: boolean;
   };
+  timeFormat?: '12h' | '24h';
   // useOpenTelemetryTerms determines whether the UI uses legacy Jaeger terminology
   // (tags, logs, process, operation name) or OpenTelemetry terminology
   // (attributes, events, resource, name).

--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -197,12 +197,12 @@ describe('format microseconds', () => {
 
   it('formatTime formats microseconds to time', () => {
     const dateInMicroseconds = dateInMilliseconds * ONE_MILLISECOND;
-    expect(formatTime(dateInMicroseconds)).toBe('10:00');
+    expect(formatTime(dateInMicroseconds)).toBe('10:00 am');
   });
 
   it('formatDateTime formats microseconds to standard date format', () => {
     const dateInMicroseconds = dateInMilliseconds * ONE_MILLISECOND;
-    expect(formatDatetime(dateInMicroseconds)).toBe('January 1 2000, 10:00:00.000');
+    expect(formatDatetime(dateInMicroseconds)).toBe('January 1 2000, 10:00:00 am.000');
   });
 
   it('formatMillisecondTime formats microseconds to milliseconds', () => {

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -8,7 +8,7 @@ import _duration, { DurationUnitType } from 'dayjs/plugin/duration';
 
 import { toFloatPrecision } from './number';
 import { Microseconds } from '../types/units';
-import { getTimeFormat } from './time-format';
+import { getTimeFormatWithSeconds, getTimeFormatWithoutSeconds } from './time-format';
 
 dayjs.extend(_duration);
 
@@ -88,7 +88,7 @@ export function formatDate(duration: number): string {
  * ```
  */
 export function formatTime(duration: number): string {
-  return dayjs(duration / ONE_MILLISECOND).format(`${getTimeFormat(false)}`);
+  return dayjs(duration / ONE_MILLISECOND).format(`${getTimeFormatWithoutSeconds()}`);
 }
 
 /**
@@ -101,7 +101,7 @@ export function formatTime(duration: number): string {
  * ```
  */
 export function formatDatetime(duration: number): string {
-  return dayjs(duration / ONE_MILLISECOND).format(`MMMM D YYYY, ${getTimeFormat(true)}.SSS`);
+  return dayjs(duration / ONE_MILLISECOND).format(`MMMM D YYYY, ${getTimeFormatWithSeconds()}.SSS`);
 }
 
 /**

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -8,6 +8,7 @@ import _duration, { DurationUnitType } from 'dayjs/plugin/duration';
 
 import { toFloatPrecision } from './number';
 import { Microseconds } from '../types/units';
+import { getTimeFormat } from './time-format';
 
 dayjs.extend(_duration);
 
@@ -87,7 +88,7 @@ export function formatDate(duration: number): string {
  * ```
  */
 export function formatTime(duration: number): string {
-  return dayjs(duration / ONE_MILLISECOND).format(STANDARD_TIME_FORMAT);
+  return dayjs(duration / ONE_MILLISECOND).format(`${getTimeFormat(false)}`);
 }
 
 /**
@@ -100,7 +101,7 @@ export function formatTime(duration: number): string {
  * ```
  */
 export function formatDatetime(duration: number): string {
-  return dayjs(duration / ONE_MILLISECOND).format(STANDARD_DATETIME_FORMAT);
+  return dayjs(duration / ONE_MILLISECOND).format(`MMMM D YYYY, ${getTimeFormat(true)}.SSS`);
 }
 
 /**

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -17,7 +17,6 @@ const YESTERDAY = 'Yesterday';
 
 export const STANDARD_DATE_FORMAT = 'YYYY-MM-DD';
 export const STANDARD_TIME_FORMAT = 'HH:mm';
-export const STANDARD_DATETIME_FORMAT = 'MMMM D YYYY, HH:mm:ss.SSS';
 
 /** @constant 1ms as the number of microseconds, which is the precision of Jaeger timestamps */
 export const ONE_MILLISECOND = 1000 * 1;

--- a/packages/jaeger-ui/src/utils/time-format.test.ts
+++ b/packages/jaeger-ui/src/utils/time-format.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getTimeFormatWithSeconds, getTimeFormatWithoutSeconds } from './time-format';
+
+jest.mock('./config/get-config', () => ({
+  getConfigValue: jest.fn(),
+}));
+
+import { getConfigValue } from './config/get-config';
+
+describe('time-format utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getTimeFormatWithSeconds', () => {
+    it('returns 24-hour format when config is "24h"', () => {
+      (getConfigValue as jest.Mock).mockReturnValue('24h');
+      expect(getTimeFormatWithSeconds()).toBe('HH:mm:ss');
+    });
+
+    it('returns 12-hour format when config is "12h"', () => {
+      (getConfigValue as jest.Mock).mockReturnValue('12h');
+      expect(getTimeFormatWithSeconds()).toBe('hh:mm:ss a');
+    });
+
+    it('is case-insensitive and accepts "24H"', () => {
+      (getConfigValue as jest.Mock).mockReturnValue('24H');
+      expect(getTimeFormatWithSeconds()).toBe('HH:mm:ss');
+    });
+
+    it('defaults to 12-hour format when config value is missing', () => {
+      (getConfigValue as jest.Mock).mockReturnValue(undefined);
+      expect(getTimeFormatWithSeconds()).toBe('hh:mm:ss a');
+    });
+
+    it('defaults to 12-hour format for unknown config values', () => {
+      (getConfigValue as jest.Mock).mockReturnValue('invalid');
+      expect(getTimeFormatWithSeconds()).toBe('hh:mm:ss a');
+    });
+  });
+
+  describe('getTimeFormatWithoutSeconds', () => {
+    it('returns short 24-hour format when config is "24h"', () => {
+      (getConfigValue as jest.Mock).mockReturnValue('24h');
+      expect(getTimeFormatWithoutSeconds()).toBe('HH:mm');
+    });
+
+    it('returns short 12-hour format when config is "12h"', () => {
+      (getConfigValue as jest.Mock).mockReturnValue('12h');
+      expect(getTimeFormatWithoutSeconds()).toBe('hh:mm a');
+    });
+
+    it('is case-insensitive and accepts "24H"', () => {
+      (getConfigValue as jest.Mock).mockReturnValue('24H');
+      expect(getTimeFormatWithoutSeconds()).toBe('HH:mm');
+    });
+
+    it('defaults to short 12-hour format when config is missing', () => {
+      (getConfigValue as jest.Mock).mockReturnValue(undefined);
+      expect(getTimeFormatWithoutSeconds()).toBe('hh:mm a');
+    });
+  });
+});

--- a/packages/jaeger-ui/src/utils/time-format.ts
+++ b/packages/jaeger-ui/src/utils/time-format.ts
@@ -1,11 +1,17 @@
 import { getConfigValue } from './config/get-config';
 
-export function getTimeFormat(withSeconds = true) {
-  const timeformat = getConfigValue('timeFormat');
-  if (timeformat === '24h') {
-    return withSeconds ? 'HH:mm:ss' : 'HH:mm';
+export function getTimeFormatWithSeconds() {
+  const timeFormat = getConfigValue('timeFormat');
+  if (timeFormat.toLowerCase() === '24h') {
+    return 'HH:mm:ss';
   }
+  return 'hh:mm:ss a';
+}
 
-  // default to 12h
-  return withSeconds ? 'hh:mm:ss a' : 'hh:mm a';
+export function getTimeFormatWithoutSeconds() {
+  const timeFormat = getConfigValue('timeFormat');
+  if (timeFormat.toLowerCase() === '24h') {
+    return 'HH:mm';
+  }
+  return 'hh:mm a';
 }

--- a/packages/jaeger-ui/src/utils/time-format.ts
+++ b/packages/jaeger-ui/src/utils/time-format.ts
@@ -2,7 +2,7 @@ import { getConfigValue } from './config/get-config';
 
 export function getTimeFormatWithSeconds() {
   const timeFormat = getConfigValue('timeFormat');
-  if (timeFormat.toLowerCase() === '24h') {
+  if (typeof timeFormat === 'string' && timeFormat.toLowerCase() === '24h') {
     return 'HH:mm:ss';
   }
   return 'hh:mm:ss a';
@@ -10,7 +10,7 @@ export function getTimeFormatWithSeconds() {
 
 export function getTimeFormatWithoutSeconds() {
   const timeFormat = getConfigValue('timeFormat');
-  if (timeFormat.toLowerCase() === '24h') {
+  if (typeof timeFormat === 'string' && timeFormat.toLowerCase() === '24h') {
     return 'HH:mm';
   }
   return 'hh:mm a';

--- a/packages/jaeger-ui/src/utils/time-format.ts
+++ b/packages/jaeger-ui/src/utils/time-format.ts
@@ -1,0 +1,11 @@
+import { getConfigValue } from './config/get-config';
+
+export function getTimeFormat(withSeconds = true) {
+  const timeformat = getConfigValue('timeFormat');
+  if (timeformat === '24h') {
+    return withSeconds ? 'HH:mm:ss' : 'HH:mm';
+  }
+
+  // default to 12h
+  return withSeconds ? 'hh:mm:ss a' : 'hh:mm a';
+}


### PR DESCRIPTION
## Which problem is this PR solving?
-  fixes #552 

## Description of the changes
- Added a new timeFormat UI configuration option ('12h' | '24h')
- Updated timestamp formatting logic to respect the configured format

## How was this change tested?
-  npm run test

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
