### PR TITLE
fix(lint): Fix Jest titles to be valid strings, promote valid-title to error

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.track.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.track.test.js
@@ -77,7 +77,7 @@ describe('TracePageHeader.track', () => {
   ];
 
   cases.forEach(({ action, arg, msg, fn, category }) => {
-    it(msg, () => {
+    it(`${msg}`, () => {
       track[fn](arg);
       expect(trackEvent.mock.calls.length).toBe(1);
       expect(trackEvent.mock.calls[0]).toEqual([category, action]);

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.ts
@@ -10,7 +10,7 @@ import testTrace from './tableValuesTestTrace/testTrace.json';
 const transformedTrace = transformTraceData(testTrace as any)!;
 const otelTrace = transformedTrace.asOtelTrace();
 
-describe(' generateDropdownValue', () => {
+describe('generateDropdownValue', () => {
   it('check generateDropdownValue (legacy)', () => {
     const expectValues = ['Service Name', 'Operation Name', 'span.kind', 'error', 'db.type'];
     const values = generateDropdownValue(otelTrace, false);

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.test.js
@@ -540,7 +540,7 @@ describe('check self time', () => {
     expect(resultArray[4].selfTotal).toBe(1.63);
   });
 
-  it(' spans among each other and two other children', () => {
+  it('spans among each other and two other children', () => {
     let resultArray = getColumnValues(
       'Service Name',
       transformedTraceSpanAmongEachOtheGroupedAndSpans,
@@ -555,7 +555,7 @@ describe('check self time', () => {
     expect(resultArray[4].selfTotal).toBe(1.56);
   });
 
-  it(' span is longer as parent', () => {
+  it('span is longer as parent', () => {
     let resultArray = getColumnValues('Service Name', transformedTraceSpanLongerAsParent, false);
     resultArray = getColumnValuesSecondDropdown(
       resultArray,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
@@ -271,7 +271,7 @@ describe('TraceTimelineViewer/duck', () => {
     tests.forEach(info => {
       const { msg, action, propName, initial, resultant } = info;
 
-      it(msg, () => {
+      it(`${msg}`, () => {
         const st0 = store.getState();
         expect(st0[propName]).toEqual(initial);
 
@@ -351,7 +351,7 @@ describe('TraceTimelineViewer/duck', () => {
     tests.forEach(info => {
       const { msg, reducerFn, initial, resultant } = info;
 
-      it(msg, () => {
+      it(`${msg}`, () => {
         const { childrenHiddenIDs } = reducerFn({ childrenHiddenIDs: initial }, { spans });
         expect(childrenHiddenIDs).toEqual(resultant);
       });
@@ -384,7 +384,7 @@ describe('TraceTimelineViewer/duck', () => {
     dispatchTests.forEach(info => {
       const { msg, action, resultant } = info;
 
-      it(msg, () => {
+      it(`${msg}`, () => {
         const st0 = store.getState();
         store.dispatch(action);
         const st1 = store.getState();
@@ -442,7 +442,7 @@ describe('TraceTimelineViewer/duck', () => {
     tests.forEach(info => {
       const { msg, action, get, unchecked, checked } = info;
 
-      it(msg, () => {
+      it(`${msg}`, () => {
         const st0 = store.getState();
         expect(get(st0)).toEqual(unchecked);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.track.test.js
@@ -207,7 +207,7 @@ describe('middlewareHooks', () => {
       extraTrackArgs = [],
       payloadCustom,
     }) => {
-      it(msg, () => {
+      it(`${msg}`, () => {
         const reduxAction = {
           type,
           payload: payloadCustom !== undefined ? payloadCustom : payload,

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -809,7 +809,7 @@ describe('<TracePage>', () => {
 
     cases.forEach(testCase => {
       const { message, timeViewRange, change, result } = testCase;
-      it(message, () => {
+      it(`${message}`, () => {
         const [start, end] = computeAdjustedRange(timeViewRange[0], timeViewRange[1], change[0], change[1]);
         expect([start, end]).toEqual(result);
       });

--- a/packages/jaeger-ui/src/components/TracePage/index.track.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/index.track.test.js
@@ -87,7 +87,7 @@ describe('trackRange', () => {
   cases.forEach(_case => {
     const { msg, rangeType, source, from, to } = _case;
 
-    it(msg, () => {
+    it(`${msg}`, () => {
       expect(trackEvent.mock.calls.length).toBe(0);
       trackRange(source, from, to);
       expect(trackEvent.mock.calls.length).toBe(1);

--- a/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/url/ReferenceLink.test.jsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 
 import ReferenceLink from './ReferenceLink';
 
-describe(ReferenceLink, () => {
+describe('ReferenceLink', () => {
   const focusMock = jest.fn();
 
   const sameTraceLink = {

--- a/packages/jaeger-ui/src/components/common/FilteredList/highlightMatches.test.jsx
+++ b/packages/jaeger-ui/src/components/common/FilteredList/highlightMatches.test.jsx
@@ -54,7 +54,7 @@ describe('highlightMatches(query, text)', () => {
   ];
 
   tests.forEach(({ message, query, text, expectedCount = 1 }) => {
-    it(message, () => {
+    it(`${message}`, () => {
       const { container } = render(<span>{highlightMatches(query, text)}</span>);
 
       const markElements = container.querySelectorAll('mark');

--- a/packages/jaeger-ui/src/reducers/metrics.test.js
+++ b/packages/jaeger-ui/src/reducers/metrics.test.js
@@ -45,7 +45,7 @@ describe('reducers/fetchAllServiceMetrics', () => {
   beforeEach(verifyInitialState);
   afterEach(verifyInitialState);
 
-  it('Pending state ', () => {
+  it('Pending state', () => {
     const state = metricReducer(initialState, {
       type: `${fetchAllServiceMetrics}_PENDING`,
     });
@@ -225,7 +225,7 @@ describe('reducers/fetchAggregatedServiceMetrics', () => {
   beforeEach(verifyInitialState);
   afterEach(verifyInitialState);
 
-  it('Pending state ', () => {
+  it('Pending state', () => {
     const state = metricReducer(initialState, {
       type: `${fetchAggregatedServiceMetrics}_PENDING`,
     });

--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -72,7 +72,7 @@ describe('getSuitableTimeUnit', () => {
     const input = 999;
     expect(getSuitableTimeUnit(input)).toBe('microseconds');
   });
-  it('time unit should be milliseconds ', () => {
+  it('time unit should be milliseconds', () => {
     const input = 5000;
     expect(getSuitableTimeUnit(input)).toBe('milliseconds');
   });
@@ -95,7 +95,7 @@ describe('getSuitableTimeUnit', () => {
 });
 
 describe('convertTimeUnitToShortTerm', () => {
-  it('convert non-existent timeUnit ', () => {
+  it('convert non-existent timeUnit', () => {
     const input = 'aaa';
     expect(convertTimeUnitToShortTerm(input)).toBe('');
   });
@@ -166,7 +166,7 @@ describe('formatRelativeDate', () => {
     currentDate = new Date(currentTimestamp);
   });
 
-  it('Displays Date MMM-DD-YYYY (Different Year) ', () => {
+  it('Displays Date MMM-DD-YYYY (Different Year)', () => {
     const input = new Date(currentTimestamp);
     input.setFullYear(currentDate.getFullYear() - 2);
     expect(formatRelativeDate(input)).toBe('Aug 19, 2021');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -120,6 +120,7 @@ export default defineConfig({
       'jest/no-disabled-tests': 'warn',
       'jest/no-focused-tests': 'error',
       'jest/no-identical-title': 'error',
+      'jest/valid-title': 'error',
       'import/extensions': 'off',
       // Disabled because dynamic computed namespace access (e.g. track[fn]())
       // in parameterised tests is a false positive this rule cannot validate.


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of #3746

## Description of the changes
- Fixed 18 warnings for `eslint-plugin-jest(valid-title)` across the codebase.
- Removed leading/trailing spaces from `it()` and `describe()` string titles.
- Wrapped variable-based titles (`msg`, `message`) in template literals to ensure they evaluate strictly as strings.
- Quoted the React component name in `ReferenceLink.test.jsx` so it passes string validation.
- Promoted `'jest/valid-title': 'error'` in `vite.config.ts` to prevent future regressions.

*(Note: Doing this as part of my bootcamp preparation for the LFX Term 2 GenAI Observability mentorship!)*

## How was this change tested?
- Ran `yarn oxlint` locally to verify 0 remaining warnings for this rule.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully: `make lint test` *(Ran `yarn oxlint` successfully)*

## AI Usage in this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)