### PR TITLE
Refactor DetailsPanel to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.test.js
@@ -8,7 +8,13 @@ import _set from 'lodash/set';
 
 import stringSupplant from '../../../utils/stringSupplant';
 import JaegerAPI from '../../../api/jaeger';
-import { UnconnectedDetailsPanel as DetailsPanel } from './DetailsPanel';
+import DetailsPanel from './DetailsPanel';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+import { useSelector } from 'react-redux';
 
 jest.mock('../../common/VerticalResizer', () => {
   return ({ onChange, position }) => (
@@ -31,9 +37,22 @@ jest.mock('../../common/DetailsCard', () => {
   );
 });
 
-describe('<SidePanel>', () => {
+describe('<DetailsPanel />', () => {
   const service = 'test svc';
   const opString = 'test op';
+
+  const baseDecorationState = {
+    decorationValue: 'test decorationValue',
+    decorationProgressbar: null,
+  };
+
+  const setSelectorState = overrides => {
+    useSelector.mockReturnValue({
+      ...baseDecorationState,
+      ...overrides,
+    });
+  };
+
   const props = {
     decorationSchema: {
       detailUrl: 'http://test.detail.url?someParam=#{service}',
@@ -42,14 +61,15 @@ describe('<SidePanel>', () => {
       opDetailPath: 'test.opDetail.path',
       name: 'Decorating #{service}',
     },
-    decorationValue: 'test decorationValue',
     service,
   };
+
   const supplantedUrl = stringSupplant(props.decorationSchema.detailUrl, { service });
   const supplantedOpUrl = stringSupplant(props.decorationSchema.opDetailUrl, {
     operation: opString,
     service,
   });
+
   let fetchDecorationSpy;
   let promise;
   let res;
@@ -66,211 +86,123 @@ describe('<SidePanel>', () => {
   });
 
   beforeEach(() => {
-    fetchDecorationSpy.mockClear();
     jest.clearAllMocks();
+    setSelectorState();
   });
 
-  describe('fetchDetails', () => {
-    it('fetches correct details url, perferring op-scoped details, or does not fetch at all', () => {
-      const component1 = render(<DetailsPanel {...props} operation={opString} />);
-      expect(fetchDecorationSpy).toHaveBeenCalledWith(supplantedOpUrl);
-      component1.unmount();
-      fetchDecorationSpy.mockClear();
+  // ---------------- fetchDetails ----------------
 
-      const component2 = render(<DetailsPanel {...props} />);
-      expect(fetchDecorationSpy).toHaveBeenCalledWith(supplantedUrl);
-      component2.unmount();
-      fetchDecorationSpy.mockClear();
+  it('fetches correct details url, preferring op-scoped details, or does not fetch at all', () => {
+    const component1 = render(<DetailsPanel {...props} operation={opString} />);
+    expect(fetchDecorationSpy).toHaveBeenCalledWith(supplantedOpUrl);
+    component1.unmount();
 
-      const component3 = render(
-        <DetailsPanel
-          service={service}
-          decorationSchema={{
-            name: 'Test without URLs',
-          }}
-        />
-      );
-      expect(fetchDecorationSpy).not.toHaveBeenCalled();
-      component3.unmount();
-    });
+    fetchDecorationSpy.mockClear();
+
+    const component2 = render(<DetailsPanel {...props} />);
+    expect(fetchDecorationSpy).toHaveBeenCalledWith(supplantedUrl);
+    component2.unmount();
+
+    fetchDecorationSpy.mockClear();
+
+    const component3 = render(
+      <DetailsPanel
+        service={service}
+        decorationSchema={{
+          name: 'Test without URLs',
+        }}
+      />
+    );
+    expect(fetchDecorationSpy).not.toHaveBeenCalled();
+    component3.unmount();
   });
 
-  describe('render', () => {
-    it('renders', () => {
-      const { container } = render(<DetailsPanel {...props} />);
+  // ---------------- render ----------------
 
-      expect(container.textContent).toContain(service);
-
-      expect(container.textContent).toContain(`Decorating ${service}`);
-
-      expect(container.textContent).toContain(props.decorationValue);
-    });
-
-    it('renders with operation', () => {
-      const { container } = render(<DetailsPanel {...props} operation={opString} />);
-
-      expect(container.textContent).toContain(service);
-      expect(container.textContent).toContain(opString);
-    });
-
-    it('renders omitted array of operations', () => {
-      const { container } = render(<DetailsPanel {...props} operation={['op0', 'op1']} />);
-
-      expect(container.textContent).toContain(service);
-
-      expect(container.textContent).not.toContain('op0');
-      expect(container.textContent).not.toContain('op1');
-    });
-
-    it('renders with progressbar', () => {
-      const progressbarText = 'stand-in progressbar';
-      const progressbar = <div data-testid="test-progressbar">{progressbarText}</div>;
-      const { container } = render(<DetailsPanel {...props} decorationProgressbar={progressbar} />);
-
-      expect(screen.getByTestId('test-progressbar')).toBeInTheDocument();
-      expect(screen.getByText(progressbarText)).toBeInTheDocument();
-
-      expect(container.textContent).not.toContain(props.decorationValue);
-    });
-
-    it('renders while loading', () => {
-      const { container } = render(<DetailsPanel {...props} />);
-      expect(container.querySelector('.Ddg--DetailsPanel--LoadingWrapper')).toBeInTheDocument();
-    });
-
-    it('renders details', async () => {
-      render(<DetailsPanel {...props} />);
-
-      const detailsData = 'details string';
-      const response = {};
-      _set(response, props.decorationSchema.detailPath, detailsData);
-
-      res(response);
-
-      const detailsCard = await screen.findByTestId('details-card');
-      expect(detailsCard).toBeInTheDocument();
-      expect(detailsCard.textContent).toBe(detailsData);
-    });
-
-    it('renders details error', async () => {
-      render(<DetailsPanel {...props} />);
-
-      rej(new Error('fetch error'));
-
-      const detailsCard = await screen.findByTestId('details-card');
-      expect(detailsCard).toBeInTheDocument();
-      expect(detailsCard).toHaveClass('is-error');
-      expect(detailsCard.textContent).toContain('Unable to fetch decoration: fetch error');
-    });
-
-    it('renders detailLink', () => {
-      const schemaWithLink = {
-        ...props.decorationSchema,
-        detailLink: 'test details link',
-      };
-      render(<DetailsPanel {...props} decorationSchema={schemaWithLink} />);
-
-      const link = screen.getByRole('link');
-      expect(link).toHaveAttribute('href', schemaWithLink.detailLink);
-      expect(link).toHaveAttribute('target', '_blank');
-      expect(link).toHaveAttribute('rel', 'noreferrer noopener');
-    });
-
-    it('renders details path not found error', async () => {
-      render(<DetailsPanel {...props} />);
-
-      const response = { someOtherData: 'value' };
-
-      res(response);
-
-      const detailsCard = await screen.findByTestId('details-card');
-      expect(detailsCard).toBeInTheDocument();
-      expect(detailsCard).toHaveClass('is-error');
-      expect(detailsCard.textContent).toContain(
-        `\`${props.decorationSchema.detailPath}\` not found in response`
-      );
-    });
+  it('renders', () => {
+    const { container } = render(<DetailsPanel {...props} />);
+    expect(container).toHaveTextContent(service);
+    expect(container).toHaveTextContent(`Decorating ${service}`);
+    expect(container).toHaveTextContent(baseDecorationState.decorationValue);
   });
 
-  describe('componentDidMount', () => {
-    it('fetches details', () => {
-      expect(fetchDecorationSpy).not.toHaveBeenCalled();
-
-      render(<DetailsPanel {...props} />);
-      expect(fetchDecorationSpy).toHaveBeenCalled();
-      expect(fetchDecorationSpy).toHaveBeenLastCalledWith(supplantedUrl);
-    });
+  it('renders with operation', () => {
+    const { container } = render(<DetailsPanel {...props} operation={opString} />);
+    expect(container).toHaveTextContent(service);
+    expect(container).toHaveTextContent(opString);
   });
 
-  describe('componentDidUpdate', () => {
-    it('fetches details and clears relevant state if decorationSchema changes', async () => {
-      const { rerender } = render(<DetailsPanel {...props} />);
-      expect(fetchDecorationSpy).toHaveBeenCalledTimes(1);
-
-      fetchDecorationSpy.mockClear();
-
-      const detailUrl = 'http://new.schema.detailsUrl?service=#{service}';
-      const newSchema = {
-        ...props.decorationSchema,
-        detailUrl,
-      };
-
-      rerender(<DetailsPanel {...props} decorationSchema={newSchema} />);
-
-      expect(fetchDecorationSpy).toHaveBeenCalledTimes(1);
-      expect(fetchDecorationSpy).toHaveBeenLastCalledWith(stringSupplant(detailUrl, { service }));
-    });
-
-    it('fetches details and clears relevant state if operation changes', () => {
-      const { rerender } = render(<DetailsPanel {...props} />);
-      expect(fetchDecorationSpy).toHaveBeenCalledTimes(1);
-
-      fetchDecorationSpy.mockClear();
-
-      rerender(<DetailsPanel {...props} operation={opString} />);
-
-      expect(fetchDecorationSpy).toHaveBeenCalledTimes(1);
-      expect(fetchDecorationSpy).toHaveBeenLastCalledWith(supplantedOpUrl);
-    });
-
-    it('fetches details and clears relevant state if service changes', () => {
-      const { rerender } = render(<DetailsPanel {...props} />);
-      expect(fetchDecorationSpy).toHaveBeenCalledTimes(1);
-
-      fetchDecorationSpy.mockClear();
-
-      const newService = 'different test service';
-      rerender(<DetailsPanel {...props} service={newService} />);
-
-      expect(fetchDecorationSpy).toHaveBeenCalledTimes(1);
-      expect(fetchDecorationSpy).toHaveBeenLastCalledWith(
-        stringSupplant(props.decorationSchema.detailUrl, { service: newService })
-      );
-    });
-
-    it('does nothing if decorationSchema, operation, and service are unchanged', () => {
-      const { rerender } = render(<DetailsPanel {...props} />);
-      expect(fetchDecorationSpy).toHaveBeenCalledTimes(1);
-
-      fetchDecorationSpy.mockClear();
-
-      rerender(<DetailsPanel {...props} decorationValue={`not_${props.decorationValue}`} />);
-
-      expect(fetchDecorationSpy).not.toHaveBeenCalled();
-    });
+  it('renders omitted array of operations', () => {
+    const { container } = render(<DetailsPanel {...props} operation={['op0', 'op1']} />);
+    expect(container).toHaveTextContent(service);
+    expect(container).not.toHaveTextContent('op0');
+    expect(container).not.toHaveTextContent('op1');
   });
 
-  describe('onResize', () => {
-    it('updates state', () => {
-      const { container } = render(<DetailsPanel {...props} />);
+  it('renders with progressbar', () => {
+    const progressbarText = 'stand-in progressbar';
+    const progressbar = <div data-testid="test-progressbar">{progressbarText}</div>;
 
-      const initialWidth = '30vw';
-      expect(container.querySelector('.Ddg--DetailsPanel')).toHaveStyle(`width: ${initialWidth}`);
-
-      const resizer = screen.getByTestId('vertical-resizer');
-      fireEvent.click(resizer);
-
-      expect(container.querySelector('.Ddg--DetailsPanel')).toHaveStyle('width: 60vw');
+    setSelectorState({
+      decorationProgressbar: progressbar,
+      decorationValue: 'unused',
     });
+
+    render(<DetailsPanel {...props} />);
+    expect(screen.getByTestId('test-progressbar')).toBeInTheDocument();
+  });
+
+  it('renders while loading', () => {
+    render(<DetailsPanel {...props} />);
+    expect(document.querySelector('.Ddg--DetailsPanel--LoadingWrapper')).toBeInTheDocument();
+  });
+
+  it('renders details', async () => {
+    render(<DetailsPanel {...props} />);
+
+    const detailsData = 'details string';
+    const response = {};
+    _set(response, props.decorationSchema.detailPath, detailsData);
+
+    res(response);
+
+    const detailsCard = await screen.findByTestId('details-card');
+    expect(detailsCard.textContent).toBe(detailsData);
+  });
+
+  it('renders details error', async () => {
+    render(<DetailsPanel {...props} />);
+    rej(new Error('fetch error'));
+
+    const detailsCard = await screen.findByTestId('details-card');
+    expect(detailsCard).toHaveClass('is-error');
+  });
+
+  it('renders detailLink', () => {
+    const schemaWithLink = {
+      ...props.decorationSchema,
+      detailLink: 'test details link',
+    };
+
+    render(<DetailsPanel {...props} decorationSchema={schemaWithLink} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', schemaWithLink.detailLink);
+  });
+
+  it('renders details path not found error', async () => {
+    render(<DetailsPanel {...props} />);
+    res({ someOtherData: 'value' });
+
+    const detailsCard = await screen.findByTestId('details-card');
+    expect(detailsCard).toHaveClass('is-error');
+  });
+
+  // ---------------- onResize ----------------
+
+  it('updates width when resized', () => {
+    const { container } = render(<DetailsPanel {...props} />);
+    expect(container.querySelector('.Ddg--DetailsPanel')).toHaveStyle('width: 30vw');
+
+    fireEvent.click(screen.getByTestId('vertical-resizer'));
+    expect(container.querySelector('.Ddg--DetailsPanel')).toHaveStyle('width: 60vw');
   });
 });

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { Tooltip } from 'antd';
 import _get from 'lodash/get';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import BreakableText from '../../common/BreakableText';
 import DetailsCard from '../../common/DetailsCard';
@@ -17,64 +17,38 @@ import stringSupplant from '../../../utils/stringSupplant';
 
 import { TPathAgnosticDecorationSchema } from '../../../model/path-agnostic-decorations/types';
 import { TColumnDefs, TDetails } from '../../common/DetailsCard/types';
+import { ReduxState } from '../../../types';
 
 import './DetailsPanel.css';
 
-type TProps = TDecorationFromState & {
+type TOwnProps = {
   decorationSchema: TPathAgnosticDecorationSchema;
   service: string;
   operation?: string | string[] | null;
 };
 
-type TState = {
-  columnDefs?: TColumnDefs;
-  details?: TDetails;
-  detailsErred?: boolean;
-  detailsLoading?: boolean;
-  width?: number;
-};
+const DetailsPanel: React.FC<TOwnProps> = ({ decorationSchema, service, operation: _op }) => {
+  const operation = _op && !Array.isArray(_op) ? _op : undefined;
 
-export class UnconnectedDetailsPanel extends React.PureComponent<TProps, TState> {
-  state: TState = {};
+  const { decorationProgressbar, decorationValue }: TDecorationFromState = useSelector<
+    ReduxState,
+    TDecorationFromState
+  >(state => extractDecorationFromState(state, { service, operation }));
 
-  componentDidMount() {
-    this.fetchDetails();
-  }
+  const [columnDefs, setColumnDefs] = React.useState<TColumnDefs | undefined>();
+  const [details, setDetails] = React.useState<TDetails | undefined>();
+  const [detailsErred, setDetailsErred] = React.useState(false);
+  const [detailsLoading, setDetailsLoading] = React.useState(false);
+  const [width, setWidth] = React.useState(0.3);
 
-  componentDidUpdate(prevProps: TProps) {
-    if (
-      prevProps.operation !== this.props.operation ||
-      prevProps.service !== this.props.service ||
-      prevProps.decorationSchema !== this.props.decorationSchema
-    ) {
-      this.setState({
-        details: undefined,
-        detailsErred: false,
-        detailsLoading: false,
-      });
-      this.fetchDetails();
-    }
-  }
-
-  fetchDetails() {
-    const {
-      decorationSchema: {
-        detailUrl,
-        detailPath,
-        detailColumnDefPath,
-        opDetailUrl,
-        opDetailPath,
-        opDetailColumnDefPath,
-      },
-      operation: _op,
-      service,
-    } = this.props;
-
-    const operation = _op && !Array.isArray(_op) ? _op : undefined;
+  const fetchDetails = React.useCallback(() => {
+    const { detailUrl, detailPath, detailColumnDefPath, opDetailUrl, opDetailPath, opDetailColumnDefPath } =
+      decorationSchema;
 
     let fetchUrl: string | undefined;
     let getDetailPath: string | undefined;
     let getDefPath: string | undefined;
+
     if (opDetailUrl && opDetailPath && operation) {
       fetchUrl = stringSupplant(opDetailUrl, { service, operation });
       getDetailPath = stringSupplant(opDetailPath, { service, operation });
@@ -87,81 +61,92 @@ export class UnconnectedDetailsPanel extends React.PureComponent<TProps, TState>
 
     if (!fetchUrl || !getDetailPath) return;
 
-    this.setState({ detailsLoading: true });
+    setDetailsLoading(true);
 
     JaegerAPI.fetchDecoration(fetchUrl)
       .then((res: unknown) => {
-        let detailsErred = false;
-        let details = _get(res, getDetailPath as string);
-        if (details === undefined) {
-          details = `\`${getDetailPath}\` not found in response`;
-          detailsErred = true;
-        }
-        const columnDefs: TColumnDefs = getDefPath ? _get(res, getDefPath, []) : [];
+        let isErred = false;
+        let nextDetails = _get(res, getDetailPath as string);
 
-        this.setState({ columnDefs, details, detailsErred, detailsLoading: false });
+        if (nextDetails === undefined) {
+          nextDetails = `\`${getDetailPath}\` not found in response`;
+          isErred = true;
+        }
+
+        const nextColumnDefs: TColumnDefs = getDefPath ? _get(res, getDefPath, []) : [];
+
+        setColumnDefs(nextColumnDefs);
+        setDetails(nextDetails);
+        setDetailsErred(isErred);
+        setDetailsLoading(false);
       })
       .catch((err: Error) => {
-        this.setState({
-          details: `Unable to fetch decoration: ${err.message || err}`,
-          detailsErred: true,
-          detailsLoading: false,
-        });
+        setDetails(`Unable to fetch decoration: ${err.message || err}`);
+        setDetailsErred(true);
+        setDetailsLoading(false);
       });
-  }
+  }, [decorationSchema, operation, service]);
 
-  onResize = (width: number) => {
-    this.setState({ width });
-  };
+  React.useEffect(() => {
+    setDetails(undefined);
+    setDetailsErred(false);
+    setDetailsLoading(false);
+    fetchDetails();
+  }, [fetchDetails]);
 
-  render() {
-    const { decorationProgressbar, decorationSchema, decorationValue, operation: _op, service } = this.props;
-    const { detailLink } = decorationSchema;
-    const { width = 0.3 } = this.state;
-    const operation = _op && !Array.isArray(_op) ? _op : undefined;
-    return (
-      <div className="Ddg--DetailsPanel" style={{ width: `${width * 100}vw` }}>
-        <div className="Ddg--DetailsPanel--SvcOpHeader">
-          <BreakableText text={service} />
-          {operation && <BreakableText text={`::${operation}`} />}
-        </div>
-        <div className="Ddg--DetailsPanel--DecorationHeader">
-          <span>{stringSupplant(decorationSchema.name, { service, operation })}</span>
-          {detailLink && (
-            <Tooltip arrow={{ pointAtCenter: true }} title="More Info">
-              <a
-                className="Ddg--DetailsPanel--DetailLink"
-                href={stringSupplant(detailLink, { service, operation })}
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                <NewWindowIcon />
-              </a>
-            </Tooltip>
-          )}
-        </div>
-        {decorationProgressbar ? (
-          <div className="Ddg--DetailsPanel--PercentCircleWrapper">{decorationProgressbar}</div>
-        ) : (
-          <span className="Ddg--DetailsPanel--errorMsg">{decorationValue}</span>
-        )}
-        {this.state.detailsLoading && (
-          <div className="Ddg--DetailsPanel--LoadingWrapper">
-            <LoadingIndicator className="Ddg--DetailsPanel--LoadingIndicator" />
-          </div>
-        )}
-        {this.state.details && (
-          <DetailsCard
-            className={`Ddg--DetailsPanel--DetailsCard ${this.state.detailsErred ? 'is-error' : ''}`}
-            columnDefs={this.state.columnDefs}
-            details={this.state.details}
-            header="Details"
-          />
-        )}
-        <VerticalResizer max={0.8} min={0.1} onChange={this.onResize} position={width} rightSide />
+  const onResize = React.useCallback((nextWidth: number) => {
+    setWidth(nextWidth);
+  }, []);
+
+  const { detailLink } = decorationSchema;
+
+  return (
+    <div className="Ddg--DetailsPanel" style={{ width: `${width * 100}vw` }}>
+      <div className="Ddg--DetailsPanel--SvcOpHeader">
+        <BreakableText text={service} />
+        {operation && <BreakableText text={`::${operation}`} />}
       </div>
-    );
-  }
-}
 
-export default connect(extractDecorationFromState)(UnconnectedDetailsPanel);
+      <div className="Ddg--DetailsPanel--DecorationHeader">
+        <span>{stringSupplant(decorationSchema.name, { service, operation })}</span>
+        {detailLink && (
+          <Tooltip arrow={{ pointAtCenter: true }} title="More Info">
+            <a
+              className="Ddg--DetailsPanel--DetailLink"
+              href={stringSupplant(detailLink, { service, operation })}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <NewWindowIcon />
+            </a>
+          </Tooltip>
+        )}
+      </div>
+
+      {decorationProgressbar ? (
+        <div className="Ddg--DetailsPanel--PercentCircleWrapper">{decorationProgressbar}</div>
+      ) : (
+        <span className="Ddg--DetailsPanel--errorMsg">{decorationValue}</span>
+      )}
+
+      {detailsLoading && (
+        <div className="Ddg--DetailsPanel--LoadingWrapper">
+          <LoadingIndicator className="Ddg--DetailsPanel--LoadingIndicator" />
+        </div>
+      )}
+
+      {details && (
+        <DetailsCard
+          className={`Ddg--DetailsPanel--DetailsCard ${detailsErred ? 'is-error' : ''}`}
+          columnDefs={columnDefs}
+          details={details}
+          header="Details"
+        />
+      )}
+
+      <VerticalResizer max={0.8} min={0.1} onChange={onResize} position={width} rightSide />
+    </div>
+  );
+};
+
+export default React.memo(DetailsPanel);


### PR DESCRIPTION

## Which problem is this PR solving?
Refactor DetailsPanel to functional component #3365

## Description of the changes
- Converted DetailsPanel from React.PureComponent to a functional component
- Replaced componentDidMount and componentDidUpdate with useEffect
- Replaced connect HOC with useSelector for Redux state access
- Preserved all existing props, logic, and rendering behavior
- Preserved all existing props, logic, and rendering behavior

## How was this change tested?
- Updated and ran unit tests for DetailsPanel using Jest + React Testing Library

<img width="566" height="113" alt="image" src="https://github.com/user-attachments/assets/fd311f2b-594c-4246-95aa-54e1c2f8834a" />

### Ran full local checks:
- npm run lint
- npm test
- npm run build