### PR TITLE
test: replace arrow ctor mocks with regular functions

### DIFF
--- a/docs/adr/0007-vite-plus-migration.md
+++ b/docs/adr/0007-vite-plus-migration.md
@@ -375,10 +375,16 @@ requires `vi.resetModules()` + `await import()` and will be handled in H3:
 - `utils/tracking/ga-coverage.test.js`
 - `prefix-url-coverage.test.js`
 
-#### PR H2b — Replace arrow function constructors with regular functions (~16 files)
+#### ✅ PR H2b — Replace arrow function constructors with regular functions ([#3693](https://github.com/jaegertracing/jaeger-ui/pull/3693))
 
 `mockImplementation(() => ({...}))` fails when the mock is called with `new` in Vitest 4.x.
-Replacing with `mockImplementation(function() { return {...}; })` is safe under Jest too.
+Replaced with `mockImplementation(function() { return {...}; })` — safe under Jest too.
+
+Six files had constructor mocks (identified by checking which `mockImplementation` targets are
+called with `new` in production code): `readJsonFile.test.js` (FileReader ×3),
+`Monitor/ServicesView/index.test.jsx` (ResizeObserver), `TraceDiff/TraceDiff.test.jsx` (ResizeObserver),
+`DeepDependencies/Graph/index.test.jsx` (LayoutManager), `TracePage/index.test.jsx` (ScrollManager ×3),
+`TracePage/TraceGraph/TraceGraph.test.jsx` (MockLayoutManager).
 
 #### PR H2c — Introduce `mockDefault` helper in affected mock factories
 
