### PR TITLE
[Fix]: DAG warning background in dark mode using theme surface token

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/dag.css
+++ b/packages/jaeger-ui/src/components/DependencyGraph/dag.css
@@ -76,6 +76,6 @@ SPDX-License-Identifier: Apache-2.0
 .DAG > div:last-child {
   position: fixed;
   z-index: 1000;
-  background: #fafafa;
+  background: var(--surface-primary, #fafafa);
   border: 1px solid #d0d0d0;
 }


### PR DESCRIPTION
Fixes #3499

## Summary

Fixes a dark mode theming issue in the **System Architecture (DAG)** view where
the warning message background caused insufficient contrast, making the text
hard to read.

## Root cause

The warning container used a hardcoded light background color (`#fafafa`), which
does not adapt to dark mode.

## Changes

- Replaced the hardcoded background color with the theme-aware CSS variable
  `var(--surface-primary, #fafafa)`
- Light mode behavior remains unchanged

## How to test

1. Open Jaeger UI
2. Navigate to **System Architecture**
3. Select **Sample Dataset → Large Graph**
4. Enable **Dark Mode**
5. Verify the warning message is readable

## Scope

- UI-only change
- No logic or layout changes

## Screenshots

**Dark mode:** Warning text is readable.  
**Light mode:** Unchanged.

<p align="center">
  <img src="https://github.com/user-attachments/assets/38b8b56e-6cc8-4a5d-bc93-965e8548dcca" width="45%" />
  <img src="https://github.com/user-attachments/assets/152f4d9c-fea4-4ac1-a3c6-d229d7ae9ee8" width="45%" />
</p>

<p align="center">
  <strong>Dark mode</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
  <strong>Light mode</strong>
</p>
