### PR TITLE
refactor(TraceGraph): migrate from class to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.js
@@ -90,8 +90,7 @@ describe('<TraceGraph>', () => {
     expect(screen.getByText('No trace found')).toBeInTheDocument();
   });
 
-  it('switches node mode when clicking mode buttons - with state verification', async () => {
-    const setStateSpy = jest.spyOn(TraceGraph.prototype, 'setState');
+  it('switches node mode when clicking mode buttons', async () => {
     render(<TraceGraph {...props} />);
 
     // Initial mode should be service
@@ -100,22 +99,31 @@ describe('<TraceGraph>', () => {
     const selftimeButton = screen.getByRole('button', { name: 'ST' });
     const serviceButton = screen.getByRole('button', { name: 'S' });
 
+    // Verify initial button states
+    expect(serviceButton).toHaveClass('active');
+    expect(timeButton).not.toHaveClass('active');
+    expect(selftimeButton).not.toHaveClass('active');
+
     // Switch to time
     await userEvent.click(timeButton);
-    expect(setStateSpy).toHaveBeenCalledWith({ mode: MODE_TIME }); // Verify state change
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_TIME);
+    expect(timeButton).toHaveClass('active');
+    expect(serviceButton).not.toHaveClass('active');
+    expect(selftimeButton).not.toHaveClass('active');
 
     // Switch to selftime
     await userEvent.click(selftimeButton);
-    expect(setStateSpy).toHaveBeenCalledWith({ mode: MODE_SELFTIME });
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_SELFTIME);
+    expect(selftimeButton).toHaveClass('active');
+    expect(serviceButton).not.toHaveClass('active');
+    expect(timeButton).not.toHaveClass('active');
 
     // Switch back to service
     await userEvent.click(serviceButton);
-    expect(setStateSpy).toHaveBeenCalledWith({ mode: MODE_SERVICE });
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_SERVICE);
-
-    setStateSpy.mockRestore();
+    expect(serviceButton).toHaveClass('active');
+    expect(timeButton).not.toHaveClass('active');
+    expect(selftimeButton).not.toHaveClass('active');
   });
 
   it('shows help', async () => {


### PR DESCRIPTION
Convert TraceGraph from React.PureComponent to a functional component using React hooks as part of the UI modernization effort (#3369).

## Which problem is this PR solving?
Resolves #3369

## Description of the changes
- Replace class component with function wrapped in React.memo
- Convert this.state to useState hooks (showHelp, mode)
- Replace componentWillUnmount with useEffect cleanup
- Use useMemo for LayoutManager to maintain instance across renders
- Update tests to verify behavior via DOM assertions instead of setState spies

## How was this change tested?
- All 10 existing unit tests pass
- Build completes successfully with no type errors
- UI working with no changes

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
