### PR TITLE
Pin s390x workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/s390x-build.yaml
+++ b/.github/workflows/s390x-build.yaml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Cache Docker layers
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1


### PR DESCRIPTION
### Motivation
- Replace mutable @v3 tags for docker/setup-qemu-action and docker/setup-buildx-action in the s390x CI workflow to reduce GitHub Actions supply-chain risk by pinning to immutable commit SHAs.

### Description
- Update .github/workflows/s390x-build.yaml to pin docker/setup-qemu-action to c7c53464625b32c7a7e944ae62b3e17d2b600130 (3.7.0)
- Update .github/workflows/s390x-build.yaml to pin docker/setup-buildx-action to 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f (3.12.0)
- Keep the change limited to the existing s390x workflow so the PR stays easy to review upstream

### Testing
- Ran 
pm run prettier successfully via ash
- 
pm run lint fails in this environment because repo shell scripts such as ./scripts/check-license.sh are not resolved from the Windows/bash setup
- 
pm test fails due existing workspace/module-resolution issues around @jaegertracing/plexus in this environment
- 
pm run build fails in this environment due a missing optional Rollup native package (@rollup/rollup-linux-x64-gnu)

These verification failures appear unrelated to this two-line workflow-only change.