### PR TITLE
fix(lint): Clear unused vars/imports, promote no-unused-vars to error in TS

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -199,7 +199,6 @@ describe('JaegerClient', () => {
     });
 
     it('aborts and throws timeout error after default timeout (10s)', async () => {
-      let abortController: AbortController | null = null;
       mockFetch.mockImplementation((url: string, options?: { signal?: AbortSignal }) => {
         return new Promise((resolve, reject) => {
           if (options?.signal) {

--- a/packages/jaeger-ui/src/components/App/ThemeProvider.test.tsx
+++ b/packages/jaeger-ui/src/components/App/ThemeProvider.test.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import '@testing-library/jest-dom';
-import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import AppThemeProvider, { useThemeMode } from './ThemeProvider';
 import { THEME_STORAGE_KEY } from './ThemeStorage';

--- a/packages/jaeger-ui/src/components/App/ThemeStorage.ts
+++ b/packages/jaeger-ui/src/components/App/ThemeStorage.ts
@@ -24,7 +24,7 @@ export function readStoredTheme(targetWindow?: Window | null): ThemeMode | null 
     if (stored === 'light' || stored === 'dark') {
       return stored;
     }
-  } catch (err) {
+  } catch {
     // Local storage may be blocked; ignore and fallback below.
   }
 
@@ -44,7 +44,7 @@ export function writeStoredTheme(mode: ThemeMode, targetWindow?: Window | null) 
 
   try {
     activeWindow.localStorage.setItem(THEME_STORAGE_KEY, mode);
-  } catch (err) {
+  } catch {
     // Ignore storage errors (e.g., Safari in private mode).
   }
 }

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -23,7 +23,6 @@ import { useTraceDiffStore } from '../../stores/trace-diff-store';
 import { useShallow } from 'zustand/react/shallow';
 import { ConfigMenuItem, ConfigMenuGroup } from '../../types/config';
 import getConfig from '../../utils/config/get-config';
-import prefixUrl from '../../utils/prefix-url';
 
 import './TopNav.css';
 import withRouteProps, { IWithRouteProps } from '../../utils/withRouteProps';

--- a/packages/jaeger-ui/src/components/PlexusDemo/url.ts
+++ b/packages/jaeger-ui/src/components/PlexusDemo/url.ts
@@ -4,7 +4,3 @@
 import prefixUrl from '../../utils/prefix-url';
 
 export const ROUTE_PATH = prefixUrl('/plexus-demo');
-
-function getUrl() {
-  return ROUTE_PATH;
-}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -10,7 +10,7 @@ import dayjs from 'dayjs';
 import memoizeOne from 'memoize-one';
 import queryString from 'query-string';
 import { IoHelp } from 'react-icons/io5';
-import { connect, ConnectedProps } from 'react-redux';
+import { connect } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { getUrl as getSearchUrl } from './url';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -791,7 +791,7 @@ export function mapStateToProps(state: ReduxState, ownProps: { search?: string }
     if (data) {
       try {
         tags = logfmtStringify(data);
-      } catch (_) {
+      } catch {
         tags = 'Parse Error';
       }
     } else {
@@ -803,7 +803,7 @@ export function mapStateToProps(state: ReduxState, ownProps: { search?: string }
     try {
       data = JSON.parse(logfmtTags as string);
       tags = logfmtStringify(data);
-    } catch (_) {
+    } catch {
       tags = 'Parse Error';
     }
   }
@@ -847,7 +847,6 @@ export function mapDispatchToProps(dispatch: Dispatch) {
 }
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
-type PropsFromRedux = ConnectedProps<typeof connector>;
 
 const ConnectedSearchForm = connector(SearchFormImpl);
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
@@ -212,18 +212,6 @@ export function SearchTracePageImpl(props: SearchTracePageImplProps) {
   );
 }
 
-// Type definitions
-interface ITraceMapEntry {
-  data: Trace;
-}
-
-interface ISearchState {
-  query?: SearchQuery;
-  results: string[];
-  state?: string;
-  error?: { message: string } | null;
-}
-
 interface IStateTraceDiff {
   cohort: string[];
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.tsx
@@ -55,7 +55,7 @@ function round2(percent: number) {
 }
 
 const OpNode = React.memo<Props>(
-  ({ count, errors, time, percent, selfTime, percentSelfTime, operation, service, mode, useOtelTerms }) => {
+  ({ count, errors, time, percent, selfTime, percentSelfTime, operation, service, mode }) => {
     // Spans over 20 % time are full red - we have probably to reconsider better approach
     let backgroundColor;
     if (mode === MODE_TIME) {

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { Button, Input, InputRef, Tooltip } from 'antd';
 import cx from 'classnames';
-import { IoLocate, IoHelp, IoClose, IoChevronDown, IoChevronUp } from 'react-icons/io5';
+import { IoLocate, IoHelp, IoChevronDown, IoChevronUp } from 'react-icons/io5';
 
 import * as markers from './TracePageSearchBar.markers';
 import { trackFilter } from '../index.track';

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.ts
@@ -4,7 +4,6 @@
 import _flatten from 'lodash/flatten';
 import _uniq from 'lodash/uniq';
 import { IOtelTrace } from '../../../types/otel';
-import { ITableSpan } from './types';
 
 import { getServiceName, getOperationName } from './tableValues';
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/types.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/types.ts
@@ -23,15 +23,3 @@ export interface ITableSpan {
   colorToPercent: string; // Color created by percent
   traceID: string;
 }
-
-interface ITableValues {
-  uid: string;
-  value: number;
-}
-
-interface IColumnValue {
-  title: string;
-  attribute: string;
-  suffix: string;
-  isDecimal: boolean;
-}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -21,7 +21,7 @@ function tryParseJson(value: string) {
   // otherwise just return as is
   try {
     return jsonObjectOrArrayStartRegex.test(value) ? JSON.parse(value) : value;
-  } catch (_) {
+  } catch {
     return value;
   }
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -66,7 +66,6 @@ export default function SpanDetail(props: SpanDetailProps) {
   // Display labels based on terminology flag
   const attributesLabel = useOtelTerms ? 'Attributes' : 'Tags';
   const resourceLabel = useOtelTerms ? 'Resource' : 'Process';
-  const eventsLabel = useOtelTerms ? 'Events' : 'Logs';
 
   const overviewItems = [
     {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -4,14 +4,12 @@
 import React, { useMemo } from 'react';
 import cx from 'classnames';
 import _get from 'lodash/get';
-import { IoChevronDown, IoChevronForward } from 'react-icons/io5';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
 import { actions } from './duck';
 import { ReduxState } from '../../../types';
 import { IOtelSpan } from '../../../types/otel';
-import spanAncestorIds from '../../../utils/span-ancestor-ids';
 import colorGenerator from '../../../utils/color-generator';
 
 import './SpanTreeOffset.css';
@@ -39,7 +37,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   showChildrenIcon = true,
   isDetailRow = false,
   span,
-  hoverIndentGuideIds,
   addHoverIndentGuideId,
   removeHoverIndentGuideId,
   color,
@@ -95,9 +92,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   // Get parent color for horizontal line
   const parentSpan = span.parentSpan;
   const parentColor = parentSpan ? colorGenerator.getColorByKey(parentSpan.resource.serviceName) : color;
-
-  // Check if this is a root span (no parent)
-  const isRootSpan = !parentSpan;
 
   // Check if this span is the last child of its parent
   const isLastChild = parentSpan

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
@@ -12,7 +12,7 @@ import {
   SPAN_NAME_COLUMN_WIDTH_MIN,
 } from './store.constants';
 
-export type TraceTimelineLayoutPrefsStore = {
+type TraceTimelineLayoutPrefsStore = {
   spanNameColumnWidth: number;
   sidePanelWidth: number;
   detailPanelMode: SpanDetailPanelMode;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.timeline.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.timeline.ts
@@ -13,7 +13,7 @@ import {
   trimFocusedDetailStatesForSidePanel,
 } from './timeline-utils';
 
-export type TraceTimelineInteractionStore = {
+type TraceTimelineInteractionStore = {
   traceID: string | null;
   childrenHiddenIDs: Set<string>;
   detailStates: Map<string, DetailState>;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
@@ -5,8 +5,6 @@ import DetailState from './SpanDetail/DetailState';
 import type { SpanDetailPanelMode } from '../../../types/config';
 import { useLayoutPrefsStore } from './store.layout';
 import { useTraceTimelineStore } from './store.timeline';
-import type { TraceTimelineInteractionStore } from './store.timeline';
-import type { TraceTimelineLayoutPrefsStore } from './store.layout';
 
 export {
   MIN_TIMELINE_COLUMN_WIDTH,
@@ -21,9 +19,6 @@ export { getInitialLayoutState, useLayoutPrefsStore } from './store.layout';
 export { useTraceTimelineStore } from './store.timeline';
 
 export { calculateFocusedFindRowStates, getSelectedSpanID } from './timeline-utils';
-
-/** Combined shape for typing/tests that span both Zustand slices. */
-type TraceTimelineLayoutStore = TraceTimelineLayoutPrefsStore & TraceTimelineInteractionStore;
 
 export function setDetailPanelMode(mode: SpanDetailPanelMode): void {
   if (mode === 'sidepanel') {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.ts
@@ -3,7 +3,7 @@
 
 import DetailState from './SpanDetail/DetailState';
 import { TNil } from '../../../types';
-import { IOtelSpan, IEvent } from '../../../types/otel';
+import { IOtelSpan } from '../../../types/otel';
 import type { SpanDetailPanelMode } from '../../../types/config';
 import filterSpans from '../../../utils/filter-spans';
 import spanAncestorIds from '../../../utils/span-ancestor-ids';

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -32,7 +32,6 @@ import { cancel as cancelScroll, scrollBy, scrollTo } from './scroll-page';
 import ScrollManager from './ScrollManager';
 import calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import TraceGraph from './TraceGraph/TraceGraph';
-import { TEv } from './TraceGraph/types';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
 import { useConfig } from '../../hooks/useConfig';
 import TracePageHeader from './TracePageHeader';

--- a/packages/jaeger-ui/src/components/common/UiFindInput.tsx
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.tsx
@@ -9,7 +9,7 @@ import _debounce from 'lodash/debounce';
 import _isString from 'lodash/isString';
 
 import updateUiFind from '../../utils/update-ui-find';
-import { TNil, ReduxState } from '../../types/index';
+import { TNil } from '../../types/index';
 import parseQuery from '../../utils/parseQuery';
 
 type TOwnProps = {

--- a/packages/jaeger-ui/src/hooks/useConfig.test.tsx
+++ b/packages/jaeger-ui/src/hooks/useConfig.test.tsx
@@ -104,7 +104,7 @@ describe('useConfig', () => {
       return { config: fullConfig } as ReduxState;
     });
 
-    const { result, rerender } = renderHook(() => useConfig(), {
+    const { result } = renderHook(() => useConfig(), {
       wrapper: createWrapper(dynamicStore),
     });
 

--- a/packages/jaeger-ui/src/reducers/metrics.ts
+++ b/packages/jaeger-ui/src/reducers/metrics.ts
@@ -75,7 +75,7 @@ function fetchServiceMetricsDone(
               try {
                 y = parseFloat(p.gaugeValue.doubleValue.toFixed(2));
                 max = y > max ? y : max;
-              } catch (e) {
+              } catch {
                 y = null;
               }
               return {
@@ -208,7 +208,7 @@ function fetchOpsMetricsDone(
                   y = parseFloat(p.gaugeValue.doubleValue.toFixed(2));
                   avg[metric.name] += y;
                   count[metric.name] += 1; // Increment count for non-NaN values
-                } catch (e) {
+                } catch {
                   y = null;
                 }
 

--- a/packages/jaeger-ui/src/types/archive.ts
+++ b/packages/jaeger-ui/src/types/archive.ts
@@ -15,5 +15,3 @@ export type TraceArchive =
   | SuccessfulTraceArchive
   | ErrorTraceArchive
   | AcknowledgedTraceArchive;
-
-type TracesArchive = Record<string, TraceArchive>;

--- a/packages/jaeger-ui/src/types/metrics.ts
+++ b/packages/jaeger-ui/src/types/metrics.ts
@@ -3,7 +3,6 @@
 
 import { ApiError } from './api-error';
 
-type MetricsType = 'latencies' | 'calls' | 'errors';
 type AvailableServiceMetrics = 'service_call_rate' | 'service_latencies' | 'service_error_rate';
 type AvailableOpsMetrics =
   | 'service_operation_call_rate'

--- a/packages/jaeger-ui/src/utils/documentTitle.ts
+++ b/packages/jaeger-ui/src/utils/documentTitle.ts
@@ -26,7 +26,7 @@ const DocumentTitle: React.FC<Props> = ({ title }) => {
       if (prevTitle != null) {
         try {
           document.title = prevTitle;
-        } catch (e) {
+        } catch {
           // ignore in weird test envs
         }
       }

--- a/packages/jaeger-ui/src/utils/readJsonFile.ts
+++ b/packages/jaeger-ui/src/utils/readJsonFile.ts
@@ -32,7 +32,7 @@ export default function readJsonFile(fileList: { file: File }): Promise<string> 
       let traceObj;
       try {
         traceObj = JSON.parse(reader.result);
-      } catch (error) {
+      } catch {
         try {
           traceObj = tryParseMultiLineInput(reader.result);
         } catch (error) {

--- a/packages/jaeger-ui/src/utils/tracking/index.ts
+++ b/packages/jaeger-ui/src/utils/tracking/index.ts
@@ -24,7 +24,7 @@ const TrackingImplementation = () => {
       }
       versionShort = joiner.join(' ');
       versionLong = data.pretty;
-    } catch (_) {
+    } catch {
       versionShort = versionInfo;
       versionLong = versionInfo;
     }

--- a/packages/plexus/src/types/TOneOf.ts
+++ b/packages/plexus/src/types/TOneOf.ts
@@ -1,26 +1,12 @@
 // Copyright (c) 2019 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-type TOneOf<A, B, C = {}, D = {}, E = {}> =
-  | ({ [P in Exclude<keyof (B & C & D & E), keyof A>]?: undefined } & A)
-  | ({ [P in Exclude<keyof (A & C & D & E), keyof B>]?: undefined } & B)
-  | ({ [P in Exclude<keyof (A & B & D & E), keyof C>]?: undefined } & C)
-  | ({ [P in Exclude<keyof (A & B & C & E), keyof D>]?: undefined } & D)
-  | ({ [P in Exclude<keyof (A & B & C & D), keyof E>]?: undefined } & E);
-
 export type TOneOfTwo<A, B> =
   | ({ [P in Exclude<keyof B, keyof A>]?: undefined } & A)
   | ({ [P in Exclude<keyof A, keyof B>]?: undefined } & B);
-
-type TOneOfThree<A, B, C> =
-  | ({ [P in Exclude<keyof (B & C), keyof A>]?: undefined } & A)
-  | ({ [P in Exclude<keyof (A & C), keyof B>]?: undefined } & B)
-  | ({ [P in Exclude<keyof (A & B), keyof C>]?: undefined } & C);
 
 export type TOneOfFour<A, B, C, D> =
   | ({ [P in Exclude<keyof (B & C & D), keyof A>]?: undefined } & A)
   | ({ [P in Exclude<keyof (A & C & D), keyof B>]?: undefined } & B)
   | ({ [P in Exclude<keyof (A & B & D), keyof C>]?: undefined } & C)
   | ({ [P in Exclude<keyof (A & B & C), keyof D>]?: undefined } & D);
-
-type TOneOfFive<A, B, C, D, E> = TOneOf<A, B, C, D, E>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -134,7 +134,6 @@ export default defineConfig({
         rules: {
           // TypeScript files: downgrade from top-level errors to warnings since
           // tsc already enforces these more precisely than the linter can.
-          'no-unused-vars': 'warn',
           'no-redeclare': 'warn',
           'no-shadow': 'warn',
           'no-use-before-define': 'warn',


### PR DESCRIPTION
Part of #3746

Cleared 38 `no-unused-vars` warnings across 27 files and removed the override that downgraded the rule to warn for TypeScript files, so future violations fail CI.

The changes fall into four buckets:
- Unused imports: dropped single entries or whole import lines (`IoChevronDown`, `IoChevronForward`, `IoClose`, `spanAncestorIds`, `IEvent`, `ReduxState`, `ITableSpan`, `TEv`, `act`, `renderHook`, `prefixUrl`, `ConnectedProps`)
- Unused type aliases / interfaces: deleted (`MetricsType`, `TraceTimelineLayoutStore`, `TracesArchive`, `ITableValues`, `IColumnValue`, `ITraceMapEntry`, `ISearchState`, `PropsFromRedux`, `TOneOf`, `TOneOfThree`, `TOneOfFive`)
- Unused local vars / dead code: deleted (`eventsLabel`, `isRootSpan`, `abortController`, `hoverIndentGuideIds` destructure, `useOtelTerms` destructure, `rerender`, `getUrl`)
- Unused catch bindings: collapsed `catch (e) {}` / `catch (_) {}` to bare `catch {}`

## AI Usage in this PR (choose one)
- [x] **Heavy**: AI walked through each warning, removed the dead code, collapsed catches, and validated end-to-end

Verified locally:
- `npm run oxlint` -> 0 errors, `no-unused-vars` count dropped from 38 to 0
- `npm run tsc-lint` -> pass
- `npm test` -> 2694 jaeger-ui + 115 plexus tests pass
- `npm run build` -> success