### PR TITLE
[fix] Fix the dark mode for TraceDiff nodes

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.css
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.css
@@ -5,8 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 .DiffNode {
   background: var(--surface-component-background);
-  border: 1px solid #777;
-  box-shadow: 0 0px 3px 1px rgba(0, 0, 0, 0.2);
+  border: var(--border-default);
+  box-shadow: var(--shadow-sm);
   cursor: pointer;
   white-space: nowrap;
 }


### PR DESCRIPTION

## Description of the changes
- This PR improves nodes ( Text ) readability in dark mode, helping reduce eye strain and enhance overall UX.
Before :
<img width="1536" height="672" alt="Screenshot_28-Jan_02-16-45_21996" src="https://github.com/user-attachments/assets/97d9004f-e783-4b13-9f94-042d993e4a60" />

After:
<img width="1513" height="613" alt="Screenshot_28-Jan_02-17-16_3123" src="https://github.com/user-attachments/assets/d8dd6f93-a2ff-41d5-a47e-3bdbc87ef26e" />

## How was this change tested?
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
