### PR TITLE
Pin PR quota manager script to a fixed commit

### DIFF
--- a/.github/workflows/pr-quota-manager.yml
+++ b/.github/workflows/pr-quota-manager.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Download PR Quota Manager script
         run: |
           curl -fsSL -o /tmp/pr-quota-manager.js \
-            https://raw.githubusercontent.com/jaegertracing/jaeger/refs/heads/main/.github/scripts/pr-quota-manager.js
+            https://raw.githubusercontent.com/jaegertracing/jaeger/67b08e2dbd4ed65200e3b3499f8cf71083b6041f/.github/scripts/pr-quota-manager.js
 
       - name: Process PR Quota
         uses: actions/github-script@v7


### PR DESCRIPTION
### Motivation
- Mitigate a supply-chain execution risk where the PR Quota Manager workflow downloaded and executed an unpinned script from a moving `main` branch while running under `pull_request_target` with elevated write permissions.

### Description
- Replace the curl URL in `.github/workflows/pr-quota-manager.yml` to fetch the PR quota manager script from a specific commit SHA (`https://raw.githubusercontent.com/jaegertracing/jaeger/67b08e2dbd4ed65200e3b3499f8cf71083b6041f/.github/scripts/pr-quota-manager.js`), preserving the workflow behavior while removing mutable-branch execution.

### Testing
- Ran `npm run prettier` which succeeded; `npm run lint` failed in this environment due to `npm-run-all: not found`; `npm test` failed due to `jest: not found`; `npm run build` failed due to missing build tooling (`npm-run-all`/`vite` not found); and `npm ci` could not run because the environment Node version is older than the repo-required `>=24`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b31213a9a0832696177e2f2e1e32ba)
