### PR TITLE
Fix (plexus): Self-loop edge label positioning [SvgEdge]

### DIFF
--- a/packages/plexus/src/Digraph/SvgEdge.tsx
+++ b/packages/plexus/src/Digraph/SvgEdge.tsx
@@ -37,11 +37,27 @@ function makePathD(points: [number, number][]) {
   return dArr.join(' ');
 }
 
-function computeLabelCoord(pathPoints: [number, number][], label?: string | undefined) {
+function computeLabelCoord(pathPoints: [number, number][], isSelfLoop: boolean, label?: string | undefined) {
+  const xOffset = (label?.length ?? 0) * 5;
+
+  if (isSelfLoop && pathPoints.length > 2) {
+    // For self-loops, position label at the center of the loop curve
+    // Average all path/control points to find the centroid of the oval
+    let sumX = 0;
+    let sumY = 0;
+    for (const [px, py] of pathPoints) {
+      sumX += px;
+      sumY += py;
+    }
+    return {
+      labelX: sumX / pathPoints.length - xOffset / 2, // center the text
+      labelY: sumY / pathPoints.length,
+    };
+  }
+
+  // Normal edge: midpoint between start and end
   const [startX, startY] = pathPoints[0];
   const [endX, endY] = pathPoints[pathPoints.length - 1];
-
-  const xOffset = (label?.length ?? 0) * 5;
   const labelX = (startX + endX) / 2 - xOffset;
   const labelY = (startY + endY) / 2;
 
@@ -65,7 +81,8 @@ export default class SvgEdge<U = {}> extends React.PureComponent<TProps<U>> {
       getProps(setOnEdge, layoutEdge, renderUtils)
     );
 
-    const { labelX, labelY } = computeLabelCoord(pathPoints, label);
+    const isSelfLoop = layoutEdge.edge.from === layoutEdge.edge.to;
+    const { labelX, labelY } = computeLabelCoord(pathPoints, isSelfLoop, label);
 
     return (
       <g>

--- a/packages/plexus/src/Digraph/SvgEdge.tsx
+++ b/packages/plexus/src/Digraph/SvgEdge.tsx
@@ -50,7 +50,7 @@ function computeLabelCoord(pathPoints: [number, number][], isSelfLoop: boolean, 
       sumY += py;
     }
     return {
-      labelX: sumX / pathPoints.length - xOffset / 2, // center the text
+      labelX: sumX / pathPoints.length - xOffset, // center the text, consistent with normal edges
       labelY: sumY / pathPoints.length,
     };
   }


### PR DESCRIPTION
Fixes #3500

## Problem

In the Trace Graph / System Architecture DAG views, edges rendered by the plexus [SvgEdge](file:///e:/Desktop/jaeger-ui/packages/plexus/src/Digraph/SvgEdge.tsx#67-107) component display labels (e.g., span counts). For **self-loop edges** (a service calling itself), the label was positioned at the midpoint of the path's start and end points — which for a self-loop lands directly on top of the node circle, making the label invisible.

## Changes

**File:** [packages/plexus/src/Digraph/SvgEdge.tsx](https://github.com/jaegertracing/jaeger-ui/blob/main/packages/plexus/src/Digraph/SvgEdge.tsx)

### 1. Self-loop detection via graph data

Self-loop edges are detected using `layoutEdge.edge.from === layoutEdge.edge.to`, which reliably identifies when an edge connects a node to itself. Coordinate-based detection was considered but rejected because self-loop bezier paths start and end at different points on the node's perimeter, making positional comparison unreliable.

### 2. Centroid-based label positioning for self-loops

For self-loop edges, the label is positioned at the **centroid of all bezier control points**, which places it at the visual center of the oval loop curve:

```tsx
if (isSelfLoop && pathPoints.length > 2) {
  let sumX = 0;
  let sumY = 0;
  for (const [px, py] of pathPoints) {
    sumX += px;
    sumY += py;
  }
  return {
    labelX: sumX / pathPoints.length - xOffset / 2,
    labelY: sumY / pathPoints.length,
  };
}
```

This approach is O(n) where n = number of path points (typically 4 for a cubic bezier), so there is no performance concern.

### 3. Normal edge positioning unchanged

For non-self-loop edges, the existing midpoint-based positioning between start and end points is preserved.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Self-loop label | Hidden behind node circle | Centered inside the oval loop |
| Normal edge label | Midpoint between nodes | Unchanged |

<img width="2245" height="1587" alt="DDG" src="https://github.com/user-attachments/assets/629c7463-cd64-4ea0-9e0f-b330a6bc876a" />


## Testing

Verified manually using HotROD demo traces in the Jaeger UI:
- **Trace Graph** view (individual trace → dropdown → "Trace Graph")
- **System Architecture** view (top navigation)

Self-loop edges (e.g., `frontend → frontend`) now display their span count labels clearly inside the loop curve.
