### PR TITLE
fix(api): resolve infinite loading on trace/service fetch errors #3079

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -16,7 +16,8 @@ export class JaegerClient {
 
   /**
    * Helper to handle Jaeger v3 specific error arrays in 200 OK responses.
-   * Graphite Fix: Throws raw message; wrapping happens in public methods.
+   * Throws an Error when the response body contains a non-empty `errors` array,
+   * surfacing the raw concatenated error messages so public methods can wrap them with context.
    */
   private throwIfBodyHasErrors(data: any): void {
     if (data?.errors && Array.isArray(data.errors) && data.errors.length > 0) {

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -20,12 +20,16 @@ export class JaegerClient {
    */
   async fetchServices(): Promise<string[]> {
     const response = await this.fetchWithTimeout(`${this.apiRoot}/services`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch services: ${response.status} ${response.statusText}`);
-    }
+
+    // Parse once. Jaeger v3 may return 200 OK with an errors array in the body.
     const data = await response.json();
 
-    // Runtime validation with Zod
+    if (data?.errors?.length > 0) {
+      // Aggregate all error messages so no detail is lost
+      const messages = data.errors.map((e: any) => e.msg).join(', ');
+      throw new Error(`[fetchServices] ${messages}`);
+    }
+
     const validated = ServicesResponseSchema.parse(data);
     return validated.services;
   }
@@ -39,12 +43,17 @@ export class JaegerClient {
     const response = await this.fetchWithTimeout(
       `${this.apiRoot}/operations?service=${encodeURIComponent(service)}`
     );
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch span names for service "${service}": ${response.status} ${response.statusText}`
-      );
-    }
+
+    // In your current code, it only throws if !response.ok
+    // But we need to check the JSON body for "hidden" errors
     const data = await response.json();
+
+    // ADD THIS: The "Melonps" logic to handle 200 OK with error bodies
+    if (data?.errors?.length > 0) {
+      // Aggregate all error messages for this specific service
+      const messages = data.errors.map((e: any) => e.msg).join(', ');
+      throw new Error(`[fetchSpanNames] Failed for "${service}": ${messages}`);
+    }
 
     // Runtime validation with Zod
     const validated = OperationsResponseSchema.parse(data);
@@ -64,6 +73,22 @@ export class JaegerClient {
 
     try {
       const response = await fetch(url, { signal: controller.signal });
+
+      if (!response.ok) {
+        let errorDetail = response.statusText;
+        try {
+          // Attempt to extract the specific backend error (e.g., "trace not found")
+          const errorBody = await response.json();
+          if (errorBody?.errors?.length > 0) {
+            errorDetail = errorBody.errors.map((e: any) => e.msg).join(', ');
+          }
+        } catch {
+          // If the body isn't JSON, we just use the default statusText
+        }
+
+        throw new Error(`HTTP ${response.status}: ${errorDetail}`);
+      }
+
       return response;
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -74,10 +74,28 @@ export class JaegerClient {
       if (!response.ok) {
         let errorDetail = response.statusText;
         try {
-          const errorBody = await response.json();
+          const errorBody: unknown = await response.json();
           // Safely check if errors is an array before mapping
-          if (errorBody?.errors && Array.isArray(errorBody.errors) && errorBody.errors.length > 0) {
-            errorDetail = errorBody.errors.map((e: any) => e.msg).join(', ');
+          if (errorBody && typeof errorBody === 'object') {
+            const errors = (errorBody as { errors?: unknown }).errors;
+            if (Array.isArray(errors) && errors.length > 0) {
+              const messages = errors
+                .map(errorItem => {
+                  if (
+                    errorItem &&
+                    typeof errorItem === 'object' &&
+                    'msg' in errorItem &&
+                    typeof (errorItem as { msg: unknown }).msg === 'string'
+                  ) {
+                    return (errorItem as { msg: string }).msg;
+                  }
+                  return null;
+                })
+                .filter((msg): msg is string => msg !== null);
+              if (messages.length > 0) {
+                errorDetail = messages.join(', ');
+              }
+            }
           }
         } catch {
           /* Fallback to statusText if body isn't JSON */

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -24,10 +24,10 @@ export class JaegerClient {
     // Parse once. Jaeger v3 may return 200 OK with an errors array in the body.
     const data = await response.json();
 
-    if (data?.errors?.length > 0) {
+    if (data?.errors && Array.isArray(data.errors) && data.errors.length > 0) {
       // Aggregate all error messages so no detail is lost
-      const messages = data.errors.map((e: any) => e.msg).join(', ');
-      throw new Error(`[fetchServices] ${messages}`);
+      const messages = data.errors.map((e: { msg: string }) => e.msg).join(', ');
+      throw new Error(`Failed to fetch services: ${messages}`);
     }
 
     const validated = ServicesResponseSchema.parse(data);
@@ -44,18 +44,15 @@ export class JaegerClient {
       `${this.apiRoot}/operations?service=${encodeURIComponent(service)}`
     );
 
-    // In your current code, it only throws if !response.ok
-    // But we need to check the JSON body for "hidden" errors
+    // Jaeger v3 may return HTTP 200 with an 'errors' array in the response body; treat that as a failure.
     const data = await response.json();
 
-    // ADD THIS: The "Melonps" logic to handle 200 OK with error bodies
-    if (data?.errors?.length > 0) {
+    if (data?.errors && Array.isArray(data.errors) && data.errors.length > 0) {
       // Aggregate all error messages for this specific service
-      const messages = data.errors.map((e: any) => e.msg).join(', ');
-      throw new Error(`[fetchSpanNames] Failed for "${service}": ${messages}`);
+      const messages = data.errors.map((e: { msg: string }) => e.msg).join(', ');
+      throw new Error(`Failed to fetch span names for service "${service}": ${messages}`);
     }
 
-    // Runtime validation with Zod
     const validated = OperationsResponseSchema.parse(data);
     return validated.operations;
   }
@@ -77,16 +74,16 @@ export class JaegerClient {
       if (!response.ok) {
         let errorDetail = response.statusText;
         try {
-          // Attempt to extract the specific backend error (e.g., "trace not found")
           const errorBody = await response.json();
-          if (errorBody?.errors?.length > 0) {
+          // Safely check if errors is an array before mapping
+          if (errorBody?.errors && Array.isArray(errorBody.errors) && errorBody.errors.length > 0) {
             errorDetail = errorBody.errors.map((e: any) => e.msg).join(', ');
           }
         } catch {
-          // If the body isn't JSON, we just use the default statusText
+          /* Fallback to statusText if body isn't JSON */
         }
 
-        throw new Error(`HTTP ${response.status}: ${errorDetail}`);
+        throw new Error(`${response.status} ${errorDetail}`);
       }
 
       return response;


### PR DESCRIPTION
This PR resolves the infinite loading state observed when the Jaeger v3 API returns an error (both 4xx/5xx and 200 OK with an error body).

Changes:
- Modified fetchWithTimeout to explicitly throw an Error when !response.ok, ensuring React Query transitions to an error state.
- Implemented internal error checking in fetchServices and fetchSpanNames to catch "hidden" errors in the JSON body (closing the blind spot identified in #3161).
- Verified: Confirmed with a 404 response for non-existent Trace IDs (now displays error UI instead of spinning).

Fixes #3079.