@@ -592,7 +598,7 @@ confirm no errors or unexpected HTML injection.
 | 🔶 F | Migrate Jest → Vitest in both packages; remove Babel test deps ([#3690](https://github.com/jaegertracing/jaeger-ui/pull/3690) plexus ✅, jaeger-ui pending) | Unknowns 3, 4, 5, 6 | Partial |
 | ✅ H1 | Rename `.test.js` → `.test.jsx` in jaeger-ui (121 files, pure rename) ([#3691](https://github.com/jaegertracing/jaeger-ui/pull/3691)) | None | Done |
 | ✅ H2a | Replace `require()` in test bodies with static `import` ([#3692](https://github.com/jaegertracing/jaeger-ui/pull/3692)) | None | Done |
-| H2b | Replace arrow function constructors with regular functions (~16 files) | None | After H1 |
+| ✅ H2b | Replace arrow function constructors with regular functions (6 files) ([#3693](https://github.com/jaegertracing/jaeger-ui/pull/3693)) | None | Done |
 | H2c | Introduce `mockDefault` helper in affected mock factories | None | After H1 |
 | H3 | Vitest switch for jaeger-ui | Unknowns 3, 4, 5, 6 | After H2a–c |
 | G  | Update CLAUDE.md, README, CI workflows | None | After H3 |

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/index.test.jsx
@@ -18,9 +18,9 @@ jest.mock('@jaegertracing/plexus', () => ({
       },
     }
   ),
-  LayoutManager: jest.fn().mockImplementation(() => ({
-    stopAndRelease: jest.fn(),
-  })),
+  LayoutManager: jest.fn().mockImplementation(function () {
+    return { stopAndRelease: jest.fn() };
+  }),
 }));
 
 jest.mock('./DdgNodeContent', () => ({

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -22,11 +22,9 @@ import {
 } from '../../../reducers/metrics.mock';
 import * as track from './index.track';
 
-global.ResizeObserver = jest.fn().mockImplementation(() => ({
-  observe: jest.fn(),
-  unobserve: jest.fn(),
-  disconnect: jest.fn(),
-}));
+global.ResizeObserver = jest.fn().mockImplementation(function () {
+  return { observe: jest.fn(), unobserve: jest.fn(), disconnect: jest.fn() };
+});
 
 jest.mock('../../../utils/config/get-config', () => ({
   __esModule: true,

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
@@ -257,11 +257,9 @@ describe('TraceDiff', () => {
   describe('TraceDiff--graphWrapper top offset', () => {
     it('applies top offset to graph wrapper based on header height', () => {
       const originalResizeObserver = window.ResizeObserver;
-      window.ResizeObserver = jest.fn().mockImplementation(() => ({
-        observe: jest.fn(),
-        unobserve: jest.fn(),
-        disconnect: jest.fn(),
-      }));
+      window.ResizeObserver = jest.fn().mockImplementation(function () {
+        return { observe: jest.fn(), unobserve: jest.fn(), disconnect: jest.fn() };
+      });
 
       const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
       Element.prototype.getBoundingClientRect = jest.fn().mockImplementation(function () {

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
@@ -45,9 +45,9 @@ jest.mock('@jaegertracing/plexus', () => {
     scaleStrokeOpacity: () => ({ strokeOpacity: 1 }),
   };
 
-  const MockLayoutManager = jest.fn().mockImplementation(() => ({
-    stopAndRelease: jest.fn(),
-  }));
+  const MockLayoutManager = jest.fn().mockImplementation(function () {
+    return { stopAndRelease: jest.fn() };
+  });
 
   const mockCacheAs = (key, fn) => {
     const cachedFn = (...args) => fn(...args);

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -71,14 +71,16 @@ jest.mock('./TraceLogsView/index', () => {
 });
 
 jest.mock('./ScrollManager', () => {
-  return jest.fn().mockImplementation(() => ({
-    scrollToNextVisibleSpan: jest.fn(),
-    scrollToPrevVisibleSpan: jest.fn(),
-    setTrace: jest.fn(),
-    destroy: jest.fn(),
-    setAccessors: jest.fn(),
-    scrollToFirstVisibleSpan: jest.fn(),
-  }));
+  return jest.fn().mockImplementation(function () {
+    return {
+      scrollToNextVisibleSpan: jest.fn(),
+      scrollToPrevVisibleSpan: jest.fn(),
+      setTrace: jest.fn(),
+      destroy: jest.fn(),
+      setAccessors: jest.fn(),
+      scrollToFirstVisibleSpan: jest.fn(),
+    };
+  });
 });
 
 jest.mock('./index.track');
@@ -412,14 +414,16 @@ describe('<TracePage>', () => {
   it('calls scrollManager.setTrace when trace data changes', () => {
     const setTraceMock = jest.fn();
 
-    ScrollManager.mockImplementation(() => ({
-      scrollToNextVisibleSpan: jest.fn(),
-      scrollToPrevVisibleSpan: jest.fn(),
-      setAccessors: jest.fn(),
-      scrollToFirstVisibleSpan: jest.fn(),
-      destroy: jest.fn(),
-      setTrace: setTraceMock,
-    }));
+    ScrollManager.mockImplementation(function () {
+      return {
+        scrollToNextVisibleSpan: jest.fn(),
+        scrollToPrevVisibleSpan: jest.fn(),
+        setAccessors: jest.fn(),
+        scrollToFirstVisibleSpan: jest.fn(),
+        destroy: jest.fn(),
+        setTrace: setTraceMock,
+      };
+    });
 
     const { rerender } = render(<TracePage {...defaultProps} trace={null} />);
     rerender(<TracePage {...defaultProps} trace={{ data: trace, state: fetchedState.DONE }} />);
@@ -438,7 +442,9 @@ describe('<TracePage>', () => {
       setTrace: jest.fn(),
     };
 
-    ScrollManager.mockImplementation(() => scrollManagerMock);
+    ScrollManager.mockImplementation(function () {
+      return scrollManagerMock;
+    });
 
     const resetShortcutsMock = jest.spyOn(keyboardShortcutsMod, 'reset');
     const cancelScrollMock = jest.spyOn(scrollPageMod, 'cancel');

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -105,7 +105,9 @@ describe('fileReader.readJsonFile', () => {
       const file = new File([''], 'error.json');
       const mockReader = { readAsText: jest.fn(), onerror: null, error: new Error('Read error') };
 
-      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(function () {
+        return mockReader;
+      });
       const promise = readJsonFile({ file });
 
       mockReader.onerror();
@@ -117,7 +119,9 @@ describe('fileReader.readJsonFile', () => {
       const file = new File([''], 'abort.json');
       const mockReader = { readAsText: jest.fn(), onabort: null };
 
-      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(function () {
+        return mockReader;
+      });
       const promise = readJsonFile({ file });
 
       mockReader.onabort();
@@ -129,7 +133,9 @@ describe('fileReader.readJsonFile', () => {
       const file = new File(['{ "test": true }'], 'dummy.json');
       const mockReader = { readAsText: jest.fn(), onload: null, result: {} };
 
-      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(function () {
+        return mockReader;
+      });
       const promise = readJsonFile({ file });
 
       mockReader.onload();


### PR DESCRIPTION
Vitest 4.x rejects arrow functions called with `new`. Replace `mockImplementation(() => ({...}))` with
`mockImplementation(function() { return {...}; })` in all 6 files where the mock target is a constructor.

Affected: FileReader (readJsonFile.test.js), ResizeObserver (ServicesView, TraceDiff), LayoutManager (Graph/index, TraceGraph), ScrollManager (TracePage/index).

Also update ADR section 9 / PR table to mark H2b done.

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
