### PR TITLE
refactor(ui): remove withRouteProps from TopNav

### DIFF
--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { CompatRouter } from 'react-router-dom-v5-compat';
 
@@ -115,10 +115,6 @@ describe('<TopNav>', () => {
         configMenuGroup,
       ],
     },
-    router: {
-      location: { pathname: '/search' },
-    },
-    pathname: '/search',
     traceDiff: {},
   };
 
@@ -126,11 +122,11 @@ describe('<TopNav>', () => {
     let component;
     beforeEach(() => {
       component = render(
-        <BrowserRouter>
+        <MemoryRouter initialEntries={['/search']}>
           <CompatRouter>
             <TopNav {...defaultProps} />
           </CompatRouter>
-        </BrowserRouter>
+        </MemoryRouter>
       );
     });
 
@@ -173,11 +169,11 @@ describe('<TopNav>', () => {
     let component;
     beforeEach(() => {
       component = render(
-        <BrowserRouter>
+        <MemoryRouter initialEntries={['/search']}>
           <CompatRouter>
             <TopNav {...defaultProps} />
           </CompatRouter>
-        </BrowserRouter>
+        </MemoryRouter>
       );
     });
 
@@ -228,11 +224,11 @@ describe('<TopNav>', () => {
 
   it('highlights the nav item matching the current pathname', () => {
     render(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/search']}>
         <CompatRouter>
           <TopNav {...defaultProps} />
         </CompatRouter>
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
     const navMenu = screen.getAllByTestId('mock-menu')[0];
@@ -241,7 +237,7 @@ describe('<TopNav>', () => {
 
   it('builds the Compare link using the trace diff cohort state', () => {
     render(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/search']}>
         <CompatRouter>
           <TopNav
             {...{
@@ -250,7 +246,7 @@ describe('<TopNav>', () => {
             }}
           />
         </CompatRouter>
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
     const compareLink = screen.getByRole('link', { name: 'Compare' });
@@ -261,11 +257,11 @@ describe('<TopNav>', () => {
 
   it('renders the Monitor navigation link when enabled', () => {
     render(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/search']}>
         <CompatRouter>
           <TopNav {...defaultProps} />
         </CompatRouter>
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
     expect(screen.getByRole('link', { name: 'Monitor' })).toBeInTheDocument();
@@ -273,11 +269,11 @@ describe('<TopNav>', () => {
 
   it('includes the Trace ID search control in the right-side menu', () => {
     render(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/search']}>
         <CompatRouter>
           <TopNav {...defaultProps} />
         </CompatRouter>
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
     expect(screen.getByTestId('TraceIDSearchInput--form')).toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -6,7 +6,6 @@ import { Dropdown, Menu, MenuProps } from 'antd';
 import { IoChevronDown } from 'react-icons/io5';
 import _has from 'lodash/has';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 
 import TraceIDSearchInput from './TraceIDSearchInput';
 import ThemeToggleButton from './ThemeToggleButton';
@@ -20,12 +19,11 @@ import * as monitorATMUrl from '../Monitor/url';
 import { ReduxState } from '../../types';
 import { ConfigMenuItem, ConfigMenuGroup } from '../../types/config';
 import { getConfigValue } from '../../utils/config/get-config';
-import prefixUrl from '../../utils/prefix-url';
 
 import './TopNav.css';
-import withRouteProps, { IWithRouteProps } from '../../utils/withRouteProps';
+import { Link, useLocation } from 'react-router-dom';
 
-type Props = ReduxState & IWithRouteProps;
+type Props = ReduxState;
 
 const NAV_LINKS = [
   {
@@ -106,7 +104,9 @@ const itemsGlobalLeft: MenuProps['items'] = [
 ];
 
 export function TopNavImpl(props: Props) {
-  const { config, pathname } = props;
+  const { config } = props;
+  // Use React Router hook instead of legacy withRouteProps HOC
+  const { pathname } = useLocation();
   const menuItems = Array.isArray(config.menu) ? config.menu : [];
 
   const itemsGlobalRight: MenuProps['items'] = [
@@ -175,4 +175,4 @@ export function mapStateToProps(state: ReduxState) {
   return state;
 }
 
-export default connect(mapStateToProps)(withRouteProps(TopNavImpl));
+export default connect(mapStateToProps)(TopNavImpl);


### PR DESCRIPTION
## Which problem is this PR solving?
- Contributes to 🧑‍🎓 LFX: Upgrading Core Routing and State Management (#3313)

## Description of the changes
- Refactored `TopNav` to remove dependency on the legacy `withRouteProps` HOC
- Migrated routing state access to React Router’s `useLocation` hook
- Simplified component props by relying only on Redux state and router hooks
- Scoped the change intentionally to `TopNav` only
- Other components (e.g. `Page.tsx`) that still use `withRouteProps` were left unchanged to keep this refactor incremental and non-breaking as part of the broader routing migration

## How was this change tested?
- Ran Jaeger UI locally using `npm start`
- Manually verified:
  - Top navigation renders correctly
  - Active menu item updates based on the current route
  - Navigation between pages works as expected
- Backend services were not required for validating this UI-only refactor

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality (not applicable for this refactor)
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test` (not run)
  - for `jaeger-ui`: `npm run lint` and `npm run test` (not run)
