### PR TITLE
refactor(plexus): migrate SvgEdge to functional component (#3396)

### DIFF
--- a/packages/plexus/src/Digraph/SvgEdge.tsx
+++ b/packages/plexus/src/Digraph/SvgEdge.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import memoizeOne from 'memoize-one';
 
 import { TAnyProps, TRendererUtils, TSetProps } from './types';
 import { assignMergeCss, getProps } from './utils';
@@ -48,42 +47,41 @@ function computeLabelCoord(pathPoints: [number, number][], label?: string | unde
   return { labelX, labelY };
 }
 
-export default class SvgEdge<U = {}> extends React.PureComponent<TProps<U>> {
-  makePathD = memoizeOne(makePathD);
+function SvgEdge<U = {}>(props: TProps<U>) {
+  const { getClassName, layoutEdge, markerEndId, markerStartId, renderUtils, setOnEdge, label } = props;
+  const { pathPoints } = layoutEdge;
 
-  render() {
-    const { getClassName, layoutEdge, markerEndId, markerStartId, renderUtils, setOnEdge, label } =
-      this.props;
-    const { pathPoints } = layoutEdge;
-    const d = makePathD(pathPoints);
-    const markerEnd = makeIriRef(renderUtils, markerEndId);
-    const markerStart = makeIriRef(renderUtils, markerStartId);
-    const customProps = assignMergeCss(
-      {
-        className: getClassName('SvgEdge'),
-      },
-      getProps(setOnEdge, layoutEdge, renderUtils)
-    );
+  const d = React.useMemo(() => makePathD(pathPoints), [pathPoints]);
 
-    const { labelX, labelY } = computeLabelCoord(pathPoints, label);
+  const markerEnd = makeIriRef(renderUtils, markerEndId);
+  const markerStart = makeIriRef(renderUtils, markerStartId);
+  const customProps = assignMergeCss(
+    {
+      className: getClassName('SvgEdge'),
+    },
+    getProps(setOnEdge, layoutEdge, renderUtils)
+  );
 
-    return (
-      <g>
-        <path
-          d={d}
-          fill="none"
-          vectorEffect="non-scaling-stroke"
-          markerEnd={markerEnd}
-          markerStart={markerStart}
-          {...customProps}
-        />
+  const { labelX, labelY } = computeLabelCoord(pathPoints, label);
 
-        {label && (
-          <text x={labelX} y={labelY} fill="#000" fontSize="1rem" fontWeight="bold">
-            {label}
-          </text>
-        )}
-      </g>
-    );
-  }
+  return (
+    <g>
+      <path
+        d={d}
+        fill="none"
+        vectorEffect="non-scaling-stroke"
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        {...customProps}
+      />
+
+      {label && (
+        <text x={labelX} y={labelY} fill="#000" fontSize="1rem" fontWeight="bold">
+          {label}
+        </text>
+      )}
+    </g>
+  );
 }
+
+export default React.memo(SvgEdge) as typeof SvgEdge;


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3396
- Part of #2610 (Jaeger UI modernization - refactor class components to functional components)

## Description of the changes
- Migrated `SvgEdge` component from class to functional component using React hooks
- Replaced `React.PureComponent` with `React.memo()` to maintain performance characteristics
- Replaced `memoizeOne` with `React.useMemo` for path computation memoization
- Removed `render()` method and converted to direct return
- Preserved all existing functionality

### Migration Details
- **State:** None (component was stateless)
- **Lifecycle Methods:** None (no lifecycle methods to convert)
- **Memoization:** `memoizeOne(makePathD)` → `React.useMemo(() => makePathD(pathPoints), [pathPoints])`
- **Performance:** Wrapped with `React.memo()` to maintain PureComponent behavior

## How was this change tested?
- [x] All existing plexus unit tests passing (34 tests)
- [x] Ran `npm run prettier` - formatting correct
- [x] Ran `npm test` in plexus package - all tests passing
- [x] Ran `npm run build` in plexus package - build successful
- [x] No new TypeScript errors introduced

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality *(N/A - migration maintains existing functionality)*
- [x] I have run lint and test steps successfully
  - `npm run prettier` 
  - `npm test` (plexus) 

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
