### PR TITLE
fix(SearchForm): sort services alphabetically in the dropdown

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -366,8 +366,15 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
     resultsLimit: initialValues?.resultsLimit,
   }));
 
-  // Fetch services using React Query
-  const { data: services = [], isLoading: isLoadingServices, error: servicesError } = useServices();
+  // Fetch services using React Query. The API may return them in storage
+  // order, which the search form has historically displayed alphabetically
+  // (issue #3733). Sort here rather than in useServices so other consumers
+  // (Monitor, DeepDependencies, QualityMetrics) keep the API-provided order.
+  const { data: rawServices = [], isLoading: isLoadingServices, error: servicesError } = useServices();
+  const services = useMemo(
+    () => [...rawServices].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+    [rawServices]
+  );
 
   // Fetch span names for the currently selected service
   const currentService = formData.service;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -366,15 +366,8 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
     resultsLimit: initialValues?.resultsLimit,
   }));
 
-  // Fetch services using React Query. The API may return them in storage
-  // order, which the search form has historically displayed alphabetically
-  // (issue #3733). Sort here rather than in useServices so other consumers
-  // (Monitor, DeepDependencies, QualityMetrics) keep the API-provided order.
-  const { data: rawServices = [], isLoading: isLoadingServices, error: servicesError } = useServices();
-  const services = useMemo(
-    () => [...rawServices].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
-    [rawServices]
-  );
+  // useServices returns services sorted alphabetically (see hook for rationale).
+  const { data: services = [], isLoading: isLoadingServices, error: servicesError } = useServices();
 
   // Fetch span names for the currently selected service
   const currentService = formData.service;

--- a/packages/jaeger-ui/src/hooks/useTraceDiscovery.ts
+++ b/packages/jaeger-ui/src/hooks/useTraceDiscovery.ts
@@ -6,6 +6,9 @@ import { jaegerClient } from '../api/v3/client';
 
 /**
  * React Query hook to fetch the list of services from the Jaeger API.
+ * Services are sorted alphabetically (case-insensitive) because the v3
+ * backend returns them in storage order, which is rarely useful for UI
+ * listings (issue #3733).
  * @returns Query result with services array
  */
 export function useServices(): UseQueryResult<string[]> {
@@ -14,6 +17,7 @@ export function useServices(): UseQueryResult<string[]> {
     queryFn: () => jaegerClient.fetchServices(),
     staleTime: 60 * 1000, // 1 minute
     refetchOnWindowFocus: true,
+    select: data => [...data].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
   });
 }
 


### PR DESCRIPTION
## Summary

Restore alphabetical ordering for services across the UI. After the v3 client migration in #3329, `useServices()` returns them in the backend's storage order, which is typically creation time rather than alphabetical.

## Approach

Sort inside the `useServices()` hook via React Query's `select` transform, so every consumer gets the sorted list. `SearchForm`, `Monitor/ServicesView`, `DeepDependencies`, and `QualityMetrics` all benefit from one fix.

The sort uses a case-insensitive `localeCompare` with `sensitivity: 'base'` so mixed-case service names group the way users expect. The transform returns a copy (`[...data].sort(...)`) so React Query's cached array is not mutated.

### Note on `Monitor/ServicesView`

`ServicesView` picks `services[0]` as the default selection when no `lastAtmSearchService` is saved. With alphabetical sort applied inside the hook, that default now lands on the alphabetically-first service instead of whatever the backend happened to return first. This is the behavior requested in review but worth flagging explicitly.

## Test plan

```
cd packages/jaeger-ui
npx vitest run src/hooks/useTraceDiscovery.test.ts src/components/SearchTracePage/SearchForm.test.jsx
# 77 tests pass

npx vitest run src/components/Monitor/ src/components/QualityMetrics/ src/components/DeepDependencies/
# 400 tests pass
```

Fixes #3733

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
