### PR TITLE
feat(monitor-ui): support service/spanKind/timeframe via query params

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
@@ -27,6 +27,14 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
+jest.mock('react-router-dom-v5-compat', () => ({
+  useSearchParams: jest.fn(() => {
+    const searchParams = new URLSearchParams();
+    const setSearchParams = jest.fn();
+    return [searchParams, setSearchParams];
+  }),
+}));
+
 jest.mock('../../../utils/config/get-config', () => ({
   getConfigValue: jest.fn(() => 'https://www.jaegertracing.io/docs/latest/spm/'),
   __esModule: true,
@@ -418,11 +426,11 @@ describe('<MonitorATMServicesView>', () => {
     });
 
     afterEach(() => {
-      trackSelectServiceSpy.mockRestore();
-      trackSelectSpanKindSpy.mockRestore();
-      trackSelectTimeframeSpy.mockRestore();
-      trackSearchOperationSpy.mockRestore();
-      trackViewAllTracesSpy.mockRestore();
+      trackSelectServiceSpy?.mockRestore();
+      trackSelectSpanKindSpy?.mockRestore();
+      trackSelectTimeframeSpy?.mockRestore();
+      trackSearchOperationSpy?.mockRestore();
+      trackViewAllTracesSpy?.mockRestore();
     });
 
     it('should handle service change and call tracking', async () => {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -39,6 +39,7 @@ import {
 } from './index.track';
 import withRouteProps from '../../../utils/withRouteProps';
 import SearchableSelect from '../../common/SearchableSelect';
+import { useSearchParams } from 'react-router-dom-v5-compat';
 
 type TReduxProps = {
   services: string[];
@@ -135,14 +136,22 @@ export const MonitorATMServicesViewImpl: React.FC<TProps> = props => {
   const [endTime, setEndTime] = useState<number>(Date.now());
   const [graphWidth, setGraphWidth] = useState<number>(300);
   const [serviceOpsMetrics, setServiceOpsMetrics] = useState<ServiceOpsMetrics[] | undefined>(undefined);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const serviceParam = searchParams.get('service');
+  const spanKindParam = searchParams.get('spankind');
+  const timeFrameParam = searchParams.get('timeframe');
   const [searchOps, setSearchOps] = useState<string>('');
   const [graphXDomain, setGraphXDomain] = useState<number[]>([]);
-  const [selectedService, setSelectedService] = useState<string>(store.get('lastAtmSearchService') || '');
+  const [selectedService, setSelectedService] = useState<string>(
+    serviceParam || store.get('lastAtmSearchService') || ''
+  );
   const [selectedSpanKind, setSelectedSpanKind] = useState<spanKinds>(
-    store.get('lastAtmSearchSpanKind') || 'server'
+    spanKindParam || store.get('lastAtmSearchSpanKind') || 'server'
   );
   const [selectedTimeFrame, setSelectedTimeFrame] = useState<number>(
-    store.get('lastAtmSearchTimeframe') || oneHourInMilliSeconds
+    (timeFrameParam ? parseInt(timeFrameParam, 10) : null) ||
+      store.get('lastAtmSearchTimeframe') ||
+      oneHourInMilliSeconds
   );
 
   const calcGraphXDomain = useCallback(() => {
@@ -240,6 +249,16 @@ export const MonitorATMServicesViewImpl: React.FC<TProps> = props => {
 
   useEffect(() => {
     fetchMetrics();
+  }, [selectedService, selectedSpanKind, selectedTimeFrame]);
+
+  useEffect(() => {
+    const params: Record<string, string> = {
+      service: selectedService,
+      spankind: selectedSpanKind,
+      timeframe: String(selectedTimeFrame),
+    };
+
+    setSearchParams(params, { replace: true });
   }, [selectedService, selectedSpanKind, selectedTimeFrame]);
 
   const { services, metrics, servicesLoading } = props;

--- a/packages/jaeger-ui/src/components/Monitor/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/index.test.js
@@ -19,6 +19,14 @@ jest.mock('../../actions/jaeger-api');
 // Mock the 'store' npm package
 jest.mock('store');
 
+jest.mock('react-router-dom-v5-compat', () => ({
+  useSearchParams: jest.fn(() => {
+    const searchParams = new URLSearchParams();
+    const setSearchParams = jest.fn();
+    return [searchParams, setSearchParams];
+  }),
+}));
+
 // --- Mock References ---
 // Reference the mocked actions module
 const mockedJaegerApiActions = jaegerApiActions;


### PR DESCRIPTION
## Description of the changes
-  Support service/spanKind/timeframe via query params

## How was this change tested?
-  `npm run test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
