### PR TITLE
fix: use WorkerGlobalScope instead of Worker for correct typing

### DIFF
--- a/packages/plexus/src/LayoutManager/layout.worker.ts
+++ b/packages/plexus/src/LayoutManager/layout.worker.ts
@@ -12,12 +12,10 @@ import {
 } from './types';
 
 type TMessageErrorTarget = {
-  onmessageerror: ((this: Worker, ev: ErrorEvent) => any | void) | null;
+  onmessageerror: ((this: WorkerGlobalScope, ev: ErrorEvent) => any | void) | null;
 };
 
-// TODO: Use WorkerGlobalScope instead of Worker
-
-const ctx: Worker & TMessageErrorTarget = self as any;
+const ctx = self as DedicatedWorkerGlobalScope & TMessageErrorTarget;
 
 let currentMeta: TLayoutWorkerMeta | null;
 


### PR DESCRIPTION
## Which problem is this PR solving?
-  a TODO comment in packages/plexus/src/LayoutManager/layout.worker.ts indicating to use a better type inference

## Description of the changes
-  This PR updates the worker context typing to use WorkerGlobalScope/DedicatedWorkerGlobalScope instead of Worker

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
