### PR TITLE
test: replaced vi.mock('react-router-dom') spread pattern with MemoryRouter

### DIFF
--- a/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.jsx
+++ b/packages/jaeger-ui/src/components/App/TraceIDSearchInput.test.jsx
@@ -6,16 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import TraceIDSearchInput from './TraceIDSearchInput';
 
 const mockNavigate = jest.fn();
-vi.mock('react-router-dom', async () => {
-  return {
-    ...(await vi.importActual('react-router-dom')),
-    useNavigate: () => mockNavigate,
-  };
-});
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
 
 describe('<TraceIDSearchInput />', () => {
   beforeEach(() => {

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
@@ -10,20 +10,13 @@ vi.mock('./calc-positioning', async () =>
   }))
 );
 
-// Mutable object so individual tests can control the location without re-creating the mock.
-const mockLocation = { search: '' };
-
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
-  useLocation: () => mockLocation,
-}));
-
 vi.mock('../../../../model/path-agnostic-decorations', () => mockDefault(jest.fn(() => ({}))));
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 import extractDecorationFromState from '../../../../model/path-agnostic-decorations';
 import DdgNodeContentWrapper, {
   getNodeRenderer,
@@ -703,10 +696,11 @@ describe('<DdgNodeContent>', () => {
     });
 
     it('injects search from useLocation() into the connected component', () => {
-      mockLocation.search = '?decoration=some-id';
       render(
         <Provider store={store}>
-          <DdgNodeContentWrapper {...props} />
+          <MemoryRouter initialEntries={['/?decoration=some-id']}>
+            <DdgNodeContentWrapper {...props} />
+          </MemoryRouter>
         </Provider>
       );
       expect(extractDecorationFromState).toHaveBeenCalledWith(

--- a/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/SidePanel/DetailsPanel.test.jsx
@@ -1,14 +1,6 @@
 // Copyright (c) 2020 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Mutable object so individual tests can control the location without re-creating the mock.
-const mockLocation = { search: '' };
-
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
-  useLocation: () => mockLocation,
-}));
-
 vi.mock('../../../model/path-agnostic-decorations', async () => ({
   default: jest.fn(() => ({})),
 }));
@@ -17,6 +9,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import _set from 'lodash/set';
+import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 
 import extractDecorationFromState from '../../../model/path-agnostic-decorations';
@@ -306,10 +299,11 @@ describe('<SidePanel>', () => {
     });
 
     it('injects search from useLocation() into the connected component', () => {
-      mockLocation.search = '?decoration=my-decoration-id';
       render(
         <Provider store={store}>
-          <DefaultDetailsPanel {...wrapperProps} />
+          <MemoryRouter initialEntries={['/?decoration=my-decoration-id']}>
+            <DefaultDetailsPanel {...wrapperProps} />
+          </MemoryRouter>
         </Provider>
       );
       expect(extractDecorationFromState).toHaveBeenCalledWith(

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
@@ -23,12 +23,13 @@ vi.mock('isomorphic-fetch', () =>
   )
 );
 
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
-  useNavigate: () => vi.fn(),
-  useLocation: () => ({ search: '?service=test-service&operation=test-op' }),
-  useParams: () => ({}),
-}));
+import * as ReactRouterDom from 'react-router-dom';
+
+vi.spyOn(ReactRouterDom, 'useNavigate').mockReturnValue(vi.fn());
+vi.spyOn(ReactRouterDom, 'useLocation').mockReturnValue({
+  search: '?service=test-service&operation=test-op',
+});
+vi.spyOn(ReactRouterDom, 'useParams').mockReturnValue({});
 
 vi.mock('../../hooks/useTraceDiscovery', async () => ({
   useServices: vi.fn(() => ({ data: ['svc1', 'svc2'], isLoading: false })),

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import _set from 'lodash/set';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -23,13 +23,11 @@ vi.mock('isomorphic-fetch', () =>
   )
 );
 
-import * as ReactRouterDom from 'react-router-dom';
-
-vi.spyOn(ReactRouterDom, 'useNavigate').mockReturnValue(vi.fn());
-vi.spyOn(ReactRouterDom, 'useLocation').mockReturnValue({
-  search: '?service=test-service&operation=test-op',
-});
-vi.spyOn(ReactRouterDom, 'useParams').mockReturnValue({});
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ search: '?service=test-service&operation=test-op' }),
+  useParams: () => ({}),
+}));
 
 vi.mock('../../hooks/useTraceDiscovery', async () => ({
   useServices: vi.fn(() => ({ data: ['svc1', 'svc2'], isLoading: false })),

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.test.jsx
@@ -18,8 +18,8 @@ const queryClient = new QueryClient({
 
 const mockNavigate = jest.fn();
 const mockLocation = { search: '?service=test-service&lookback=48' };
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
+
+vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => mockLocation,
 }));

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import '@testing-library/jest-dom';
 
 import { createBlob, UnconnectedSearchResults as SearchResults, SelectSort } from '.';
@@ -17,13 +17,18 @@ import DiffSelection from './DiffSelection';
 import { StatusCode } from '../../../types/otel';
 
 const mockNavigate = jest.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  };
-});
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  Link: props => {
+    const to = props.to;
+    const href = typeof to === 'string' ? to : `${to?.pathname || ''}${to?.search || ''}`;
+    return (
+      <a href={href} {...props}>
+        {props.children}
+      </a>
+    );
+  },
+}));
 
 vi.mock('./AltViewOptions', () =>
   mockDefault(

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import queryString from 'query-string';
 import * as redux from 'redux';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import { mapStateToProps, mapDispatchToProps, TraceDiffImpl } from './TraceDiff';
 import * as TraceDiffUrl from './url';
@@ -16,8 +16,7 @@ import * as jaegerApiActions from '../../actions/jaeger-api';
 import { fetchedState, TOP_NAV_HEIGHT } from '../../constants';
 
 const mockNavigate = jest.fn();
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
+vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
@@ -73,7 +72,7 @@ describe('TraceDiff', () => {
 
   // Helper function to render with router context
   const renderWithRouter = component => {
-    return render(<BrowserRouter>{component}</BrowserRouter>);
+    return render(<MemoryRouter>{component}</MemoryRouter>);
   };
   const newAValue = 'newAValue';
   const newBValue = 'newBValue';

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 import {
   computeAdjustedRange,
@@ -17,9 +17,8 @@ import {
 } from './index';
 import * as track from './index.track';
 import * as keyboardShortcutsMod from './keyboard-shortcuts';
-import { reset as resetShortcuts, merge as mergeShortcuts } from './keyboard-shortcuts';
+import { merge as mergeShortcuts } from './keyboard-shortcuts';
 import * as scrollPageMod from './scroll-page';
-import { cancel as cancelScroll } from './scroll-page';
 import * as calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
 import * as getUiFindVertexKeys from '../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
@@ -90,13 +89,10 @@ vi.mock('./keyboard-shortcuts');
 vi.mock('./scroll-page');
 vi.mock('../../utils/filter-spans');
 vi.mock('../../utils/update-ui-find');
-vi.mock('react-router-dom', async () => {
-  const navigate = jest.fn();
-  return {
-    ...(await vi.importActual('react-router-dom')),
-    useNavigate: () => navigate,
-  };
-});
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
 vi.mock('./TracePageHeader/SpanGraph', async () =>
   mockDefault(() => <div data-testid="span-graph">SpanGraph</div>)
 );
@@ -588,7 +584,7 @@ describe('<TracePage>', () => {
     describe('showArchiveButton', () => {
       it('shows archive button based on conditions', () => {
         const getShowArchiveButton = (embedded, archiveEnabled, storageCapabilities) => {
-          const hasStorage = storageCapabilities && storageCapabilities.archiveStorage;
+          const hasStorage = storageCapabilities?.archiveStorage;
           return !embedded && archiveEnabled && hasStorage;
         };
 

--- a/packages/jaeger-ui/src/components/TracePage/useNormalizeTraceId.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useNormalizeTraceId.test.ts
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import * as React from 'react';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
 const mockNavigate = vi.fn();
 let mockLocation: { search: string; state: unknown } = { search: '', state: null };
 
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
+vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => mockLocation,
 }));
@@ -16,8 +19,6 @@ vi.mock('./url', async () => ({
   getUrl: (id: string) => `/trace/${id}`,
 }));
 
-import { renderHook } from '@testing-library/react';
-
 import { useNormalizeTraceId } from './useNormalizeTraceId';
 
 describe('useNormalizeTraceId', () => {
@@ -26,11 +27,24 @@ describe('useNormalizeTraceId', () => {
     mockLocation = { search: '', state: null };
   });
 
+  const makeWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        MemoryRouter,
+        {
+          initialEntries: ['/'],
+        },
+        children
+      );
+  };
+
   it('normalizes uppercase trace IDs to lowercase in the URL', () => {
     const uppercaseTraceId = 'ABC123DEF456';
     const lowercaseTraceId = uppercaseTraceId.toLowerCase();
 
-    const { result } = renderHook(() => useNormalizeTraceId(uppercaseTraceId));
+    const { result } = renderHook(() => useNormalizeTraceId(uppercaseTraceId), {
+      wrapper: makeWrapper(),
+    });
 
     expect(result.current).toBe(lowercaseTraceId);
     expect(mockNavigate).toHaveBeenCalledWith(`/trace/${lowercaseTraceId}`, {
@@ -43,10 +57,11 @@ describe('useNormalizeTraceId', () => {
     const uppercaseTraceId = 'ABC123DEF456';
     const lowercaseTraceId = uppercaseTraceId.toLowerCase();
     const searchParams = '?uiFind=foo&x=1';
-
     mockLocation = { search: searchParams, state: null };
 
-    const { result } = renderHook(() => useNormalizeTraceId(uppercaseTraceId));
+    const { result } = renderHook(() => useNormalizeTraceId(uppercaseTraceId), {
+      wrapper: makeWrapper(),
+    });
 
     expect(result.current).toBe(lowercaseTraceId);
     expect(mockNavigate).toHaveBeenCalledWith(`/trace/${lowercaseTraceId}${searchParams}`, {
@@ -58,7 +73,9 @@ describe('useNormalizeTraceId', () => {
   it('does not redirect when trace ID is already lowercase', () => {
     const lowercaseTraceId = 'abc123def456';
 
-    const { result } = renderHook(() => useNormalizeTraceId(lowercaseTraceId));
+    const { result } = renderHook(() => useNormalizeTraceId(lowercaseTraceId), {
+      wrapper: makeWrapper(),
+    });
 
     expect(result.current).toBe(lowercaseTraceId);
     expect(mockNavigate).not.toHaveBeenCalled();

--- a/packages/jaeger-ui/src/components/common/UiFindInput.test.jsx
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.test.jsx
@@ -18,8 +18,7 @@ vi.mock('../../utils/update-ui-find');
 const mockNavigate = jest.fn();
 const mockLocation = { search: '', pathname: '/test' };
 
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
+vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => mockLocation,
 }));
@@ -148,7 +147,7 @@ describe('UiFind', () => {
 
       // Verify that updateUiFind was not called with the same value
       const calls = updateUiFindSpy.mock.calls;
-      const calledWithUnchanged = calls.some(([args]) => args && args.uiFind === uiFind);
+      const calledWithUnchanged = calls.some(([args]) => args?.uiFind === uiFind);
       expect(calledWithUnchanged).toBe(false);
 
       // Verify the input value matches props.uiFind
@@ -285,7 +284,7 @@ describe('UiFind', () => {
 
     it('delegates to parseUiFind using window.location.search', () => {
       const result = extractUiFindFromState({});
-      expect(queryStringParseSpy).toHaveBeenCalledWith(window.location.search);
+      expect(queryStringParseSpy).toHaveBeenCalledWith(globalThis.location.search);
       expect(result).toEqual({ uiFind });
     });
   });


### PR DESCRIPTION

<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
part-off: #3698 

## Description of the changes
- 15 test files mock `react-router-dom`  by loading the entire actual module and spreading it, just to override one or two hooks (typically `useLocation` or `useNavigate`).
- This is unnecessarily heavy,  this make  whole module is loaded and re-exported just to patch a single export.

## - changes are being applied according to  the issue descriptions

## How was this change tested?
- npm test
- npm run build

<img width="968" height="142" alt="Screenshot_07-Apr_18-32-34_32278" src="https://github.com/user-attachments/assets/616cd1d7-0b1d-464b-93bb-038fb5eb9fe2" />


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
