### PR TITLE
Handle Windows line endings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,7 +80,7 @@ const commonSettings = {
 };
 
 const baseRules = {
-  'prettier/prettier': ['error'],
+  'prettier/prettier': ['error', { endOfLine: 'auto' }],
   'no-unused-vars': 'off',
   'no-redeclare': 'off',
   'no-shadow': 'off',

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "prettier": {
     "arrowParens": "avoid",
+    "endOfLine": "auto",
     "printWidth": 110,
     "proseWrap": "never",
     "singleQuote": true,


### PR DESCRIPTION
## Summary
- configure Prettier and `eslint-plugin-prettier` to tolerate Windows line endings
- stop `eslint` from failing on CRLF-only checkout differences
- keep `npm run prettier` from rewriting the whole repo in a Windows worktree

## Changes
- set `endOfLine: 'auto'` in the root Prettier config
- pass `{ endOfLine: 'auto' }` to the `prettier/prettier` ESLint rule

## Verification
- `npm run prettier`
- `npm run lint`
- `npm test`

## Notes
- `npm run build` still fails on Windows because `packages/plexus` uses `rimraf src/LayoutManager/layout.worker*js*`, which is a separate script portability issue
