### PR TITLE
fix(test): Inline all deps through Vite to fix threads pool ESM interop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,7 @@ ComponentName/
 - Follow [good commit message](https://chris.beams.io/posts/git-commit/) guidelines
 - Keep subject line under 50 characters
 - Use imperative mood in subject line
+- **Capitalize the first word of the description** after the `type(scope):` prefix, e.g. `fix(test): Inline all deps…` not `fix(test): inline all deps…`
 
 ## Working with GitHub CLI (`gh`)
 

--- a/packages/jaeger-ui/vitest.config.ts
+++ b/packages/jaeger-ui/vitest.config.ts
@@ -50,11 +50,12 @@ export default defineConfig({
   },
   server: {
     deps: {
-      // cookie is CJS-only; its dist file has duplicate exports.X assignments
-      // that break Node.js's static CJS named-export analysis when react-router's
-      // ESM chunks do `import { parse, serialize } from 'cookie'`.
-      // Inlining it through Vite's transform handles CJS→ESM conversion reliably.
-      inline: ['cookie'],
+      // Inline all node_modules through Vite's transform pipeline.
+      // The threads pool uses SSR resolve conditions that prefer .mjs files,
+      // causing CJS/ESM named-export interop failures for packages like
+      // react-router and cookie. inline:true fixes this class of problem
+      // universally rather than playing whack-a-mole with individual packages.
+      inline: true,
     },
   },
   resolve: {


### PR DESCRIPTION
The threads pool uses SSR resolve conditions that prefer .mjs exports, causing CJS/ESM named-export failures for packages like react-router and cookie. Fixing per-package with server.deps.inline is whack-a-mole; inline:true fixes the whole class universally with no measurable speed cost (Vite caches transforms; 22.8s vs 22.5s on 230 test files).

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
