### PR TITLE
refactor(plexus): migrate SvgLayer to functional component

### DIFF
--- a/packages/plexus/src/Digraph/SvgLayer.tsx
+++ b/packages/plexus/src/Digraph/SvgLayer.tsx
@@ -29,61 +29,58 @@ const STYLE: React.CSSProperties = {
   top: 0,
 };
 
-export default class SvgLayer<T = {}, U = {}> extends React.PureComponent<TProps<T, U>> {
-  render() {
-    const {
-      children,
-      classNamePart,
-      getClassName,
-      defs,
-      extraWrapper,
-      graphState,
-      setOnContainer,
-      standalone,
-      topLayer,
-    } = this.props;
+function SvgLayer<T = {}, U = {}>(props: TProps<T, U>) {
+  const {
+    children,
+    classNamePart,
+    getClassName,
+    defs,
+    extraWrapper,
+    graphState,
+    setOnContainer,
+    standalone,
+    topLayer,
+  } = props;
 
-    const containerProps = assignMergeCss(
-      {
-        className: getClassName(classNamePart),
-      },
-      getProps(setOnContainer, graphState)
-    );
-    let content = (
-      <g {...containerProps}>
-        {defs && (
-          <defs>
-            {defs.map(defEntry => (
-              <SvgDefEntry<T, U>
-                key={defEntry.localId}
-                {...defEntry}
-                getClassName={getClassName}
-                graphState={graphState}
-              />
-            ))}
-          </defs>
-        )}
-        {children}
-      </g>
-    );
-    if (extraWrapper) {
-      content = <g {...extraWrapper}>{content}</g>;
-    }
-
-    if (!standalone && !topLayer) {
-      return content;
-    }
-
-    const { zoomTransform } = graphState;
-    return (
-      <svg className={getClassName('SvgLayer')} style={STYLE}>
-        <g
-          className={getClassName('SvgLayer--transformer')}
-          transform={ZoomManager.getZoomAttr(zoomTransform)}
-        >
-          {content}
-        </g>
-      </svg>
-    );
+  const containerProps = assignMergeCss(
+    {
+      className: getClassName(classNamePart),
+    },
+    getProps(setOnContainer, graphState)
+  );
+  let content = (
+    <g {...containerProps}>
+      {defs && (
+        <defs>
+          {defs.map(defEntry => (
+            <SvgDefEntry<T, U>
+              key={defEntry.localId}
+              {...defEntry}
+              getClassName={getClassName}
+              graphState={graphState}
+            />
+          ))}
+        </defs>
+      )}
+      {children}
+    </g>
+  );
+  if (extraWrapper) {
+    content = <g {...extraWrapper}>{content}</g>;
   }
+
+  if (!standalone && !topLayer) {
+    return content;
+  }
+
+  const { zoomTransform } = graphState;
+  return (
+    <svg className={getClassName('SvgLayer')} style={STYLE}>
+      <g className={getClassName('SvgLayer--transformer')} transform={ZoomManager.getZoomAttr(zoomTransform)}>
+        {content}
+      </g>
+    </svg>
+  );
 }
+
+export default React.memo(SvgLayer) as typeof SvgLayer;


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of [UI Refactor] [plexus] Migrate SvgLayer to Functional Component (#3399)
- Contributes to the broader UI modernization effort (#2610)

## Description of the changes
- Migrated SvgLayer from a React class component to a functional component
- Replaced React.PureComponent with React.memo to preserve performance characteristics
- Converted this.props usage to direct props destructuring
- Kept rendering logic, SVG structure, and public API unchanged
- Preserved generic type parameters to avoid downstream type regressions

## Before -
<img width="676" height="308" alt="before 3399" src="https://github.com/user-attachments/assets/694b89b1-69ed-4bf5-9e21-c5e0a0c5595a" />

## After -
<img width="682" height="309" alt="after 3399" src="https://github.com/user-attachments/assets/c345226f-eb79-4f4b-9682-700ea46b7e94" />

## How was this change tested?
- Ran Plexus package test suite (all tests passing)
- Verified TypeScript compilation for plexus package
- Verified lint with no new errors introduced

## Additional notes
- SvgLayer was a stateless component with no lifecycle methods or memoizeOne usage
- Refactor is intentionally minimal and scoped to a single file
- No visual or behavioral changes are expected