### PR TITLE
fix(scripts): handle missing binaries in prepare-release

### DIFF
--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -10,37 +10,48 @@ import tempfile
 import time
 from datetime import date
 
-def run_command(command, cwd=None, capture_stdout=True, capture_stderr=True):
+def run_command(command, cwd=None, capture_stdout=True, capture_stderr=True, sensitive=False):
+    if isinstance(command, str):
+        raise TypeError(f"command must be a list of arguments, not a string: {command!r}")
     try:
         result = subprocess.run(
             command,
             cwd=cwd,
             check=True,
-            shell=True,
+            shell=False,
             text=True,
             stdout=subprocess.PIPE if capture_stdout else None,
             stderr=subprocess.PIPE if capture_stderr else None
         )
         return result.stdout.strip() if capture_stdout and result.stdout else ""
     except subprocess.CalledProcessError as e:
-        print(f"Error running command: {command}")
-        if capture_stdout and e.stdout:
-            print(f"STDOUT: {e.stdout}")
-        if capture_stderr and e.stderr:
-            print(f"STDERR: {e.stderr}")
+        if sensitive:
+            print("Error running sensitive command (output suppressed)")
+        else:
+            print(f"Error running command: {command}")
+            if capture_stdout and e.stdout:
+                print(f"STDOUT: {e.stdout}")
+            if capture_stderr and e.stderr:
+                print(f"STDERR: {e.stderr}")
+        raise
+    except FileNotFoundError:
+        if sensitive:
+            print("Error: Sensitive command binary not found (output suppressed)")
+        else:
+            print(f"Error: Command binary not found for: {command}")
         raise
 
 def check_dependencies():
     try:
-        run_command("gh --version")
-    except:
+        run_command(["gh", "--version"])
+    except (subprocess.CalledProcessError, FileNotFoundError):
         print("Error: 'gh' CLI is not installed or not in PATH.")
         sys.exit(1)
 
 def get_gh_token():
     try:
