### PR TITLE
fix: prevent timeline tick labels from overlapping when column is narrow

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
 import Ticks from './Ticks';
 
@@ -10,5 +10,49 @@ describe('<Ticks>', () => {
   it('renders without exploding', () => {
     const { container } = render(<Ticks endTime={200} numTicks={5} showLabels startTime={100} />);
     expect(container).toBeDefined();
+  });
+
+  it('renders tick lines for every tick regardless of showLabels', () => {
+    const { container } = render(<Ticks numTicks={5} />);
+    expect(container.querySelectorAll('.Ticks--tick')).toHaveLength(5);
+  });
+
+  it('renders labels when showLabels is true', () => {
+    const { container } = render(<Ticks endTime={1000} numTicks={5} showLabels startTime={0} />);
+    expect(container.querySelectorAll('.Ticks--tickLabel').length).toBeGreaterThan(0);
+  });
+
+  it('applies isEndAnchor class only to the last label', () => {
+    const { container } = render(<Ticks endTime={1000} numTicks={5} showLabels startTime={0} />);
+    const anchors = container.querySelectorAll('.Ticks--tickLabel.isEndAnchor');
+    expect(anchors).toHaveLength(1);
+  });
+
+  it('does not render labels when showLabels is omitted', () => {
+    const { container } = render(<Ticks numTicks={5} />);
+    expect(container.querySelectorAll('.Ticks--tickLabel')).toHaveLength(0);
+  });
+
+  it('skips intermediate labels and keeps first and last when container is narrow', () => {
+    let observerCallback;
+    const mockResizeObserver = vi.fn().mockImplementation(function (cb) {
+      observerCallback = cb;
+      this.observe = vi.fn();
+      this.disconnect = vi.fn();
+    });
+    vi.stubGlobal('ResizeObserver', mockResizeObserver);
+
+    const { container } = render(<Ticks endTime={1000} numTicks={5} showLabels startTime={0} />);
+
+    act(() => {
+      observerCallback([{ contentRect: { width: 200 } }]);
+    });
+
+    const labels = container.querySelectorAll('.Ticks--tickLabel');
+    expect(labels.length).toBeLessThan(5);
+    expect(labels[0].classList.contains('isEndAnchor')).toBe(false);
+    expect(labels[labels.length - 1].classList.contains('isEndAnchor')).toBe(true);
+
+    vi.unstubAllGlobals();
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/Ticks.tsx
@@ -3,11 +3,14 @@
 
 import * as React from 'react';
 
-import { formatDuration } from '../../../utils/date';
+import { formatDurationCompact } from '../../../utils/date';
 import { TNil } from '../../../types';
 import { IOtelSpan } from '../../../types/otel';
 
 import './Ticks.css';
+
+// The last label is right-anchored so the final interval needs ~2× a single label's width.
+const MIN_LABEL_SPACING_PX = 130;
 
 type TicksProps = {
   numTicks: number;
@@ -17,18 +20,45 @@ type TicksProps = {
 };
 
 export default function Ticks({ endTime = null, numTicks, showLabels = null, startTime = null }: TicksProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = React.useState(0);
+
+  React.useLayoutEffect(() => {
+    if (!showLabels || !containerRef.current) return undefined;
+    const el = containerRef.current;
+    setContainerWidth(el.getBoundingClientRect().width);
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(entries => {
+      setContainerWidth(entries[0].contentRect.width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [showLabels]);
+
   let labels: undefined | string[];
   if (showLabels) {
     labels = [];
     const viewingDuration = (endTime || 0) - (startTime || 0);
     for (let i = 0; i < numTicks; i++) {
       const durationAtTick = (startTime || 0) + (i / (numTicks - 1)) * viewingDuration;
-      labels.push(formatDuration(durationAtTick as IOtelSpan['duration']));
+      labels.push(formatDurationCompact(durationAtTick as IOtelSpan['duration']));
     }
   }
+
+  let labelStep = 1;
+  if (labels && containerWidth > 0 && numTicks > 1) {
+    const tickSpacing = containerWidth / (numTicks - 1);
+    while (tickSpacing * labelStep < MIN_LABEL_SPACING_PX && labelStep < numTicks) {
+      labelStep *= 2;
+    }
+  }
+
   const ticks: React.ReactNode[] = [];
   for (let i = 0; i < numTicks; i++) {
     const portion = i / (numTicks - 1);
+    const isLast = i === numTicks - 1;
+    const showLabel = labels != null && (i === 0 || isLast || i % labelStep === 0);
+    if (labels && !showLabel) continue;
     ticks.push(
       <div
         key={portion}
@@ -37,11 +67,15 @@ export default function Ticks({ endTime = null, numTicks, showLabels = null, sta
           left: `${portion * 100}%`,
         }}
       >
-        {labels && (
-          <span className={`Ticks--tickLabel ${portion >= 1 ? 'isEndAnchor' : ''}`}>{labels[i]}</span>
+        {showLabel && (
+          <span className={`Ticks--tickLabel ${portion >= 1 ? 'isEndAnchor' : ''}`}>{labels![i]}</span>
         )}
       </div>
     );
   }
-  return <div className="Ticks">{ticks}</div>;
+  return (
+    <div className="Ticks" ref={containerRef}>
+      {ticks}
+    </div>
+  );
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3767

## Description of the changes
- Added a `ResizeObserver` in the `Ticks` component to measure the timeline column width on mount and resize
- Intermediate tick labels are skipped using a power-of-2 step when they would overlap, so remaining labels stay evenly spaced
- The first and last labels are always shown regardless of column width

## How was this change tested?
- Added unit tests for the `Ticks` component covering label rendering, `isEndAnchor` class, and no-label case
- Manually verified in the browser by narrowing the timeline column (screenshots below)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes


## Before
<img width="1914" height="667" alt="Screenshot 2026-04-21 130622" src="https://github.com/user-attachments/assets/6dd8d50a-50f7-467b-a1d0-00f862377b2c" />

## After
<img width="1907" height="562" alt="Screenshot 2026-04-21 130759" src="https://github.com/user-attachments/assets/b9b4c0c1-5e9c-4fcf-8b3c-dcbbb3217341" />

<img width="1904" height="412" alt="Screenshot 2026-04-21 130831" src="https://github.com/user-attachments/assets/6cf02e85-342e-4fa8-bf96-4abca3ae1d29" />
