### PR TITLE
Refactor: Migrate DetailsPanel to Functional Component

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.tsx
@@ -4,7 +4,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Tooltip } from 'antd';
 import _get from 'lodash/get';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 
 import BreakableText from '../../common/BreakableText';
 import DetailsCard from '../../common/DetailsCard';
@@ -147,9 +147,12 @@ export const UnconnectedDetailsPanel = React.memo(function UnconnectedDetailsPan
 });
 
 const DetailsPanel: React.FC<TOwnProps> = props => {
-  const decorationState = useSelector((state: ReduxState) => extractDecorationFromState(state, props));
+  const decorationState = useSelector(
+    (state: ReduxState) => extractDecorationFromState(state, props),
+    shallowEqual
+  );
 
   return <UnconnectedDetailsPanel {...props} {...decorationState} />;
 };
 
-export default React.memo(DetailsPanel);
+export default DetailsPanel;


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3365
- This is part of the larger effort #2610 

## Description of the changes
- Migrated `DetailsPanel` from a React Class-Based Component to a Functional Component in adherence to the acceptance criterion as described in #3365

## How was this change tested?
- Verified that all 16 existing unit tests pass 
<img width="1511" height="336" alt="image" src="https://github.com/user-attachments/assets/f0ec47aa-851b-4934-b051-d7f1dee743c9" />


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
