### PR TITLE
Remove history from TraceIDSearchInput.test.js

### DIFF
--- a/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.js
+++ b/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.js
@@ -4,24 +4,29 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import React from 'react';
-import { createMemoryHistory } from 'history';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import TraceIDSearchInput from './TraceIDSearchInput';
 import { CompatRouter } from 'react-router-dom-v5-compat';
 
-describe('<TraceIDSearchInput />', () => {
-  let history;
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom-v5-compat', () => {
+  return {
+    ...jest.requireActual('react-router-dom-v5-compat'),
+    useNavigate: () => mockNavigate,
+  };
+});
 
+describe('<TraceIDSearchInput />', () => {
   beforeEach(() => {
-    history = createMemoryHistory();
+    mockNavigate.mockReset();
     render(
-      <Router history={history}>
+      <MemoryRouter>
         <CompatRouter>
           <TraceIDSearchInput />
         </CompatRouter>
-      </Router>
+      </MemoryRouter>
     );
   });
 
@@ -29,19 +34,19 @@ describe('<TraceIDSearchInput />', () => {
     expect(screen.getByTestId('idInput')).toBeInTheDocument();
   });
 
-  it('pushes input id to history', () => {
+  it('navigates to trace page when input is provided', () => {
     const traceId = 'MOCK-TRACE-ID';
     const idInput = screen.getByPlaceholderText('Lookup by Trace ID...');
     fireEvent.change(idInput, { target: { value: traceId } });
     fireEvent.submit(screen.getByTestId('TraceIDSearchInput--form'));
 
-    expect(history.length).toEqual(2);
-    expect(history.location.pathname).toEqual(`/trace/${traceId}`);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`/trace/${traceId}`);
   });
 
-  it('does not push to history on falsy input value', () => {
+  it('does not navigate when input is empty', () => {
     fireEvent.submit(screen.getByTestId('TraceIDSearchInput--form'));
 
-    expect(history.length).toEqual(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves part of https://github.com/jaegertracing/jaeger-ui/issues/2531

## Description of the changes
- Update the tests to mock and use navigate calls instead of history

## How was this change tested?
- Unit tests

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality (more like changed initial ones than adding)
- [X] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
