### PR TITLE
fix(lint): Fix no-use-before-define warnings, promote to error in TS

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
@@ -70,6 +70,18 @@ interface IDispatchProps {
 
 type SearchTracePageImplProps = ISearchTracePageImplOwnProps & IStateProps & IDispatchProps;
 
+interface IStateTraceDiff {
+  cohort: string[];
+}
+
+export const stateTraceDiffXformer = memoizeOne(
+  (stateTrace: ReduxState['trace'], stateTraceDiff: IStateTraceDiff) => {
+    const { traces } = stateTrace;
+    const { cohort } = stateTraceDiff;
+    return cohort.map(id => traces[id] || { id, state: null });
+  }
+);
+
 // export for tests
 export function SearchTracePageImpl(props: SearchTracePageImplProps) {
   const {
@@ -212,10 +224,6 @@ export function SearchTracePageImpl(props: SearchTracePageImplProps) {
   );
 }
 
-interface IStateTraceDiff {
-  cohort: string[];
-}
-
 const stateTraceXformer = memoizeOne((stateTrace: ReduxState['trace']) => {
   const { traces: traceMap, search } = stateTrace;
   const { query, results, state, error: traceError } = search;
@@ -227,14 +235,6 @@ const stateTraceXformer = memoizeOne((stateTrace: ReduxState['trace']) => {
   const maxDuration = Math.max(0, ...traces.map(tr => tr.duration || 0));
   return { traces, rawTraces, maxDuration, traceError, loadingTraces, query };
 });
-
-export const stateTraceDiffXformer = memoizeOne(
-  (stateTrace: ReduxState['trace'], stateTraceDiff: IStateTraceDiff) => {
-    const { traces } = stateTrace;
-    const { cohort } = stateTraceDiff;
-    return cohort.map(id => traces[id] || { id, state: null });
-  }
-);
 
 const sortedTracesXformer = memoizeOne((traces: Trace[], sortBy: string) => {
   const traceResults = traces.slice();

--- a/packages/jaeger-ui/src/components/common/UiFindInput.tsx
+++ b/packages/jaeger-ui/src/components/common/UiFindInput.tsx
@@ -25,6 +25,22 @@ const defaultProps: Partial<TProps> = {
   inputProps: {},
 };
 
+export type TExtractUiFindFromStateReturn = {
+  uiFind: string | undefined;
+};
+
+export function parseUiFind(search: string): string | undefined {
+  const { uiFind } = parseQuery(search);
+  return Array.isArray(uiFind) ? uiFind.join(' ') : uiFind;
+}
+
+// This is used by various components to extract uiFind from the URL.
+// The "fromState" part of the name is a legacy leftover from when
+// this was reading from Redux state.
+export function extractUiFindFromState(_unused: any = null): TExtractUiFindFromStateReturn {
+  return { uiFind: parseUiFind(window.location.search) };
+}
+
 export const UnconnectedUiFindInput = React.forwardRef<InputRef, TProps>((props, ref) => {
   const {
     allowClear,
@@ -107,21 +123,5 @@ export const UnconnectedUiFindInput = React.forwardRef<InputRef, TProps>((props,
 });
 
 UnconnectedUiFindInput.displayName = 'UnconnectedUiFindInput';
-
-export type TExtractUiFindFromStateReturn = {
-  uiFind: string | undefined;
-};
-
-export function parseUiFind(search: string): string | undefined {
-  const { uiFind } = parseQuery(search);
-  return Array.isArray(uiFind) ? uiFind.join(' ') : uiFind;
-}
-
-// This is used by various components to extract uiFind from the URL.
-// The "fromState" part of the name is a legacy leftover from when
-// this was reading from Redux state.
-export function extractUiFindFromState(_unused: any = null): TExtractUiFindFromStateReturn {
-  return { uiFind: parseUiFind(window.location.search) };
-}
 
 export default UnconnectedUiFindInput as any;

--- a/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.ts
+++ b/packages/jaeger-ui/src/model/ddg/transformTracesToPaths.ts
@@ -21,21 +21,6 @@ function transformTracesToPaths(
       const rootSpans = data.rootSpans;
       const { traceID } = data;
 
-      // Helper function to walk all paths through the tree, building IOtelSpan[] paths directly
-      const walkPaths = (span: IOtelSpan, currentPath: IOtelSpan[]) => {
-        const pathWithCurrent = [...currentPath, span];
-
-        if (span.childSpans.length === 0) {
-          // Leaf node - process the complete path
-          processPath(pathWithCurrent);
-        } else {
-          // Continue walking through children
-          span.childSpans.forEach(child => {
-            walkPaths(child, pathWithCurrent);
-          });
-        }
-      };
-
       const processPath = (pathSpans: IOtelSpan[]) => {
         if (pathSpans.length === 0) return;
 
@@ -78,6 +63,21 @@ function transformTracesToPaths(
               value: traceID,
             });
           }
+        }
+      };
+
+      // Helper function to walk all paths through the tree, building IOtelSpan[] paths directly
+      const walkPaths = (span: IOtelSpan, currentPath: IOtelSpan[]) => {
+        const pathWithCurrent = [...currentPath, span];
+
+        if (span.childSpans.length === 0) {
+          // Leaf node - process the complete path
+          processPath(pathWithCurrent);
+        } else {
+          // Continue walking through children
+          span.childSpans.forEach(child => {
+            walkPaths(child, pathWithCurrent);
+          });
         }
       };
 

--- a/packages/jaeger-ui/test/vitest-setup.ts
+++ b/packages/jaeger-ui/test/vitest-setup.ts
@@ -26,24 +26,18 @@ global.ResizeObserver = vi.fn().mockImplementation(function () {
 // Ant Design v6 uses MessageChannel which is not available in jsdom.
 // Must use a regular function (not arrow) because it is called with `new`.
 (global as any).MessageChannel = vi.fn().mockImplementation(function () {
-  const port1: any = {
-    onmessage: null,
-    postMessage: vi.fn((data: unknown) => {
-      if (port2.onmessage) {
-        setTimeout(() => port2.onmessage({ data }), 0);
-      }
-    }),
-    close: vi.fn(),
-  };
-  const port2: any = {
-    onmessage: null,
-    postMessage: vi.fn((data: unknown) => {
-      if (port1.onmessage) {
-        setTimeout(() => port1.onmessage({ data }), 0);
-      }
-    }),
-    close: vi.fn(),
-  };
+  const port1: any = { onmessage: null, close: vi.fn() };
+  const port2: any = { onmessage: null, close: vi.fn() };
+  port1.postMessage = vi.fn((data: unknown) => {
+    if (port2.onmessage) {
+      setTimeout(() => port2.onmessage({ data }), 0);
+    }
+  });
+  port2.postMessage = vi.fn((data: unknown) => {
+    if (port1.onmessage) {
+      setTimeout(() => port1.onmessage({ data }), 0);
+    }
+  });
   return { port1, port2 };
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -133,8 +133,10 @@ export default defineConfig({
       {
         files: ['**/*.{ts,tsx,mts}'],
         rules: {
-          // TypeScript files: downgrade from top-level errors to warnings since
-          // tsc already enforces these more precisely than the linter can.
+          // TypeScript files: most rules here are downgraded from top-level
+          // errors to warnings since tsc already enforces them more precisely
+          // than the linter can. no-use-before-define is kept as an error
+          // because tsc does not flag every case the rule catches.
           'no-redeclare': 'warn',
           'no-shadow': 'warn',
           'no-use-before-define': 'error',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,7 +137,7 @@ export default defineConfig({
           // tsc already enforces these more precisely than the linter can.
           'no-redeclare': 'warn',
           'no-shadow': 'warn',
-          'no-use-before-define': 'warn',
+          'no-use-before-define': 'error',
           'no-useless-constructor': 'warn',
           'no-empty-function': 'off',
           'typescript/no-this-alias': 'off',


### PR DESCRIPTION
reorders declarations in four files so each identifier is defined before it's used, then promotes no-use-before-define from warn to error in the TS override.

- UiFindInput.tsx: parseUiFind was defined after the component that calls it. moved the utility functions and related type above the component.
- transformTracesToPaths.ts: walkPaths called processPath before it was declared. swapped the two arrow-function consts.
- SearchTracePage/index.tsx: the component used stateTraceDiffXformer before the export const. moved the memoized selector and its interface above the component.
- vitest-setup.ts: the MessageChannel mock had port1.postMessage referencing port2 inside its closure before port2 was declared. initialized both port shells first, then attached postMessage.

all behavior is identical. closures still capture correctly, the memoized selector is still exported with the same name, tests pass unchanged.

Refs #3746