### PR TITLE
fix(lint): Replace new Array(n) with Array.from, promote no-new-array to error

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/calc-positioning.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/calc-positioning.test.js
@@ -31,7 +31,7 @@ describe('calcPositioning', () => {
   let svcMeasurements;
   let opMeasurements;
   let genStrCalls = 0;
-  const genStr = n => `${new Array(n).fill('foo').join(':')}${genStrCalls++}`;
+  const genStr = n => `${Array.from({ length: n }, () => 'foo').join(':')}${genStrCalls++}`;
   const lineHeight = LINE_HEIGHT * FONT_SIZE;
   const measureSvc = jest.fn().mockImplementation(() => [svcMeasurements[measureSvc.mock.calls.length - 1]]);
   const measureOp = jest.fn().mockImplementation(() => [opMeasurements[measureOp.mock.calls.length - 1]]);
@@ -150,11 +150,12 @@ describe('calcPositioning', () => {
       it('treats multiple operations as a single word', () => {
         const maxSvcLines = 2;
         const operationCount = 10;
-        svcMeasurements = genWidths(new Array(maxSvcLines).fill(0.5));
-        opMeasurements = genWidths(new Array(operationCount).fill(3));
+        svcMeasurements = genWidths(Array.from({ length: maxSvcLines }, () => 0.5));
+        opMeasurements = genWidths(Array.from({ length: operationCount }, () => 3));
+        const filler = genStr(1);
         const { opWidth, radius, svcWidth, svcMarginTop } = calcPositioning(
           genStr(maxSvcLines),
-          new Array(operationCount).fill(genStr(1))
+          Array.from({ length: operationCount }, () => filler)
         );
         expect(measureSvc).toHaveBeenCalledTimes(maxSvcLines);
         expect(measureOp).toHaveBeenCalledTimes(1);
@@ -235,7 +236,7 @@ describe('calcPositioning', () => {
       const wordCount = xssString.match(WORD_RX)?.length || 1;
       const capturedHtml = [];
       const originalImplementation = measureSvc.getMockImplementation();
-      svcMeasurements = genWidths(new Array(wordCount).fill(1));
+      svcMeasurements = genWidths(Array.from({ length: wordCount }, () => 1));
 
       measureSvc.mockImplementation(() => {
         capturedHtml.push(svcSpan.innerHTML);

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/index.test.jsx
@@ -41,7 +41,7 @@ vi.mock('./getNodeRenderers', () =>
 vi.mock('./getSetOnEdge', () => mockDefault(jest.fn(() => jest.fn())));
 
 describe('<Graph />', () => {
-  const vertices = new Array(10).fill().map((_, i) => ({ key: `key${i}` }));
+  const vertices = Array.from({ length: 10 }, (_, i) => ({ key: `key${i}` }));
   const edges = [
     {
       from: vertices[0].key,

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
@@ -54,7 +54,7 @@ window.HTMLCanvasElement.prototype.getContext = function getContext() {
     clearRect() {},
     getImageData(x, y, w, h) {
       return {
-        data: new Array(w * h * 4),
+        data: Array.from({ length: w * h * 4 }),
       };
     },
     putImageData() {},

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
@@ -127,7 +127,7 @@ describe('SearchTracePage/url', () => {
 
         expect(
           getUrl({
-            traceID: new Array(numberOfArgs).fill(trace0),
+            traceID: Array.from({ length: numberOfArgs }, () => trace0),
           }).length
         ).toBeLessThan(MAX_LENGTH);
       });
@@ -135,7 +135,7 @@ describe('SearchTracePage/url', () => {
       it('does not over shorten', () => {
         const numberOfArgs = Math.floor(maxLengthOfArgs / lengthOfOneArg);
         const remainder = maxLengthOfArgs % lengthOfOneArg;
-        const ids = new Array(numberOfArgs).fill(trace0);
+        const ids = Array.from({ length: numberOfArgs }, () => trace0);
         ids[ids.length - 1] = `${ids[ids.length - 1]}${'x'.repeat(remainder)}`;
         ids.push(trace0);
 

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.jsx
@@ -68,8 +68,8 @@ describe('drawNode', () => {
     const key = 'vertex-key';
     const vertex = {
       data: {
-        a: new Array(lenA),
-        b: new Array(lenB),
+        a: Array.from({ length: lenA }),
+        b: Array.from({ length: lenB }),
         operation,
         service,
       },

--- a/packages/jaeger-ui/src/components/common/ExamplesLink.test.jsx
+++ b/packages/jaeger-ui/src/components/common/ExamplesLink.test.jsx
@@ -19,7 +19,7 @@ describe('ExamplesLink', () => {
 
   const spanLinks = traceLinks.map(({ traceID }, i) => ({
     traceID: `${traceID}${i}`,
-    spanIDs: Array.from({ length: i + 1 }, () => 'spanID').map((str, j) => `${str}${i}${j}`),
+    spanIDs: Array.from({ length: i + 1 }, (_, j) => `spanID${i}${j}`),
   }));
 
   const expectedTraceParams = 'traceID=foo&traceID=bar';

--- a/packages/jaeger-ui/src/components/common/ExamplesLink.test.jsx
+++ b/packages/jaeger-ui/src/components/common/ExamplesLink.test.jsx
@@ -19,7 +19,7 @@ describe('ExamplesLink', () => {
 
   const spanLinks = traceLinks.map(({ traceID }, i) => ({
     traceID: `${traceID}${i}`,
-    spanIDs: new Array(i + 1).fill('spanID').map((str, j) => `${str}${i}${j}`),
+    spanIDs: Array.from({ length: i + 1 }, () => 'spanID').map((str, j) => `${str}${i}${j}`),
   }));
 
   const expectedTraceParams = 'traceID=foo&traceID=bar';

--- a/packages/jaeger-ui/src/model/ddg/visibility-codec.test.jsx
+++ b/packages/jaeger-ui/src/model/ddg/visibility-codec.test.jsx
@@ -6,7 +6,7 @@ import { focalPayloadElem, longSimplePath, shortPath, simplePath, wrap } from '.
 import transformDdgData from './transformDdgData';
 
 describe('visibility-codec', () => {
-  const sampleLargestDecoded = new Array(31).fill().map((_undef, i) => i);
+  const sampleLargestDecoded = Array.from({ length: 31 }, (_undef, i) => i);
   const sampleLargestEncoded = 'zik0zj';
   const sampleRepeatedDecoded = [0, 1, 31, 32, 124, 156, 187];
   const sampleRepeatedEncoded = '3~2.~2.1.2~2';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -116,6 +116,7 @@ export default defineConfig({
       'valid-typeof': 'error',
       'react/no-children-prop': 'error',
       'unicorn/no-useless-spread': 'error',
+      'unicorn/no-new-array': 'error',
       'react-x/rules-of-hooks': 'error',
       'react-x/exhaustive-deps': 'error',
       'jest/no-disabled-tests': 'warn',


### PR DESCRIPTION
Part of #3746

`new Array(n)` with a single numeric arg builds a sparse array (`[empty × n]`), a well-known JavaScript footgun. Swapped all 13 sites to `Array.from({ length: n })` (with a mapper when the original used `.fill`) and promoted the rule in oxlint so future uses fail CI.

One subtle case in `calc-positioning.test.js`: the original `new Array(operationCount).fill(genStr(1))` called `genStr(1)` once and filled N copies. `genStr` increments a counter so calling it N times via an Array.from mapper would change semantics. Cached the result in a local (`const filler = genStr(1)`) so the mapper reuses the same value.

## AI Usage in this PR (choose one)
- [x] **Moderate**: AI identified each site and applied the Array.from conversion, noticing the side-effect case that needed caching

Verified locally:
- `npm run lint` (oxlint + knip + tsc + checks) -> exit 0
- `npm run fmt` -> clean
- `npm test` -> 2694 jaeger-ui + 115 plexus tests pass
- `npm run build` -> success