### PR TITLE
Add error path test for tryParseMultiLineInput and fix mock leakage

### DIFF
--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -87,39 +87,54 @@ describe('fileReader.readJsonFile', () => {
     return expect(p).resolves.toMatchObject(expectedOutput);
   });
 
-  it('handles FileReader error', () => {
-    const file = new File([''], 'error.json');
-    const mockReader = { readAsText: jest.fn(), onerror: null, error: new Error('Read error') };
-
-    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
-    const promise = readJsonFile({ file });
-
-    mockReader.onerror();
-
-    return expect(promise).rejects.toThrow(/Read error/);
+  it('rejects multi-line JSON with a malformed line', () => {
+    const fileContent = '{"a":1}\n{"b":';
+    const file = new File([fileContent], 'multi-error.json', { type: 'application/json' });
+    const p = readJsonFile({ file });
+    return expect(p).rejects.toThrow(/Error parsing JSON at line 2:/);
   });
 
-  it('handles FileReader abort', () => {
-    const file = new File([''], 'abort.json');
-    const mockReader = { readAsText: jest.fn(), onabort: null };
+  describe('FileReader mocking', () => {
+    let fileReaderSpy;
 
-    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
-    const promise = readJsonFile({ file });
+    afterEach(() => {
+      fileReaderSpy.mockRestore();
+    });
 
-    mockReader.onabort();
+    it('handles FileReader error', () => {
+      const file = new File([''], 'error.json');
+      const mockReader = { readAsText: jest.fn(), onerror: null, error: new Error('Read error') };
 
-    return expect(promise).rejects.toThrow(/aborted/);
-  });
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      const promise = readJsonFile({ file });
 
-  it('rejects if FileReader result is not a string', () => {
-    const file = new File(['{ "test": true }'], 'dummy.json');
-    const mockReader = { readAsText: jest.fn(), onload: null, result: {} };
+      mockReader.onerror();
 
-    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
-    const promise = readJsonFile({ file });
+      return expect(promise).rejects.toThrow(/Read error/);
+    });
 
-    mockReader.onload();
+    it('handles FileReader abort', () => {
+      const file = new File([''], 'abort.json');
+      const mockReader = { readAsText: jest.fn(), onabort: null };
 
-    return expect(promise).rejects.toThrow(/Invalid result type/);
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      const promise = readJsonFile({ file });
+
+      mockReader.onabort();
+
+      return expect(promise).rejects.toThrow(/aborted/);
+    });
+
+    it('rejects if FileReader result is not a string', () => {
+      const file = new File(['{ "test": true }'], 'dummy.json');
+      const mockReader = { readAsText: jest.fn(), onload: null, result: {} };
+
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      const promise = readJsonFile({ file });
+
+      mockReader.onload();
+
+      return expect(promise).rejects.toThrow(/Invalid result type/);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add a test for the error path in `tryParseMultiLineInput` when a malformed line is present in multi-line JSON input, verifying the rejection includes the correct line number
- Wrap the existing FileReader-mocking tests in a scoped `describe` block with targeted `mockRestore()` to prevent the `FileReader` spy from leaking into subsequent tests (previously the mock was never cleaned up, which would cause any later test using the real `FileReader` to hang)

## Test plan
- [x] All 11 tests in `readJsonFile.test.js` pass (including the new one)
- [x] Prettier formatting verified
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)