### PR TITLE
fix(lint): disable eslint(no-shadow) warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
       'jest/no-identical-title': 'error',
       'jest/valid-title': 'error',
       'jest/valid-expect': 'error',
+      'no-shadow': 'off',
       'import/extensions': 'off',
       // Disabled because dynamic computed namespace access (e.g. track[fn]())
       // in parameterised tests is a false positive this rule cannot validate.
@@ -136,7 +137,7 @@ export default defineConfig({
           // TypeScript files: downgrade from top-level errors to warnings since
           // tsc already enforces these more precisely than the linter can.
           'no-redeclare': 'warn',
-          'no-shadow': 'warn',
+          'no-shadow': 'off',
           'no-use-before-define': 'warn',
           'no-useless-constructor': 'warn',
           'no-empty-function': 'off',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,8 @@ export default defineConfig({
       'jest/no-identical-title': 'error',
       'jest/valid-title': 'error',
       'jest/valid-expect': 'error',
+      // no-shadow forces awkward renaming even when there's no real shadowing, e.g.,
+      //     const { a, b } = () => { something that prepares a, b }
       'no-shadow': 'off',
       'import/extensions': 'off',
       // Disabled because dynamic computed namespace access (e.g. track[fn]())
@@ -137,7 +139,6 @@ export default defineConfig({
           // TypeScript files: downgrade from top-level errors to warnings since
           // tsc already enforces these more precisely than the linter can.
           'no-redeclare': 'warn',
-          'no-shadow': 'off',
           'no-use-before-define': 'warn',
           'no-useless-constructor': 'warn',
           'no-empty-function': 'off',


### PR DESCRIPTION
Part of #3746

## What changed
Disabled lint warnings for no-shadow
## AI Usage in this PR (choose one)
- [x] **Heavy**: AI generated most or all of the code changes