### PR TITLE
chore: Unexport 32 types not imported outside their own file

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -55,7 +55,7 @@ interface IErrorState {
   error: ApiError;
 }
 
-export type TDispatchProps = {
+type TDispatchProps = {
   addViewModifier?: (kwarg: TDdgModelParams & { viewModifier: number; visibilityIndices: number[] }) => void;
   fetchDeepDependencyGraph?: (query: TDdgModelParams) => void;
   removeViewModifierFromIndices?: (
@@ -70,12 +70,12 @@ export type TReduxProps = TExtractUiFindFromStateReturn & {
   urlState: TDdgSparseUrlState;
 };
 
-export type THookProps = {
+type THookProps = {
   services: string[];
   serverOps?: string[];
 };
 
-export type TOwnProps = {
+type TOwnProps = {
   baseUrl: string;
   extraUrlArgs?: { [key: string]: unknown };
   navigate: ReturnType<typeof useNavigate>;
@@ -83,9 +83,9 @@ export type TOwnProps = {
   showSvcOpsHeader: boolean;
 };
 
-export type TExternalProps = Partial<Omit<TOwnProps, 'navigate' | 'location'>>;
+type TExternalProps = Partial<Omit<TOwnProps, 'navigate' | 'location'>>;
 
-export type TProps = TDispatchProps & TReduxProps & TOwnProps & THookProps;
+type TProps = TDispatchProps & TReduxProps & TOwnProps & THookProps;
 
 type TState = {
   selectedVertex?: TDdgVertex;

--- a/packages/jaeger-ui/src/components/QualityMetrics/BannerText.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/BannerText.tsx
@@ -7,7 +7,7 @@ import { TQualityMetrics } from './types';
 
 import './BannerText.css';
 
-export type TProps = {
+type TProps = {
   bannerText: TQualityMetrics['bannerText'];
 };
 

--- a/packages/jaeger-ui/src/components/QualityMetrics/CountCard.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/CountCard.tsx
@@ -7,7 +7,7 @@ import ExamplesLink, { TExample } from '../common/ExamplesLink';
 
 import './CountCard.css';
 
-export type TProps = {
+type TProps = {
   count?: number;
   title?: string;
   examples?: TExample[];

--- a/packages/jaeger-ui/src/components/QualityMetrics/MetricCard.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/MetricCard.tsx
@@ -13,7 +13,7 @@ import { TQualityMetrics } from './types';
 
 import './MetricCard.css';
 
-export type TProps = {
+type TProps = {
   metric: TQualityMetrics['metrics'][0];
 };
 

--- a/packages/jaeger-ui/src/components/QualityMetrics/ScoreCard.tsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/ScoreCard.tsx
@@ -10,7 +10,7 @@ import { TQualityMetrics } from './types';
 
 import './ScoreCard.css';
 
-export type TProps = {
+type TProps = {
   link: string;
   score: TQualityMetrics['scores'][0];
 };

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
@@ -20,7 +20,7 @@ import { ONE_MILLISECOND, formatDuration } from '../../../utils/date';
 
 import './ScatterPlot.css';
 
-export type TScatterPlotPoint = {
+type TScatterPlotPoint = {
   x: number;
   y: number;
   traceID: string;

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/types.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/types.ts
@@ -24,12 +24,12 @@ export interface ITableSpan {
   traceID: string;
 }
 
-export interface ITableValues {
+interface ITableValues {
   uid: string;
   value: number;
 }
 
-export interface IColumnValue {
+interface IColumnValue {
   title: string;
   attribute: string;
   suffix: string;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
@@ -30,7 +30,7 @@ type TTraceUiFindValue = { trace: IOtelTrace; uiFind: string | TNil; allowHide?:
 export type TWidthValue = { width: number };
 export type TDetailPanelModeValue = { mode: SpanDetailPanelMode };
 export type TTimelineVisibleValue = { visible: boolean };
-export type TActionTypes =
+type TActionTypes =
   | TSpanIdLogValue
   | TSpanIdValue
   | TSpansValue

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
@@ -17,10 +17,8 @@ export {
 } from './store.constants';
 
 export { getInitialLayoutState, useLayoutPrefsStore } from './store.layout';
-export type { TraceTimelineLayoutPrefsStore } from './store.layout';
 
 export { useTraceTimelineStore } from './store.timeline';
-export type { TraceTimelineInteractionStore } from './store.timeline';
 
 export {
   applyDetailSubsectionToggle,
@@ -28,10 +26,9 @@ export {
   getSelectedSpanID,
   trimFocusedDetailStatesForSidePanel,
 } from './timeline-utils';
-export type { FocusedFindRowStates } from './timeline-utils';
 
 /** Combined shape for typing/tests that span both Zustand slices. */
-export type TraceTimelineLayoutStore = TraceTimelineLayoutPrefsStore & TraceTimelineInteractionStore;
+type TraceTimelineLayoutStore = TraceTimelineLayoutPrefsStore & TraceTimelineInteractionStore;
 
 export function setDetailPanelMode(mode: SpanDetailPanelMode): void {
   if (mode === 'sidepanel') {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.ts
@@ -15,7 +15,7 @@ export function shouldDisableCollapse(
   return allSpans.filter(s => s.hasChildren).every(p => hiddenSpansIds.has(p.spanID));
 }
 
-export type FocusedFindRowStates = {
+type FocusedFindRowStates = {
   childrenHiddenIDs: Set<string>;
   detailStates: Map<string, DetailState>;
   shouldScrollToFirstUiFindMatch: boolean;

--- a/packages/jaeger-ui/src/components/common/FilteredList/index.tsx
+++ b/packages/jaeger-ui/src/components/common/FilteredList/index.tsx
@@ -27,7 +27,7 @@ type TProps = {
   value: Set<string> | string | null;
 };
 
-export interface IFilteredListRef {
+interface IFilteredListRef {
   focusInput: () => void;
 }
 

--- a/packages/jaeger-ui/src/components/common/SearchableSelect.tsx
+++ b/packages/jaeger-ui/src/components/common/SearchableSelect.tsx
@@ -25,7 +25,7 @@ export const filterOptionsFuzzy = (input: string, option?: DefaultOptionType) =>
   return matchSorter([label], input).length > 0;
 };
 
-export type SearchableSelectProps = SelectProps & {
+type SearchableSelectProps = SelectProps & {
   /**
    * Enable fuzzy matching instead of simple substring matching.
    * Uses match-sorter library for more forgiving search.

--- a/packages/jaeger-ui/src/model/trace-viewer.ts
+++ b/packages/jaeger-ui/src/model/trace-viewer.ts
@@ -5,7 +5,7 @@ import _memoize from 'lodash/memoize';
 
 import { Span } from '../types/trace';
 
-export type TracePageHeaderParts = {
+type TracePageHeaderParts = {
   serviceName: string;
   operationName: string;
 };

--- a/packages/jaeger-ui/src/stores/archive-store.ts
+++ b/packages/jaeger-ui/src/stores/archive-store.ts
@@ -6,7 +6,7 @@ import JaegerAPI from '../api/jaeger';
 import { toApiError } from '../types/api-error';
 import { ErrorTraceArchive, LoadingTraceArchive, TraceArchive } from '../types/archive';
 
-export type ArchiveStore = {
+type ArchiveStore = {
   archives: Record<string, TraceArchive>;
   submitTraceToArchive: (traceId: string) => Promise<void>;
   acknowledge: (traceId: string) => void;

--- a/packages/jaeger-ui/src/stores/trace-diff-store.ts
+++ b/packages/jaeger-ui/src/stores/trace-diff-store.ts
@@ -41,7 +41,7 @@ function diffSetBState(state: TTraceDiffState, traceID: string): TTraceDiffState
   return { ...state, b: traceID };
 }
 
-export type TraceDiffStore = TTraceDiffState & {
+type TraceDiffStore = TTraceDiffState & {
   cohortAddTrace: (traceID: string) => void;
   cohortRemoveTrace: (traceID: string) => void;
   diffSetA: (traceID: string) => void;

--- a/packages/jaeger-ui/src/types/archive.ts
+++ b/packages/jaeger-ui/src/types/archive.ts
@@ -16,4 +16,4 @@ export type TraceArchive =
   | ErrorTraceArchive
   | AcknowledgedTraceArchive;
 
-export type TracesArchive = Record<string, TraceArchive>;
+type TracesArchive = Record<string, TraceArchive>;

--- a/packages/jaeger-ui/src/types/index.ts
+++ b/packages/jaeger-ui/src/types/index.ts
@@ -7,13 +7,11 @@ import { EmbeddedState } from './embedded';
 import { SearchQuery } from './search';
 import TDdgState from './TDdgState';
 import tNil from './TNil';
-import iWebAnalytics from './tracking';
 import { Trace } from './trace';
 import TTraceTimeline from './TTraceTimeline';
 import { MetricsReduxState } from './metrics';
 
 export type TNil = tNil;
-export type IWebAnalytics = iWebAnalytics;
 
 export type FetchedState = 'FETCH_DONE' | 'FETCH_ERROR' | 'FETCH_LOADING';
 

--- a/packages/jaeger-ui/src/types/metrics.ts
+++ b/packages/jaeger-ui/src/types/metrics.ts
@@ -3,9 +3,9 @@
 
 import { ApiError } from './api-error';
 
-export type MetricsType = 'latencies' | 'calls' | 'errors';
-export type AvailableServiceMetrics = 'service_call_rate' | 'service_latencies' | 'service_error_rate';
-export type AvailableOpsMetrics =
+type MetricsType = 'latencies' | 'calls' | 'errors';
+type AvailableServiceMetrics = 'service_call_rate' | 'service_latencies' | 'service_error_rate';
+type AvailableOpsMetrics =
   | 'service_operation_call_rate'
   | 'service_operation_latencies'
   | 'service_operation_error_rate';
@@ -115,7 +115,7 @@ export type MetricsReduxState = {
   serviceOpsMetrics: ServiceOpsMetrics[] | undefined;
 };
 
-export enum PromiseStatus {
+enum PromiseStatus {
   fulfilled = 'fulfilled',
   rejected = 'rejected',
 }

--- a/packages/jaeger-ui/src/types/tracking.ts
+++ b/packages/jaeger-ui/src/types/tracking.ts
@@ -8,7 +8,7 @@ export interface IWebAnalyticsFunc {
   (config: Config, versionShort: string, versionLong: string): IWebAnalytics;
 }
 
-export default interface IWebAnalytics {
+interface IWebAnalytics {
   init: () => void;
   context: boolean | null;
   isEnabled: () => boolean;

--- a/packages/plexus/src/Digraph/Node.tsx
+++ b/packages/plexus/src/Digraph/Node.tsx
@@ -7,7 +7,7 @@ import { TRendererUtils, TLayerType, ELayerType, TRenderNodeFn, TSetProps, TAnyP
 import { assignMergeCss, getProps } from './utils';
 import { TLayoutVertex } from '../types';
 
-export type TProps<T = {}> = {
+type TProps<T = {}> = {
   getClassName: (name: string) => string;
   layerType: TLayerType;
   layoutVertex: TLayoutVertex<T>;

--- a/packages/plexus/src/types/TOneOf.ts
+++ b/packages/plexus/src/types/TOneOf.ts
@@ -14,7 +14,7 @@ export type TOneOfTwo<A, B> =
   | ({ [P in Exclude<keyof B, keyof A>]?: undefined } & A)
   | ({ [P in Exclude<keyof A, keyof B>]?: undefined } & B);
 
-export type TOneOfThree<A, B, C> =
+type TOneOfThree<A, B, C> =
   | ({ [P in Exclude<keyof (B & C), keyof A>]?: undefined } & A)
   | ({ [P in Exclude<keyof (A & C), keyof B>]?: undefined } & B)
   | ({ [P in Exclude<keyof (A & B), keyof C>]?: undefined } & C);
@@ -25,4 +25,4 @@ export type TOneOfFour<A, B, C, D> =
   | ({ [P in Exclude<keyof (A & B & D), keyof C>]?: undefined } & C)
   | ({ [P in Exclude<keyof (A & B & C), keyof D>]?: undefined } & D);
 
-export type TOneOfFive<A, B, C, D, E> = TOneOf<A, B, C, D, E>;
+type TOneOfFive<A, B, C, D, E> = TOneOf<A, B, C, D, E>;


### PR DESCRIPTION
Remove `export` from type/interface/enum declarations that knip identified as exported but never imported by any other module. All types remain available within their own file; no functional changes.

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes
