### PR TITLE
Fix PR quota workflow

### DIFF
--- a/.github/workflows/pr-quota-manager.yml
+++ b/.github/workflows/pr-quota-manager.yml
@@ -49,5 +49,5 @@ jobs:
             }
             const owner = context.repo.owner
             const repo = context.repo.repo
-            const dryRun = context.payload.inputs?.dryRun || false
+            const dryRun = context.payload.inputs?.dryRun === 'true'
             await handler({github, core, username, owner, repo, dryRun})


### PR DESCRIPTION
## Which problem is this PR solving?
On line 52:                                                                
```                                                                                            
  const dryRun = context.payload.inputs?.dryRun || false                                    
```
GitHub Actions passes workflow_dispatch boolean inputs as strings ("true" or "false"), not actual booleans. When the checkbox is unchecked, dryRun becomes the string "false", which is truthy in JavaScript, so `"false" || false` evaluates to `"false"` — and that truthy string activates dry run mode.

## Description of the changes
- Fix to check for `"true"` string