-        return run_command("gh auth token")
-    except:
+        return run_command(["gh", "auth", "token"], sensitive=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
         print("Error: Could not retrieve GitHub token using 'gh auth token'. Please login via 'gh auth login'.")
         sys.exit(1)
 
@@ -50,7 +61,7 @@ def validate_version(version):
         sys.exit(1)
 
 def check_git_status():
-    status = run_command("git status --porcelain")
+    status = run_command(["git", "status", "--porcelain"])
     if status:
         print("Error: Git working directory is not clean. Please commit or stash changes.")
         sys.exit(1)
@@ -61,14 +72,14 @@ def create_branch(version, dry_run=False):
         print(f"[Dry Run] Would create branch {branch_name}")
     else:
         print(f"Creating branch {branch_name}...")
-        run_command(f"git checkout -b {branch_name}")
+        run_command(["git", "checkout", "-b", branch_name])
     return branch_name
 
 def generate_release_notes():
     print("Generating release notes via 'make changelog'...")
     # Run make -s (silent) to suppress echoing commands, capturing only the script output
     # Stream stderr (capture_stderr=False) to show progress bars from release-notes.py
-    return run_command("make -s changelog", capture_stderr=False)
+    return run_command(["make", "-s", "changelog"], capture_stderr=False)
 
 def update_changelog(version, notes, dry_run=False):
     print("Updating CHANGELOG.md...")
@@ -129,20 +140,20 @@ def run_fmt(dry_run=False):
         print("[Dry Run] Would run 'npm run fmt'")
     else:
         print("Running fmt on the modified files to ensure correct formatting...")
-        run_command("npm run fmt -- packages/jaeger-ui/package.json")
+        run_command(["npm", "run", "fmt", "--", "packages/jaeger-ui/package.json"])
 
 def git_commit_and_pr(version, branch_name):
     print("Committing changes...")
-    run_command("git add CHANGELOG.md packages/jaeger-ui/package.json")
+    run_command(["git", "add", "CHANGELOG.md", "packages/jaeger-ui/package.json"])
     commit_msg = f"Prepare release {version}"
-    run_command(f"git commit -s -m '{commit_msg}'")
+    run_command(["git", "commit", "-s", "-m", commit_msg])
     
     print("Pushing branch...")
-    run_command(f"git push -u origin {branch_name}")
+    run_command(["git", "push", "-u", "origin", branch_name])
     
     print("Creating Pull Request...")
     pr_body = f"Prepare release {version}.\n\nAutomated release preparation."
-    run_command(f"gh pr create --title '{commit_msg}' --body '{pr_body}' --label 'changelog:skip' --head {branch_name}", capture_stdout=False, capture_stderr=False)
+    run_command(["gh", "pr", "create", "--title", commit_msg, "--body", pr_body, "--label", "changelog:skip", "--head", branch_name], capture_stdout=False, capture_stderr=False)
 
 def main():
     parser = argparse.ArgumentParser(description="Prepare Jaeger UI release")

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -3,16 +3,11 @@
 import argparse
 import json
 import re
-import shlex
 import subprocess
 import sys
 import time
 from collections.abc import Sequence
 from datetime import date
-
-
-def format_command_for_display(command):
-    return shlex.join([str(part) for part in command])
 
 
 def run_command(
@@ -21,14 +16,12 @@ def run_command(
     capture_stdout=True,
     capture_stderr=True,
     sensitive=False,
-    print_errors=True,
+    print_error=True,
 ):
     if isinstance(command, str) or not isinstance(command, Sequence):
         raise TypeError(
             'run_command() requires command to be a sequence of arguments when shell=False'
         )
-    formatted_command = format_command_for_display(command)
-    executable = str(command[0]) if command else None
     try:
         result = subprocess.run(
             command,
@@ -41,60 +34,21 @@ def run_command(
         )
         return result.stdout.strip() if capture_stdout and result.stdout else ""
     except subprocess.CalledProcessError as e:
-        if print_errors:
-            print(f"Error running command: {formatted_command}")
+        if print_error:
+            print(f"Error running command: {command}")
             if not sensitive and capture_stdout and e.stdout:
                 print(f"STDOUT: {e.stdout}")
             if not sensitive and capture_stderr and e.stderr:
                 print(f"STDERR: {e.stderr}")
         raise
-    except FileNotFoundError as e:
-        missing_path = getattr(e, 'filename', None)
-        cwd_str = str(cwd) if cwd is not None else None
-        is_missing_cwd = cwd_str is not None and missing_path == cwd_str
-        is_missing_executable = executable is not None and missing_path == executable
-        if print_errors:
-            if sensitive:
-                if is_missing_cwd:
-                    print(
-                        'Error: Sensitive command could not run because the working directory '
-                        'was not found (output suppressed)'
-                    )
-                elif is_missing_executable:
-                    print(
-                        'Error: Sensitive command executable not found in PATH: '
-                        f'{executable} (output suppressed)'
-                    )
-                elif missing_path:
-                    print(
-                        'Error: Sensitive command could not run because a required path was '
-                        f'not found: {missing_path} (output suppressed)'
-                    )
-                else:
-                    print(
-                        'Error: Sensitive command could not run because a required path was '
-                        'not found (output suppressed)'
-                    )
-            else:
-                if is_missing_cwd:
-                    print(f"Error: Working directory not found for command {formatted_command}: {cwd_str}")
-                elif is_missing_executable:
-                    print(
-                        'Error: Executable not found in PATH while running command '
-                        f'{formatted_command}: {executable}'
-                    )
-                elif missing_path:
-                    print(
-                        'Error: Required path not found while running command '
-                        f'{formatted_command}: {missing_path}'
-                    )
-                else:
-                    print(f"Error: Required path not found while running command: {formatted_command}")
+    except FileNotFoundError:
+        if print_error:
+            print(f"Error running command: {command}")
         raise
 
 def check_dependencies():
     try:
-        run_command(["gh", "--version"], print_errors=False)
+        run_command(["gh", "--version"], print_error=False)
     except (subprocess.CalledProcessError, FileNotFoundError):
         print("Error: 'gh' CLI is not installed or not in PATH.")
         sys.exit(1)
@@ -106,7 +60,7 @@ def check_gh_auth():
             capture_stdout=False,
             capture_stderr=False,
             sensitive=True,
-            print_errors=False,
+            print_error=False,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
         print("Error: GitHub CLI is not authenticated. Please login via 'gh auth login'.")
@@ -237,4 +191,7 @@ def main():
         git_commit_and_pr(version, branch_name)
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        sys.exit(1)

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -15,12 +15,20 @@ def format_command_for_display(command):
     return shlex.join([str(part) for part in command])
 
 
-def run_command(command, cwd=None, capture_stdout=True, capture_stderr=True, sensitive=False):
+def run_command(
+    command,
+    cwd=None,
+    capture_stdout=True,
+    capture_stderr=True,
+    sensitive=False,
+    print_errors=True,
+):
     if isinstance(command, str) or not isinstance(command, Sequence):
         raise TypeError(
             'run_command() requires command to be a sequence of arguments when shell=False'
         )
     formatted_command = format_command_for_display(command)
+    executable = str(command[0]) if command else None
     try:
         result = subprocess.run(
             command,
@@ -33,46 +41,60 @@ def run_command(command, cwd=None, capture_stdout=True, capture_stderr=True, sen
         )
         return result.stdout.strip() if capture_stdout and result.stdout else ""
     except subprocess.CalledProcessError as e:
-        print(f"Error running command: {formatted_command}")
-        if not sensitive and capture_stdout and e.stdout:
-            print(f"STDOUT: {e.stdout}")
-        if not sensitive and capture_stderr and e.stderr:
-            print(f"STDERR: {e.stderr}")
+        if print_errors:
+            print(f"Error running command: {formatted_command}")
+            if not sensitive and capture_stdout and e.stdout:
+                print(f"STDOUT: {e.stdout}")
+            if not sensitive and capture_stderr and e.stderr:
+                print(f"STDERR: {e.stderr}")
         raise
     except FileNotFoundError as e:
         missing_path = getattr(e, 'filename', None)
         cwd_str = str(cwd) if cwd is not None else None
-        if sensitive:
-            if cwd_str and missing_path == cwd_str:
-                print(
-                    'Error: Sensitive command could not run because the working directory '
-                    'was not found (output suppressed)'
-                )
-            elif missing_path:
-                print(
-                    'Error: Sensitive command could not run because a required path was '
-                    f'not found: {missing_path} (output suppressed)'
-                )
+        is_missing_cwd = cwd_str is not None and missing_path == cwd_str
+        is_missing_executable = executable is not None and missing_path == executable
+        if print_errors:
+            if sensitive:
+                if is_missing_cwd:
+                    print(
+                        'Error: Sensitive command could not run because the working directory '
+                        'was not found (output suppressed)'
+                    )
+                elif is_missing_executable:
+                    print(
+                        'Error: Sensitive command executable not found in PATH: '
+                        f'{executable} (output suppressed)'
+                    )
+                elif missing_path:
+                    print(
+                        'Error: Sensitive command could not run because a required path was '
+                        f'not found: {missing_path} (output suppressed)'
+                    )
+                else:
+                    print(
+                        'Error: Sensitive command could not run because a required path was '
+                        'not found (output suppressed)'
+                    )
             else:
-                print(
-                    'Error: Sensitive command could not run because a required path was '
-                    'not found (output suppressed)'
-                )
-        else:
-            if cwd_str and missing_path == cwd_str:
-                print(f"Error: Working directory not found for command {formatted_command}: {cwd_str}")
-            elif missing_path:
-                print(
-                    'Error: Required path not found while running command '
-                    f'{formatted_command}: {missing_path}'
-                )
-            else:
-                print(f"Error: Required path not found while running command: {formatted_command}")
+                if is_missing_cwd:
+                    print(f"Error: Working directory not found for command {formatted_command}: {cwd_str}")
+                elif is_missing_executable:
+                    print(
+                        'Error: Executable not found in PATH while running command '
+                        f'{formatted_command}: {executable}'
+                    )
+                elif missing_path:
+                    print(
+                        'Error: Required path not found while running command '
+                        f'{formatted_command}: {missing_path}'
+                    )
+                else:
+                    print(f"Error: Required path not found while running command: {formatted_command}")
         raise
 
 def check_dependencies():
     try:
-        run_command(["gh", "--version"])
+        run_command(["gh", "--version"], print_errors=False)
     except (subprocess.CalledProcessError, FileNotFoundError):
         print("Error: 'gh' CLI is not installed or not in PATH.")
         sys.exit(1)
@@ -83,7 +105,8 @@ def check_gh_auth():
             ["gh", "auth", "status"],
             capture_stdout=False,
             capture_stderr=False,
-            sensitive=True
+            sensitive=True,
+            print_errors=False,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
         print("Error: GitHub CLI is not authenticated. Please login via 'gh auth login'.")

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -3,17 +3,24 @@
 import argparse
 import json
 import re
+import shlex
 import subprocess
 import sys
 import time
 from collections.abc import Sequence
 from datetime import date
 
+
+def format_command_for_display(command):
+    return shlex.join([str(part) for part in command])
+
+
 def run_command(command, cwd=None, capture_stdout=True, capture_stderr=True, sensitive=False):
     if isinstance(command, str) or not isinstance(command, Sequence):
         raise TypeError(
             'run_command() requires command to be a sequence of arguments when shell=False'
         )
+    formatted_command = format_command_for_display(command)
     try:
         result = subprocess.run(
             command,
@@ -26,17 +33,41 @@ def run_command(command, cwd=None, capture_stdout=True, capture_stderr=True, sen
         )
         return result.stdout.strip() if capture_stdout and result.stdout else ""
     except subprocess.CalledProcessError as e:
-        print(f"Error running command: {command}")
+        print(f"Error running command: {formatted_command}")
         if not sensitive and capture_stdout and e.stdout:
             print(f"STDOUT: {e.stdout}")
         if not sensitive and capture_stderr and e.stderr:
             print(f"STDERR: {e.stderr}")
         raise
-    except FileNotFoundError:
+    except FileNotFoundError as e:
+        missing_path = getattr(e, 'filename', None)
+        cwd_str = str(cwd) if cwd is not None else None
         if sensitive:
-            print("Error: Sensitive command binary not found (output suppressed)")
+            if cwd_str and missing_path == cwd_str:
+                print(
+                    'Error: Sensitive command could not run because the working directory '
+                    'was not found (output suppressed)'
+                )
+            elif missing_path:
+                print(
+                    'Error: Sensitive command could not run because a required path was '
+                    f'not found: {missing_path} (output suppressed)'
+                )
+            else:
+                print(
+                    'Error: Sensitive command could not run because a required path was '
+                    'not found (output suppressed)'
+                )
         else:
-            print(f"Error: Command binary not found for: {command}")
+            if cwd_str and missing_path == cwd_str:
+                print(f"Error: Working directory not found for command {formatted_command}: {cwd_str}")
+            elif missing_path:
+                print(
+                    'Error: Required path not found while running command '
+                    f'{formatted_command}: {missing_path}'
+                )
+            else:
+                print(f"Error: Required path not found while running command: {formatted_command}")
         raise
 
 def check_dependencies():


### PR DESCRIPTION
## Summary
- catch `FileNotFoundError` in `scripts/prepare-release.py` after the move to `subprocess.run(..., shell=False)`
- preserve the script's normal error reporting for missing tools such as `git`, `make`, and `npm`
- keep sensitive-command output suppressed as before

## Why this fix is needed
The earlier hardening changed command execution from shell strings to argv lists with `shell=False`, which is the right security fix. That change also altered the failure mode for missing executables: Python now raises `FileNotFoundError` instead of `CalledProcessError`.

`run_command()` only handled `CalledProcessError`, so missing binaries started surfacing as uncaught tracebacks instead of the script's normal user-facing error output. This change restores that behavior without undoing the security improvement.

## Validation
- `npm run fmt`
- `npm run lint`
- `npm run build`
- `npm test` still reports pre-existing unrelated failures in `packages/plexus`

Related: https://github.com/jkowall/jaeger-ui-F/pull/26
