### PR TITLE
Fix: normalize uppercase trace IDs in URL (#3477)

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -100,7 +100,7 @@ describe('makeShortcutCallbacks()', () => {
   });
 
   it('returns callbacks that adjust the range based on the `shortcutConfig` values', () => {
-    const fakeEvent = { preventDefault: () => {} };
+    const fakeEvent = { preventDefault: () => { } };
     const callbacks = makeShortcutCallbacks(adjRange);
     Object.keys(shortcutConfig).forEach((key, i) => {
       callbacks[key](fakeEvent);
@@ -351,6 +351,27 @@ describe('<TracePage>', () => {
         pathname: expect.stringContaining(trace.traceID),
       })
     );
+  });
+
+  it('forces lowercase id when trace is not yet fetched', () => {
+    const replaceMock = jest.fn();
+    const fetchTraceMock = jest.fn();
+    const props = {
+      ...defaultProps,
+      id: trace.traceID.toUpperCase(),
+      trace: null,
+      fetchTrace: fetchTraceMock,
+      history: {
+        replace: replaceMock,
+      },
+    };
+    render(<TracePage {...props} />);
+    expect(replaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: expect.stringContaining(trace.traceID),
+      })
+    );
+    expect(fetchTraceMock).not.toHaveBeenCalled();
   });
 
   it('focuses on search bar when there is a search bar and focusOnSearchBar is called', () => {
@@ -1105,7 +1126,7 @@ describe('<TracePage>', () => {
 
 describe('mapDispatchToProps()', () => {
   it('creates the actions correctly', () => {
-    expect(mapDispatchToProps(() => {})).toEqual({
+    expect(mapDispatchToProps(() => { })).toEqual({
       acknowledgeArchive: expect.any(Function),
       archiveTrace: expect.any(Function),
       fetchTrace: expect.any(Function),

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -285,14 +285,14 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
   };
 
   ensureTraceFetched() {
-    const { fetchTrace, location, trace, id } = this.props;
+    const { fetchTrace, location, trace, id, history } = this.props;
+    if (id && id !== id.toLowerCase()) {
+      history.replace(getLocation(id.toLowerCase(), location.state));
+      return;
+    }
     if (!trace) {
       fetchTrace(id);
       return;
-    }
-    const { history } = this.props;
-    if (id && id !== id.toLowerCase()) {
-      history.replace(getLocation(id.toLowerCase(), location.state));
     }
   }
 


### PR DESCRIPTION
- Resolves #3477 

## Description of the changes
- This PR modifies the TracePage component to ensure that any Trace ID provided in the URL is normalized to lowercase before the application attempts to fetch the trace data.

Previously, visiting a URL with an uppercase ID (e.g., /trace/ABC...) cause the application to attempt a fetch with the uppercase ID, which could fail or result in a 500 error, and the URL would remain uppercase in the browser address bar.

The fix involves checking for uppercase characters in 
ensureTraceFetched and immediately performing a history.replace() to the lowercase version if detected. This prevents the invalid fetch and updates the user's URL to the canonical lowercase format.

## How was this change tested?
- Automated Regression Test:
Added a new test case forces lowercase id when trace is not yet fetched in 
TracePage/index.test.js.
The test asserts that history.replace() is called with the lowercase ID and, crucially, that fetchTrace() is not called.
Verified that all tests passed: npm test -- src/components/TracePage/index.test.js (62/62 passed).

- Manual Verification:
Ran functionality locally via npm start.
Navigated to http://localhost:5173/trace/ABC123DEF.
Verified that the browser URL automatically updated to http://localhost:5173/trace/abc123def.

## Checklist
- [ x ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ x ] I have signed all commits
- [ x ] I have added unit tests for the new functionality
- [ x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`



https://github.com/user-attachments/assets/65708c05-baed-4a88-bfd4-30b770ef7d75

