### PR TITLE
Fix responsiveness of Search screen components

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.css
@@ -33,14 +33,10 @@ SPDX-License-Identifier: Apache-2.0
 
 .SearchForm--submit:hover {
   background-color: var(--surface-primary);
-  float: right;
-  max-width: 100%;
 }
 
 .SearchForm--submit:active {
   background-color: var(--surface-primary);
-  float: right;
-  max-width: 100%;
 }
 
 .SearchForm--tagsHintInfo {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.css
@@ -28,16 +28,19 @@ SPDX-License-Identifier: Apache-2.0
   background-color: var(--interactive-primary);
   color: var(--text-inverse);
   float: right;
+  max-width: 100%;
 }
 
 .SearchForm--submit:hover {
   background-color: var(--surface-primary);
   float: right;
+  max-width: 100%;
 }
 
 .SearchForm--submit:active {
   background-color: var(--surface-primary);
   float: right;
+  max-width: 100%;
 }
 
 .SearchForm--tagsHintInfo {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -723,14 +723,16 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
         />
       </FormItem>
 
-      <Button
-        htmlType="submit"
-        className="SearchForm--submit"
-        disabled={submitting || noSelectedService || invalid || invalidDuration !== undefined}
-        data-test={markers.SUBMIT_BTN}
-      >
-        Find Traces
-      </Button>
+      <FormItem>
+        <Button
+          htmlType="submit"
+          className="SearchForm--submit"
+          disabled={submitting || noSelectedService || invalid || invalidDuration !== undefined}
+          data-test={markers.SUBMIT_BTN}
+        >
+          Find Traces
+        </Button>
+      </FormItem>
     </Form>
   );
 };

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -81,7 +81,7 @@ export default function ResultItem({
       />
       <Link to={linkTo}>
         <Row>
-          <Col span={4} className="ub-p2">
+          <Col xs={6} sm={6} md={4} lg={4} className="ub-p2">
             <Tag className="ub-m1" data-testid={markers.NUM_SPANS} variant="outlined">
               {numSpans} Span{numSpans > 1 && 's'}
             </Tag>
@@ -101,7 +101,7 @@ export default function ResultItem({
               </Tag>
             )}
           </Col>
-          <Col span={16} className="ub-p2">
+          <Col xs={12} sm={12} md={16} lg={16} className="ub-p2">
             <ul className="ub-list-reset" data-testid={markers.SERVICE_TAGS}>
               {_sortBy(services, s => s.name).map(service => {
                 const { name, numberOfSpans: count } = service;
@@ -120,7 +120,7 @@ export default function ResultItem({
               })}
             </ul>
           </Col>
-          <Col span={4} className="ub-p3 ub-tx-right-align">
+          <Col xs={6} sm={6} md={4} lg={4} className="ub-p3 ub-tx-right-align">
             {formatRelativeDate(startTime / 1000)}
             <Divider vertical />
             {timeStr.slice(0, -3)}&nbsp;{timeStr.slice(-2)}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.css
@@ -19,7 +19,20 @@ SPDX-License-Identifier: Apache-2.0
   align-items: center;
   background-color: var(--surface-secondary);
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   padding: 1rem;
+}
+
+@media (max-width: 768px) {
+  .SearchResults--headerOverview {
+    gap: 0.5rem;
+  }
+
+  .SearchResults--headerOverview h2 {
+    flex-basis: 100%;
+    margin-bottom: 0.5rem;
+  }
 }
 
 .SearchResults--headerScatterPlot {


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves : #3456 

## Description of the changes
- Fixed responsiveness of few components 

Screenshots : 

Before : 
<img width="372" height="155" alt="Screenshot 2026-01-21 at 3 28 02 PM" src="https://github.com/user-attachments/assets/7c8d542a-01d7-4c69-92c7-aad38062ae03" />
<img width="372" height="194" alt="Screenshot 2026-01-21 at 3 28 10 PM" src="https://github.com/user-attachments/assets/5046c2ca-b48a-43ca-96ba-89ad3b6d66e5" />
<img width="145" height="241" alt="Screenshot 2026-01-21 at 3 28 20 PM" src="https://github.com/user-attachments/assets/5d2df867-a6cc-4d88-81cc-527e47d2150c" />
After : 
<img width="377" height="155" alt="Screenshot 2026-01-21 at 3 27 19 PM" src="https://github.com/user-attachments/assets/56c5ba66-bc54-47f5-812d-a0b7f950923b" />
<img width="377" height="155" alt="Screenshot 2026-01-21 at 3 27 26 PM" src="https://github.com/user-attachments/assets/5f93cc41-0d82-481f-8390-9fba45698b8f" />
<img width="119" height="155" alt="Screenshot 2026-01-21 at 3 27 37 PM" src="https://github.com/user-attachments/assets/799516e5-1a76-468e-b0e8-2ae693d565ce" />
