### PR TITLE
Refactor TimelineViewingLayer to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.js
@@ -1,7 +1,6 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -47,46 +46,26 @@ describe('<TimelineViewingLayer>', () => {
     expect(container.querySelector('.TimelineViewingLayer')).toBeInTheDocument();
   });
 
-  it('sets _root to the root DOM node', () => {
+  it('sets ref to the root DOM node', () => {
     const { container } = render(<TimelineViewingLayer {...props} />);
     const timelineLayer = container.querySelector('.TimelineViewingLayer');
     expect(timelineLayer).toBeDefined();
   });
 
   describe('uses DraggableManager', () => {
-    it('initializes the DraggableManager', () => {
-      const comp = new TimelineViewingLayer(props);
-      expect(comp._draggerReframe).toBeDefined();
-    });
-
-    it('returns the dragging bounds from _getDraggingBounds()', () => {
-      const comp = new TimelineViewingLayer(props);
-      comp._root.current = document.createElement('div');
-      comp._root.current.getBoundingClientRect = () => ({ left: 10, width: 100 });
-      expect(comp._getDraggingBounds()).toEqual({ clientXLeft: 10, width: 100 });
-    });
-
-    it('throws error on call to _getDraggingBounds() on unmounted component', () => {
-      const comp = new TimelineViewingLayer(props);
-      comp._root.current = null;
-      expect(() => comp._getDraggingBounds()).toThrow(
-        'Component must be mounted in order to determine DraggableBounds'
-      );
-    });
-
-    it('updates viewRange.time.cursor via _draggerReframe._onMouseMove', () => {
+    it('updates viewRange.time.cursor via mouse move', () => {
       const { container } = render(<TimelineViewingLayer {...props} />);
       fireEvent.mouseMove(container.querySelector('.TimelineViewingLayer'), { clientX: 60 });
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({ cursor: expect.any(Number) });
     });
 
-    it('resets viewRange.time.cursor via _draggerReframe._onMouseLeave', () => {
+    it('resets viewRange.time.cursor via mouse leave', () => {
       const { container } = render(<TimelineViewingLayer {...props} />);
       fireEvent.mouseLeave(container.querySelector('.TimelineViewingLayer'));
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({ cursor: undefined });
     });
 
-    it('handles drag start via _draggerReframe._onDragStart', () => {
+    it('handles drag start via mouse down', () => {
       const { container } = render(<TimelineViewingLayer {...props} />);
       fireEvent.mouseDown(container.querySelector('.TimelineViewingLayer'), { clientX: 60 });
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({
@@ -97,7 +76,7 @@ describe('<TimelineViewingLayer>', () => {
       });
     });
 
-    it('handles drag move via _draggerReframe._onDragMove', () => {
+    it('handles drag move', () => {
       const anchor = 0.25;
       const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
       const { container } = render(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);
@@ -110,7 +89,7 @@ describe('<TimelineViewingLayer>', () => {
       });
     });
 
-    it('handles drag end via _draggerReframe._onDragEnd', () => {
+    it('handles drag end', () => {
       const anchor = 0.75;
       const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
       const { container } = render(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -213,9 +213,9 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
   const { current, cursor, reframe, shiftEnd, shiftStart } = viewRangeTime;
   const [viewStart, viewEnd] = current;
   const haveNextTimeRange = reframe != null || shiftEnd != null || shiftStart != null;
-  let cusrorPosition: string | TNil;
+  let cusorPosition: string | TNil;
   if (!haveNextTimeRange && cursor != null && cursor >= viewStart && cursor <= viewEnd) {
-    cusrorPosition = `${mapToViewSubRange(viewStart, viewEnd, cursor) * 100}%`;
+    cusorPosition = `${mapToViewSubRange(viewStart, viewEnd, cursor) * 100}%`;
   }
 
   return (
@@ -227,8 +227,8 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
       onMouseLeave={draggerReframe.handleMouseLeave}
       onMouseMove={draggerReframe.handleMouseMove}
     >
-      {cusrorPosition != null && (
-        <div className="TimelineViewingLayer--cursorGuide" style={{ left: cusrorPosition }} />
+      {cusorPosition != null && (
+        <div className="TimelineViewingLayer--cursorGuide" style={{ left: cusorPosition }} />
       )}
       {reframe != null && getMarkers(viewStart, viewEnd, reframe.anchor, reframe.shift, false)}
       {shiftEnd != null && getMarkers(viewStart, viewEnd, viewEnd, shiftEnd, true)}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -194,9 +194,13 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
     ]
   );
 
-  // Reset bounds when boundsInvalidator changes
+  // Reset bounds when boundsInvalidator changes, but not on initial mount
+  const prevBoundsInvalidatorRef = useRef(boundsInvalidator);
   useEffect(() => {
-    draggerReframe.resetBounds();
+    if (prevBoundsInvalidatorRef.current !== boundsInvalidator) {
+      draggerReframe.resetBounds();
+      prevBoundsInvalidatorRef.current = boundsInvalidator;
+    }
   }, [boundsInvalidator, draggerReframe]);
 
   // Cleanup on unmount

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -126,7 +126,7 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
     viewRangeTimeRef.current = viewRangeTime;
     updateNextViewRangeTimeRef.current = updateNextViewRangeTime;
     updateViewRangeTimeRef.current = updateViewRangeTime;
-  });
+  }, [viewRangeTime, updateNextViewRangeTime, updateViewRangeTime]);
 
   const getDraggingBounds = useCallback((): DraggableBounds => {
     const current = rootRef.current;
@@ -213,9 +213,9 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
   const { current, cursor, reframe, shiftEnd, shiftStart } = viewRangeTime;
   const [viewStart, viewEnd] = current;
   const haveNextTimeRange = reframe != null || shiftEnd != null || shiftStart != null;
-  let cusorPosition: string | TNil;
+  let cursorPosition: string | TNil;
   if (!haveNextTimeRange && cursor != null && cursor >= viewStart && cursor <= viewEnd) {
-    cusorPosition = `${mapToViewSubRange(viewStart, viewEnd, cursor) * 100}%`;
+    cursorPosition = `${mapToViewSubRange(viewStart, viewEnd, cursor) * 100}%`;
   }
 
   return (
@@ -227,8 +227,8 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
       onMouseLeave={draggerReframe.handleMouseLeave}
       onMouseMove={draggerReframe.handleMouseMove}
     >
-      {cusorPosition != null && (
-        <div className="TimelineViewingLayer--cursorGuide" style={{ left: cusorPosition }} />
+      {cursorPosition != null && (
+        <div className="TimelineViewingLayer--cursorGuide" style={{ left: cursorPosition }} />
       )}
       {reframe != null && getMarkers(viewStart, viewEnd, reframe.anchor, reframe.shift, false)}
       {shiftEnd != null && getMarkers(viewStart, viewEnd, viewEnd, shiftEnd, true)}


### PR DESCRIPTION
## Summary
Converts `TimelineViewingLayer` from a React class component to a functional component using hooks, as part of the codebase modernization effort.

Resolves #3368 

## Changes
- Replace class component with functional component
- Replace `React.createRef` with `useRef` hook
- Replace `componentDidUpdate` with `useEffect` for boundsInvalidator changes
- Replace `componentWillUnmount` with `useEffect` cleanup
- Use `useCallback` for event handlers to maintain referential stability
- Use `useMemo` to create DraggableManager instance
- Wrap component with `React.memo` (was `PureComponent`)
- Update tests to work with functional component

## Test plan
- [x] All 16 existing unit tests pass
- [x] No visual regression (component renders identically)
- [x] Manual testing in browser

Signed-off-by: Taanvi Khevaria <taanvikhevaria@gmail.com>