### PR TITLE
test: Add mockDefault helper for default-export mocks

### DIFF
--- a/docs/adr/0007-vite-plus-migration.md
+++ b/docs/adr/0007-vite-plus-migration.md
@@ -386,23 +386,26 @@ called with `new` in production code): `readJsonFile.test.js` (FileReader ×3),
 `DeepDependencies/Graph/index.test.jsx` (LayoutManager), `TracePage/index.test.jsx` (ScrollManager ×3),
 `TracePage/TraceGraph/TraceGraph.test.jsx` (MockLayoutManager).
 
-#### PR H2c — Introduce `mockDefault` helper in affected mock factories
+#### ✅ PR H2c — Introduce `mockDefault` helper in affected mock factories ([#3694](https://github.com/jaegertracing/jaeger-ui/pull/3694))
 
 In Vitest ESM, `vi.mock()` factories must return `{ default: MockComponent }` for default-exported
-modules; Jest CJS interop does not require this. Instead of leaving the full rewrite to H3, introduce
-a helper that makes the flip a one-line change:
+modules; Jest CJS interop does not require this. A helper is introduced so the flip in H3 is a
+single-line change rather than touching every factory:
 
 ```js
-// H2c: add to each affected file — Jest passes mod through unchanged
-function mockDefault(mod) { return mod; }
-jest.mock('./Foo', () => mockDefault(MockFoo));
+// test/jest-per-test-setup.js  (H3: change body to `{ default: mod }`)
+global.mockDefault = mod => mod;
 ```
 
-In H3, change only the function body to `return { default: mod }`. Jest hoists `jest.mock()` factories
-before imports but specifically allows variables whose names start with `mock` in factory scope —
-naming the helper `mockDefault` satisfies this constraint.
+All ~33 `jest.mock()` factories that return a function/component directly have been wrapped:
 
-Alternatively, attach it to `global` in the per-test-setup file for a single-location flip in H3.
+```js
+jest.mock('./Foo', () => mockDefault(function MockFoo() { return <JSX/>; }));
+jest.mock('./Bar', () => mockDefault(() => <JSX/>));
+jest.mock('./Baz', () => mockDefault(jest.fn(() => <JSX/>)));
+```
+
+In H3, only `jest-per-test-setup.js` changes: `mod => mod` → `mod => ({ default: mod })`.
 
 #### PR H3 — The actual switch
 
