### PR TITLE
🧪 [testing improvement] Add unit tests for getSelectedSpanID

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
@@ -11,6 +11,7 @@ import reducer, {
   collapseOne,
   expandAll,
   expandOne,
+  getSelectedSpanID,
   MIN_TIMELINE_COLUMN_WIDTH,
   SPAN_NAME_COLUMN_WIDTH_MIN,
   SPAN_NAME_COLUMN_WIDTH_MAX,
@@ -789,6 +790,25 @@ describe('TraceTimelineViewer/duck', () => {
       const action = actions.removeHoverIndentGuideId(existingSpanId);
       store.dispatch(action);
       expect(store.getState().hoverIndentGuideIds).toEqual(new Set([secondExistingSpanId]));
+    });
+  });
+
+  describe('getSelectedSpanID', () => {
+    it('returns null when detailStates is empty', () => {
+      expect(getSelectedSpanID(new Map())).toBeNull();
+    });
+
+    it('returns the span ID when detailStates has one entry', () => {
+      const detailStates = new Map([['span-a', null]]);
+      expect(getSelectedSpanID(detailStates)).toBe('span-a');
+    });
+
+    it('returns the first span ID when detailStates has multiple entries', () => {
+      const detailStates = new Map([
+        ['span-a', null],
+        ['span-b', null],
+      ]);
+      expect(getSelectedSpanID(detailStates)).toBe('span-a');
     });
   });
 });


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `getSelectedSpanID` utility function in `packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts` lacked unit tests, leading to incomplete coverage of the module's exported logic.

### 📊 Coverage: What scenarios are now tested
Added a new `describe` block in `packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js` covering:
- **Empty state:** Verified it returns `null` when no spans are selected (`detailStates` is empty).
- **Single selection:** Verified it correctly extracts the span ID when one span is selected.
- **Multiple selections:** Verified it returns the first selected span ID (the first key in `detailStates`) when multiple spans are present.

### ✨ Result: The improvement in test coverage
This change ensures that the logic for determining the active span in side-panel mode is fully verified and protected against regressions. The tests are designed to be efficient by using dummy Map values instead of full `DetailState` instances.

---
*PR created automatically by Jules for task [125477236104796336](https://jules.google.com/task/125477236104796336) started by @jkowall*
