### PR TITLE
chore(router): extract route config in preparation for v7 migration

### DIFF
--- a/packages/jaeger-ui/src/components/App/index.tsx
+++ b/packages/jaeger-ui/src/components/App/index.tsx
@@ -47,6 +47,20 @@ const queryClient = new QueryClient({
 JaegerAPI.apiRoot = DEFAULT_API_ROOT;
 processScripts();
 
+/**
+ Route configuration extracted to prepare for migration to React Router v7 data-driven routing.
+ See issue #3313.
+ NOTE: No behavior changes intended.*/
+const APP_ROUTE_CONFIG = [
+  { path: searchPath, element: <SearchTracePage /> },
+  { path: traceDiffPath, element: <TraceDiff /> },
+  { path: tracePath, element: <TracePage /> },
+  { path: dependenciesPath, element: <DependencyGraph /> },
+  { path: deepDependenciesPath, element: <DeepDependencies /> },
+  { path: qualityMetricsPath, element: <QualityMetrics /> },
+  { path: monitorATMPath, element: <MonitorATMPage /> },
+];
+
 export default function JaegerUIApp() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -61,27 +75,11 @@ export default function JaegerUIApp() {
           {/* @ts-expect-error - TypeScript error with Redux 5/9, React 19, and complex HOCs */}
           <Page>
             <Switch>
-              <Route path={searchPath}>
-                <SearchTracePage />
-              </Route>
-              <Route path={traceDiffPath}>
-                <TraceDiff />
-              </Route>
-              <Route path={tracePath}>
-                <TracePage />
-              </Route>
-              <Route path={dependenciesPath}>
-                <DependencyGraph />
-              </Route>
-              <Route path={deepDependenciesPath}>
-                <DeepDependencies />
-              </Route>
-              <Route path={qualityMetricsPath}>
-                <QualityMetrics />
-              </Route>
-              <Route path={monitorATMPath}>
-                <MonitorATMPage />
-              </Route>
+              {APP_ROUTE_CONFIG.map(({ path, element }) => (
+                <Route key={path} path={path}>
+                  {element}
+                </Route>
+              ))}
 
               <Route exact path="/">
                 <Redirect to={searchPath} />


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #3313 (Modernizing Jaeger-UI: Upgrading Core Routing and State Management)

## Description of the changes
- Extracted existing route definitions in `App/index.tsx` into a centralized configuration structure.
- This is a non-breaking preparatory step to support migration to React Router v7's data-driven routing model.
- No runtime or behavioral changes are intended.

## How was this change tested?
- Verified that the change is a refactor-only extraction with no intended behavioral differences.
- Existing routes and redirects remain unchanged.
- CI is expected to validate linting and tests.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`