@@ -599,7 +602,7 @@ confirm no errors or unexpected HTML injection.
 | ✅ H1 | Rename `.test.js` → `.test.jsx` in jaeger-ui (121 files, pure rename) ([#3691](https://github.com/jaegertracing/jaeger-ui/pull/3691)) | None | Done |
 | ✅ H2a | Replace `require()` in test bodies with static `import` ([#3692](https://github.com/jaegertracing/jaeger-ui/pull/3692)) | None | Done |
 | ✅ H2b | Replace arrow function constructors with regular functions (6 files) ([#3693](https://github.com/jaegertracing/jaeger-ui/pull/3693)) | None | Done |
-| H2c | Introduce `mockDefault` helper in affected mock factories | None | After H1 |
+| ✅ H2c | Introduce `mockDefault` helper in affected mock factories ([#3694](https://github.com/jaegertracing/jaeger-ui/pull/3694)) | None | Done |
 | H3 | Vitest switch for jaeger-ui | Unknowns 3, 4, 5, 6 | After H2a–c |
 | G  | Update CLAUDE.md, README, CI workflows | None | After H3 |
 

--- a/packages/jaeger-ui/src/actions/jaeger-api.test.js
+++ b/packages/jaeger-ui/src/actions/jaeger-api.test.js
@@ -1,14 +1,14 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-jest.mock(
-  'node-fetch',
-  () => () =>
+jest.mock('node-fetch', () =>
+  mockDefault(() =>
     Promise.resolve({
       status: 200,
       data: () => Promise.resolve({ data: null }),
       json: () => Promise.resolve({ data: null }),
     })
+  )
 );
 
 function isPromise(p) {

--- a/packages/jaeger-ui/src/actions/path-agnostic-decorations.test.js
+++ b/packages/jaeger-ui/src/actions/path-agnostic-decorations.test.js
@@ -8,7 +8,7 @@ import * as getConfig from '../utils/config/get-config';
 import stringSupplant from '../utils/stringSupplant';
 import JaegerAPI from '../api/jaeger';
 
-jest.mock('lru-memoize', () => () => x => x);
+jest.mock('lru-memoize', () => mockDefault(() => x => x));
 
 describe('getDecoration', () => {
   let getConfigSpy;

--- a/packages/jaeger-ui/src/components/App/NotFound.test.jsx
+++ b/packages/jaeger-ui/src/components/App/NotFound.test.jsx
@@ -7,10 +7,10 @@ import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import NotFound from './NotFound';
 
-jest.mock('../../utils/prefix-url', () => () => '/');
-jest.mock('../common/ErrorMessage', () => ({ error }) => (
-  <div data-testid="error-message">{error?.message}</div>
-));
+jest.mock('../../utils/prefix-url', () => mockDefault(() => '/'));
+jest.mock('../common/ErrorMessage', () =>
+  mockDefault(({ error }) => <div data-testid="error-message">{error?.message}</div>)
+);
 
 describe('NotFound tests', () => {
   it('renders error title and home link without error', () => {

--- a/packages/jaeger-ui/src/components/App/Page.test.jsx
+++ b/packages/jaeger-ui/src/components/App/Page.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-jest.mock('./TopNav', () => () => <div />);
+jest.mock('./TopNav', () => mockDefault(() => <div />));
 jest.mock('../../utils/tracking');
 
 import React from 'react';

--- a/packages/jaeger-ui/src/components/App/index.dev.test.jsx
+++ b/packages/jaeger-ui/src/components/App/index.dev.test.jsx
@@ -11,15 +11,15 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 
-jest.mock('./NotFound', () => () => <div data-testid="not-found" />);
-jest.mock('./Page', () => ({ children }) => <div data-testid="page">{children}</div>);
-jest.mock('../DependencyGraph', () => () => <div data-testid="dependency-graph" />);
-jest.mock('../DeepDependencies', () => () => <div data-testid="deep-dependencies" />);
-jest.mock('../QualityMetrics', () => () => <div data-testid="quality-metrics" />);
-jest.mock('../SearchTracePage', () => () => <div data-testid="search-trace" />);
+jest.mock('./NotFound', () => mockDefault(() => <div data-testid="not-found" />));
+jest.mock('./Page', () => mockDefault(({ children }) => <div data-testid="page">{children}</div>));
+jest.mock('../DependencyGraph', () => mockDefault(() => <div data-testid="dependency-graph" />));
+jest.mock('../DeepDependencies', () => mockDefault(() => <div data-testid="deep-dependencies" />));
+jest.mock('../QualityMetrics', () => mockDefault(() => <div data-testid="quality-metrics" />));
+jest.mock('../SearchTracePage', () => mockDefault(() => <div data-testid="search-trace" />));
 jest.mock('../TraceDiff', () => ({ __esModule: true, default: () => <div data-testid="trace-diff" /> }));
 jest.mock('../TracePage', () => ({ __esModule: true, default: () => <div data-testid="trace-page" /> }));
-jest.mock('../Monitor', () => () => <div data-testid="monitor" />);
+jest.mock('../Monitor', () => mockDefault(() => <div data-testid="monitor" />));
 jest.mock('../PlexusDemo', () => ({ __esModule: true, default: () => <div data-testid="plexus-demo" /> }));
 
 jest.mock('../DependencyGraph/url', () => ({ ROUTE_PATH: '/dependencies' }));
@@ -36,8 +36,8 @@ jest.mock('../../api/jaeger', () => ({
   default: { apiRoot: null },
   DEFAULT_API_ROOT: 'http://localhost:16686/api',
 }));
-jest.mock('../../utils/config/process-scripts', () => jest.fn());
-jest.mock('../../utils/prefix-url', () => jest.fn(() => '/prefix'));
+jest.mock('../../utils/config/process-scripts', () => mockDefault(jest.fn()));
+jest.mock('../../utils/prefix-url', () => mockDefault(jest.fn(() => '/prefix')));
 jest.mock('../../utils/configure-store', () => ({
   store: {
     getState: jest.fn(() => ({})),

--- a/packages/jaeger-ui/src/components/App/index.test.jsx
+++ b/packages/jaeger-ui/src/components/App/index.test.jsx
@@ -6,15 +6,15 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 
-jest.mock('./NotFound', () => () => <div data-testid="not-found" />);
-jest.mock('./Page', () => ({ children }) => <div data-testid="page">{children}</div>);
-jest.mock('../DependencyGraph', () => () => <div data-testid="dependency-graph" />);
-jest.mock('../DeepDependencies', () => () => <div data-testid="deep-dependencies" />);
-jest.mock('../QualityMetrics', () => () => <div data-testid="quality-metrics" />);
-jest.mock('../SearchTracePage', () => () => <div data-testid="search-trace" />);
+jest.mock('./NotFound', () => mockDefault(() => <div data-testid="not-found" />));
+jest.mock('./Page', () => mockDefault(({ children }) => <div data-testid="page">{children}</div>));
+jest.mock('../DependencyGraph', () => mockDefault(() => <div data-testid="dependency-graph" />));
+jest.mock('../DeepDependencies', () => mockDefault(() => <div data-testid="deep-dependencies" />));
+jest.mock('../QualityMetrics', () => mockDefault(() => <div data-testid="quality-metrics" />));
+jest.mock('../SearchTracePage', () => mockDefault(() => <div data-testid="search-trace" />));
 jest.mock('../TraceDiff', () => ({ __esModule: true, default: () => <div data-testid="trace-diff" /> }));
 jest.mock('../TracePage', () => ({ __esModule: true, default: () => <div data-testid="trace-page" /> }));
-jest.mock('../Monitor', () => () => <div data-testid="monitor" />);
+jest.mock('../Monitor', () => mockDefault(() => <div data-testid="monitor" />));
 
 jest.mock('../DependencyGraph/url', () => ({ ROUTE_PATH: '/dependencies' }));
 jest.mock('../DeepDependencies/url', () => ({ ROUTE_PATH: '/deep-dependencies' }));
@@ -33,8 +33,8 @@ jest.mock('../../api/jaeger', () => ({
   DEFAULT_API_ROOT: 'http://localhost:16686/api',
 }));
 
-jest.mock('../../utils/config/process-scripts', () => jest.fn());
-jest.mock('../../utils/prefix-url', () => jest.fn(() => '/prefix'));
+jest.mock('../../utils/config/process-scripts', () => mockDefault(jest.fn()));
+jest.mock('../../utils/prefix-url', () => mockDefault(jest.fn(() => '/prefix')));
 
 const createMockHistory = (pathname = '/') => ({
   length: 1,

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
@@ -1,12 +1,14 @@
 // Copyright (c) 2019 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-jest.mock('./calc-positioning', () => () => ({
-  radius: 50,
-  svcWidth: 20,
-  opWidth: 30,
-  svcMarginTop: 10,
-}));
+jest.mock('./calc-positioning', () =>
+  mockDefault(() => ({
+    radius: 50,
+    svcWidth: 20,
+    opWidth: 30,
+    svcMarginTop: 10,
+  }))
+);
 
 // Mutable object so individual tests can control the location without re-creating the mock.
 const mockLocation = { search: '' };

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/index.test.jsx
@@ -10,14 +10,14 @@ import * as track from '../index.track';
 
 jest.mock('./HopsSelector', () => {
   const mockReact = jest.requireActual('react');
-  return function MockHopsSelector(props) {
+  return mockDefault(function MockHopsSelector(props) {
     return mockReact.createElement('div', { 'data-testid': 'hops-selector', ...props });
-  };
+  });
 });
 
 jest.mock('../../common/SearchableSelect', () => {
   const mockReact = jest.requireActual('react');
-  return function MockSearchableSelect(props) {
+  return mockDefault(function MockSearchableSelect(props) {
     const { value, onChange, allowClear, onClear, placeholder, children, className, status } = props;
     // Extract options from children
     const options = mockReact.Children.toArray(children)
@@ -52,43 +52,45 @@ jest.mock('../../common/SearchableSelect', () => {
         value &&
         mockReact.createElement('button', { onClick: onClear, 'data-testid': 'clear-button' }, 'Clear')
     );
-  };
+  });
 });
 
 jest.mock('./LayoutSettings', () => {
   const mockReact = jest.requireActual('react');
-  return function MockLayoutSettings(props) {
+  return mockDefault(function MockLayoutSettings(props) {
     return mockReact.createElement('div', { 'data-testid': 'layout-settings', ...props });
-  };
+  });
 });
 
 jest.mock('../../common/UiFindInput', () => {
   const mockReact = jest.requireActual('react');
-  return mockReact.forwardRef(function MockUiFindInput(props, ref) {
-    const inputRef = mockReact.useRef(null);
+  return mockDefault(
+    mockReact.forwardRef(function MockUiFindInput(props, ref) {
+      const inputRef = mockReact.useRef(null);
 
-    mockReact.useEffect(() => {
-      if (ref) {
-        const current = {
-          focus: () => inputRef.current && inputRef.current.focus(),
-          blur: () => inputRef.current && inputRef.current.blur(),
-          select: () => inputRef.current && inputRef.current.select(),
-          input: inputRef.current,
-        };
-        if (typeof ref === 'function') {
-          ref(current);
-        } else {
-          ref.current = current;
+      mockReact.useEffect(() => {
+        if (ref) {
+          const current = {
+            focus: () => inputRef.current && inputRef.current.focus(),
+            blur: () => inputRef.current && inputRef.current.blur(),
+            select: () => inputRef.current && inputRef.current.select(),
+            input: inputRef.current,
+          };
+          if (typeof ref === 'function') {
+            ref(current);
+          } else {
+            ref.current = current;
+          }
         }
-      }
-    });
+      });
 
-    return mockReact.createElement('input', {
-      ref: inputRef,
-      'data-testid': 'ui-find-input',
-      ...props.inputProps,
-    });
-  });
+      return mockReact.createElement('input', {
+        ref: inputRef,
+        'data-testid': 'ui-find-input',
+        ...props.inputProps,
+      });
+    })
+  );
 });
 
 describe('<Header>', () => {

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/index.test.jsx
@@ -18,7 +18,7 @@ jest.mock('antd', () => ({
   Table: () => <div data-testid="mock-table">Table Mock</div>,
 }));
 
-jest.mock('./DetailsPanel', () => jest.fn(() => <div data-testid="details-panel" />));
+jest.mock('./DetailsPanel', () => mockDefault(jest.fn(() => <div data-testid="details-panel" />)));
 
 describe('<SidePanel>', () => {
   let getConfigValueSpy;

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
@@ -53,33 +53,33 @@ import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { ECheckedStatus, EDirection, EDdgDensity, EViewModifier } from '../../model/ddg/types';
 
 jest.mock('./Graph', () => {
-  return function MockGraph(props) {
+  return mockDefault(function MockGraph(props) {
     return <div data-testid="graph" {...props} />;
-  };
+  });
 });
 
 jest.mock('./Header', () => {
-  return function MockHeader(props) {
+  return mockDefault(function MockHeader(props) {
     return <div data-testid="header" {...props} />;
-  };
+  });
 });
 
 jest.mock('./SidePanel', () => {
-  return function MockSidePanel(props) {
+  return mockDefault(function MockSidePanel(props) {
     return <div data-testid="side-panel" {...props} />;
-  };
+  });
 });
 
 jest.mock('../common/ErrorMessage', () => {
-  return function MockErrorMessage(props) {
+  return mockDefault(function MockErrorMessage(props) {
     return <div data-testid="error-message" error={JSON.stringify(props.error)} />;
-  };
+  });
 });
 
 jest.mock('../common/LoadingIndicator', () => {
-  return function MockLoadingIndicator(props) {
+  return mockDefault(function MockLoadingIndicator(props) {
     return <div data-testid="loading-indicator" {...props} />;
-  };
+  });
 });
 
 describe('DeepDependencyGraphPage', () => {

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.jsx
@@ -9,9 +9,9 @@ import * as constants from '../../utils/constants';
 
 // Mock UiFindInput and its store dependencies
 jest.mock('../common/UiFindInput', () => {
-  return function MockUiFindInput({ inputProps }) {
+  return mockDefault(function MockUiFindInput({ inputProps }) {
     return <input data-testid="search-input" className={inputProps?.className} />;
-  };
+  });
 });
 
 const mockDependencies = [

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.test.jsx
@@ -12,29 +12,29 @@ let lastDAGOptionsProps = {};
 let lastDAGProps = {};
 
 jest.mock('./DAG', () => {
-  return function MockDAG(props) {
+  return mockDefault(function MockDAG(props) {
     lastDAGProps = props;
     return <div data-testid="dag-component" />;
-  };
+  });
 });
 
 jest.mock('./DAGOptions', () => {
-  return function MockDAGOptions(props) {
+  return mockDefault(function MockDAGOptions(props) {
     lastDAGOptionsProps = props;
     return <div data-testid="dag-options" />;
-  };
+  });
 });
 
 jest.mock('../common/LoadingIndicator', () => {
-  return function MockLoadingIndicator(props) {
+  return mockDefault(function MockLoadingIndicator(props) {
     return <div data-testid="loading-indicator" {...props} />;
-  };
+  });
 });
 
 jest.mock('../common/ErrorMessage', () => {
-  return function MockErrorMessage(props) {
+  return mockDefault(function MockErrorMessage(props) {
     return <div data-testid="error-message" {...props} />;
-  };
+  });
 });
 
 const childId = 'boomya';

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -56,22 +56,22 @@ jest.mock('../../../hooks/useTraceDiscovery', () => ({
 // Store the default mock implementation for reset in afterEach
 const defaultUseServicesImpl = () => ({ data: ['service1', 'service2'], isLoading: false });
 
-jest.mock('lodash/debounce', () => fn => fn);
+jest.mock('lodash/debounce', () => mockDefault(fn => fn));
 
 jest.mock('../../common/LoadingIndicator', () => {
-  return function LoadingIndicator() {
+  return mockDefault(function LoadingIndicator() {
     return <div data-testid="loading-indicator">Loading...</div>;
-  };
+  });
 });
 
 jest.mock('../EmptyState', () => {
-  return function MonitorATMEmptyState() {
+  return mockDefault(function MonitorATMEmptyState() {
     return <div data-testid="empty-state">ATM not configured</div>;
-  };
+  });
 });
 
 jest.mock('./serviceGraph', () => {
-  return function ServiceGraph({ yAxisTickFormat, name, error }) {
+  return mockDefault(function ServiceGraph({ yAxisTickFormat, name, error }) {
     const testValue = yAxisTickFormat ? yAxisTickFormat(1000) : null;
     return (
       <div data-testid={`service-graph-${name?.toLowerCase().replace(/[^a-z0-9]/g, '-')}`}>
@@ -80,11 +80,11 @@ jest.mock('./serviceGraph', () => {
         {error && <span data-testid="graph-error">Error occurred</span>}
       </div>
     );
-  };
+  });
 });
 
 jest.mock('./operationDetailsTable', () => {
-  return function OperationTableDetails({ loading, error, data }) {
+  return mockDefault(function OperationTableDetails({ loading, error, data }) {
     return (
       <div data-testid="operation-table">
         {loading && <span data-testid="table-loading">Loading operations...</span>}
@@ -92,11 +92,18 @@ jest.mock('./operationDetailsTable', () => {
         {data && <span data-testid="table-data">Operations data loaded</span>}
       </div>
     );
-  };
+  });
 });
 
 jest.mock('../../common/SearchableSelect', () => {
-  return function SearchableSelect({ children, value, onChange, placeholder, disabled, className }) {
+  return mockDefault(function SearchableSelect({
+    children,
+    value,
+    onChange,
+    placeholder,
+    disabled,
+    className,
+  }) {
     return (
       <select
         data-testid={className}
@@ -114,7 +121,7 @@ jest.mock('../../common/SearchableSelect', () => {
         {children}
       </select>
     );
-  };
+  });
 });
 
 jest.mock('antd', () => {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.test.jsx
@@ -8,16 +8,16 @@ import OperationTableDetails from '.';
 import { originInitialState, serviceOpsMetrics } from '../../../../reducers/metrics.mock';
 import * as track from './index.track';
 
-jest.mock('../../../../utils/prefix-url', () => jest.fn(url => url));
+jest.mock('../../../../utils/prefix-url', () => mockDefault(jest.fn(url => url)));
 
 jest.mock('../../../common/LoadingIndicator', () => {
-  return function MockLoadingIndicator(props) {
+  return mockDefault(function MockLoadingIndicator(props) {
     return (
       <div data-testid="loading-indicator" {...props}>
         Loading...
       </div>
     );
-  };
+  });
 });
 
 const props = {

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.test.jsx
@@ -38,47 +38,45 @@ jest.mock('./Header', () => {
     headerMock.setLookback = props.setLookback;
     return <div data-testid="header">Header Component</div>;
   });
-  return mockHeader;
+  return mockDefault(mockHeader);
 });
 
 jest.mock('../common/LoadingIndicator', () => {
-  return function MockLoadingIndicator() {
+  return mockDefault(function MockLoadingIndicator() {
     return <div data-testid="loading-indicator">Loading...</div>;
-  };
+  });
 });
 
 jest.mock('./BannerText', () => {
-  return function MockBannerText({ bannerText }) {
+  return mockDefault(function MockBannerText({ bannerText }) {
     return <div data-testid="banner-text">{bannerText}</div>;
-  };
+  });
 });
 
 jest.mock('./ScoreCard', () => {
-  return function MockScoreCard({ score }) {
+  return mockDefault(function MockScoreCard({ score }) {
     return (
       <div data-testid="score-card" data-key={score.key}>
         {score.key}
       </div>
     );
-  };
+  });
 });
 
 jest.mock('./MetricCard', () => {
-  return function MockMetricCard({ metric }) {
+  return mockDefault(function MockMetricCard({ metric }) {
     return (
       <div data-testid="metric-card" data-name={metric.name}>
         {metric.name}
       </div>
     );
-  };
+  });
 });
 
-jest.mock(
-  '../common/ExamplesLink',
-  () =>
-    function MockExamplesLink() {
-      return <div>ExamplesLink Component</div>;
-    }
+jest.mock('../common/ExamplesLink', () =>
+  mockDefault(function MockExamplesLink() {
+    return <div>ExamplesLink Component</div>;
+  })
 );
 
 describe('QualityMetrics', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -26,38 +26,46 @@ jest.mock('react-router-dom', () => {
 });
 
 jest.mock('./AltViewOptions', () =>
-  jest.fn(({ onDdgViewClicked }) => (
-    <button type="button" data-testid="alt-toggle" onClick={onDdgViewClicked}>
-      toggle
-    </button>
-  ))
+  mockDefault(
+    jest.fn(({ onDdgViewClicked }) => (
+      <button type="button" data-testid="alt-toggle" onClick={onDdgViewClicked}>
+        toggle
+      </button>
+    ))
+  )
 );
 
 jest.mock('./DiffSelection', () =>
-  jest.fn(({ traces }) => <div data-testid="diffselection">{traces.length}</div>)
+  mockDefault(jest.fn(({ traces }) => <div data-testid="diffselection">{traces.length}</div>))
 );
 
-jest.mock('./ResultItem', () => jest.fn(({ trace }) => <div data-testid={`result-${trace.traceID}`} />));
+jest.mock('./ResultItem', () =>
+  mockDefault(jest.fn(({ trace }) => <div data-testid={`result-${trace.traceID}`} />))
+);
 
-jest.mock('./ScatterPlot', () => jest.fn(props => <div data-testid="scatterplot" {...props} />));
+jest.mock('./ScatterPlot', () => mockDefault(jest.fn(props => <div data-testid="scatterplot" {...props} />)));
 
 jest.mock('./DownloadResults', () =>
-  jest.fn(({ onDownloadResultsClicked }) => (
-    <button type="button" data-testid="download" onClick={onDownloadResultsClicked}>
-      download
-    </button>
-  ))
+  mockDefault(
+    jest.fn(({ onDownloadResultsClicked }) => (
+      <button type="button" data-testid="download" onClick={onDownloadResultsClicked}>
+        download
+      </button>
+    ))
+  )
 );
 
-jest.mock('../../DeepDependencies/traces', () => jest.fn(() => <div data-testid="ddg" />));
+jest.mock('../../DeepDependencies/traces', () => mockDefault(jest.fn(() => <div data-testid="ddg" />)));
 
-jest.mock('../../common/LoadingIndicator', () => jest.fn(() => <div data-testid="loading" />));
+jest.mock('../../common/LoadingIndicator', () => mockDefault(jest.fn(() => <div data-testid="loading" />)));
 
-jest.mock('../../common/NewWindowIcon', () => jest.fn(() => <span data-testid="new-window-icon" />));
+jest.mock('../../common/NewWindowIcon', () =>
+  mockDefault(jest.fn(() => <span data-testid="new-window-icon" />))
+);
 
 jest.mock('../../common/SearchableSelect', () => {
   const mockReact = jest.requireActual('react');
-  return function MockSearchableSelect({ value, onChange, children, ...rest }) {
+  return mockDefault(function MockSearchableSelect({ value, onChange, children, ...rest }) {
     const options = mockReact.Children.map(children, child => (
       <option key={child.props.value} value={child.props.value}>
         {child.props.children}
@@ -73,7 +81,7 @@ jest.mock('../../common/SearchableSelect', () => {
         {options}
       </select>
     );
-  };
+  });
 });
 
 afterEach(() => {

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
@@ -28,7 +28,7 @@ It has to be explicitly told using `__esModule` to babel for compiling it with t
 */
 jest.mock('redux', () => ({ __esModule: true, ...jest.requireActual('redux') }));
 jest.mock('./TraceDiffHeader', () => {
-  return function MockTraceDiffHeader(props) {
+  return mockDefault(function MockTraceDiffHeader(props) {
     return (
       <div data-testid="trace-diff-header">
         <button type="button" data-testid="diff-set-a-btn" onClick={() => props.diffSetA('newAValue')}>
@@ -45,13 +45,13 @@ jest.mock('./TraceDiffHeader', () => {
         </button>
       </div>
     );
-  };
+  });
 });
 
 jest.mock('./TraceDiffGraph', () => {
-  return function MockTraceDiffGraph() {
+  return mockDefault(function MockTraceDiffGraph() {
     return <div data-testid="trace-diff-graph">Graph</div>;
-  };
+  });
 });
 
 describe('TraceDiff', () => {

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.test.jsx
@@ -22,8 +22,12 @@ jest.mock('../../common/UiFindInput', () => ({
   parseUiFind: jest.requireActual('../../common/UiFindInput').parseUiFind,
   extractUiFindFromState: jest.requireActual('../../common/UiFindInput').extractUiFindFromState,
 }));
-jest.mock('../../common/ErrorMessage', () => props => <div data-testid="error-message">{props.error}</div>);
-jest.mock('../../common/LoadingIndicator', () => () => <div data-testid="loading-indicator">Loading...</div>);
+jest.mock('../../common/ErrorMessage', () =>
+  mockDefault(props => <div data-testid="error-message">{props.error}</div>)
+);
+jest.mock('../../common/LoadingIndicator', () =>
+  mockDefault(() => <div data-testid="loading-indicator">Loading...</div>)
+);
 
 afterEach(cleanup);
 

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceDiffHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceDiffHeader.test.jsx
@@ -10,7 +10,7 @@ import TraceDiffHeader from './TraceDiffHeader';
 import { fetchedState } from '../../../constants';
 
 jest.mock('./CohortTable', () => {
-  return function MockCohortTable({ selectTrace }) {
+  return mockDefault(function MockCohortTable({ selectTrace }) {
     return (
       <div data-testid="cohort-table">
         <button type="button" onClick={() => selectTrace('test-id')}>
@@ -18,13 +18,13 @@ jest.mock('./CohortTable', () => {
         </button>
       </div>
     );
-  };
+  });
 });
 
-jest.mock('./TraceHeader', () => () => <div data-testid="trace-header">TraceHeader</div>);
+jest.mock('./TraceHeader', () => mockDefault(() => <div data-testid="trace-header">TraceHeader</div>));
 
 jest.mock('./TraceIdInput', () => {
-  return function MockTraceIdInput({ selectTrace }) {
+  return mockDefault(function MockTraceIdInput({ selectTrace }) {
     return (
       <div data-testid="trace-id-input">
         <button type="button" onClick={() => selectTrace('test-id')}>
@@ -32,7 +32,7 @@ jest.mock('./TraceIdInput', () => {
         </button>
       </div>
     );
-  };
+  });
 });
 
 describe('TraceDiffHeader', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/ViewingLayer.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/ViewingLayer.test.jsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 import ViewingLayer, { dragTypes } from './ViewingLayer';
 import { EUpdateTypes } from '../../../../utils/DraggableManager';
 
-jest.mock('./Scrubber', () => props => <div data-testid="scrubber" {...props} />);
+jest.mock('./Scrubber', () => mockDefault(props => <div data-testid="scrubber" {...props} />));
 
 function getViewRange(viewStart, viewEnd) {
   return { time: { current: [viewStart, viewEnd] } };

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/SpanGraph/index.test.jsx
@@ -12,9 +12,9 @@ import traceGenerator from '../../../../demo/trace-generators';
 import transformTraceData from '../../../../model/transform-trace-data';
 import * as canvasSpanGraphModule from './CanvasSpanGraph';
 
-jest.mock('./CanvasSpanGraph', () => jest.fn(() => <div data-testid="CanvasSpanGraph" />));
-jest.mock('./TickLabels', () => jest.fn(() => <div data-testid="TickLabels" />));
-jest.mock('./ViewingLayer', () => jest.fn(() => <div data-testid="ViewingLayer" />));
+jest.mock('./CanvasSpanGraph', () => mockDefault(jest.fn(() => <div data-testid="CanvasSpanGraph" />)));
+jest.mock('./TickLabels', () => mockDefault(jest.fn(() => <div data-testid="TickLabels" />)));
+jest.mock('./ViewingLayer', () => mockDefault(jest.fn(() => <div data-testid="ViewingLayer" />)));
 
 describe('<SpanGraph>', () => {
   const trace = transformTraceData(traceGenerator.trace({})).asOtelTrace();

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.test.jsx
@@ -15,31 +15,31 @@ import transformTraceData from '../../../model/transform-trace-data';
 import { ETraceViewType } from '../types';
 
 jest.mock('./AltViewOptions', () => {
-  return function MockAltViewOptions(props) {
+  return mockDefault(function MockAltViewOptions(props) {
     return <div data-testid="alt-view-options" {...props} />;
-  };
+  });
 });
 
 jest.mock('./TraceViewSettings', () => {
-  return function MockTraceViewSettings(props) {
+  return mockDefault(function MockTraceViewSettings(props) {
     return <div data-testid="trace-view-settings" {...props} />;
-  };
+  });
 });
 
 jest.mock('./SpanGraph', () => {
-  return function MockSpanGraph(props) {
+  return mockDefault(function MockSpanGraph(props) {
     return <div data-testid="span-graph" {...props} />;
-  };
+  });
 });
 
 jest.mock('./TracePageSearchBar', () => {
-  return function MockTracePageSearchBar(props) {
+  return mockDefault(function MockTracePageSearchBar(props) {
     return <div data-testid="trace-page-search-bar" {...props} />;
-  };
+  });
 });
 
 jest.mock('../../common/LabeledList', () => {
-  return function MockLabeledList(props) {
+  return mockDefault(function MockLabeledList(props) {
     return (
       <div data-testid="labeled-list" className={props.className}>
         {props.items &&
@@ -51,29 +51,29 @@ jest.mock('../../common/LabeledList', () => {
           ))}
       </div>
     );
-  };
+  });
 });
 
 jest.mock('../../common/TraceName', () => {
-  return function MockTraceName({ traceName }) {
+  return mockDefault(function MockTraceName({ traceName }) {
     return (
       <span data-testid="trace-name" data-trace-name={traceName}>
         {traceName}
       </span>
     );
-  };
+  });
 });
 
 jest.mock('../../common/ExternalLinks', () => {
-  return function MockExternalLinks({ links }) {
+  return mockDefault(function MockExternalLinks({ links }) {
     return <div data-testid="external-links" data-links-count={links.length} />;
-  };
+  });
 });
 
 jest.mock('../../common/NewWindowIcon', () => {
-  return function MockNewWindowIcon({ isLarge }) {
+  return mockDefault(function MockNewWindowIcon({ isLarge }) {
     return <span data-testid="new-window-icon" data-large={isLarge} />;
-  };
+  });
 });
 
 jest.mock('../../../model/link-patterns', () => ({

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.test.jsx
@@ -23,10 +23,12 @@ jest.mock('../url/ReferenceLink', () => {
     </a>
   );
   MockReferenceLink.displayName = 'ReferenceLink';
-  return MockReferenceLink;
+  return mockDefault(MockReferenceLink);
 });
 
-jest.mock('../../common/NewWindowIcon', () => () => <span data-testid="new-window-icon">↗</span>);
+jest.mock('../../common/NewWindowIcon', () =>
+  mockDefault(() => <span data-testid="new-window-icon">↗</span>)
+);
 
 describe('<ReferencesButton>', () => {
   const trace = transformTraceData(traceGenerator.trace({ numberOfSpans: 10 }));

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -8,14 +8,16 @@ import '@testing-library/jest-dom';
 import AccordionEvents from './AccordionEvents';
 
 const mockAccordionAttributes = jest.fn();
-jest.mock('./AccordionAttributes', () => props => {
-  mockAccordionAttributes(props);
-  return (
-    <div data-testid="event-item" onClick={props.onToggle}>
-      LogItem
-    </div>
-  );
-});
+jest.mock('./AccordionAttributes', () =>
+  mockDefault(props => {
+    mockAccordionAttributes(props);
+    return (
+      <div data-testid="event-item" onClick={props.onToggle}>
+        LogItem
+      </div>
+    );
+  })
+);
 
 describe('<AccordionEvents>', () => {
   const events = [

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.test.jsx
@@ -7,13 +7,13 @@ import '@testing-library/jest-dom';
 import AccordionLinks, { References } from './AccordionLinks';
 
 jest.mock('../../url/ReferenceLink', () => {
-  return function MockReferenceLink({ children, link }) {
+  return mockDefault(function MockReferenceLink({ children, link }) {
     return (
       <div data-testid="reference-link" data-span-id={link.spanID}>
         {children}
       </div>
     );
-  };
+  });
 });
 
 const traceID = 'trace1';

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -15,7 +15,7 @@ import transformTraceData from '../../../../model/transform-trace-data';
 import OtelSpanFacade from '../../../../model/OtelSpanFacade';
 
 jest.mock('./AccordionAttributes', () => {
-  return function MockAccordionAttributes({ label, onToggle }) {
+  return mockDefault(function MockAccordionAttributes({ label, onToggle }) {
     return (
       <div data-testid={`accordian-keyvalues-${label.toLowerCase()}`}>
         <button type="button" onClick={onToggle} data-testid={`toggle-${label.toLowerCase()}`}>
@@ -23,11 +23,11 @@ jest.mock('./AccordionAttributes', () => {
         </button>
       </div>
     );
-  };
+  });
 });
 
 jest.mock('./AccordionEvents', () => {
-  return function MockAccordionEvents({ onToggle, onItemToggle }) {
+  return mockDefault(function MockAccordionEvents({ onToggle, onItemToggle }) {
     return (
       <div data-testid="accordian-logs">
         <button type="button" onClick={onToggle} data-testid="toggle-logs">
@@ -38,11 +38,11 @@ jest.mock('./AccordionEvents', () => {
         </button>
       </div>
     );
-  };
+  });
 });
 
 jest.mock('./AccordionLinks', () => {
-  return function MockAccordionLinks({ onToggle }) {
+  return mockDefault(function MockAccordionLinks({ onToggle }) {
     return (
       <div data-testid="accordion-links">
         <button type="button" onClick={onToggle} data-testid="toggle-links">
@@ -50,11 +50,11 @@ jest.mock('./AccordionLinks', () => {
         </button>
       </div>
     );
-  };
+  });
 });
 
 jest.mock('./AccordionText', () => {
-  return function MockAccordionText({ onToggle }) {
+  return mockDefault(function MockAccordionText({ onToggle }) {
     return (
       <div data-testid="accordian-warnings">
         <button type="button" onClick={onToggle} data-testid="toggle-warnings">
@@ -62,11 +62,11 @@ jest.mock('./AccordionText', () => {
         </button>
       </div>
     );
-  };
+  });
 });
 
 jest.mock('../../../common/LabeledList', () => {
-  return function MockLabeledList({ items }) {
+  return mockDefault(function MockLabeledList({ items }) {
     return (
       <div data-testid="labeled-list">
         {items.map(item => (
@@ -76,17 +76,17 @@ jest.mock('../../../common/LabeledList', () => {
         ))}
       </div>
     );
-  };
+  });
 });
 
 jest.mock('../../../common/CopyIcon', () => {
-  return function MockCopyIcon({ copyText }) {
+  return mockDefault(function MockCopyIcon({ copyText }) {
     return (
       <button type="button" data-testid="copy-icon" data-copy-text={copyText}>
         Copy
       </button>
     );
-  };
+  });
 });
 
 describe('<SpanDetail>', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailSidePanel/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailSidePanel/index.test.jsx
@@ -12,18 +12,20 @@ import traceGenerator from '../../../../demo/trace-generators';
 import transformTraceData from '../../../../model/transform-trace-data';
 
 jest.mock('../SpanDetail', () =>
-  jest.fn(({ span, focusSpan, linksGetter }) => {
-    linksGetter([], 0);
-    return (
-      <div data-testid="span-detail-mock" data-span-id={span.spanID}>
-        <button data-testid="focus-span-button" type="button" onClick={() => focusSpan('test-find')} />
-      </div>
-    );
-  })
+  mockDefault(
+    jest.fn(({ span, focusSpan, linksGetter }) => {
+      linksGetter([], 0);
+      return (
+        <div data-testid="span-detail-mock" data-span-id={span.spanID}>
+          <button data-testid="focus-span-button" type="button" onClick={() => focusSpan('test-find')} />
+        </div>
+      );
+    })
+  )
 );
 
-jest.mock('../../../../model/link-patterns', () => jest.fn(() => []));
-jest.mock('../../../../utils/update-ui-find', () => jest.fn());
+jest.mock('../../../../model/link-patterns', () => mockDefault(jest.fn(() => [])));
+jest.mock('../../../../utils/update-ui-find', () => mockDefault(jest.fn()));
 
 describe('<SpanDetailSidePanelImpl>', () => {
   let trace;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -11,8 +11,12 @@ import * as KeyboardShortcuts from '../keyboard-shortcuts';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
 
-jest.mock('./VirtualizedTraceView', () => () => <div data-testid="virtualized-trace-view-mock" />);
-jest.mock('./SpanDetailSidePanel', () => () => <div data-testid="span-detail-side-panel-mock" />);
+jest.mock('./VirtualizedTraceView', () =>
+  mockDefault(() => <div data-testid="virtualized-trace-view-mock" />)
+);
+jest.mock('./SpanDetailSidePanel', () =>
+  mockDefault(() => <div data-testid="span-detail-side-panel-mock" />)
+);
 jest.mock('../../common/VerticalResizer', () => ({
   __esModule: true,
   default: ({ onChange }) => (
@@ -21,22 +25,24 @@ jest.mock('../../common/VerticalResizer', () => ({
     </div>
   ),
 }));
-jest.mock('./TimelineHeaderRow', () => props => (
-  <div data-testid="timeline-header-row-mock" data-side-panel-label={props.sidePanelLabel}>
-    <button data-testid="collapse-all-button" type="button" onClick={props.onCollapseAll}>
-      Collapse All
-    </button>
-    <button data-testid="expand-all-button" type="button" onClick={props.onExpandAll}>
-      Expand All
-    </button>
-    <button data-testid="collapse-one-button" type="button" onClick={props.onCollapseOne}>
-      Collapse One
-    </button>
-    <button data-testid="expand-one-button" type="button" onClick={props.onExpandOne}>
-      Expand One
-    </button>
-  </div>
-));
+jest.mock('./TimelineHeaderRow', () =>
+  mockDefault(props => (
+    <div data-testid="timeline-header-row-mock" data-side-panel-label={props.sidePanelLabel}>
+      <button data-testid="collapse-all-button" type="button" onClick={props.onCollapseAll}>
+        Collapse All
+      </button>
+      <button data-testid="expand-all-button" type="button" onClick={props.onExpandAll}>
+        Expand All
+      </button>
+      <button data-testid="collapse-one-button" type="button" onClick={props.onCollapseOne}>
+        Collapse One
+      </button>
+      <button data-testid="expand-one-button" type="button" onClick={props.onExpandOne}>
+        Expand One
+      </button>
+    </div>
+  ))
+);
 
 describe('<TraceTimelineViewer>', () => {
   const legacyTrace = transformTraceData(traceGenerator.trace({ numberOfSpans: 5 }));

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -35,52 +35,54 @@ let capturedHeaderProps = {};
 let capturedArchiveNotifierProps = {};
 
 jest.mock('./TraceTimelineViewer', () => {
-  return function MockTraceTimelineViewer() {
+  return mockDefault(function MockTraceTimelineViewer() {
     return <div data-testid="mock-timeline-viewer">TraceTimelineViewer</div>;
-  };
+  });
 });
 
 jest.mock('./TraceGraph/TraceGraph', () => {
-  return function MockTraceGraph() {
+  return mockDefault(function MockTraceGraph() {
     return <div data-testid="mock-trace-graph">TraceGraph</div>;
-  };
+  });
 });
 
 jest.mock('./TraceStatistics/index', () => {
-  return function MockTraceStatistics() {
+  return mockDefault(function MockTraceStatistics() {
     return <div data-testid="mock-trace-statistics">TraceStatistics</div>;
-  };
+  });
 });
 
 jest.mock('./TraceSpanView/index', () => {
-  return function MockTraceSpanView() {
+  return mockDefault(function MockTraceSpanView() {
     return <div data-testid="mock-trace-span-view">TraceSpanView</div>;
-  };
+  });
 });
 
 jest.mock('./TraceFlamegraph/index', () => {
-  return function MockTraceFlamegraph() {
+  return mockDefault(function MockTraceFlamegraph() {
     return <div data-testid="mock-trace-flamegraph">TraceFlamegraph</div>;
-  };
+  });
 });
 
 jest.mock('./TraceLogsView/index', () => {
-  return function MockTraceLogsView() {
+  return mockDefault(function MockTraceLogsView() {
     return <div data-testid="mock-trace-logs-view">TraceLogsView</div>;
-  };
+  });
 });
 
 jest.mock('./ScrollManager', () => {
-  return jest.fn().mockImplementation(function () {
-    return {
-      scrollToNextVisibleSpan: jest.fn(),
-      scrollToPrevVisibleSpan: jest.fn(),
-      setTrace: jest.fn(),
-      destroy: jest.fn(),
-      setAccessors: jest.fn(),
-      scrollToFirstVisibleSpan: jest.fn(),
-    };
-  });
+  return mockDefault(
+    jest.fn().mockImplementation(function () {
+      return {
+        scrollToNextVisibleSpan: jest.fn(),
+        scrollToPrevVisibleSpan: jest.fn(),
+        setTrace: jest.fn(),
+        destroy: jest.fn(),
+        setAccessors: jest.fn(),
+        scrollToFirstVisibleSpan: jest.fn(),
+      };
+    })
+  );
 });
 
 jest.mock('./index.track');
@@ -95,20 +97,28 @@ jest.mock('react-router-dom', () => {
     useNavigate: () => navigate,
   };
 });
-jest.mock('./TracePageHeader/SpanGraph', () => () => <div data-testid="span-graph">SpanGraph</div>);
+jest.mock('./TracePageHeader/SpanGraph', () =>
+  mockDefault(() => <div data-testid="span-graph">SpanGraph</div>)
+);
 jest.mock('./TracePageHeader/TracePageHeader.track');
-jest.mock('./TracePageHeader/TracePageSearchBar', () => () => <div data-testid="search-bar">SearchBar</div>);
+jest.mock('./TracePageHeader/TracePageSearchBar', () =>
+  mockDefault(() => <div data-testid="search-bar">SearchBar</div>)
+);
 jest.mock('./CriticalPath/index');
 jest.mock('./TraceGraph/calculateTraceDagEV', () => ({
   __esModule: true,
   default: jest.fn(() => ({})),
 }));
-jest.mock('../common/ErrorMessage', () => () => <div data-testid="error-message">Error</div>);
-jest.mock('../common/LoadingIndicator', () => () => <div data-testid="loading-indicator">Loading</div>);
-jest.mock('./ArchiveNotifier', () => props => {
-  capturedArchiveNotifierProps = props;
-  return <div data-testid="archive-notifier">ArchiveNotifier</div>;
-});
+jest.mock('../common/ErrorMessage', () => mockDefault(() => <div data-testid="error-message">Error</div>));
+jest.mock('../common/LoadingIndicator', () =>
+  mockDefault(() => <div data-testid="loading-indicator">Loading</div>)
+);
+jest.mock('./ArchiveNotifier', () =>
+  mockDefault(props => {
+    capturedArchiveNotifierProps = props;
+    return <div data-testid="archive-notifier">ArchiveNotifier</div>;
+  })
+);
 
 jest.mock('./TracePageHeader', () => {
   const { forwardRef } = require('react');

--- a/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.test.jsx
+++ b/packages/jaeger-ui/src/components/common/DetailsCard/DetailTableDropdown.test.jsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 import DetailTableDropdown from './DetailTableDropdown';
 import FilteredList from '../FilteredList';
 
-jest.mock('../FilteredList', () => jest.fn(() => <div data-testid="FilteredList" />));
+jest.mock('../FilteredList', () => mockDefault(jest.fn(() => <div data-testid="FilteredList" />)));
 
 describe('DetailTableDropdown', () => {
   const optionsArray = ['foo', 'bar', 'baz'];

--- a/packages/jaeger-ui/src/middlewares/index.test.js
+++ b/packages/jaeger-ui/src/middlewares/index.test.js
@@ -1,14 +1,14 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-jest.mock(
-  'node-fetch',
-  () => () =>
+jest.mock('node-fetch', () =>
+  mockDefault(() =>
     Promise.resolve({
       status: 200,
       data: () => Promise.resolve({ data: null }),
       json: () => Promise.resolve({ data: null }),
     })
+  )
 );
 
 import * as jaegerMiddlewares from './index';

--- a/packages/jaeger-ui/src/utils/tracking/getTrackFilter.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/getTrackFilter.test.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-jest.mock('lodash/throttle', () => jest.fn(fn => fn));
+jest.mock('lodash/throttle', () => mockDefault(jest.fn(fn => fn)));
 jest.mock('../../utils/tracking');
 
 import _throttle from 'lodash/throttle';

--- a/packages/jaeger-ui/test/jest-per-test-setup.js
+++ b/packages/jaeger-ui/test/jest-per-test-setup.js
@@ -65,3 +65,6 @@ window.matchMedia = jest.fn().mockImplementation(query => ({
 global.__APP_ENVIRONMENT__ = 'test';
 global.__REACT_APP_GA_DEBUG__ = '';
 global.__REACT_APP_VSN_STATE__ = '';
+
+// H2c: identity for default-export mocks; change body to `{ default: mod }` in H3
+global.mockDefault = mod => mod;


### PR DESCRIPTION
Add global.mockDefault = mod => mod to jest-per-test-setup.js. Wrap all jest.mock() factories that return a function/component directly with mockDefault(...) across 33 test files.

In H3, only the setup file changes:
  mod => mod  →  mod => ({ default: mod })
to make all default-export mocks ESM-compatible in Vitest.

Also update ADR section 9 / PR table to mark H2c done.

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
