### PR TITLE
Add environment checks to prepare-release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,12 @@ draft-release:
 	chmod 755 ./scripts/draft-release.py
 	./scripts/draft-release.py --title "Jaeger UI" --repo jaeger-ui
 
+.PHONY: check-env
+check-env:
+	nvm use
+
 .PHONY: prepare-release
-prepare-release:
+prepare-release: check-env
 	@test $(VERSION) || (echo "VERSION is not set. Use 'make prepare-release VERSION=vX.Y.Z'"; exit 1)
 	python3 scripts/prepare-release.py --version $(VERSION)
 


### PR DESCRIPTION
This PR adds a  target to the  that validates the Node.js version and ensures  exists before running . This addresses issues where running the release preparation in an unconfigured environment causes problems.