### PR TITLE
fix(lint): Fix Jest expects to have matcher calls, promote valid-expect to error

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffHeader/TraceHeader.test.jsx
@@ -38,10 +38,10 @@ describe('TraceHeader', () => {
       state: fetchedState.DONE,
     });
 
-    expect(screen.getByTestId('TraceDiffHeader--traceAttributes'));
-    expect(screen.getByTestId('TraceDiffHeader--traceAttr--date'));
-    expect(screen.getByTestId('TraceDiffHeader--traceAttr--duration'));
-    expect(screen.getByTestId('TraceDiffHeader--traceAttr--spans'));
+    expect(screen.getByTestId('TraceDiffHeader--traceAttributes')).toBeInTheDocument();
+    expect(screen.getByTestId('TraceDiffHeader--traceAttr--date')).toBeInTheDocument();
+    expect(screen.getByTestId('TraceDiffHeader--traceAttr--duration')).toBeInTheDocument();
+    expect(screen.getByTestId('TraceDiffHeader--traceAttr--spans')).toBeInTheDocument();
 
     expect(() => screen.getByTestId('TraceDiffHeader--emptyTraceAttributes')).toThrow();
   });
@@ -53,7 +53,7 @@ describe('TraceHeader', () => {
       state: fetchedState.LOADING,
     });
 
-    expect(screen.getByTestId('TraceDiffHeader--emptyTraceAttributes'));
+    expect(screen.getByTestId('TraceDiffHeader--emptyTraceAttributes')).toBeInTheDocument();
     expect(() => screen.getByTestId('TraceDiffHeader--traceAttributes')).toThrow();
   });
 
@@ -62,14 +62,14 @@ describe('TraceHeader', () => {
       traceID: null,
     });
 
-    expect(screen.getByText('Select a Trace...'));
+    expect(screen.getByText('Select a Trace...')).toBeInTheDocument();
   });
 
   describe('EmptyAttrs', () => {
     it('renders as expected', () => {
       render(<EmptyAttrs />);
 
-      expect(screen.getByTestId('TraceDiffHeader--traceAttr--empty'));
+      expect(screen.getByTestId('TraceDiffHeader--traceAttr--empty')).toBeInTheDocument();
     });
   });
 
@@ -81,7 +81,7 @@ describe('TraceHeader', () => {
       render(<Attrs duration={700} startTime={ONE_MINUTE} totalSpans={50} />);
 
       // Test that the shown values are correctly formatted
-      expect(screen.getByText('January 1, 1970, 12:01:00 am'));
+      expect(screen.getByText('January 1, 1970, 12:01:00 am')).toBeInTheDocument();
       expect(screen.getByTestId('TraceDiffHeader--traceAttr--duration').textContent).toBe('700μs');
       expect(screen.getByTestId('TraceDiffHeader--traceAttr--spans').textContent).toBe('50');
     });
@@ -90,7 +90,7 @@ describe('TraceHeader', () => {
       render(<Attrs />);
 
       // Test that the default values are correctly
-      expect(screen.getByText('January 1, 1970, 12:00:00 am'));
+      expect(screen.getByText('January 1, 1970, 12:00:00 am')).toBeInTheDocument();
       expect(screen.getByTestId('TraceDiffHeader--traceAttr--duration').textContent).toBe('0μs');
       expect(screen.getByTestId('TraceDiffHeader--traceAttr--spans').textContent).toBe('0');
     });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -121,6 +121,7 @@ export default defineConfig({
       'jest/no-focused-tests': 'error',
       'jest/no-identical-title': 'error',
       'jest/valid-title': 'error',
+      'jest/valid-expect': 'error',
       'import/extensions': 'off',
       // Disabled because dynamic computed namespace access (e.g. track[fn]())
       // in parameterised tests is a false positive this rule cannot validate.


### PR DESCRIPTION
## Which problem is this PR solving?
- Part of **#3746**

## Description of the changes
- Fixed 9 warnings for `eslint-plugin-jest(valid-expect)` in a single file.
- Replaced bare `expect()` calls (missing matchers) with `.toBeInTheDocument()`
  for clearer intent, better failure output, and consistency with other
  jaeger-ui tests.
- Promoted `'jest/valid-expect': 'error'` in `vite.config.ts` to prevent
  future regressions.

*(Note: Doing this as part of my bootcamp preparation for the LFX Term 2
GenAI Observability mentorship!)*

## How was this change tested?
- Ran `yarn oxlint` locally to verify 0 remaining warnings for this rule.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully: `make lint test`
  *(Ran `yarn oxlint` successfully)*

## AI Usage in this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)

Signed-off-by: jayant chauhan <0001jayant@gmail.com>