### PR TITLE
Test(ui): Remove unused mocked history from TopNav tests

### DIFF
--- a/packages/jaeger-ui/.gitignore
+++ b/packages/jaeger-ui/.gitignore
@@ -7,9 +7,3 @@ stats.html
 # Local UI config files for development (see README.md for details)
 jaeger-ui.config.js
 jaeger-ui.config.json
-
-# npm / windows garbage
-AppData/
-npm-cache
-**/_cacache
-node_modules


### PR DESCRIPTION
## Which problem is this PR solving?
Removes an unused mocked history object from the TopNav test suite.
The existing tests already validate TopNav behavior using router context, so the mocked history was unnecessary and potentially confusing.

## Description of the changes
- Removes unused mocked history from TopNav tests.
- Cleans up related imports.
- Keeps all existing router-based tests intact (BrowserRouter + CompatRouter).
- No production code changes.
- No behavior changes.

## How was this change tested?
- Ran the Jaeger-UI unit test suite locally.
- Verified the new TopNav test passes successfully:
```bash
        npm install --ignore-scripts
        npm test -- TopNav
```

## Checklist
- [*] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [*] I have signed all commits
- [*] I have added unit tests for the new functionality
- [*] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
