### PR TITLE
Hide minimap when timeline is hidden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5814,6 +5814,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -6787,6 +6801,20 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
@@ -6808,6 +6836,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/immer": {
@@ -7897,6 +7939,32 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/match-sorter": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-8.3.0.tgz",
@@ -7961,6 +8029,20 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -8146,6 +8228,24 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/needle": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -8763,6 +8863,17 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pixelmatch": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
@@ -8880,6 +8991,14 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -9391,6 +9510,25 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/saxes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9496,6 +9496,25 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -606,13 +606,18 @@ describe('<TracePage>', () => {
         expect(spanGraph).not.toBeInTheDocument();
       });
 
-      it('is true when timeline bars are hidden', () => {
-        mockLayoutPrefsStore.timelineBarsVisible = false;
-        renderWithRouter(<TracePage {...defaultProps} />);
+      describe('when timeline bars are hidden', () => {
+        afterEach(() => {
+          mockLayoutPrefsStore.timelineBarsVisible = true;
+        });
 
-        const spanGraph = screen.queryByTestId('span-graph');
-        expect(spanGraph).not.toBeInTheDocument();
-        mockLayoutPrefsStore.timelineBarsVisible = true;
+        it('is true when timeline bars are hidden', () => {
+          mockLayoutPrefsStore.timelineBarsVisible = false;
+          renderWithRouter(<TracePage {...defaultProps} />);
+
+          const spanGraph = screen.queryByTestId('span-graph');
+          expect(spanGraph).not.toBeInTheDocument();
+        });
       });
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -605,6 +605,15 @@ describe('<TracePage>', () => {
         const spanGraph = screen.queryByTestId('span-graph');
         expect(spanGraph).not.toBeInTheDocument();
       });
+
+      it('is true when timeline bars are hidden', () => {
+        mockLayoutPrefsStore.timelineBarsVisible = false;
+        renderWithRouter(<TracePage {...defaultProps} />);
+
+        const spanGraph = screen.queryByTestId('span-graph');
+        expect(spanGraph).not.toBeInTheDocument();
+        mockLayoutPrefsStore.timelineBarsVisible = true;
+      });
     });
 
     describe('calculates hideSummary correctly', () => {

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -608,13 +608,18 @@ describe('<TracePage>', () => {
         expect(spanGraph).not.toBeInTheDocument();
       });
 
-      it('is true when timeline bars are hidden', () => {
-        mockLayoutPrefsStore.timelineBarsVisible = false;
-        renderWithRouter(<TracePage {...defaultProps} />);
+      describe('when timeline bars are hidden', () => {
+        afterEach(() => {
+          mockLayoutPrefsStore.timelineBarsVisible = true;
+        });
 
-        const spanGraph = screen.queryByTestId('span-graph');
-        expect(spanGraph).not.toBeInTheDocument();
-        mockLayoutPrefsStore.timelineBarsVisible = true;
+        it('is true when timeline bars are hidden', () => {
+          mockLayoutPrefsStore.timelineBarsVisible = false;
+          renderWithRouter(<TracePage {...defaultProps} />);
+
+          const spanGraph = screen.queryByTestId('span-graph');
+          expect(spanGraph).not.toBeInTheDocument();
+        });
       });
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -607,6 +607,15 @@ describe('<TracePage>', () => {
         const spanGraph = screen.queryByTestId('span-graph');
         expect(spanGraph).not.toBeInTheDocument();
       });
+
+      it('is true when timeline bars are hidden', () => {
+        mockLayoutPrefsStore.timelineBarsVisible = false;
+        renderWithRouter(<TracePage {...defaultProps} />);
+
+        const spanGraph = screen.queryByTestId('span-graph');
+        expect(spanGraph).not.toBeInTheDocument();
+        mockLayoutPrefsStore.timelineBarsVisible = true;
+      });
     });
 
     describe('calculates hideSummary correctly', () => {

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -584,6 +584,17 @@ describe('<TracePage>', () => {
     });
 
     describe('calculates hideMap correctly', () => {
+      afterEach(() => {
+        mockLayoutPrefsStore.timelineBarsVisible = true;
+      });
+
+      it('is false on the timeline view', () => {
+        renderWithRouter(<TracePage {...defaultProps} />);
+
+        const spanGraph = screen.queryByTestId('span-graph');
+        expect(spanGraph).toBeInTheDocument();
+      });
+
       it('is true if on traceGraphView', () => {
         renderWithRouter(<TracePage {...defaultProps} />);
 
@@ -607,18 +618,12 @@ describe('<TracePage>', () => {
         expect(spanGraph).not.toBeInTheDocument();
       });
 
-      describe('when timeline bars are hidden', () => {
-        afterEach(() => {
-          mockLayoutPrefsStore.timelineBarsVisible = true;
-        });
+      it('is true if timeline bars are hidden', () => {
+        mockLayoutPrefsStore.timelineBarsVisible = false;
+        renderWithRouter(<TracePage {...defaultProps} />);
 
-        it('is true when timeline bars are hidden', () => {
-          mockLayoutPrefsStore.timelineBarsVisible = false;
-          renderWithRouter(<TracePage {...defaultProps} />);
-
-          const spanGraph = screen.queryByTestId('span-graph');
-          expect(spanGraph).not.toBeInTheDocument();
-        });
+        const spanGraph = screen.queryByTestId('span-graph');
+        expect(spanGraph).not.toBeInTheDocument();
       });
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -606,6 +606,15 @@ describe('<TracePage>', () => {
         const spanGraph = screen.queryByTestId('span-graph');
         expect(spanGraph).not.toBeInTheDocument();
       });
+
+      it('is true when timeline bars are hidden', () => {
+        mockLayoutPrefsStore.timelineBarsVisible = false;
+        renderWithRouter(<TracePage {...defaultProps} />);
+
+        const spanGraph = screen.queryByTestId('span-graph');
+        expect(spanGraph).not.toBeInTheDocument();
+        mockLayoutPrefsStore.timelineBarsVisible = true;
+      });
     });
 
     describe('calculates hideSummary correctly', () => {

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -607,13 +607,18 @@ describe('<TracePage>', () => {
         expect(spanGraph).not.toBeInTheDocument();
       });
 
-      it('is true when timeline bars are hidden', () => {
-        mockLayoutPrefsStore.timelineBarsVisible = false;
-        renderWithRouter(<TracePage {...defaultProps} />);
+      describe('when timeline bars are hidden', () => {
+        afterEach(() => {
+          mockLayoutPrefsStore.timelineBarsVisible = true;
+        });
 
-        const spanGraph = screen.queryByTestId('span-graph');
-        expect(spanGraph).not.toBeInTheDocument();
-        mockLayoutPrefsStore.timelineBarsVisible = true;
+        it('is true when timeline bars are hidden', () => {
+          mockLayoutPrefsStore.timelineBarsVisible = false;
+          renderWithRouter(<TracePage {...defaultProps} />);
+
+          const spanGraph = screen.queryByTestId('span-graph');
+          expect(spanGraph).not.toBeInTheDocument();
+        });
       });
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -397,7 +397,9 @@ export function TracePageImpl(props: TProps) {
     detailPanelMode,
     enableSidePanel,
     hideMap: Boolean(
-      viewType !== ETraceViewType.TraceTimelineViewer || (embedded && embedded.timeline.hideMinimap)
+      viewType !== ETraceViewType.TraceTimelineViewer ||
+      (embedded && embedded.timeline.hideMinimap) ||
+      !timelineBarsVisible
     ),
     hideSummary: Boolean(embedded && embedded.timeline.hideSummary),
     linkToStandalone: getUrl(id),

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -393,7 +393,9 @@ export function TracePageImpl(props: TProps) {
     detailPanelMode,
     enableSidePanel,
     hideMap: Boolean(
-      viewType !== ETraceViewType.TraceTimelineViewer || Boolean(embedded?.timeline?.hideMinimap)
+      viewType !== ETraceViewType.TraceTimelineViewer ||
+      Boolean(embedded?.timeline?.hideMinimap) ||
+      !timelineBarsVisible
     ),
     hideSummary: Boolean(embedded?.timeline?.hideSummary),
     linkToStandalone: getUrl(id),

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -415,7 +415,10 @@ export function TracePageImpl(props: TProps) {
     clearSearch,
     detailPanelMode,
     enableSidePanel,
-    hideMap: !viewTypeShowsMinimap(viewType) || Boolean(embedded?.timeline?.hideMinimap),
+    hideMap:
+      !viewTypeShowsMinimap(viewType) ||
+      Boolean(embedded?.timeline?.hideMinimap) ||
+      !timelineBarsVisible,
     hideSummary: Boolean(embedded?.timeline?.hideSummary),
     linkToStandalone: getUrl(id),
     nextResult,

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -416,9 +416,7 @@ export function TracePageImpl(props: TProps) {
     detailPanelMode,
     enableSidePanel,
     hideMap:
-      !viewTypeShowsMinimap(viewType) ||
-      Boolean(embedded?.timeline?.hideMinimap) ||
-      !timelineBarsVisible,
+      !viewTypeShowsMinimap(viewType) || Boolean(embedded?.timeline?.hideMinimap) || !timelineBarsVisible,
     hideSummary: Boolean(embedded?.timeline?.hideSummary),
     linkToStandalone: getUrl(id),
     nextResult,


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #3762

When the trace timeline is hidden via Settings, the minimap (which is just another representation of the timeline) remains visible. It should be hidden too.

## Description of the changes

Added `!timelineBarsVisible` to the `hideMap` condition in `TracePage`, so the minimap is hidden whenever the timeline bars are not visible.

## How was this change tested?

Added a unit test that verifies the minimap is hidden when `timelineBarsVisible` is `false`.