### PR TITLE
fix: replace unsafe _get() with optional chaining in embedded reducer

### DIFF
--- a/packages/jaeger-ui/src/reducers/embedded.ts
+++ b/packages/jaeger-ui/src/reducers/embedded.ts
@@ -1,14 +1,12 @@
 // Copyright (c) 2018 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import _get from 'lodash/get';
-
 import { EmbeddedState } from '../types/embedded';
 import { getEmbeddedState } from '../utils/embedded-url';
 
 export default function embeddedConfig(state: EmbeddedState | undefined) {
   if (state === undefined) {
-    const search = _get(window, 'location.search');
+    const search = window?.location?.search;
     return search ? getEmbeddedState(search) : null;
   }
   return state;


### PR DESCRIPTION
hey, i saw the issue about removing unsafe _get() calls and started with the embedded reducer. this one was straightforward - just replaced _get(window, 'location.search') with window?.location?.search. let me know if you want me to tackle more of these!