### PR TITLE
Refactor #3366: Migrate ReferencesButton to Functional Component 

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Dropdown, Tooltip } from 'antd';
 import { TooltipPlacement } from 'antd/es/tooltip';
 import ReferenceLink from '../url/ReferenceLink';
@@ -18,60 +18,54 @@ type TReferencesButtonProps = {
 
 // ReferencesButton is displayed as a menu at the span level.
 // Example: https://github.com/jaegertracing/jaeger-ui/assets/94157520/2b29921a-2225-4a01-9018-1a1952f186ef
-export default class ReferencesButton extends React.PureComponent<TReferencesButtonProps> {
-  linksList = (links: ReadonlyArray<ILink>) => {
-    const dropdownItems = links.map(link => {
-      const { span } = link;
-      // Link within the trace should have link.span defined
-      const isSameTrace = span !== undefined;
+function ReferencesButton({ links, children, tooltipText, focusSpan }: TReferencesButtonProps) {
+  const linksList = useCallback(
+    (items: ReadonlyArray<ILink>) =>
+      items.map(link => {
+        const { span } = link;
+        const isSameTrace = span !== undefined;
 
-      return {
-        key: `${link.spanID}`,
-        label: (
-          <ReferenceLink
-            link={link}
-            focusSpan={this.props.focusSpan}
-            className="ReferencesButton--TraceRefLink"
-          >
-            {isSameTrace
-              ? `${span.resource.serviceName}:${span.name} - ${link.spanID}`
-              : `(another trace) - ${link.spanID}`}
-          </ReferenceLink>
-        ),
-      };
-    });
-    return dropdownItems;
+        return {
+          key: `${link.spanID}`,
+          label: (
+            <ReferenceLink link={link} focusSpan={focusSpan} className="ReferencesButton--TraceRefLink">
+              {isSameTrace
+                ? `${span.resource.serviceName}:${span.name} - ${link.spanID}`
+                : `(another trace) - ${link.spanID}`}
+            </ReferenceLink>
+          ),
+        };
+      }),
+    [focusSpan]
+  );
+
+  const tooltipProps = {
+    arrowPointAtCenter: true,
+    mouseLeaveDelay: 0.5,
+    placement: 'bottom' as TooltipPlacement,
+    title: tooltipText,
+    classNames: { root: 'ReferencesButton--tooltip' },
   };
 
-  render() {
-    const { links, children, tooltipText, focusSpan } = this.props;
-
-    const tooltipProps = {
-      arrowPointAtCenter: true,
-      mouseLeaveDelay: 0.5,
-      placement: 'bottom' as TooltipPlacement,
-      title: tooltipText,
-      classNames: { root: 'ReferencesButton--tooltip' },
-    };
-
-    if (links.length > 1) {
-      return (
-        <Tooltip {...tooltipProps}>
-          <Dropdown menu={{ items: this.linksList(links) }} placement="bottomRight" trigger={['click']}>
-            <a className="ReferencesButton-MultiParent">{children}</a>
-          </Dropdown>
-        </Tooltip>
-      );
-    }
-
-    const link = links[0];
-
+  if (links.length > 1) {
     return (
       <Tooltip {...tooltipProps}>
-        <ReferenceLink link={link} focusSpan={focusSpan} className="ReferencesButton-MultiParent">
-          {children}
-        </ReferenceLink>
+        <Dropdown menu={{ items: linksList(links) }} placement="bottomRight" trigger={['click']}>
+          <a className="ReferencesButton-MultiParent">{children}</a>
+        </Dropdown>
       </Tooltip>
     );
   }
+
+  const link = links[0];
+
+  return (
+    <Tooltip {...tooltipProps}>
+      <ReferenceLink link={link} focusSpan={focusSpan} className="ReferencesButton-MultiParent">
+        {children}
+      </ReferenceLink>
+    </Tooltip>
+  );
 }
+
+export default React.memo(ReferencesButton);


### PR DESCRIPTION
## Which problem is this PR solving?
- Migrate ReferencesButton to Functional Component #3366

## Description of the changes
- Refactored ReferencesButton from React.PureComponent to a functional component.
- Replaced class methods with hook-friendly functions.
- Replaced class methods with hook-friendly functions.
- Preserved all existing props, rendering logic, and behavior.
- Ensured dropdown and single-link rendering work exactly as before.
- No intended visual or behavioral changes — refactor only.

## How was this change tested?
- Updated and ran unit tests using React Testing Library to validate
- Verified that all existing tests pass.
<img width="670" height="124" alt="image" src="https://github.com/user-attachments/assets/401b4dfc-0d4f-467a-914b-3543f4266d6d" />
