### PR TITLE
chore: fix misleading parameter names in IScroller interface

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/ScrollManager.ts
+++ b/packages/jaeger-ui/src/components/TracePage/ScrollManager.ts
@@ -27,9 +27,8 @@ export type Accessors = {
 };
 
 interface IScroller {
-  scrollTo: (rowIndex: number) => void;
-  // TODO arg names throughout
-  scrollBy: (rowIndex: number, opt?: boolean) => void;
+  scrollTo: (y: number) => void;
+  scrollBy: (yDelta: number, appendToLast?: boolean) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rename `rowIndex` → `y` and `rowIndex` → `yDelta` in the `IScroller` interface to match the actual pixel-coordinate semantics of the `scroll-page.ts` implementations (`scrollTo(y)` and `scrollBy(yDelta, appendToLast)`)
- Rename `opt` → `appendToLast` for clarity
- Remove stale `// TODO arg names throughout` comment

## Test plan
- Interface-only change (parameter names), no runtime behavior change
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)