### PR TITLE
Part of Phase 3.2 (task 1): Move config props out of TOwnProps in the TracePage

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.js
@@ -1209,6 +1209,8 @@ describe('mapStateToProps()', () => {
       archiveTraceState: undefined,
       timelineBarsVisible: true,
       trace: { data: {}, state: fetchedState.DONE },
+      archiveEnabled: false,
+      enableSidePanel: false,
     });
   });
 
@@ -1239,6 +1241,9 @@ describe('mapStateToProps()', () => {
       timelineBarsVisible: true,
       uiFind: undefined,
       trace: { data: {}, state: fetchedState.DONE },
+      archiveEnabled: false,
+      enableSidePanel: false,
+      traceGraphConfig: { layoutManagerMemory: fakeMemory },
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -27,7 +27,6 @@ import calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import TraceGraph from './TraceGraph/TraceGraph';
 import { TEv } from './TraceGraph/types';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
-import { useConfig } from '../../hooks/useConfig';
 import TracePageHeader from './TracePageHeader';
 import TraceTimelineViewer from './TraceTimelineViewer';
 import { actions as timelineActions } from './TraceTimelineViewer/duck';
@@ -68,13 +67,6 @@ type TOwnProps = {
   history: RouterHistory;
   location: Location<LocationState>;
   params: { id: string };
-  archiveEnabled: boolean;
-  enableSidePanel: boolean;
-  storageCapabilities: StorageCapabilities | TNil;
-  criticalPathEnabled: boolean;
-  disableJsonView: boolean;
-  traceGraphConfig?: TraceGraphConfig;
-  useOtelTerms: boolean;
 };
 
 type TReduxProps = {
@@ -85,6 +77,13 @@ type TReduxProps = {
   timelineBarsVisible: boolean;
   trace: FetchedTrace | TNil;
   uiFind: string | TNil;
+  archiveEnabled: boolean;
+  enableSidePanel: boolean;
+  storageCapabilities: StorageCapabilities | TNil;
+  criticalPathEnabled: boolean;
+  disableJsonView: boolean;
+  traceGraphConfig?: TraceGraphConfig;
+  useOtelTerms: boolean;
 };
 
 type TProps = TDispatchProps & TOwnProps & TReduxProps;
@@ -468,7 +467,7 @@ export class TracePageImpl extends React.PureComponent<TProps, TState> {
 // export for tests
 export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxProps {
   const { id } = ownProps.params;
-  const { archive, embedded } = state;
+  const { archive, config, embedded } = state;
   const { traces } = state.trace;
   const trace = id ? traces[id] : null;
   const archiveTraceState = id ? archive[id] : null;
@@ -483,6 +482,13 @@ export function mapStateToProps(state: ReduxState, ownProps: TOwnProps): TReduxP
     id,
     timelineBarsVisible,
     trace,
+    archiveEnabled: Boolean(config.archiveEnabled),
+    enableSidePanel: Boolean(config.traceTimeline?.enableSidePanel),
+    storageCapabilities: config.storageCapabilities,
+    criticalPathEnabled: config.criticalPathEnabled,
+    disableJsonView: config.disableJsonView,
+    traceGraphConfig: config.traceGraph,
+    useOtelTerms: config.useOpenTelemetryTerms,
   };
 }
 
@@ -513,23 +519,9 @@ type TracePageProps = {
 };
 
 const TracePage = (props: TracePageProps) => {
-  const config = useConfig();
-  const traceID = props.params.id;
-  const normalizedTraceID = useNormalizeTraceId(traceID);
+  const normalizedTraceID = useNormalizeTraceId(props.params.id);
 
-  return (
-    <ConnectedTracePage
-      {...props}
-      params={{ ...props.params, id: normalizedTraceID }}
-      archiveEnabled={Boolean(config.archiveEnabled)}
-      enableSidePanel={Boolean(config.traceTimeline?.enableSidePanel)}
-      storageCapabilities={config.storageCapabilities}
-      criticalPathEnabled={config.criticalPathEnabled}
-      disableJsonView={config.disableJsonView}
-      traceGraphConfig={config.traceGraph}
-      useOtelTerms={config.useOpenTelemetryTerms}
-    />
-  );
+  return <ConnectedTracePage {...props} params={{ ...props.params, id: normalizedTraceID }} />;
 };
 
 export default withRouteProps(TracePage);


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves part of #3313
- Resolves part of #3381 

## Description of the changes
The component had two separate workers:
  - `TracePage` wrapper: used `useConfig()` to fetch config settings, then handed each one to the `TracePageImpl`
  - `TracePageImpl`: received those settings as props.

The new way is we cutting out the middleman. Now `mapStateToProps` read `state.config` directly and gives it to `TracePageImpl`. So now `TracePage` no longer needs to touch config at all.

#### How this helping in the class conversion?? 
When we convert `TracePageImpl` to a functional component, we will not need to add `useConfig()` inside it, because config is already arriving as Redux props. The functional component will just read the props, same as the class doing today.

## How was this change tested?
- Unit tests
- Checked the component features behaving same as before (like `traceGraphConfig`: switching to Trace Graph view should load the graph)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
