### PR TITLE
refactor(TracePage): extract keyboard shortcut setup into dedicated module

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -7,7 +7,6 @@ import { useNormalizeTraceId } from './useNormalizeTraceId';
 import { Location, History as RouterHistory } from 'history';
 import _clamp from 'lodash/clamp';
 import _get from 'lodash/get';
-import _mapValues from 'lodash/mapValues';
 import _memoize from 'lodash/memoize';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -15,13 +14,9 @@ import { bindActionCreators, Dispatch } from 'redux';
 import ArchiveNotifier from './ArchiveNotifier';
 import { actions as archiveActions } from './ArchiveNotifier/duck';
 import { trackFilter, trackFocusMatches, trackNextMatch, trackPrevMatch, trackRange } from './index.track';
-import {
-  CombokeysHandler,
-  merge as mergeShortcuts,
-  reset as resetShortcuts,
-  ShortcutCallbacks,
-} from './keyboard-shortcuts';
-import { cancel as cancelScroll, scrollBy, scrollTo } from './scroll-page';
+import { setupTracePageShortcuts } from './keyboard-setup';
+import { reset as resetShortcuts } from './keyboard-shortcuts';
+import { scrollBy, scrollTo } from './scroll-page';
 import ScrollManager from './ScrollManager';
 import calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import TraceGraph from './TraceGraph/TraceGraph';
