### PR TITLE
fix: make spanKind optional in v3 operations schema

### DIFF
--- a/packages/jaeger-ui/src/api/v3/generated-client.ts
+++ b/packages/jaeger-ui/src/api/v3/generated-client.ts
@@ -27,7 +27,9 @@ type KeyValueList = Partial<{
   values: Array<KeyValue>;
 }>;
 
-const Operation = z.object({ name: z.string(), spanKind: z.string() }).passthrough();
+// NOTE: spanKind is made optional because some storage backends (e.g. Elasticsearch)
+// may omit it. See jaegertracing/jaeger#7989
+const Operation = z.object({ name: z.string(), spanKind: z.string().optional().default('') }).passthrough();
 const GetOperationsResponse = z.object({ operations: z.array(Operation) }).passthrough();
 const GoogleProtobufAny = z.object({ '@type': z.string() }).passthrough();
 const Status = z


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #3521
Relates to jaegertracing/jaeger#7989

The Jaeger UI v2.15.0 fails to load operations for a selected service. The `/api/v3/operations` endpoint returns operation objects without `spanKind` in certain storage configurations (e.g. Elasticsearch), but the UI's Zod schema strictly requires `spanKind` as a string. This causes validation to reject the entire response, and the operations dropdown never loads.

## Description of the changes

- Makes `spanKind` optional with a safe default in the Zod schema (`z.string().optional().default('')`) so the inferred TypeScript type remains `string` and no downstream code changes are needed
- Adds a regression test verifying `fetchSpanNames()` works correctly when `spanKind` is missing from the backend response

**Note:** `generated-client.ts` is auto-generated via `npm run generate:api-types`. This change should ideally be preserved in the generation pipeline or upstream OpenAPI spec across regenerations.

## How was this change tested?

- Added a new unit test `handles operations without spanKind from backend` that mocks a backend response without `spanKind` and verifies the schema defaults it to empty string
- All 19 existing tests continue to pass
- Ran `npx jest --testPathPatterns="api/v3/client.test"` — all passed

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`