### PR TITLE
fix(lint): Disable jest/no-conditional-expect

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -125,6 +125,9 @@ export default defineConfig({
       'jest/valid-title': 'error',
       'jest/valid-expect': 'error',
       'jest/no-conditional-expect': 'off',
+      // no-shadow forces awkward renaming even when there's no real shadowing, e.g.,
+      //     const { a, b } = () => { something that prepares a, b }
+      'no-shadow': 'off',
       'import/extensions': 'off',
       // Disabled because dynamic computed namespace access (e.g. track[fn]())
       // in parameterised tests is a false positive this rule cannot validate.
@@ -137,7 +140,6 @@ export default defineConfig({
           // TypeScript files: downgrade from top-level errors to warnings since
           // tsc already enforces these more precisely than the linter can.
           'no-redeclare': 'warn',
-          'no-shadow': 'warn',
           'no-use-before-define': 'warn',
           'no-useless-constructor': 'warn',
           'no-empty-function': 'off',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
       'jest/no-identical-title': 'error',
       'jest/valid-title': 'error',
       'jest/valid-expect': 'error',
+      'jest/no-conditional-expect': 'off',
       'import/extensions': 'off',
       // Disabled because dynamic computed namespace access (e.g. track[fn]())
       // in parameterised tests is a false positive this rule cannot validate.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
       'jest/no-identical-title': 'error',
       'jest/valid-title': 'error',
       'jest/valid-expect': 'error',
+      // many data-driven tests use conditionals, this linter makes them unreadable
       'jest/no-conditional-expect': 'off',
       // no-shadow forces awkward renaming even when there's no real shadowing, e.g.,
       //     const { a, b } = () => { something that prepares a, b }


### PR DESCRIPTION
This PR removes the `jest/no-conditional-expect` warning from linter warnings
Resolves #3746.