@@ -99,31 +94,9 @@ type TState = {
 
 // export for tests
 export const VIEW_MIN_RANGE = 0.01;
-const VIEW_CHANGE_BASE = 0.005;
-const VIEW_CHANGE_FAST = 0.05;
 
-// export for tests
-export const shortcutConfig: { [name: string]: [number, number] } = {
-  panLeft: [-VIEW_CHANGE_BASE, -VIEW_CHANGE_BASE],
-  panLeftFast: [-VIEW_CHANGE_FAST, -VIEW_CHANGE_FAST],
-  panRight: [VIEW_CHANGE_BASE, VIEW_CHANGE_BASE],
-  panRightFast: [VIEW_CHANGE_FAST, VIEW_CHANGE_FAST],
-  zoomIn: [VIEW_CHANGE_BASE, -VIEW_CHANGE_BASE],
-  zoomInFast: [VIEW_CHANGE_FAST, -VIEW_CHANGE_FAST],
-  zoomOut: [-VIEW_CHANGE_BASE, VIEW_CHANGE_BASE],
-  zoomOutFast: [-VIEW_CHANGE_FAST, VIEW_CHANGE_FAST],
-};
-
-// export for tests
-export function makeShortcutCallbacks(adjRange: (start: number, end: number) => void): ShortcutCallbacks {
-  function getHandler([startChange, endChange]: [number, number]): CombokeysHandler {
-    return function combokeyHandler(event: React.KeyboardEvent<HTMLElement>) {
-      event.preventDefault();
-      adjRange(startChange, endChange);
-    };
-  }
-  return _mapValues(shortcutConfig, getHandler);
-}
+// Re-export from keyboard-setup for backward compatibility with tests
+export { shortcutConfig, makeShortcutCallbacks } from './keyboard-setup';
 
 // export for tests
 export class TracePageImpl extends React.PureComponent<TProps, TState> {
@@ -133,6 +106,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
   _filterSpans: typeof filterSpans;
   _searchBar = React.createRef<InputRef>();
   _scrollManager: ScrollManager;
+  _cleanupShortcuts: (() => void) | null = null;
   traceDagEV: TEv | TNil;
 
   constructor(props: TProps) {
@@ -170,17 +144,12 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
     if (!this._scrollManager) {
       throw new Error('Invalid state - scrollManager is unset');
     }
-    const { scrollPageDown, scrollPageUp, scrollToNextVisibleSpan, scrollToPrevVisibleSpan } =
-      this._scrollManager;
-    const adjViewRange = (a: number, b: number) => this._adjustViewRange(a, b, 'kbd');
-    const shortcutCallbacks = makeShortcutCallbacks(adjViewRange);
-    shortcutCallbacks.scrollPageDown = scrollPageDown;
-    shortcutCallbacks.scrollPageUp = scrollPageUp;
-    shortcutCallbacks.scrollToNextVisibleSpan = scrollToNextVisibleSpan;
-    shortcutCallbacks.scrollToPrevVisibleSpan = scrollToPrevVisibleSpan;
-    shortcutCallbacks.clearSearch = this.clearSearch;
-    shortcutCallbacks.searchSpans = this.focusOnSearchBar;
-    mergeShortcuts(shortcutCallbacks);
+    this._cleanupShortcuts = setupTracePageShortcuts({
+      scrollManager: this._scrollManager,
+      adjustViewRange: (a, b, src) => this._adjustViewRange(a, b, src),
+      clearSearch: this.clearSearch,
+      focusOnSearchBar: this.focusOnSearchBar,
+    });
   }
 
   componentDidUpdate({ id: prevID }: TProps) {
@@ -200,8 +169,9 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
   }
 
   componentWillUnmount() {
-    resetShortcuts();
-    cancelScroll();
+    if (this._cleanupShortcuts) {
+      this._cleanupShortcuts();
+    }
     this._scrollManager.destroy();
     this._scrollManager = new ScrollManager(undefined, {
       scrollBy,

--- a/packages/jaeger-ui/src/components/TracePage/keyboard-setup.ts
+++ b/packages/jaeger-ui/src/components/TracePage/keyboard-setup.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Jaeger Authors
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { KeyboardEvent } from 'react';
+import _mapValues from 'lodash/mapValues';
+
+import {
+  CombokeysHandler,
+  merge as mergeShortcuts,
+  reset as resetShortcuts,
+  ShortcutCallbacks,
+} from './keyboard-shortcuts';
+import { cancel as cancelScroll } from './scroll-page';
+import type ScrollManager from './ScrollManager';
+
+const VIEW_CHANGE_BASE = 0.005;
+const VIEW_CHANGE_FAST = 0.05;
+
+// export for tests
+export const shortcutConfig: { [name: string]: [number, number] } = {
+  panLeft: [-VIEW_CHANGE_BASE, -VIEW_CHANGE_BASE],
+  panLeftFast: [-VIEW_CHANGE_FAST, -VIEW_CHANGE_FAST],
+  panRight: [VIEW_CHANGE_BASE, VIEW_CHANGE_BASE],
+  panRightFast: [VIEW_CHANGE_FAST, VIEW_CHANGE_FAST],
+  zoomIn: [VIEW_CHANGE_BASE, -VIEW_CHANGE_BASE],
+  zoomInFast: [VIEW_CHANGE_FAST, -VIEW_CHANGE_FAST],
+  zoomOut: [-VIEW_CHANGE_BASE, VIEW_CHANGE_BASE],
+  zoomOutFast: [-VIEW_CHANGE_FAST, VIEW_CHANGE_FAST],
+};
+
+// export for tests
+export function makeShortcutCallbacks(adjRange: (start: number, end: number) => void): ShortcutCallbacks {
+  function getHandler([startChange, endChange]: [number, number]): CombokeysHandler {
+    return function combokeyHandler(event: KeyboardEvent<HTMLElement>) {
+      event.preventDefault();
+      adjRange(startChange, endChange);
+    };
+  }
+  return _mapValues(shortcutConfig, getHandler);
+}
+
+type SetupParams = {
+  scrollManager: ScrollManager;
+  adjustViewRange: (startChange: number, endChange: number, trackSrc: string) => void;
+  clearSearch: () => void;
+  focusOnSearchBar: () => void;
+};
+
+/**
+ * Register all TracePage keyboard shortcuts (pan/zoom, scroll, search).
+ * Returns a cleanup function that resets shortcuts and cancels any pending scroll.
+ */
+export function setupTracePageShortcuts({
+  scrollManager,
+  adjustViewRange,
+  clearSearch,
+  focusOnSearchBar,
+}: SetupParams): () => void {
+  const { scrollPageDown, scrollPageUp, scrollToNextVisibleSpan, scrollToPrevVisibleSpan } = scrollManager;
+  const adjViewRange = (a: number, b: number) => adjustViewRange(a, b, 'kbd');
+  const shortcutCallbacks = makeShortcutCallbacks(adjViewRange);
+  shortcutCallbacks.scrollPageDown = scrollPageDown;
+  shortcutCallbacks.scrollPageUp = scrollPageUp;
+  shortcutCallbacks.scrollToNextVisibleSpan = scrollToNextVisibleSpan;
+  shortcutCallbacks.scrollToPrevVisibleSpan = scrollToPrevVisibleSpan;
+  shortcutCallbacks.clearSearch = clearSearch;
+  shortcutCallbacks.searchSpans = focusOnSearchBar;
+  mergeShortcuts(shortcutCallbacks);
+
+  return () => {
+    resetShortcuts();
+    cancelScroll();
+  };
+}


### PR DESCRIPTION
## Summary
- Extract keyboard shortcut registration/teardown from `componentDidMount`/`componentWillUnmount` into a new `keyboard-setup.ts` module
- Pure code movement with no behavior changes — the same shortcuts are registered in the same order
- `shortcutConfig` and `makeShortcutCallbacks` move to the new module and are re-exported from `index.tsx` for backward compatibility

This is the second in a series of incremental PRs preparing TracePage for conversion to a functional component (#3381). The extracted `setupTracePageShortcuts()` function will map directly to a `useEffect` in the final conversion.

Follows the approach agreed upon in #3435:
> "agreed, let's make smaller changes ideally starting with just those that don't change the logic but simply move things around." — @yurishkuro

## Changes
- **New:** `keyboard-setup.ts` — exports `setupTracePageShortcuts()` (returns cleanup fn), `shortcutConfig`, `makeShortcutCallbacks`
- **Modified:** `index.tsx` — `componentDidMount` calls `setupTracePageShortcuts()`, `componentWillUnmount` calls the returned cleanup. Removed `_mapValues` import (no longer needed here).

## Test plan
- [x] All 66 existing TracePage tests pass unchanged
- [x] `makeShortcutCallbacks` tests still work via re-export
- [x] Keyboard shortcut setup test still verifies `mergeShortcuts` is called with correct callbacks
- [x] Unmount test still verifies `resetShortcuts` and `cancelScroll` are called
- [x] Pre-commit hooks (eslint, prettier) pass

Depends on: #3592 (can be reviewed independently but should merge after)
Closes partially #3381