### PR TITLE
refactor: Control Monitor tab visibility via storage capabilities of the backend

### DIFF
--- a/packages/jaeger-ui/index.html
+++ b/packages/jaeger-ui/index.html
@@ -35,7 +35,7 @@
       }
       // Jaeger storage compabilities data is embedded by the query-service via search-replace.
       function getJaegerStorageCapabilities() {
-        const DEFAULT_STORAGE_CAPABILITIES = { "archiveStorage": false };
+        const DEFAULT_STORAGE_CAPABILITIES = { "archiveStorage": false, "metricsStorage": false };
         const JAEGER_STORAGE_CAPABILITIES = DEFAULT_STORAGE_CAPABILITIES;
         return JAEGER_STORAGE_CAPABILITIES;
       }

--- a/packages/jaeger-ui/src/components/App/TopNav.test.js
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.js
@@ -51,7 +51,7 @@ jest.mock('../../utils/config/get-config', () => {
         case 'dependencies.menuEnabled':
         case 'deepDependencies.menuEnabled':
         case 'qualityMetrics.menuEnabled':
-        case 'monitor.menuEnabled':
+        case 'storageCapabilities.metricsStorage':
         case 'themes.enabled':
           return true;
         case 'qualityMetrics.menuLabel':

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -64,7 +64,7 @@ if (getConfigValue('qualityMetrics.menuEnabled')) {
   });
 }
 
-if (getConfigValue('monitor.menuEnabled')) {
+if (getConfigValue('storageCapabilities.metricsStorage')) {
   NAV_LINKS.push({
     to: monitorATMUrl.getUrl(),
     matches: monitorATMUrl.matches,

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -69,6 +69,7 @@ const defaultConfig: Config = {
   traceIdDisplayLength: 7,
   storageCapabilities: {
     archiveStorage: false,
+    metricsStorage: false,
   },
   tracking: {
     gaID: null,

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -74,6 +74,8 @@ export type TraceGraphConfig = {
 export type StorageCapabilities = {
   // archiveStorage indicates whether the query service supports archive storage.
   archiveStorage?: boolean;
+  // metricsStorage indicates whether the query service supports metrics storage (for Monitor/SPM tab).
+  metricsStorage?: boolean;
 };
 
 // Default values are provided in packages/jaeger-ui/src/constants/default-config.tsx

--- a/packages/jaeger-ui/src/utils/config/get-config.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-config.test.js
@@ -61,7 +61,7 @@ describe('getConfig()', () => {
 
     it('merges the defaultConfig with the embedded config and storage capabilities', () => {
       embedded = { novel: 'prop' };
-      capabilities = { archiveStorage: true };
+      capabilities = { archiveStorage: true, metricsStorage: false };
       expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, storageCapabilities: capabilities });
     });
 


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #3540 - Control Monitor tab visibility via storage capabilities

## Problem

Three overlapping mechanisms controlled Monitor/SPM tab visibility:

- `monitor.menuEnabled` — static local config flag (default `true`, always on)
- `isATMActivated` — fragile runtime detection via HTTP 501 probing
- `StorageCapabilities` — correct server-reported mechanism, but only had `archiveStorage`

## Changes

Replace `isATMActivated` and `monitor.menuEnabled` with a single source of truth: `storageCapabilities.metricsStorage`, reported by the query service at startup.

- **Types**: added `metricsStorage?: boolean` to `StorageCapabilities`; removed `menuEnabled`/`emptyState` from `MonitorConfig`; deleted `MonitorEmptyStateConfig`; removed `isATMActivated` from `MetricsReduxState`
- **Defaults**: added `metricsStorage: false` to default `storageCapabilities` and `index.html`; removed `monitor.menuEnabled`/`emptyState` from default config
- **Reducer**: removed `isATMActivated` state and HTTP 501 detection; 501 errors now stored in `serviceError` like any other API error
- **Components**: `TopNav` reads `storageCapabilities.metricsStorage` instead of `monitor.menuEnabled`; `ServicesView` drops `isATMActivated` fetch guard and `EmptyState` render
- **Deleted**: `Monitor/EmptyState/` directory (4 files)
- **Tests**: removed all `isATMActivated` references; updated config mocks; deleted obsolete EmptyState tests
