### PR TITLE
Do not fail bundle size workflow on main branch

### DIFF
--- a/.github/workflows/check_bundle.yml
+++ b/.github/workflows/check_bundle.yml
@@ -47,7 +47,7 @@ jobs:
             jaeger-ui-bundle-size
 
       - name: Compare bundle sizes
-        if: steps.cache-bundle-size.outputs.cache-matched-key != ''
+        if: steps.cache-bundle-size.outputs.cache-matched-key != '' && github.ref != 'refs/heads/main'
         run: |
           OLD_BUNDLE_SIZE=$(cat bundle_size.txt)
           NEW_BUNDLE_SIZE=$(cat new_bundle_size.txt)


### PR DESCRIPTION
## Which problem is this PR solving?
- The workflow failed on main because of expected bundle size change, but the check should only be failing on PRs, on main it needs to always write out the current bundle size to artifact.

## Description of the changes
- Skip compare step on main
