### PR TITLE
fix(lint): Drop useless array spread, promote no-useless-spread to error

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -72,16 +72,14 @@ export default function AltViewOptions(props: Props) {
     onTraceViewChange(item);
   };
 
-  const dropdownItems = [
-    ...MENU_ITEMS.filter(item => item.viewType !== viewType).map(item => ({
-      key: item.viewType as ETraceViewType | string,
-      label: (
-        <a onClick={() => handleSelectView(item.viewType)} role="button">
-          {item.label}
-        </a>
-      ),
-    })),
-  ];
+  const dropdownItems = MENU_ITEMS.filter(item => item.viewType !== viewType).map(item => ({
+    key: item.viewType as ETraceViewType | string,
+    label: (
+      <a onClick={() => handleSelectView(item.viewType)} role="button">
+        {item.label}
+      </a>
+    ),
+  }));
   if (!disableJsonView) {
     dropdownItems.push(
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,6 +115,7 @@ export default defineConfig({
       'use-isnan': 'error',
       'valid-typeof': 'error',
       'react/no-children-prop': 'error',
+      'unicorn/no-useless-spread': 'error',
       'react-x/rules-of-hooks': 'error',
       'react-x/exhaustive-deps': 'error',
       'jest/no-disabled-tests': 'warn',


### PR DESCRIPTION
Part of #3746

The spread wrapping `MENU_ITEMS.filter(...).map(...)` in `AltViewOptions.tsx` rebuilds an array that `filter`/`map` already returned fresh. Dropping it and promoting the rule so future violations fail CI.

## AI Usage in this PR (choose one)
- [x] **Moderate**: AI helped with the fix location and the oxlint config promotion