### PR TITLE
Fix Monitor charts rendering at half width on initial load

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.js
@@ -417,20 +417,7 @@ describe('<MonitorATMServicesView>', () => {
     expect(screen.getByText('Span Kind')).toBeInTheDocument();
   });
 
-  it('ComponentWillUnmount remove listener', () => {
-    const remover = jest.spyOn(global, 'removeEventListener').mockImplementation(() => {});
-    const { unmount } = renderWithRouter(
-      <MonitorATMServicesView
-        {...props}
-        fetchAllServiceMetrics={mockFetchAllServiceMetrics}
-        fetchAggregatedServiceMetrics={mockFetchAggregatedServiceMetrics}
-      />
-    );
-    unmount();
-    expect(remover).toHaveBeenCalled();
-  });
-
-  it('resize window test', () => {
+  it('renders correctly without resize listener', () => {
     const testProps = {
       ...props,
       fetchServices: mockFetchServices,
@@ -439,7 +426,6 @@ describe('<MonitorATMServicesView>', () => {
     };
     renderWithRouter(<MonitorATMServicesView {...testProps} />);
 
-    global.dispatchEvent(new Event('resize'));
     const spanKindSelectors = screen.getAllByTestId('span-kind-selector');
     expect(spanKindSelectors.length).toBeGreaterThan(0);
     expect(spanKindSelectors[0]).toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -130,9 +130,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   const { isATMActivated } = metrics;
   const { data: services = [], isLoading: servicesLoading } = useServices();
   const docsLink = getConfigValue('monitor.docsLink');
-  const graphDivWrapper = useRef<HTMLDivElement>(null);
   const [endTime, setEndTime] = useState<number>(Date.now());
-  const [graphWidth, setGraphWidth] = useState<number>(300);
   const [serviceOpsMetrics, setServiceOpsMetrics] = useState<ServiceOpsMetrics[] | undefined>(undefined);
   const [searchOps, setSearchOps] = useState<string>('');
   const [graphXDomain, setGraphXDomain] = useState<number[]>([]);
@@ -150,12 +148,6 @@ export function MonitorATMServicesViewImpl(props: TProps) {
     const currentTime = Date.now();
     setGraphXDomain([currentTime - selectedTimeFrame, currentTime]);
   }, [selectedTimeFrame]);
-
-  const updateDimensions = useCallback(() => {
-    if (graphDivWrapper.current) {
-      setGraphWidth(graphDivWrapper.current.offsetWidth - 24);
-    }
-  }, []);
 
   const getSelectedService = useCallback(() => {
     return selectedService || store.get('lastAtmSearchService') || services[0];
@@ -212,17 +204,6 @@ export function MonitorATMServicesViewImpl(props: TProps) {
     selectedSpanKind,
     selectedTimeFrame,
   ]);
-
-  // componentDidMount equivalent
-  useEffect(() => {
-    window.addEventListener('resize', updateDimensions);
-    updateDimensions();
-    calcGraphXDomain();
-
-    return () => {
-      window.removeEventListener('resize', updateDimensions);
-    };
-  }, [updateDimensions, calcGraphXDomain]);
 
   // componentDidUpdate equivalent
   useEffect(() => {
@@ -339,7 +320,6 @@ export function MonitorATMServicesViewImpl(props: TProps) {
         </Row>
         <Row>
           <Col span={8}>
-            <div ref={graphDivWrapper} />
             <ServiceGraph
               key="latency"
               error={
@@ -349,7 +329,6 @@ export function MonitorATMServicesViewImpl(props: TProps) {
               }
               loading={metrics.loading}
               name={`Latency (${convertTimeUnitToShortTerm(displayTimeUnit)})`}
-              width={graphWidth}
               metricsData={serviceLatencies}
               showLegend
               marginClassName="latency-margins"
@@ -364,7 +343,6 @@ export function MonitorATMServicesViewImpl(props: TProps) {
               error={metrics.serviceError.service_error_rate}
               loading={metrics.loading}
               name="Error rate (%)"
-              width={graphWidth}
               metricsData={convertServiceErrorRateToPercentages(serviceErrorRate)}
               marginClassName="error-rate-margins"
               color="#CD513A"
@@ -378,7 +356,6 @@ export function MonitorATMServicesViewImpl(props: TProps) {
               loading={metrics.loading}
               error={metrics.serviceError.service_call_rate}
               name="Request rate (req/s)"
-              width={graphWidth}
               metricsData={metrics.serviceMetrics ? metrics.serviceMetrics.service_call_rate : null}
               showHorizontalLines
               color="#4795BA"

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Row, Col, Input, Alert, Select } from 'antd';
 import { ActionFunctionAny, Action } from 'redux-actions';
 import _debounce from 'lodash/debounce';

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.css
@@ -34,9 +34,10 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .center-placeholder {
-  vertical-align: middle;
-  text-align: center;
-  display: table-cell;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .crosshair-value {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.css
@@ -13,6 +13,8 @@ SPDX-License-Identifier: Apache-2.0
   border: 1px solid #d7d7d7;
   padding: 14px 12px 12px 12px;
   border-radius: 4px;
+  display: flex;
+  flex-direction: column;
 }
 
 .graph-header {
@@ -38,6 +40,7 @@ SPDX-License-Identifier: Apache-2.0
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 1;
 }
 
 .crosshair-value {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.test.js
@@ -431,8 +431,8 @@ describe('<ServiceGraph>', () => {
       );
       const placeholderDiv = container.querySelector('.center-placeholder');
       expect(placeholderDiv).toHaveTextContent('Test');
-      // Check that the height calculation is correct (242 - 74 = 168)
-      expect(placeholderDiv.style.height).toBe('168px');
+      // Check that the height calculation is correct (242)
+      expect(placeholderDiv.style.height).toBe('242px');
     });
   });
 });

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.test.js
@@ -53,7 +53,6 @@ window.getComputedStyle = () => ({
 });
 
 const defaultProps = {
-  width: 300,
   error: null,
   name: 'Hello Graph',
   metricsData: null,
@@ -357,7 +356,6 @@ describe('<ServiceGraph>', () => {
   describe('tooltip and legend formatting', () => {
     it('formats tooltip values correctly', () => {
       const testProps = {
-        width: 100,
         name: 'Test Graph',
         metricsData: mockMetricsData,
         loading: false,
@@ -393,7 +391,6 @@ describe('<ServiceGraph>', () => {
 
     it('formats legend values correctly', () => {
       const rendered = ServiceGraphImpl({
-        width: 100,
         name: 'Test Graph',
         metricsData: mockMetricsData,
         loading: false,
@@ -425,7 +422,7 @@ describe('<ServiceGraph>', () => {
       // The Placeholder component is used by the functional component
       // Test it via direct render instead
       const { container } = render(
-        <Placeholder name="Test Graph" width={100} height={242}>
+        <Placeholder name="Test Graph" height={242}>
           <div>Test</div>
         </Placeholder>
       );
@@ -451,7 +448,7 @@ describe('Placeholder component', () => {
   it('renders with all props', () => {
     cleanup();
     const { container } = render(
-      <Placeholder name="Test" width={300} height={200} marginClassName="test-margin">
+      <Placeholder name="Test" height={200} marginClassName="test-margin">
         <div>Test content</div>
       </Placeholder>
     );
@@ -463,7 +460,7 @@ describe('Placeholder component', () => {
   it('renders without optional marginClassName', () => {
     cleanup();
     const { container } = render(
-      <Placeholder name="Test" width={300} height={200}>
+      <Placeholder name="Test" height={200}>
         <div>Test content</div>
       </Placeholder>
     );

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/serviceGraph.tsx
@@ -9,7 +9,6 @@ import './serviceGraph.css';
 import { ApiError } from '../../../types/api-error';
 
 type TProps = {
-  width: number;
   error: null | ApiError;
   name: string;
   metricsData: ServiceMetricsObject | ServiceMetricsObject[] | null;
@@ -39,18 +38,11 @@ export const tickFormat = (v: number): string => {
 type TPlaceholder = {
   name: string;
   marginClassName?: string;
-  width: number;
   height: number;
   children: React.ReactNode;
 };
 
-export const Placeholder = ({
-  name,
-  marginClassName,
-  width,
-  height,
-  children,
-}: TPlaceholder): React.JSX.Element => {
+export const Placeholder = ({ name, marginClassName, height, children }: TPlaceholder): React.JSX.Element => {
   return (
     <div
       className={`graph-container ${marginClassName}`}
@@ -63,8 +55,8 @@ export const Placeholder = ({
       <div
         className="center-placeholder"
         style={{
-          width,
-          height: height - 74,
+          width: '100%',
+          height: height,
         }}
       >
         {children}
@@ -202,7 +194,6 @@ export function calculateNumericTicks(xDomain: number[]): number[] {
 }
 
 export function ServiceGraphImpl({
-  width,
   yDomain,
   showHorizontalLines,
   showLegend,
@@ -217,21 +208,21 @@ export function ServiceGraphImpl({
 }: TProps): React.JSX.Element {
   if (loading || !xDomain || xDomain[0] === undefined || xDomain[1] === undefined)
     return (
-      <Placeholder name={name} marginClassName={marginClassName} width={width} height={HEIGHT}>
+      <Placeholder name={name} marginClassName={marginClassName} height={HEIGHT}>
         <LoadingIndicator centered />
       </Placeholder>
     );
 
   if (error)
     return (
-      <Placeholder name={name} marginClassName={marginClassName} width={width} height={HEIGHT}>
+      <Placeholder name={name} marginClassName={marginClassName} height={HEIGHT}>
         Could not fetch data
       </Placeholder>
     );
 
   if (metricsData === null)
     return (
-      <Placeholder name={name} marginClassName={marginClassName} width={width} height={HEIGHT}>
+      <Placeholder name={name} marginClassName={marginClassName} height={HEIGHT}>
         No Data
       </Placeholder>
     );
@@ -262,7 +253,7 @@ export function ServiceGraphImpl({
   };
 
   return (
-    <Placeholder name={name} marginClassName={marginClassName} width={width} height={HEIGHT}>
+    <Placeholder name={name} marginClassName={marginClassName} height={HEIGHT}>
       <ResponsiveContainer width="100%" height={HEIGHT}>
         <AreaChart data={data} margin={{ top: 20, bottom: 55, left: 0, right: 0 }}>
           <XAxis


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger-ui/issues/3539

## Description of the changes
- Removed manual DOM width measurement using `offsetWidth`
- Removed window resize listener used for recalculating graph width
- Eliminated `graphWidth` state and related logic
- Updated `Placeholder` component to rely on fixed height and `width: 100%`
- Updated tests accordingly

## How was this change tested?
- Manually verified Monitor page renders correctly on first load. Screen recording-

https://github.com/user-attachments/assets/0eda9132-15f8-40ce-b4d0-eb82ea2b4c44


## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [X] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
