### PR TITLE
perf(test): switch Vitest pool to threads

### DIFF
--- a/packages/jaeger-ui/vitest.config.ts
+++ b/packages/jaeger-ui/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     __APP_ENVIRONMENT__: JSON.stringify('test'),
   },
   test: {
+    pool: 'threads',
     environment: 'jsdom',
     globals: true,
     globalSetup: path.resolve(__dirname, 'test/vitest-global-setup.ts'),


### PR DESCRIPTION
Vitest default pool ('forks') spawns a fresh child process per test file, paying OS fork + module reload cost for every file. Switching to 'threads' uses worker_threads instead, eliminating the process-spawn overhead.
```
Benchmark (230 test files, 2650 tests, Apple M-series, 10 cores):

  forks   (baseline):  37.3s wall  import=158s  env=209s
  threads:             29.4s wall  import=110s  env=161s  (-21%)
```
The import and environment timings are cumulative across all workers (not wall-clock), so the absolute numbers are large; the wall-clock reduction is what matters in CI.

NODE_COMPILE_CACHE was also evaluated: it has no effect with the forks pool, and saves ~1-2s additional with the threads pool on a warm cache. Not applied here as the gain does not justify the CI cache complexity.

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
