### PR TITLE
refactor(plexus): convert NodesLayer from class to functional component

### DIFF
--- a/packages/plexus/src/Digraph/NodesLayer.test.js
+++ b/packages/plexus/src/Digraph/NodesLayer.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 The Jaeger Authors.
+// Copyright (c) 2026 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
@@ -11,7 +11,7 @@ const mockNodesProps = [];
 const mockHtmlLayerProps = [];
 const mockSvgLayerProps = [];
 
-// 使用 React.createElement 而非 JSX，因為 jest.mock 的工廠函數不允許引用外部變數
+// Use React.createElement instead of JSX because jest.mock factory functions cannot reference external variables
 jest.mock('./Nodes', () => {
   const React = require('react');
   const MockNodes = props => {
@@ -181,8 +181,14 @@ describe('NodesLayer', () => {
   });
 
   describe('React.memo behavior', () => {
-    it('is wrapped with React.memo for performance', () => {
-      expect(NodesLayer.$$typeof).toBe(Symbol.for('react.memo'));
+    it('skips re-render when props are unchanged', () => {
+      const props = { ...defaultProps };
+      const { rerender } = render(<NodesLayer {...props} />);
+      const nodesCallCount = mockNodesProps.length;
+      const svgCallCount = mockSvgLayerProps.length;
+      rerender(<NodesLayer {...props} />);
+      expect(mockNodesProps.length).toBe(nodesCallCount);
+      expect(mockSvgLayerProps.length).toBe(svgCallCount);
     });
   });
 });

--- a/packages/plexus/src/Digraph/NodesLayer.tsx
+++ b/packages/plexus/src/Digraph/NodesLayer.tsx
@@ -40,5 +40,4 @@ const NodesLayer = <T = {}, U = {}>(props: TProps<T, U>) => {
   );
 };
 
-// React.memo provides shallow comparison equivalent to PureComponent
 export default React.memo(NodesLayer) as typeof NodesLayer;


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #3394

This PR converts the `NodesLayer` component from a React Class Component to a React Functional Component as part of the larger effort to modernize the Jaeger UI codebase (Parent Issue #2610).

## Description of the changes

- Convert `NodesLayer` from `React.PureComponent` to functional component
- Wrap component with `React.memo` for equivalent shallow prop comparison
- Add comprehensive unit tests (17 test cases)

## How was this change tested?

- All 17 new unit tests pass
- TypeScript compilation passes with no errors
- Existing visual behavior preserved

### Test Coverage

```
Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
```

Test categories:
- Conditional rendering (3 tests)
- Layer type selection (2 tests)
- Layer component props (5 tests)
- Nodes child props (6 tests)
- React.memo behavior (1 test)

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully locally

Signed-off-by: thc1006 <84045975+thc1006@users.noreply.github.com>