### PR TITLE
fix: replace remaining tooltip arrow prop

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.tsx
@@ -44,7 +44,7 @@ const ReferencesButton: React.FC<TReferencesButtonProps> = memo(function ({
   }, [links, focusSpan]);
 
   const tooltipProps = {
-    arrowPointAtCenter: true,
+    arrow: { pointAtCenter: true },
     mouseLeaveDelay: 0.5,
     placement: 'bottom' as TooltipPlacement,
     title: tooltipText,


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2221

## Description of the changes

- replace the deprecated `arrowPointAtCenter` Tooltip prop in `ReferencesButton`
- switch it to the current Ant Design API: `arrow={{ pointAtCenter: true }}`

## How was this change tested?
- `npm run prettier`
- `npm run lint`
- `npm test`
- `npm run build`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
