### PR TITLE
docs: add AI trace analysis starter code for LFX mentorship

### DIFF
--- a/docs/ai-trace-analysis-starter-code/README.md
+++ b/docs/ai-trace-analysis-starter-code/README.md
@@ -1,0 +1,147 @@
+# AI-Powered Trace Analysis - Starter Code
+
+This directory contains ready-to-use Go code for the LFX Mentorship project:
+**"AI-Powered Trace Analysis with Local LLM Support"**
+
+## Overview
+
+This starter code implements **Feature 1: Natural Language → Jaeger Search Parameters**.
+
+Users can write queries like:
+- "Show me 500 errors from payment-service taking more than 2 seconds"
+- "Find slow traces for checkout operation, latency above 1s, limit 50"
+- "auth-service errors"
+
+And get structured Jaeger search parameters back.
+
+## Files
+
+```
+nlquery/
+├── doc.go           # Package documentation
+├── config.go        # YAML configuration structs
+├── schema.go        # SearchParams definition + validation
+├── prompt.go        # System prompt + few-shot examples
+├── provider.go      # LLMProvider interface + Ollama implementation
+├── parser.go        # Core NL → SearchParams logic
+├── parser_test.go   # Comprehensive table-driven tests
+└── go.mod           # Module definition
+
+example-config.yaml  # Jaeger v2 configuration example
+```
+
+## Prerequisites
+
+1. **Go 1.22+**
+2. **Ollama** installed and running:
+   ```bash
+   # Install Ollama (macOS)
+   brew install ollama
+
+   # Start Ollama server
+   ollama serve
+
+   # Pull a small model
+   ollama pull qwen2.5:0.5b
+   ```
+
+## Running Tests
+
+```bash
+cd nlquery
+
+# Install dependencies
+go mod tidy
+
+# Run tests
+go test -v ./...
+
+# Run tests with coverage
+go test -v -cover ./...
+```
+
+## Integration with Jaeger
+
+This code is designed to be placed in the Jaeger repository at:
+```
+cmd/jaeger/internal/extension/jaegerquery/nlquery/
+```
+
+To integrate:
+
+1. Copy the `nlquery/` directory to the Jaeger codebase
+2. Update the Jaeger Query Service extension to use the parser
+3. Add configuration loading for the `nlquery` section
+4. Wire up an HTTP/gRPC endpoint for NL queries
+
+## Example Usage
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    "github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/nlquery"
+)
+
+func main() {
+    // Create provider
+    provider, err := nlquery.NewOllamaProvider(nlquery.OllamaConfig{
+        ServerURL:   "http://localhost:11434",
+        Model:       "qwen2.5:0.5b",
+        Timeout:     10 * time.Second,
+        Temperature: 0.0,
+        MaxTokens:   256,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Create parser
+    parser := nlquery.NewParser(provider)
+
+    // Parse a natural language query
+    params, err := parser.ParseNLQueryToSearchParams(
+        context.Background(),
+        "Show me 500 errors from payment-service taking more than 2 seconds",
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Use the extracted parameters
+    fmt.Printf("Service: %v\n", *params.ServiceName)
+    fmt.Printf("MinDuration: %v\n", *params.MinDuration)
+    fmt.Printf("Error: %v\n", *params.Error)
+    fmt.Printf("Tags: %v\n", params.Tags)
+}
+```
+
+## Recommended Models
+
+| Model | Size | Speed | Accuracy | Notes |
+|-------|------|-------|----------|-------|
+| `qwen2.5:0.5b` | 0.5B | ⚡ Fastest | Good | **Primary recommendation** |
+| `phi3:mini` | 3.8B | Medium | Better | Use if accuracy issues with Qwen |
+| `llama3.2:1b` | 1B | Fast | Good | Alternative option |
+
+## What's NOT Included
+
+This starter code intentionally does NOT include:
+
+- ❌ UI components
+- ❌ Streaming responses
+- ❌ Multiple model providers (OpenAI, etc.)
+- ❌ Trace summarization
+- ❌ Smart filtering
+- ❌ Time range parsing ("last hour")
+
+These are explicitly out of scope for the initial PR as per the proposal.
+
+## License
+
+Apache-2.0 (consistent with Jaeger)

--- a/docs/ai-trace-analysis-starter-code/example-config.yaml
+++ b/docs/ai-trace-analysis-starter-code/example-config.yaml
@@ -1,0 +1,69 @@
+# Jaeger v2 Configuration Example
+# This shows how to enable the Natural Language Query feature
+#
+# To run:
+#   1. Start Ollama: ollama serve
+#   2. Pull model: ollama pull qwen2.5:0.5b
+#   3. Start Jaeger with this config: jaeger --config config.yaml
+
+extensions:
+  jaeger_query:
+    # Main query service configuration
+    grpc:
+      endpoint: 0.0.0.0:16685
+    http:
+      endpoint: 0.0.0.0:16686
+
+    # Natural Language Query configuration (NEW)
+    nlquery:
+      # Enable/disable the feature (default: false)
+      enabled: true
+
+      # LLM provider to use (currently only "ollama" is supported)
+      provider: ollama
+
+      # Ollama-specific configuration
+      ollama:
+        # URL of the Ollama server
+        server_url: http://localhost:11434
+
+        # Model to use for query parsing
+        # Recommended models (smallest to largest):
+        #   - qwen2.5:0.5b (fastest, good accuracy)
+        #   - phi3:mini (better accuracy, slower)
+        #   - llama3.2:1b (alternative)
+        model: qwen2.5:0.5b
+
+        # Request timeout
+        timeout: 10s
+
+        # Temperature for generation (0.0 = deterministic)
+        # IMPORTANT: Keep at 0.0 for consistent, reproducible results
+        temperature: 0.0
+
+        # Maximum tokens in response
+        max_tokens: 256
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: memstore
+
+service:
+  extensions: [jaeger_query]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter]

--- a/docs/ai-trace-analysis-starter-code/nlquery/config.go
+++ b/docs/ai-trace-analysis-starter-code/nlquery/config.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package nlquery
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Config holds NL query parser configuration.
+// Designed to be embedded in Jaeger Query Service configuration.
+type Config struct {
+	// Enabled controls whether NL query parsing is available
+	Enabled bool `mapstructure:"enabled"`
+
+	// Provider specifies which LLM backend to use (currently only "ollama")
+	Provider string `mapstructure:"provider"`
+
+	// Ollama contains Ollama-specific configuration
+	Ollama OllamaConfig `mapstructure:"ollama"`
+}
+
+// OllamaConfig contains Ollama provider settings
+type OllamaConfig struct {
+	// ServerURL is the Ollama API endpoint (e.g., "http://localhost:11434")
+	ServerURL string `mapstructure:"server_url"`
+
+	// Model is the model name to use (e.g., "qwen2.5:0.5b", "phi3:mini")
+	Model string `mapstructure:"model"`
+
+	// Timeout is the maximum duration for LLM requests
+	Timeout time.Duration `mapstructure:"timeout"`
+
+	// Temperature controls randomness (0.0 = deterministic)
+	Temperature float64 `mapstructure:"temperature"`
+
+	// MaxTokens limits the response length
+	MaxTokens int `mapstructure:"max_tokens"`
+}
+
+// DefaultConfig returns a Config with sensible defaults
+func DefaultConfig() Config {
+	return Config{
+		Enabled:  false, // Opt-in feature
+		Provider: "ollama",
+		Ollama: OllamaConfig{
+			ServerURL:   "http://localhost:11434",
+			Model:       "qwen2.5:0.5b",
+			Timeout:     10 * time.Second,
+			Temperature: 0.0, // Deterministic
+			MaxTokens:   256,
+		},
+	}
+}
+
+// Validate checks the configuration for errors
+func (c *Config) Validate() error {
+	if !c.Enabled {
+		return nil // No validation needed if disabled
+	}
+
+	if c.Provider == "" {
+		return errors.New("nlquery.provider is required when enabled")
+	}
+
+	if c.Provider != "ollama" {
+		return fmt.Errorf("nlquery.provider '%s' is not supported, only 'ollama' is available", c.Provider)
+	}
+
+	return c.Ollama.Validate()
+}
+
+// Validate checks OllamaConfig for errors
+func (c *OllamaConfig) Validate() error {
+	if c.ServerURL == "" {
+		return errors.New("nlquery.ollama.server_url is required")
+	}
+
+	if c.Model == "" {
+		return errors.New("nlquery.ollama.model is required")
+	}
+
+	if c.Timeout <= 0 {
+		return errors.New("nlquery.ollama.timeout must be positive")
+	}
+
+	if c.Temperature < 0 || c.Temperature > 2 {
+		return fmt.Errorf("nlquery.ollama.temperature must be between 0 and 2, got %f", c.Temperature)
+	}
+
+	if c.MaxTokens <= 0 {
+		return errors.New("nlquery.ollama.max_tokens must be positive")
+	}
+
+	return nil
+}

--- a/docs/ai-trace-analysis-starter-code/nlquery/doc.go
+++ b/docs/ai-trace-analysis-starter-code/nlquery/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nlquery provides natural language to Jaeger search parameter parsing.
+//
+// This package enables users to express trace search queries in natural language,
+// which are then converted to structured Jaeger TraceQueryParameters using a
+// local Small Language Model (SLM) via Ollama.
+//
+// Example usage:
+//
+//	provider, _ := nlquery.NewOllamaProvider(nlquery.OllamaConfig{
+//	    ServerURL: "http://localhost:11434",
+//	    Model:     "qwen2.5:0.5b",
+//	    Timeout:   10 * time.Second,
+//	})
+//	parser := nlquery.NewParser(provider)
+//	params, err := parser.ParseNLQueryToSearchParams(ctx, "500 errors from payment-service")
+//
+// The package is designed to be:
+//   - Local-first: Uses Ollama with small models, no external API calls
+//   - Deterministic: Temperature=0, strict JSON output validation
+//   - Extensible: LLMProvider interface allows swapping implementations
+package nlquery

--- a/docs/ai-trace-analysis-starter-code/nlquery/go.mod
+++ b/docs/ai-trace-analysis-starter-code/nlquery/go.mod
@@ -1,0 +1,14 @@
+module github.com/jaegertracing/jaeger/cmd/jaeger/internal/extension/jaegerquery/nlquery
+
+go 1.22
+
+require (
+	github.com/stretchr/testify v1.9.0
+	github.com/tmc/langchaingo v0.1.12
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/docs/ai-trace-analysis-starter-code/nlquery/parser.go
+++ b/docs/ai-trace-analysis-starter-code/nlquery/parser.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package nlquery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	// ErrEmptyQuery indicates an empty or whitespace-only user query.
+	ErrEmptyQuery = errors.New("query cannot be empty")
+
+	// ErrInvalidJSON indicates the LLM returned non-JSON output.
+	ErrInvalidJSON = errors.New("LLM returned invalid JSON")
+
+	// ErrValidationFailed indicates extracted params failed validation.
+	ErrValidationFailed = errors.New("extracted parameters failed validation")
+
+	// ErrLLMFailure indicates the LLM provider returned an error.
+	ErrLLMFailure = errors.New("LLM generation failed")
+)
+
+// Parser converts natural language queries to structured SearchParams.
+// It uses an LLMProvider to parse queries and validates the result.
+type Parser struct {
+	provider LLMProvider
+}
+
+// NewParser creates a new NL query parser with the given LLM provider.
+func NewParser(provider LLMProvider) *Parser {
+	if provider == nil {
+		panic("nlquery: provider cannot be nil")
+	}
+	return &Parser{provider: provider}
+}
+
+// ParseNLQueryToSearchParams extracts SearchParams from a natural language query.
+//
+// The process:
+//  1. Validates input is non-empty
+//  2. Builds a prompt with system instructions and few-shot examples
+//  3. Calls the LLM provider
+//  4. Extracts JSON from the response (handles LLM quirks like markdown blocks)
+//  5. Unmarshals to SearchParams
+//  6. Validates the extracted parameters
+//
+// Returns an error if any step fails. The error will wrap one of:
+// ErrEmptyQuery, ErrInvalidJSON, ErrValidationFailed, or ErrLLMFailure.
+func (p *Parser) ParseNLQueryToSearchParams(ctx context.Context, userQuery string) (*SearchParams, error) {
+	// 1. Input validation
+	userQuery = strings.TrimSpace(userQuery)
+	if userQuery == "" {
+		return nil, ErrEmptyQuery
+	}
+
+	// 2. Build prompt
+	prompt := BuildPrompt(userQuery)
+
+	// 3. Call LLM
+	rawResponse, err := p.provider.Generate(ctx, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrLLMFailure, err)
+	}
+
+	// 4. Extract JSON from response
+	jsonStr := extractJSON(rawResponse)
+	if jsonStr == "" {
+		return nil, fmt.Errorf("%w: no JSON found in response: %q", ErrInvalidJSON, truncate(rawResponse, 100))
+	}
+
+	// 5. Unmarshal to struct
+	var params SearchParams
+	if err := json.Unmarshal([]byte(jsonStr), &params); err != nil {
+		return nil, fmt.Errorf("%w: %v (raw JSON: %q)", ErrInvalidJSON, err, truncate(jsonStr, 100))
+	}
+
+	// 6. Validate extracted parameters
+	if err := params.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrValidationFailed, err)
+	}
+
+	return &params, nil
+}
+
+// extractJSON attempts to extract a JSON object from potentially noisy LLM output.
+// SLMs sometimes wrap JSON in markdown code blocks or add explanatory text.
+func extractJSON(response string) string {
+	response = strings.TrimSpace(response)
+
+	// Fast path: response is already clean JSON
+	if strings.HasPrefix(response, "{") && strings.HasSuffix(response, "}") {
+		// Verify it's valid JSON before returning
+		if json.Valid([]byte(response)) {
+			return response
+		}
+	}
+
+	// Try to extract from markdown code blocks: ```json ... ``` or ``` ... ```
+	codeBlockRe := regexp.MustCompile("(?s)```(?:json)?\\s*({.+?})\\s*```")
+	if matches := codeBlockRe.FindStringSubmatch(response); len(matches) > 1 {
+		candidate := strings.TrimSpace(matches[1])
+		if json.Valid([]byte(candidate)) {
+			return candidate
+		}
+	}
+
+	// Fallback: find first { to last } and hope for the best
+	start := strings.Index(response, "{")
+	end := strings.LastIndex(response, "}")
+	if start != -1 && end > start {
+		candidate := response[start : end+1]
+		if json.Valid([]byte(candidate)) {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
+// truncate shortens a string for error messages
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/docs/ai-trace-analysis-starter-code/nlquery/parser_test.go
+++ b/docs/ai-trace-analysis-starter-code/nlquery/parser_test.go
@@ -1,0 +1,651 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package nlquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ptr is a helper to create pointers to values in test literals
+func ptr[T any](v T) *T { return &v }
+
+// MockProvider implements LLMProvider for testing
+type MockProvider struct {
+	Response string
+	Err      error
+}
+
+func (m *MockProvider) Generate(ctx context.Context, prompt string) (string, error) {
+	if m.Err != nil {
+		return "", m.Err
+	}
+	return m.Response, nil
+}
+
+func TestParseNLQueryToSearchParams(t *testing.T) {
+	tests := []struct {
+		name         string
+		userQuery    string
+		mockResponse string
+		mockErr      error
+		expected     *SearchParams
+		expectErrIs  error
+		expectErrMsg string
+	}{
+		// === Success Cases ===
+		{
+			name:         "500 errors from payment-service with latency",
+			userQuery:    "Show me 500 errors from payment-service taking more than 2 seconds",
+			mockResponse: `{"service":"payment-service","tags":{"http.status_code":"500"},"minDuration":"2s","error":true}`,
+			expected: &SearchParams{
+				ServiceName: ptr("payment-service"),
+				Tags:        map[string]string{"http.status_code": "500"},
+				MinDuration: ptr("2s"),
+				Error:       ptr(true),
+			},
+		},
+		{
+			name:         "checkout operation with latency and limit",
+			userQuery:    "Find slow traces for checkout operation, latency above 1s, limit 50",
+			mockResponse: `{"operation":"checkout","minDuration":"1s","limit":50}`,
+			expected: &SearchParams{
+				OperationName: ptr("checkout"),
+				MinDuration:   ptr("1s"),
+				Limit:         ptr(50),
+			},
+		},
+		{
+			name:         "simple service errors",
+			userQuery:    "auth-service errors",
+			mockResponse: `{"service":"auth-service","error":true}`,
+			expected: &SearchParams{
+				ServiceName: ptr("auth-service"),
+				Error:       ptr(true),
+			},
+		},
+		{
+			name:         "tag-based query",
+			userQuery:    "traces where user.id equals 12345",
+			mockResponse: `{"tags":{"user.id":"12345"}}`,
+			expected: &SearchParams{
+				Tags: map[string]string{"user.id": "12345"},
+			},
+		},
+		{
+			name:         "duration range query",
+			userQuery:    "traces between 100ms and 5s",
+			mockResponse: `{"minDuration":"100ms","maxDuration":"5s"}`,
+			expected: &SearchParams{
+				MinDuration: ptr("100ms"),
+				MaxDuration: ptr("5s"),
+			},
+		},
+		{
+			name:         "complex query with multiple fields",
+			userQuery:    "payment-service processOrder operation with errors and latency over 500ms limit 100",
+			mockResponse: `{"service":"payment-service","operation":"processOrder","minDuration":"500ms","error":true,"limit":100}`,
+			expected: &SearchParams{
+				ServiceName:   ptr("payment-service"),
+				OperationName: ptr("processOrder"),
+				MinDuration:   ptr("500ms"),
+				Error:         ptr(true),
+				Limit:         ptr(100),
+			},
+		},
+		{
+			name:         "only limit specified",
+			userQuery:    "show me 20 traces",
+			mockResponse: `{"limit":20}`,
+			expected: &SearchParams{
+				Limit: ptr(20),
+			},
+		},
+		{
+			name:         "microsecond duration",
+			userQuery:    "traces faster than 100 microseconds",
+			mockResponse: `{"maxDuration":"100us"}`,
+			expected: &SearchParams{
+				MaxDuration: ptr("100us"),
+			},
+		},
+
+		// === JSON Extraction Edge Cases ===
+		{
+			name:         "handles markdown code block in response",
+			userQuery:    "payment errors",
+			mockResponse: "```json\n{\"service\":\"payment\",\"error\":true}\n```",
+			expected: &SearchParams{
+				ServiceName: ptr("payment"),
+				Error:       ptr(true),
+			},
+		},
+		{
+			name:         "handles markdown code block without json tag",
+			userQuery:    "payment errors",
+			mockResponse: "```\n{\"service\":\"payment\",\"error\":true}\n```",
+			expected: &SearchParams{
+				ServiceName: ptr("payment"),
+				Error:       ptr(true),
+			},
+		},
+		{
+			name:         "handles JSON with surrounding text",
+			userQuery:    "payment errors",
+			mockResponse: "Here is the result: {\"service\":\"payment\"} That's all.",
+			expected: &SearchParams{
+				ServiceName: ptr("payment"),
+			},
+		},
+		{
+			name:         "handles extra whitespace in JSON",
+			userQuery:    "auth service",
+			mockResponse: "  \n{\"service\":\"auth\"}\n  ",
+			expected: &SearchParams{
+				ServiceName: ptr("auth"),
+			},
+		},
+
+		// === Error Cases ===
+		{
+			name:        "empty query returns error",
+			userQuery:   "",
+			expectErrIs: ErrEmptyQuery,
+		},
+		{
+			name:        "whitespace-only query returns error",
+			userQuery:   "   \t\n  ",
+			expectErrIs: ErrEmptyQuery,
+		},
+		{
+			name:         "invalid JSON response",
+			userQuery:    "find traces",
+			mockResponse: "I don't understand your query",
+			expectErrIs:  ErrInvalidJSON,
+		},
+		{
+			name:         "malformed JSON response",
+			userQuery:    "find traces",
+			mockResponse: `{"service": "test", invalid}`,
+			expectErrIs:  ErrInvalidJSON,
+		},
+		{
+			name:         "empty JSON object is valid but empty",
+			userQuery:    "nothing specific",
+			mockResponse: `{}`,
+			expected:     &SearchParams{},
+		},
+		{
+			name:         "invalid duration format in minDuration",
+			userQuery:    "traces over 2 seconds",
+			mockResponse: `{"minDuration":"2sec"}`,
+			expectErrIs:  ErrValidationFailed,
+			expectErrMsg: "invalid minDuration",
+		},
+		{
+			name:         "invalid duration format in maxDuration",
+			userQuery:    "traces under 2 seconds",
+			mockResponse: `{"maxDuration":"2 seconds"}`,
+			expectErrIs:  ErrValidationFailed,
+			expectErrMsg: "invalid maxDuration",
+		},
+		{
+			name:         "minDuration exceeds maxDuration",
+			userQuery:    "traces between 10s and 2s",
+			mockResponse: `{"minDuration":"10s","maxDuration":"2s"}`,
+			expectErrIs:  ErrValidationFailed,
+			expectErrMsg: "cannot exceed",
+		},
+		{
+			name:         "limit too high",
+			userQuery:    "show all traces",
+			mockResponse: `{"limit":9999}`,
+			expectErrIs:  ErrValidationFailed,
+			expectErrMsg: "cannot exceed 1000",
+		},
+		{
+			name:         "limit zero",
+			userQuery:    "show no traces",
+			mockResponse: `{"limit":0}`,
+			expectErrIs:  ErrValidationFailed,
+			expectErrMsg: "must be at least 1",
+		},
+		{
+			name:         "limit negative",
+			userQuery:    "show negative traces",
+			mockResponse: `{"limit":-5}`,
+			expectErrIs:  ErrValidationFailed,
+			expectErrMsg: "must be at least 1",
+		},
+		{
+			name:        "LLM error propagates",
+			userQuery:   "find traces",
+			mockErr:     errors.New("connection refused"),
+			expectErrIs: ErrLLMFailure,
+		},
+		{
+			name:        "LLM timeout error",
+			userQuery:   "find traces",
+			mockErr:     context.DeadlineExceeded,
+			expectErrIs: ErrLLMFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockProvider{
+				Response: tt.mockResponse,
+				Err:      tt.mockErr,
+			}
+			parser := NewParser(mock)
+
+			result, err := parser.ParseNLQueryToSearchParams(context.Background(), tt.userQuery)
+
+			if tt.expectErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.expectErrIs)
+				if tt.expectErrMsg != "" {
+					assert.Contains(t, err.Error(), tt.expectErrMsg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSearchParams_Validate(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     SearchParams
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:   "empty params are valid",
+			params: SearchParams{},
+		},
+		{
+			name:   "valid minDuration only",
+			params: SearchParams{MinDuration: ptr("2s")},
+		},
+		{
+			name:   "valid maxDuration only",
+			params: SearchParams{MaxDuration: ptr("5s")},
+		},
+		{
+			name:   "valid duration range",
+			params: SearchParams{MinDuration: ptr("2s"), MaxDuration: ptr("5s")},
+		},
+		{
+			name:   "equal durations are valid",
+			params: SearchParams{MinDuration: ptr("2s"), MaxDuration: ptr("2s")},
+		},
+		{
+			name:   "valid milliseconds",
+			params: SearchParams{MinDuration: ptr("500ms")},
+		},
+		{
+			name:   "valid microseconds",
+			params: SearchParams{MinDuration: ptr("100us")},
+		},
+		{
+			name:   "valid nanoseconds",
+			params: SearchParams{MinDuration: ptr("1000ns")},
+		},
+		{
+			name:   "valid limit 1",
+			params: SearchParams{Limit: ptr(1)},
+		},
+		{
+			name:   "valid limit 1000",
+			params: SearchParams{Limit: ptr(1000)},
+		},
+		{
+			name:       "invalid minDuration format",
+			params:     SearchParams{MinDuration: ptr("invalid")},
+			wantErr:    true,
+			errContain: "invalid minDuration",
+		},
+		{
+			name:       "invalid maxDuration format",
+			params:     SearchParams{MaxDuration: ptr("2sec")},
+			wantErr:    true,
+			errContain: "invalid maxDuration",
+		},
+		{
+			name:       "min > max duration",
+			params:     SearchParams{MinDuration: ptr("10s"), MaxDuration: ptr("5s")},
+			wantErr:    true,
+			errContain: "cannot exceed",
+		},
+		{
+			name:       "limit too high",
+			params:     SearchParams{Limit: ptr(1001)},
+			wantErr:    true,
+			errContain: "cannot exceed 1000",
+		},
+		{
+			name:       "limit zero",
+			params:     SearchParams{Limit: ptr(0)},
+			wantErr:    true,
+			errContain: "must be at least 1",
+		},
+		{
+			name:       "limit negative",
+			params:     SearchParams{Limit: ptr(-1)},
+			wantErr:    true,
+			errContain: "must be at least 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.params.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSearchParams_ToQueryParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   SearchParams
+		expected map[string]interface{}
+	}{
+		{
+			name:     "empty params",
+			params:   SearchParams{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "all fields set",
+			params: SearchParams{
+				ServiceName:   ptr("payment"),
+				OperationName: ptr("checkout"),
+				MinDuration:   ptr("1s"),
+				MaxDuration:   ptr("5s"),
+				Tags:          map[string]string{"env": "prod"},
+				Limit:         ptr(100),
+			},
+			expected: map[string]interface{}{
+				"service":     "payment",
+				"operation":   "checkout",
+				"minDuration": "1s",
+				"maxDuration": "5s",
+				"tags":        map[string]string{"env": "prod"},
+				"limit":       100,
+			},
+		},
+		{
+			name: "partial fields",
+			params: SearchParams{
+				ServiceName: ptr("auth"),
+			},
+			expected: map[string]interface{}{
+				"service": "auth",
+			},
+		},
+		{
+			name: "empty tags map is omitted",
+			params: SearchParams{
+				ServiceName: ptr("test"),
+				Tags:        map[string]string{},
+			},
+			expected: map[string]interface{}{
+				"service": "test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.params.ToQueryParams()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSearchParams_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  SearchParams
+		isEmpty bool
+	}{
+		{
+			name:    "zero value is empty",
+			params:  SearchParams{},
+			isEmpty: true,
+		},
+		{
+			name:    "nil tags is empty",
+			params:  SearchParams{Tags: nil},
+			isEmpty: true,
+		},
+		{
+			name:    "empty tags map is empty",
+			params:  SearchParams{Tags: map[string]string{}},
+			isEmpty: true,
+		},
+		{
+			name:    "service set is not empty",
+			params:  SearchParams{ServiceName: ptr("test")},
+			isEmpty: false,
+		},
+		{
+			name:    "operation set is not empty",
+			params:  SearchParams{OperationName: ptr("test")},
+			isEmpty: false,
+		},
+		{
+			name:    "tags set is not empty",
+			params:  SearchParams{Tags: map[string]string{"k": "v"}},
+			isEmpty: false,
+		},
+		{
+			name:    "limit set is not empty",
+			params:  SearchParams{Limit: ptr(10)},
+			isEmpty: false,
+		},
+		{
+			name:    "error set is not empty",
+			params:  SearchParams{Error: ptr(true)},
+			isEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isEmpty, tt.params.IsEmpty())
+		})
+	}
+}
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "clean JSON",
+			input:    `{"foo":"bar"}`,
+			expected: `{"foo":"bar"}`,
+		},
+		{
+			name:     "JSON with whitespace",
+			input:    `   {"foo":"bar"}   `,
+			expected: `{"foo":"bar"}`,
+		},
+		{
+			name:     "markdown code block with json tag",
+			input:    "```json\n{\"foo\":\"bar\"}\n```",
+			expected: `{"foo":"bar"}`,
+		},
+		{
+			name:     "markdown code block without tag",
+			input:    "```\n{\"foo\":\"bar\"}\n```",
+			expected: `{"foo":"bar"}`,
+		},
+		{
+			name:     "JSON surrounded by text",
+			input:    "Here is the result: {\"foo\":\"bar\"} done",
+			expected: `{"foo":"bar"}`,
+		},
+		{
+			name:     "nested JSON",
+			input:    `{"outer":{"inner":"value"}}`,
+			expected: `{"outer":{"inner":"value"}}`,
+		},
+		{
+			name:     "no JSON present",
+			input:    "just some text",
+			expected: "",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "invalid JSON syntax",
+			input:    `{"foo": bar}`,
+			expected: "",
+		},
+		{
+			name:     "only opening brace",
+			input:    "{",
+			expected: "",
+		},
+		{
+			name:     "only braces wrong order",
+			input:    "}{",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractJSON(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     Config
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:   "disabled config is always valid",
+			config: Config{Enabled: false},
+		},
+		{
+			name: "valid enabled config",
+			config: Config{
+				Enabled:  true,
+				Provider: "ollama",
+				Ollama: OllamaConfig{
+					ServerURL:   "http://localhost:11434",
+					Model:       "qwen2.5:0.5b",
+					Timeout:     10_000_000_000, // 10s in nanoseconds
+					Temperature: 0.0,
+					MaxTokens:   256,
+				},
+			},
+		},
+		{
+			name: "missing provider",
+			config: Config{
+				Enabled: true,
+			},
+			wantErr:    true,
+			errContain: "provider is required",
+		},
+		{
+			name: "unsupported provider",
+			config: Config{
+				Enabled:  true,
+				Provider: "openai",
+			},
+			wantErr:    true,
+			errContain: "not supported",
+		},
+		{
+			name: "missing server URL",
+			config: Config{
+				Enabled:  true,
+				Provider: "ollama",
+				Ollama: OllamaConfig{
+					Model:     "test",
+					Timeout:   10_000_000_000,
+					MaxTokens: 256,
+				},
+			},
+			wantErr:    true,
+			errContain: "server_url is required",
+		},
+		{
+			name: "missing model",
+			config: Config{
+				Enabled:  true,
+				Provider: "ollama",
+				Ollama: OllamaConfig{
+					ServerURL: "http://localhost:11434",
+					Timeout:   10_000_000_000,
+					MaxTokens: 256,
+				},
+			},
+			wantErr:    true,
+			errContain: "model is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	prompt := BuildPrompt("test query")
+
+	// Verify prompt structure
+	assert.Contains(t, prompt, "You are a Jaeger trace query parameter extractor")
+	assert.Contains(t, prompt, "RULES:")
+	assert.Contains(t, prompt, "EXAMPLES:")
+	assert.Contains(t, prompt, `Query: "test query"`)
+	assert.Contains(t, prompt, "Output:")
+}
+
+func TestNewParser_PanicOnNil(t *testing.T) {
+	assert.Panics(t, func() {
+		NewParser(nil)
+	})
+}

--- a/docs/ai-trace-analysis-starter-code/nlquery/prompt.go
+++ b/docs/ai-trace-analysis-starter-code/nlquery/prompt.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package nlquery
+
+import "fmt"
+
+// systemPrompt contains the core instructions for the LLM.
+// Optimized for Small Language Models (SLMs) - short, rule-based.
+const systemPrompt = `You are a Jaeger trace query parameter extractor.
+Your ONLY job is to extract search parameters from natural language queries.
+
+RULES:
+1. Output ONLY valid JSON. No explanations. No markdown code blocks.
+2. Use ONLY these fields: service, operation, tags, minDuration, maxDuration, error, limit
+3. Duration format: number + unit (e.g., "2s", "500ms", "1m")
+4. For HTTP errors (4xx, 5xx), set error:true AND add http.status_code to tags
+5. If a field is not mentioned, DO NOT include it in output
+6. Never invent or guess values not explicitly stated in the query
+
+OUTPUT: Single-line JSON object`
+
+// fewShotExamples provides concrete examples for the LLM to learn from.
+// Kept minimal (3 examples) for SLM context window efficiency.
+const fewShotExamples = `
+EXAMPLES:
+
+Query: "Show me 500 errors from payment-service taking more than 2 seconds"
+Output: {"service":"payment-service","tags":{"http.status_code":"500"},"minDuration":"2s","error":true}
+
+Query: "Find slow traces for checkout operation, latency above 1s, limit 50"
+Output: {"operation":"checkout","minDuration":"1s","limit":50}
+
+Query: "auth-service errors"
+Output: {"service":"auth-service","error":true}`
+
+// BuildPrompt constructs the full prompt for the LLM.
+// Combines system prompt, few-shot examples, and the user's query.
+func BuildPrompt(userQuery string) string {
+	return fmt.Sprintf(`%s
+
+%s
+
+Query: "%s"
+Output:`, systemPrompt, fewShotExamples, userQuery)
+}
+
+// GetSystemPrompt returns the system prompt for testing or debugging.
+func GetSystemPrompt() string {
+	return systemPrompt
+}
+
+// GetFewShotExamples returns the few-shot examples for testing or debugging.
+func GetFewShotExamples() string {
+	return fewShotExamples
+}

--- a/docs/ai-trace-analysis-starter-code/nlquery/provider.go
+++ b/docs/ai-trace-analysis-starter-code/nlquery/provider.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package nlquery
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/ollama"
+)
+
+// LLMProvider abstracts LLM generation for testability and extensibility.
+// Implementations must be safe for concurrent use.
+type LLMProvider interface {
+	// Generate sends a prompt to the LLM and returns the raw response string.
+	// The response should ideally be JSON, but may include LLM artifacts
+	// (markdown code blocks, explanations) that need to be extracted.
+	Generate(ctx context.Context, prompt string) (string, error)
+}
+
+// OllamaProvider implements LLMProvider using Ollama via LangChainGo.
+// It connects to a local Ollama instance running the specified model.
+type OllamaProvider struct {
+	llm    llms.Model
+	config OllamaConfig
+}
+
+// NewOllamaProvider creates a new Ollama-backed LLM provider.
+// Returns an error if the Ollama client cannot be initialized.
+func NewOllamaProvider(cfg OllamaConfig) (*OllamaProvider, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	opts := []ollama.Option{
+		ollama.WithModel(cfg.Model),
+		ollama.WithServerURL(cfg.ServerURL),
+	}
+
+	llm, err := ollama.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize ollama client: %w", err)
+	}
+
+	return &OllamaProvider{
+		llm:    llm,
+		config: cfg,
+	}, nil
+}
+
+// Generate implements LLMProvider.
+// It sends the prompt to Ollama and returns the raw response.
+func (p *OllamaProvider) Generate(ctx context.Context, prompt string) (string, error) {
+	// Apply timeout from config
+	ctx, cancel := context.WithTimeout(ctx, p.config.Timeout)
+	defer cancel()
+
+	// Use deterministic settings from config
+	response, err := llms.GenerateFromSinglePrompt(ctx, p.llm, prompt,
+		llms.WithTemperature(p.config.Temperature),
+		llms.WithMaxTokens(p.config.MaxTokens),
+	)
+	if err != nil {
+		return "", fmt.Errorf("ollama generation failed: %w", err)
+	}
+
+	return response, nil
+}
+
+// Model returns the configured model name.
+func (p *OllamaProvider) Model() string {
+	return p.config.Model
+}
+
+// ServerURL returns the configured Ollama server URL.
+func (p *OllamaProvider) ServerURL() string {
+	return p.config.ServerURL
+}

--- a/docs/ai-trace-analysis-starter-code/nlquery/schema.go
+++ b/docs/ai-trace-analysis-starter-code/nlquery/schema.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package nlquery
+
+import (
+	"fmt"
+	"time"
+)
+
+// SearchParams represents extracted search parameters from natural language.
+// All fields are pointers to distinguish between "not mentioned" (nil) and "explicit value".
+// Maps directly to Jaeger v3 TraceQueryParameters.
+type SearchParams struct {
+	// ServiceName filters traces by service name
+	ServiceName *string `json:"service,omitempty"`
+
+	// OperationName filters traces by operation/span name
+	OperationName *string `json:"operation,omitempty"`
+
+	// Tags are key-value attribute filters
+	// Example: {"http.status_code": "500", "error": "true"}
+	Tags map[string]string `json:"tags,omitempty"`
+
+	// MinDuration filters traces with duration >= this value
+	// Format: Go duration string (e.g., "2s", "500ms", "1m30s")
+	MinDuration *string `json:"minDuration,omitempty"`
+
+	// MaxDuration filters traces with duration <= this value
+	// Format: Go duration string (e.g., "2s", "500ms", "1m30s")
+	MaxDuration *string `json:"maxDuration,omitempty"`
+
+	// Error filters traces that contain error spans
+	// true = only errors, false = only success, nil = no filter
+	Error *bool `json:"error,omitempty"`
+
+	// Limit restricts the number of results (max 1000)
+	Limit *int `json:"limit,omitempty"`
+}
+
+// Validate checks SearchParams for semantic correctness.
+// Returns an error if any field contains an invalid value.
+func (p *SearchParams) Validate() error {
+	// Validate duration formats
+	if p.MinDuration != nil {
+		if _, err := time.ParseDuration(*p.MinDuration); err != nil {
+			return fmt.Errorf("invalid minDuration '%s': %w", *p.MinDuration, err)
+		}
+	}
+
+	if p.MaxDuration != nil {
+		if _, err := time.ParseDuration(*p.MaxDuration); err != nil {
+			return fmt.Errorf("invalid maxDuration '%s': %w", *p.MaxDuration, err)
+		}
+	}
+
+	// Validate min <= max if both specified
+	if p.MinDuration != nil && p.MaxDuration != nil {
+		minDur, _ := time.ParseDuration(*p.MinDuration)
+		maxDur, _ := time.ParseDuration(*p.MaxDuration)
+		if minDur > maxDur {
+			return fmt.Errorf("minDuration (%s) cannot exceed maxDuration (%s)",
+				*p.MinDuration, *p.MaxDuration)
+		}
+	}
+
+	// Validate limit range
+	if p.Limit != nil {
+		if *p.Limit < 1 {
+			return fmt.Errorf("limit must be at least 1, got %d", *p.Limit)
+		}
+		if *p.Limit > 1000 {
+			return fmt.Errorf("limit cannot exceed 1000, got %d", *p.Limit)
+		}
+	}
+
+	return nil
+}
+
+// ToQueryParams converts SearchParams to a map suitable for Jaeger API calls.
+// Only non-nil fields are included in the result.
+func (p *SearchParams) ToQueryParams() map[string]interface{} {
+	result := make(map[string]interface{})
+
+	if p.ServiceName != nil {
+		result["service"] = *p.ServiceName
+	}
+	if p.OperationName != nil {
+		result["operation"] = *p.OperationName
+	}
+	if p.MinDuration != nil {
+		result["minDuration"] = *p.MinDuration
+	}
+	if p.MaxDuration != nil {
+		result["maxDuration"] = *p.MaxDuration
+	}
+	if p.Tags != nil && len(p.Tags) > 0 {
+		result["tags"] = p.Tags
+	}
+	if p.Limit != nil {
+		result["limit"] = *p.Limit
+	}
+	// Note: 'error' field may need special handling in Jaeger API
+
+	return result
+}
+
+// IsEmpty returns true if no parameters were extracted from the query.
+func (p *SearchParams) IsEmpty() bool {
+	return p.ServiceName == nil &&
+		p.OperationName == nil &&
+		len(p.Tags) == 0 &&
+		p.MinDuration == nil &&
+		p.MaxDuration == nil &&
+		p.Error == nil &&
+		p.Limit == nil
+}
+
+// GetMinDuration returns the parsed MinDuration or zero if not set.
+func (p *SearchParams) GetMinDuration() time.Duration {
+	if p.MinDuration == nil {
+		return 0
+	}
+	d, _ := time.ParseDuration(*p.MinDuration)
+	return d
+}
+
+// GetMaxDuration returns the parsed MaxDuration or zero if not set.
+func (p *SearchParams) GetMaxDuration() time.Duration {
+	if p.MaxDuration == nil {
+		return 0
+	}
+	d, _ := time.ParseDuration(*p.MaxDuration)
+	return d
+}


### PR DESCRIPTION
Add experimental UI support for natural language trace search (LFX mentorship)
 fixes # 7832

This PR adds a **reference UI implementation** for Feature 1 of the LFX Mentorship project
**“AI-Powered Trace Analysis with Local LLM Support”** (#7832).

It introduces a Natural Language Search input on the Trace Search page that allows users
to enter queries such as “Show me 500 errors from payment-service > 2s” or
“checkout operation with latency above 1s”. These inputs are parsed into structured
Jaeger search parameters and automatically mapped to the existing search form fields.

The implementation is intentionally **experimental, UI-only, and backend-agnostic**.
It uses a mock, regex-based parser to demonstrate the UX and integration points without
introducing backend dependencies or modifying existing query execution paths.

## Which problem is this PR solving?
- Related to #7832 (AI-Powered Trace Analysis with Local LLM Support)
- Provides a UI foundation for Natural Language → Search Parameters mapping
- Allows early validation of UX and form-mapping logic before backend integration

## Description of the changes
- Added a new `NaturalLanguageSearch` React component to the trace search page
- Allows users to input natural language queries for trace search
- Uses a mock, regex-based parser to extract structured search parameters
- Automatically populates existing search form fields (service, operation, tags, duration, limit)
- Includes loading, error, disabled, and reset states
- Adds comprehensive unit tests for component behavior
- Does not alter existing manual search behavior or backend APIs

**Note:**  
The mock parser is a placeholder and is expected to be replaced by a backend endpoint
implemented in the Jaeger Query Service (Go + LangChainGo) as part of the LFX mentorship work.

## How was this change tested?
- Added Jest and React Testing Library tests for the new component
- Verified:
  - Successful query parsing and form auto-population
  - Loading and error states
  - Keyboard interaction and reset behavior
- Tests executed with:
  ```bash
  npm run test -- --testPathPattern="NaturalLanguageSearch"

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
