### PR TITLE
chore: add fetch timeout to backend config in dev mode

### DIFF
--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -39,14 +39,22 @@ function jaegerUiConfigPlugin() {
   let cachedBackendConfig: Record<string, any> | null | undefined = undefined;
   let cacheTimestamp = 0;
   const CACHE_TTL_MS = 30_000;
+  // Abort the backend config fetch if it takes longer than this to avoid
+  // blocking transformIndexHtml (and therefore page loads) indefinitely on a
+  // stalled proxy, long TLS handshake, or slow network.
+  const FETCH_TIMEOUT_MS = 3_000;
 
   async function fetchBackendConfig() {
     const now = Date.now();
     if (cachedBackendConfig !== undefined && now - cacheTimestamp < CACHE_TTL_MS) {
       return cachedBackendConfig;
     }
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-      const response = await fetch(`${proxyConfig.target}/api/ui/config`);
+      const response = await fetch(`${proxyConfig.target}/api/ui/config`, {
+        signal: controller.signal,
+      });
       if (response.ok) {
         cachedBackendConfig = await response.json();
         cacheTimestamp = Date.now();
@@ -57,10 +65,12 @@ function jaegerUiConfigPlugin() {
         cacheTimestamp = Date.now();
       }
     } catch {
-      // Backend not running or timed out — cache the negative result so we
-      // don't retry on every page load while the backend is down.
+      // Backend not running, request timed out, or aborted — cache the negative
+      // result so we don't retry on every page load while the backend is down.
       cachedBackendConfig = null;
       cacheTimestamp = Date.now();
+    } finally {
+      clearTimeout(timeoutId);
     }
     return cachedBackendConfig;
   }

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -43,36 +43,47 @@ function jaegerUiConfigPlugin() {
   // blocking transformIndexHtml (and therefore page loads) indefinitely on a
   // stalled proxy, long TLS handshake, or slow network.
   const FETCH_TIMEOUT_MS = 3_000;
+  // In-flight promise shared across concurrent callers so only one fetch runs
+  // at a time — prevents a timed-out sibling from overwriting a successful result.
+  let inflightFetch: Promise<Record<string, any> | null> | null = null;
 
   async function fetchBackendConfig() {
     const now = Date.now();
     if (cachedBackendConfig !== undefined && now - cacheTimestamp < CACHE_TTL_MS) {
       return cachedBackendConfig;
     }
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    try {
-      const response = await fetch(`${proxyConfig.target}/api/ui/config`, {
-        signal: controller.signal,
-      });
-      if (response.ok) {
-        cachedBackendConfig = await response.json();
-        cacheTimestamp = Date.now();
-        console.log('[jaeger-ui-config] Fetched config from backend');
-      } else {
-        // Non-2xx response (e.g. 404 if endpoint not yet implemented) — treat as unavailable
+    // If a fetch is already in-flight, all concurrent callers await the same promise.
+    if (inflightFetch) {
+      return inflightFetch;
+    }
+    inflightFetch = (async () => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const response = await fetch(`${proxyConfig.target}/api/ui/config`, {
+          signal: controller.signal,
+        });
+        if (response.ok) {
+          cachedBackendConfig = await response.json();
+          cacheTimestamp = Date.now();
+          console.log('[jaeger-ui-config] Fetched config from backend');
+        } else {
+          // Non-2xx response (e.g. 404 if endpoint not yet implemented) — treat as unavailable
+          cachedBackendConfig = null;
+          cacheTimestamp = Date.now();
+        }
+      } catch {
+        // Backend not running, request timed out, or aborted — cache the negative
+        // result so we don't retry on every page load while the backend is down.
         cachedBackendConfig = null;
         cacheTimestamp = Date.now();
+      } finally {
+        clearTimeout(timeoutId);
+        inflightFetch = null;
       }
-    } catch {
-      // Backend not running, request timed out, or aborted — cache the negative
-      // result so we don't retry on every page load while the backend is down.
-      cachedBackendConfig = null;
-      cacheTimestamp = Date.now();
-    } finally {
-      clearTimeout(timeoutId);
-    }
-    return cachedBackendConfig;
+      return cachedBackendConfig ?? null;
+    })();
+    return inflightFetch;
   }
 
   function readLocalConfig(): Record<string, any> | null {


### PR DESCRIPTION
Add a 3-second fetch timeout via AbortController so that transformIndexHtml does not block dev page loads indefinitely when the backend is reachable but stalled (e.g. slow proxy, long TLS handshake). Aborted requests are treated as backend-unavailable and the negative result is cached within the normal TTL window to avoid repeated retries.

Follow-up to PR #3561 (jkowall's optional suggestion). Part of issue #2610.
<img width="838" height="382" alt="Screenshot 2026-03-13 at 1 47 03 AM" src="https://github.com/user-attachments/assets/0d9c6dae-dbcb-4655-ab8e-a188b263acf0" />
## Which problem is this PR solving?
- Resolves the optional follow-up raised by @jkowall in PR #3561: [fetch()](cci:1://file:///Users/harshsaini/Desktop/jaeger-ui/packages/jaeger-ui/vite.config.mts:46:2-75:3) in `transformIndexHtml` had no explicit timeout/abort, so in some network-failure modes the dev HTML transform could stall until socket timeout, blocking page loads.

## Description of the changes
- Added `FETCH_TIMEOUT_MS = 3_000` constant in [vite.config.mts](cci:7://file:///Users/harshsaini/Desktop/jaeger-ui/packages/jaeger-ui/vite.config.mts:0:0-0:0)
- Created an `AbortController` before each [fetch()](cci:1://file:///Users/harshsaini/Desktop/jaeger-ui/packages/jaeger-ui/vite.config.mts:46:2-75:3) call and set a `setTimeout` to call `controller.abort()` after 3 seconds
- Passed `signal: controller.signal` to the [fetch()](cci:1://file:///Users/harshsaini/Desktop/jaeger-ui/packages/jaeger-ui/vite.config.mts:46:2-75:3) options
- Added `finally { clearTimeout(timeoutId) }` to always clean up the timer
- Aborted/timed-out requests fall into the existing `catch` block and are cached as backend-unavailable within the normal 30-second TTL

## How was this change tested?
- `tsc-lint` passes with no errors
- Manually verified the dev server starts normally when backend is available
- The timeout path is exercised by the existing TTL cache logic when backend is unreachable


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
