### PR TITLE
refactor: convert TracePage from class to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -590,10 +590,10 @@ describe('<TracePage>', () => {
       });
 
       it('hides summary if embedded indicates it should be', () => {
-        // This test verifies the hideSummary logic
-        const embedded = { timeline: { hideSummary: true } };
-        const hideSummary = Boolean(embedded && embedded.timeline.hideSummary);
-        expect(hideSummary).toBe(true);
+        renderWithRouter(<TracePage {...defaultProps} embedded={{ timeline: { hideSummary: true } }} />);
+
+        const summary = document.querySelector('.TracePageHeader--overviewItems');
+        expect(summary).not.toBeInTheDocument();
       });
     });
 
@@ -639,14 +639,10 @@ describe('<TracePage>', () => {
     });
 
     describe('resultCount', () => {
-      let getUiFindVertexKeysSpy;
-
-      beforeAll(() => {
-        getUiFindVertexKeysSpy = jest.spyOn(getUiFindVertexKeys, 'getUiFindVertexKeys');
-      });
+      let getUiFindVertexKeysMock;
 
       beforeEach(() => {
-        getUiFindVertexKeysSpy.mockReset();
+        getUiFindVertexKeysMock = jest.fn();
         filterSpansSpy.mockReset();
       });
 
@@ -681,7 +677,7 @@ describe('<TracePage>', () => {
           mockSet.add(`vertex-${i}`);
         }
 
-        getUiFindVertexKeysSpy.mockReturnValue(mockSet);
+        getUiFindVertexKeysMock.mockReturnValue(mockSet);
 
         const props = {
           ...defaultProps,
@@ -693,7 +689,7 @@ describe('<TracePage>', () => {
 
         if (viewType === ETraceViewType.TraceGraph && props.uiFind) {
           const vertices = [];
-          const graphFindMatches = getUiFindVertexKeysSpy(props.uiFind, vertices);
+          const graphFindMatches = getUiFindVertexKeysMock(props.uiFind, vertices);
           resultCount = graphFindMatches ? graphFindMatches.size : 0;
         }
 

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -99,6 +99,33 @@ type TState = {
 };
 
 // export for tests
+export type TracePageHandle = {
+  readonly state: TState;
+  setState: (newState: Partial<TState> | ((prev: TState) => Partial<TState>), callback?: () => void) => void;
+  _headerElm: React.MutableRefObject<HTMLElement | null>;
+  _searchBar: React.RefObject<InputRef | null>;
+  _scrollManager: ScrollManager;
+  _filterSpans: typeof filterSpans;
+  readonly traceDagEV: TEv | TNil;
+  _adjustViewRange: (startChange: number, endChange: number, trackSrc: string) => void;
+  setHeaderHeight: (elm: HTMLElement | TNil) => void;
+  clearSearch: () => void;
+  focusOnSearchBar: () => void;
+  updateViewRangeTime: TUpdateViewRangeTimeFunction;
+  updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
+  toggleSlimView: () => void;
+  setTraceView: (viewType: ETraceViewType) => void;
+  archiveTrace: () => void;
+  acknowledgeArchive: () => void;
+  ensureTraceFetched: () => void;
+  focusUiFindMatches: () => void;
+  nextResult: () => void;
+  prevResult: () => void;
+  onDetailPanelModeToggle: () => void;
+  onTimelineToggle: () => void;
+};
+
+// export for tests
 export const VIEW_MIN_RANGE = 0.01;
 const VIEW_CHANGE_BASE = 0.005;
 const VIEW_CHANGE_FAST = 0.05;
@@ -128,7 +155,7 @@ export function makeShortcutCallbacks(adjRange: (start: number, end: number) => 
 
 // export for tests
 export const TracePageImpl = React.memo(
-  forwardRef<unknown, TProps>(function TracePageImpl(props, ref) {
+  forwardRef<TracePageHandle, TProps>(function TracePageImpl(props, ref) {
     const {
       acknowledgeArchive: acknowledgeArchiveProp,
       archiveEnabled,


### PR DESCRIPTION
## Summary
- Convert `TracePage` component from class-based to functional component with React hooks
- Replace class lifecycle methods with `useEffect` hooks
- Replace `shouldComponentUpdate` with `React.memo` where appropriate
- Maintain all existing functionality and behavior

Closes #3381

## Test plan
- [x] Existing tests pass
- [x] Component renders correctly
- [x] Trace data loading works as expected
- [x] All child components render properly