### PR TITLE
bug : Increase Increment/decrement buttons visibility in DDG in dark mode

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/Selector.css
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/Selector.css
@@ -11,12 +11,13 @@ SPDX-License-Identifier: Apache-2.0
 
 .HopsSelector--Selector--decrement,
 .HopsSelector--Selector--increment {
-  background-color: #f4f4f4;
+  background-color: var(--surface-tertiary);
   border: none;
   cursor: pointer;
   height: 27px;
   padding: 0em 0.3em 0.3em;
   width: 27px;
+  color: var(--surface-tertiary-text);
 }
 
 .HopsSelector--Selector--decrement {


### PR DESCRIPTION


## Which problem is this PR solving?
-  Resolves #3444  

## Description of the changes
- Increase the visibility of Increment/Decreament buttons in DDG "Visible downstream hops" in the dark mode 
- Now Images in dark mode:
<img width="610" height="160" alt="dark" src="https://github.com/user-attachments/assets/f7bc83c4-202d-4742-ad00-6b101ba4eeb1" />

-And in light mode:
<img width="537" height="168" alt="light" src="https://github.com/user-attachments/assets/67de4b3d-900a-4af9-8047-6af4dbdd9714" />
 

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
