### PR TITLE
fix: Dark mode is not working correctly on the Quality Metrics page

### DIFF
--- a/packages/jaeger-ui/src/components/QualityMetrics/CountCard.css
+++ b/packages/jaeger-ui/src/components/QualityMetrics/CountCard.css
@@ -17,8 +17,8 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .CountCard--TitleHeader {
-  border-bottom: solid 1px #ddd;
-  box-shadow: 0px 5px 5px -5px rgba(0, 0, 0, 0.3);
+  border-bottom: solid 1px var(--border-default);
+  box-shadow: var(--shadow-sm);
   font-size: 1.1em;
   margin: 0 auto;
 }

--- a/packages/jaeger-ui/src/components/QualityMetrics/Header.css
+++ b/packages/jaeger-ui/src/components/QualityMetrics/Header.css
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 .QualityMetrics--Header {
   align-items: center;
-  background: #fafafa;
-  border-bottom: 1px solid #ddd;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  background: var(--surface-secondary);
+  border-bottom: 1px solid var(--border-default);
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: row;
   padding: 0.75rem 1.25rem 0.75rem 1.25rem;

--- a/packages/jaeger-ui/src/components/QualityMetrics/MetricCard.css
+++ b/packages/jaeger-ui/src/components/QualityMetrics/MetricCard.css
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 
 .MetricCard {
   border-radius: 7px;
-  border: 1px rgba(0, 0, 0, 0.5) solid;
+  border: 1px solid var(--border-strong);
   display: flex;
   margin: 5px 5%;
 }
 
 .MetricCard--Body {
-  border-left: solid 1px rgba(0, 0, 0, 0.3);
-  box-shadow: -3px 0 3px rgba(0, 0, 0, 0.1);
+  border-left: solid 1px var(--border-default);
+  box-shadow: var(--shadow-sm);
   flex-grow: 1;
   padding: 5px;
   text-align: center;
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .MetricCard--TitleHeader {
-  border-bottom: solid 1px #ddd;
-  box-shadow: 0px 5px 5px -5px rgba(0, 0, 0, 0.3);
+  border-bottom: solid 1px var(--border-default);
+  box-shadow: var(--shadow-sm);
   font-size: 1.5em;
 }

--- a/packages/jaeger-ui/src/components/QualityMetrics/ScoreCard.css
+++ b/packages/jaeger-ui/src/components/QualityMetrics/ScoreCard.css
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .ScoreCard--TitleHeader {
-  border-bottom: solid 1px #ddd;
-  box-shadow: 0px 5px 5px -5px rgba(0, 0, 0, 0.3);
+  border-bottom: solid 1px var(--border-default);
+  box-shadow: var(--shadow-sm);
   font-size: 1.8em;
 }

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.css
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.css
@@ -4,6 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 .QualityMetrics {
+  background: var(--surface-primary);
+  color: var(--text-primary);
   display: flex;
   flex-direction: column;
   height: calc(100vh - var(--nav-height));


### PR DESCRIPTION


## Which problem is this PR solving?
- Resolves #3566 

## Description of the changes
The Quality Metrics page CSS files used hardcoded color values like => (#fafafa, #ddd, rgba(0,0,0,) that don't adapt when the theme switches to dark mode. The project uses CSS custom properties (design tokens) defined in `vars.css`  with `[data-theme='dark']` overrides, but the Quality Metrics components weren't using them.
- In dark mode : 
<img width="1918" height="959" alt="Screenshot_09-Mar_00-39-20_31646" src="https://github.com/user-attachments/assets/ccfc8b1c-4b32-4cf6-a3c6-d301a6915b30" />

- In Light mode : 
<img width="1920" height="961" alt="Screenshot_09-Mar_00-40-17_30916" src="https://github.com/user-attachments/assets/f874cd2a-09f4-4ffa-bbcd-7871291d15d1" />


## How was this change tested?
- 
- npm test
- npm run build
- npm run lint

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
