### PR TITLE
refactor(TraceTimelineViewer): decouple SpanTreeOffset from span model

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
@@ -9,19 +9,33 @@ import { describe, expect, it, vi } from 'vitest';
 import PrunedSpanRow from './PrunedSpanRow';
 import { IOtelSpan } from '../../../types/otel';
 
-vi.mock('./SpanTreeOffset', () =>
-  mockDefault(({ span, color }: { span: IOtelSpan; color: string }) => (
-    <span data-testid="span-tree-offset" data-depth={span.depth} data-color={color} />
-  ))
-);
+vi.mock('./SpanTreeOffset', () => {
+  return {
+    default: ({ ancestors, color }: { ancestors: any[]; color: string }) => (
+      <span data-testid="span-tree-offset" data-depth={ancestors ? ancestors.length : 0} data-color={color} />
+    ),
+  };
+});
 
 function makeSpan(depth: number): IOtelSpan {
+  let current: IOtelSpan | undefined;
+  for (let i = 0; i < depth; i++) {
+    current = {
+      spanID: `span-${i}`,
+      depth: i,
+      hasChildren: true,
+      childSpans: [],
+      resource: { serviceName: 'svc-a', attributes: [] },
+      parentSpan: current as any,
+    } as unknown as IOtelSpan;
+  }
   return {
-    spanID: 'span-1',
+    spanID: 'span-target',
     depth,
     hasChildren: true,
     childSpans: [],
     resource: { serviceName: 'svc-a', attributes: [] },
+    parentSpan: current as any,
   } as unknown as IOtelSpan;
 }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
@@ -8,73 +8,141 @@ import { describe, expect, it, vi } from 'vitest';
 
 import PrunedSpanRow from './PrunedSpanRow';
 import { IOtelSpan } from '../../../types/otel';
+import { SpanTreeOffsetState } from './utils';
+import colorGenerator from '../../../utils/color-generator';
 
-vi.mock('./SpanTreeOffset', () =>
-  mockDefault(({ span, color }: { span: IOtelSpan; color: string }) => (
-    <span data-testid="span-tree-offset" data-depth={span.depth} data-color={color} />
-  ))
-);
-
-function makeSpan(depth: number): IOtelSpan {
+vi.mock('./SpanTreeOffset', () => {
   return {
-    spanID: 'span-1',
+    default: ({ ancestors, color }: { ancestors: unknown[]; color: string }) => {
+      const lastAncestor =
+        ancestors && ancestors.length > 0 ? (ancestors[ancestors.length - 1] as { color: string }) : null;
+      return (
+        <span
+          data-testid="span-tree-offset"
+          data-depth={ancestors ? ancestors.length : 0}
+          data-color={color}
+          data-ancestor-color={lastAncestor?.color ?? ''}
+        />
+      );
+    },
+  };
+});
+
+/**
+ * Build a chain of `depth` parent spans and return the leaf span.
+ * Connects parentSpan pointers but does NOT build childSpans arrays,
+ * since buildTreeOffsetMap is not called here — we supply the map directly.
+ */
+function makeSpan(depth: number): IOtelSpan {
+  let current: IOtelSpan | undefined;
+  for (let i = 0; i < depth; i++) {
+    current = {
+      spanID: `span-${i}`,
+      depth: i,
+      hasChildren: true,
+      childSpans: [],
+      resource: { serviceName: 'svc-a', attributes: [] },
+      parentSpan: current as unknown as IOtelSpan,
+    } as unknown as IOtelSpan;
+  }
+  return {
+    spanID: 'span-target',
     depth,
     hasChildren: true,
     childSpans: [],
     resource: { serviceName: 'svc-a', attributes: [] },
+    parentSpan: current as unknown as IOtelSpan,
   } as unknown as IOtelSpan;
+}
+
+/** Build a minimal treeOffsetMap with one entry for parentSpan. */
+function makeMap(
+  parentSpan: IOtelSpan,
+  state?: Partial<SpanTreeOffsetState>
+): Map<string, SpanTreeOffsetState> {
+  const map = new Map<string, SpanTreeOffsetState>();
+  map.set(parentSpan.spanID, {
+    ancestors: [],
+    isLastChild: false,
+    ...state,
+  });
+  return map;
 }
 
 describe('PrunedSpanRow', () => {
   it('renders singular label for 1 pruned child', () => {
+    const parent = makeSpan(2);
     render(
       <PrunedSpanRow
-        parentSpan={makeSpan(2)}
+        parentSpan={parent}
         prunedChildrenCount={1}
         prunedErrorCount={0}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={makeMap(parent)}
       />
     );
     expect(screen.getByText('1 span pruned')).toBeInTheDocument();
   });
 
   it('renders plural label for multiple pruned children', () => {
+    const parent = makeSpan(1);
     render(
       <PrunedSpanRow
-        parentSpan={makeSpan(1)}
+        parentSpan={parent}
         prunedChildrenCount={5}
         prunedErrorCount={0}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={makeMap(parent)}
       />
     );
     expect(screen.getByText('5 spans pruned')).toBeInTheDocument();
   });
 
-  it('renders SpanTreeOffset at parent depth + 1 with gray color', () => {
+  it('renders SpanTreeOffset at parent depth + 1 with parentSpan service color (not grandparent color)', () => {
+    // parentSpan has depth=3 and 3 ancestors in the map, so the pruned
+    // placeholder adds one more => data-depth=4.
+    // IMPORTANT: selfAncestorEntry.color must come from parentSpan.resource.serviceName,
+    // NOT from parentState.parentColor (which is the grandparent's color).
+    const parent = makeSpan(3);
+    const ancestorEntries = [
+      { spanID: 'a0', color: '#aaa', isTerminated: false },
+      { spanID: 'a1', color: '#bbb', isTerminated: false },
+      { spanID: 'a2', color: '#ccc', isTerminated: false },
+    ];
+    const grandparentColor = '#ddd'; // parentState.parentColor — should NOT be used for stripes
+    const map = makeMap(parent, { ancestors: ancestorEntries });
     render(
       <PrunedSpanRow
-        parentSpan={makeSpan(3)}
+        parentSpan={parent}
         prunedChildrenCount={2}
         prunedErrorCount={0}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={map}
       />
     );
     const offset = screen.getByTestId('span-tree-offset');
+    // ancestors = parentState.ancestors (3) + selfAncestorEntry (1) = 4
     expect(offset).toHaveAttribute('data-depth', '4');
-    expect(offset).toHaveAttribute('data-color', '#bbb');
+    // Color must be derived from parentSpan's own serviceName, not from grandparentColor.
+    // selfAncestorEntry (the last entry in ancestors) holds parentSpan's color.
+    const expectedColor = colorGenerator.getColorByKey(parent.resource.serviceName);
+    expect(offset).toHaveAttribute('data-ancestor-color', expectedColor);
+    expect(offset).not.toHaveAttribute('data-ancestor-color', grandparentColor);
   });
 
   it('renders label inside endpoint-name (operation name font size)', () => {
+    const parent = makeSpan(0);
     const { container } = render(
       <PrunedSpanRow
-        parentSpan={makeSpan(0)}
+        parentSpan={parent}
         prunedChildrenCount={3}
         prunedErrorCount={0}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={makeMap(parent)}
       />
     );
     const small = container.querySelector('.endpoint-name');
@@ -83,39 +151,45 @@ describe('PrunedSpanRow', () => {
   });
 
   it('includes error count in label when errors are present', () => {
+    const parent = makeSpan(0);
     render(
       <PrunedSpanRow
-        parentSpan={makeSpan(0)}
+        parentSpan={parent}
         prunedChildrenCount={5}
         prunedErrorCount={2}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={makeMap(parent)}
       />
     );
     expect(screen.getByText('5 spans pruned, 2 errors')).toBeInTheDocument();
   });
 
   it('uses singular "error" for 1 error', () => {
+    const parent = makeSpan(0);
     render(
       <PrunedSpanRow
-        parentSpan={makeSpan(0)}
+        parentSpan={parent}
         prunedChildrenCount={3}
         prunedErrorCount={1}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={makeMap(parent)}
       />
     );
     expect(screen.getByText('3 spans pruned, 1 error')).toBeInTheDocument();
   });
 
   it('renders hollow error icon when errors are present', () => {
+    const parent = makeSpan(0);
     const { container } = render(
       <PrunedSpanRow
-        parentSpan={makeSpan(0)}
+        parentSpan={parent}
         prunedChildrenCount={5}
         prunedErrorCount={2}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={makeMap(parent)}
       />
     );
     const icon = container.querySelector('.SpanBarRow--errorIcon');
@@ -124,13 +198,15 @@ describe('PrunedSpanRow', () => {
   });
 
   it('does not render error icon when no errors', () => {
+    const parent = makeSpan(0);
     const { container } = render(
       <PrunedSpanRow
-        parentSpan={makeSpan(0)}
+        parentSpan={parent}
         prunedChildrenCount={5}
         prunedErrorCount={0}
         nameColumnWidth={0.5}
         timelineBarsVisible={true}
+        treeOffsetMap={makeMap(parent)}
       />
     );
     expect(container.querySelector('.SpanBarRow--errorIcon')).not.toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
@@ -7,6 +7,7 @@ import { IoAlert } from 'react-icons/io5';
 import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
 import { IOtelSpan } from '../../../types/otel';
+import colorGenerator from '../../../utils/color-generator';
 
 import './PrunedSpanRow.css';
 
@@ -33,34 +34,50 @@ export default function PrunedSpanRow({
     prunedErrorCount > 0 ? `, ${prunedErrorCount} ${prunedErrorCount === 1 ? 'error' : 'errors'}` : '';
   const label = `${prunedChildrenCount} ${spanWord} pruned${errorSuffix}`;
 
-  // Create a fake span so SpanTreeOffset renders proper tree lines and a dot
-  // at depth = parentSpan.depth + 1. Use a synthetic parent that appends the
-  // fake span as the last child so SpanTreeOffset correctly terminates the
-  // vertical tree line (it checks parentSpan.childSpans[last].spanID === spanID).
-  const fakeSpan = useMemo(() => {
-    const spanID = `${parentSpan.spanID}--pruned`;
-    const fake = {
-      spanID,
-      depth: parentSpan.depth + 1,
-      hasChildren: false,
-      childSpans: [],
-      parentSpan: null as unknown as IOtelSpan,
-      resource: parentSpan.resource,
-    } as unknown as IOtelSpan;
-    // Prototype-based copy: syntheticParent delegates all properties (including
-    // parentSpan for ancestor walks) to the real parentSpan, with only childSpans
-    // overridden. This lets SpanTreeOffset see the placeholder as the last child.
-    const syntheticParent = Object.create(parentSpan) as IOtelSpan;
-    (syntheticParent as unknown as { childSpans: IOtelSpan[] }).childSpans = [...parentSpan.childSpans, fake];
-    (fake as { parentSpan: IOtelSpan }).parentSpan = syntheticParent;
-    return fake;
+  // computes two things by walking span.parentSpan directly — no fake span, no prototype hacks.
+  const treeOffsetState = useMemo(() => {
+    const ancestorsArr: IOtelSpan[] = [];
+    let current: IOtelSpan | undefined = parentSpan;
+    while (current) {
+      ancestorsArr.unshift(current);
+      current = current.parentSpan;
+    }
+
+    const parentColor = colorGenerator.getColorByKey(parentSpan.resource.serviceName);
+
+    const ancestors = ancestorsArr.map((ancestor, index) => {
+      const isLastAncestor = index === ancestorsArr.length - 1;
+      let shouldTerminate = false;
+      if (isLastAncestor) {
+        shouldTerminate = true;
+      } else {
+        const descendantInChain = ancestorsArr[index + 1];
+        if (descendantInChain && descendantInChain.parentSpan) {
+          const parentChildren = descendantInChain.parentSpan.childSpans;
+          shouldTerminate = parentChildren[parentChildren.length - 1]?.spanID === descendantInChain.spanID;
+        }
+      }
+      return {
+        spanID: ancestor.spanID,
+        color: colorGenerator.getColorByKey(ancestor.resource.serviceName),
+        isTerminated: shouldTerminate,
+      };
+    });
+
+    return { ancestors, isLastChild: true, parentColor };
   }, [parentSpan]);
 
   return (
     <TimelineRow className="span-row PrunedSpanRow">
       <TimelineRow.Cell className="span-name-column" width={nameColumnWidth}>
         <div className="span-name-wrapper">
-          <SpanTreeOffset span={fakeSpan} color={PRUNED_DOT_COLOR} />
+          <SpanTreeOffset
+            spanID={`${parentSpan.spanID}--pruned`}
+            hasChildren={false}
+            childCount={0}
+            color={PRUNED_DOT_COLOR}
+            {...treeOffsetState}
+          />
           <span className="span-name PrunedSpanRow--name">
             <span className="span-svc-name">
               {prunedErrorCount > 0 && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
@@ -1,12 +1,14 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { IoAlert } from 'react-icons/io5';
 
 import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
 import { IOtelSpan } from '../../../types/otel';
+import { SpanTreeOffsetState } from './utils';
+import colorGenerator from '../../../utils/color-generator';
 
 import './PrunedSpanRow.css';
 
@@ -16,6 +18,7 @@ type PrunedSpanRowProps = {
   prunedErrorCount: number;
   nameColumnWidth: number;
   timelineBarsVisible: boolean;
+  treeOffsetMap: Map<string, SpanTreeOffsetState>;
 };
 
 // Gray color for the pruned placeholder dot (not tied to any service).
@@ -27,40 +30,47 @@ export default function PrunedSpanRow({
   prunedErrorCount,
   nameColumnWidth,
   timelineBarsVisible,
+  treeOffsetMap,
 }: PrunedSpanRowProps) {
   const spanWord = prunedChildrenCount === 1 ? 'span' : 'spans';
   const errorSuffix =
     prunedErrorCount > 0 ? `, ${prunedErrorCount} ${prunedErrorCount === 1 ? 'error' : 'errors'}` : '';
   const label = `${prunedChildrenCount} ${spanWord} pruned${errorSuffix}`;
 
-  // Create a fake span so SpanTreeOffset renders proper tree lines and a dot
-  // at depth = parentSpan.depth + 1. Use a synthetic parent that appends the
-  // fake span as the last child so SpanTreeOffset correctly terminates the
-  // vertical tree line (it checks parentSpan.childSpans[last].spanID === spanID).
-  const fakeSpan = useMemo(() => {
-    const spanID = `${parentSpan.spanID}--pruned`;
-    const fake = {
-      spanID,
-      depth: parentSpan.depth + 1,
-      hasChildren: false,
-      childSpans: [],
-      parentSpan: null as unknown as IOtelSpan,
-      resource: parentSpan.resource,
-    } as unknown as IOtelSpan;
-    // Prototype-based copy: syntheticParent delegates all properties (including
-    // parentSpan for ancestor walks) to the real parentSpan, with only childSpans
-    // overridden. This lets SpanTreeOffset see the placeholder as the last child.
-    const syntheticParent = Object.create(parentSpan) as IOtelSpan;
-    (syntheticParent as unknown as { childSpans: IOtelSpan[] }).childSpans = [...parentSpan.childSpans, fake];
-    (fake as { parentSpan: IOtelSpan }).parentSpan = syntheticParent;
-    return fake;
-  }, [parentSpan]);
+  // The pruned placeholder renders at the same depth as a real child of parentSpan.
+  // Look up parentSpan's own state from the map (O(1)) and derive the child's view:
+  // ancestors = parentSpan's ancestors + parentSpan itself; isLastChild = true since
+  // the placeholder is always rendered last after all visible siblings.
+  const parentState = treeOffsetMap.get(parentSpan.spanID) ?? {
+    ancestors: [],
+    isLastChild: false,
+  };
+
+  // Derive the color from parentSpan's own service name — NOT from
+  // parentState.parentColor, which is the *grandparent's* color.
+  const parentSpanColor = colorGenerator.getColorByKey(parentSpan.resource.serviceName);
+
+  const selfAncestorEntry = {
+    spanID: parentSpan.spanID,
+    color: parentSpanColor, // the stripe for parentSpan itself
+    isTerminated: true, // placeholder is always last — bar terminates here
+  };
+  const treeOffsetState: SpanTreeOffsetState = {
+    ancestors: [...parentState.ancestors, selfAncestorEntry],
+    isLastChild: true,
+  };
 
   return (
     <TimelineRow className="span-row PrunedSpanRow">
       <TimelineRow.Cell className="span-name-column" width={nameColumnWidth}>
         <div className="span-name-wrapper">
-          <SpanTreeOffset span={fakeSpan} color={PRUNED_DOT_COLOR} />
+          <SpanTreeOffset
+            spanID={`${parentSpan.spanID}--pruned`}
+            hasChildren={false}
+            childCount={0}
+            color={PRUNED_DOT_COLOR}
+            {...treeOffsetState}
+          />
           <span className="span-name PrunedSpanRow--name">
             <span className="span-svc-name">
               {prunedErrorCount > 0 && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -9,9 +9,9 @@ import SpanBarRow from './SpanBarRow';
 import SpanBar from './SpanBar';
 
 vi.mock('./SpanTreeOffset', () => ({
-  default: jest.fn(({ span, childrenVisible, onClick }) => (
+  default: jest.fn(({ spanID, childrenVisible, onClick }) => (
     <div data-testid="span-tree-offset" onClick={onClick}>
-      SpanTreeOffset: {span.spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
+      SpanTreeOffset: {spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
     </div>
   )),
 }));
@@ -36,6 +36,11 @@ vi.mock('./SpanBar', () => ({
 vi.mock('./utils', () => ({
   formatDuration: jest.fn(d => `formatted-${d}`),
   ViewedBoundsFunctionType: {},
+  buildSpanTreeOffsetState: jest.fn(() => ({
+    ancestors: [],
+    parentColor: 'test-parent-color',
+    isLastChild: true,
+  })),
 }));
 
 describe('<SpanBarRow>', () => {
@@ -78,6 +83,8 @@ describe('<SpanBarRow>', () => {
       instrumentationScope: { name: 'scope' },
       depth: 0,
       hasChildren: true,
+      childSpans: [],
+      parentSpan: null,
       relativeStartTime: 100,
       inboundLinks: [],
       warnings: null,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -9,9 +9,9 @@ import SpanBarRow from './SpanBarRow';
 import SpanBar from './SpanBar';
 
 vi.mock('./SpanTreeOffset', () => ({
-  default: jest.fn(({ span, childrenVisible, onClick }) => (
+  default: jest.fn(({ spanID, childrenVisible, onClick }) => (
     <div data-testid="span-tree-offset" onClick={onClick}>
-      SpanTreeOffset: {span.spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
+      SpanTreeOffset: {spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
     </div>
   )),
 }));
@@ -78,6 +78,8 @@ describe('<SpanBarRow>', () => {
       instrumentationScope: { name: 'scope' },
       depth: 0,
       hasChildren: true,
+      childSpans: [],
+      parentSpan: null,
       relativeStartTime: 100,
       inboundLinks: [],
       warnings: null,
@@ -86,6 +88,7 @@ describe('<SpanBarRow>', () => {
     traceDuration: 1000,
     focusSpan: jest.fn(),
     useOtelTerms: false,
+    treeOffsetMap: new Map([['some-id', { ancestors: [], isLastChild: false }]]),
   };
 
   beforeEach(() => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -9,6 +9,7 @@ import { formatDuration, ViewedBoundsFunctionType } from './utils';
 import SpanTreeOffset from './SpanTreeOffset';
 import SpanBar from './SpanBar';
 import Ticks from './Ticks';
+import { buildSpanTreeOffsetState } from './utils';
 
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
@@ -135,9 +136,12 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
         <div className={`span-name-wrapper ${isMatchingFilter ? 'is-matching-filter' : ''}`}>
           <SpanTreeOffset
             childrenVisible={isChildrenExpanded}
-            span={span}
+            spanID={span.spanID}
+            hasChildren={isParent}
+            childCount={span.childSpans.length}
             onClick={isParent ? _childrenToggle : undefined}
             color={color}
+            {...buildSpanTreeOffsetState(span)}
           />
           <a
             className={`span-name ${isDetailExpanded ? 'is-detail-expanded' : ''}`}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -5,7 +5,7 @@ import React, { useCallback } from 'react';
 import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
-import { formatDurationCompact, ViewedBoundsFunctionType } from './utils';
+import { formatDurationCompact, ViewedBoundsFunctionType, SpanTreeOffsetState } from './utils';
 import SpanTreeOffset from './SpanTreeOffset';
 import SpanBar from './SpanBar';
 import Ticks from './Ticks';
@@ -49,6 +49,7 @@ type SpanBarRowProps = {
   getViewedBounds: ViewedBoundsFunctionType;
   traceStartTime: number;
   span: IOtelSpan;
+  treeOffsetMap: Map<string, SpanTreeOffsetState>;
   focusSpan: (spanID: string) => void;
   traceDuration: number;
   useOtelTerms: boolean;
@@ -80,6 +81,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   getViewedBounds,
   traceStartTime,
   span,
+  treeOffsetMap,
   focusSpan,
   traceDuration,
   onDetailToggled,
@@ -130,6 +132,11 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   const hasLinks = span.links && span.links.length > 0;
   const hasInboundLinks = span.inboundLinks && span.inboundLinks.length > 0;
 
+  const treeOffsetState = treeOffsetMap.get(span.spanID) ?? {
+    ancestors: [],
+    isLastChild: false,
+  };
+
   return (
     <TimelineRow
       className={`
@@ -144,9 +151,12 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
         <div className={`span-name-wrapper ${isMatchingFilter ? 'is-matching-filter' : ''}`}>
           <SpanTreeOffset
             childrenVisible={isChildrenExpanded}
-            span={span}
+            spanID={span.spanID}
+            hasChildren={isParent}
+            childCount={span.childSpans.length}
             onClick={isParent ? _childrenToggle : undefined}
             color={color}
+            {...treeOffsetState}
           />
           <a
             className={`span-name ${isDetailExpanded ? 'is-detail-expanded' : ''}`}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
@@ -71,6 +71,8 @@ describe('<SpanDetailRow> icon behavior', () => {
     currentViewRangeTime: [0, 100],
     traceDuration: 1000,
     useOtelTerms: false,
+    timelineBarsVisible: true,
+    treeOffsetMap: new Map([]),
   };
 
   it('does not render expand/collapse icon even when span has children', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
@@ -30,6 +30,8 @@ describe('<SpanDetailRow>', () => {
     durationMicros: 100n,
     attributes: [],
     events: [],
+    hasChildren: false,
+    childSpans: [],
     resource: {
       serviceName: 'service',
       attributes: [],
@@ -91,7 +93,7 @@ describe('<SpanDetailRow>', () => {
     expect(MockSpanTreeOffset).toHaveBeenCalledTimes(1);
     expect(MockSpanTreeOffset).toHaveBeenCalledWith(
       expect.objectContaining({
-        span: props.span,
+        spanID: props.span.spanID,
         isDetailRow: true,
       })
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
@@ -30,6 +30,8 @@ describe('<SpanDetailRow>', () => {
     durationMicros: 100n,
     attributes: [],
     events: [],
+    hasChildren: false,
+    childSpans: [],
     resource: {
       serviceName: 'service',
       attributes: [],
@@ -55,6 +57,7 @@ describe('<SpanDetailRow>', () => {
     currentViewRangeTime: [0, 100],
     traceDuration: 1000,
     useOtelTerms: false,
+    treeOffsetMap: new Map([['some-id', { ancestors: [], isLastChild: false }]]),
   };
 
   beforeEach(() => {
@@ -91,7 +94,7 @@ describe('<SpanDetailRow>', () => {
     expect(MockSpanTreeOffset).toHaveBeenCalledTimes(1);
     expect(MockSpanTreeOffset).toHaveBeenCalledWith(
       expect.objectContaining({
-        span: props.span,
+        spanID: props.span.spanID,
         isDetailRow: true,
       })
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -7,6 +7,7 @@ import SpanDetail from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
 import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
+import { buildSpanTreeOffsetState } from './utils';
 
 import { IOtelSpan, IAttribute, IEvent } from '../../../types/otel';
 import { Hyperlink } from '../../../types/hyperlink';
@@ -62,7 +63,15 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
     <TimelineRow className="detail-row">
       {timelineBarsVisible && (
         <TimelineRow.Cell width={nameColumnWidth}>
-          <SpanTreeOffset span={span} showChildrenIcon={false} isDetailRow color={color} />
+          <SpanTreeOffset
+            spanID={span.spanID}
+            hasChildren={span.hasChildren}
+            childCount={span.childSpans.length}
+            showChildrenIcon={false}
+            isDetailRow
+            color={color}
+            {...buildSpanTreeOffsetState(span)}
+          />
           <span>
             <span
               className="detail-row-expanded-accent"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -7,6 +7,7 @@ import SpanDetail from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
 import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
+import { SpanTreeOffsetState } from './utils';
 
 import { IOtelSpan, IAttribute, IEvent } from '../../../types/otel';
 import { Hyperlink } from '../../../types/hyperlink';
@@ -32,6 +33,7 @@ type SpanDetailRowProps = {
   currentViewRangeTime: [number, number];
   traceDuration: number;
   useOtelTerms: boolean;
+  treeOffsetMap: Map<string, SpanTreeOffsetState>;
 };
 
 const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
@@ -57,12 +59,25 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
     linksGetter,
     eventItemToggle,
     useOtelTerms,
+    treeOffsetMap,
   } = props;
+  const treeOffsetState = treeOffsetMap.get(span.spanID) ?? {
+    ancestors: [],
+    isLastChild: false,
+  };
   return (
     <TimelineRow className="detail-row">
       {timelineBarsVisible && (
         <TimelineRow.Cell width={nameColumnWidth}>
-          <SpanTreeOffset span={span} showChildrenIcon={false} isDetailRow color={color} />
+          <SpanTreeOffset
+            spanID={span.spanID}
+            hasChildren={span.hasChildren}
+            childCount={span.childSpans.length}
+            showChildrenIcon={false}
+            isDetailRow
+            color={color}
+            {...treeOffsetState}
+          />
           <span>
             <span
               className="detail-row-expanded-accent"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -15,49 +15,29 @@ describe('SpanTreeOffset', () => {
   const parentSpanID = 'parentSpanID';
   const rootSpanID = 'rootSpanID';
   let props;
-  let rootSpan;
-  let parentSpan;
-  let ownSpan;
 
   beforeEach(() => {
-    // Create span chain with parentSpan references
-    rootSpan = {
-      spanID: rootSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: null,
-      resource: { serviceName: 'root-service' },
-    };
-    parentSpan = {
-      spanID: parentSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: rootSpan,
-      resource: { serviceName: 'parent-service' },
-    };
-    ownSpan = {
+    props = {
+      addHoverIndentGuideId: vi.fn(),
+      hoverIndentGuideIds: new Set(),
+      removeHoverIndentGuideId: vi.fn(),
+      color: '#000000',
       spanID: ownSpanID,
       hasChildren: false,
-      childSpans: [],
-      parentSpan,
-      resource: { serviceName: 'own-service' },
-    };
-    rootSpan.childSpans = [parentSpan];
-    parentSpan.childSpans = [ownSpan];
-
-    props = {
-      addHoverIndentGuideId: jest.fn(),
-      hoverIndentGuideIds: new Set(),
-      removeHoverIndentGuideId: jest.fn(),
-      color: '#000000',
-      span: ownSpan,
+      childCount: 0,
+      isLastChild: true,
+      parentColor: '#111111',
+      ancestors: [
+        { spanID: rootSpanID, color: '#ff0000', isTerminated: false },
+        { spanID: parentSpanID, color: '#00ff00', isTerminated: false },
+      ],
     };
   });
 
   describe('.SpanTreeOffset--indentGuide', () => {
-    it('renders no .SpanTreeOffset--indentGuide if span has no ancestors', () => {
-      const propsWithRootSpan = { ...props, span: rootSpan };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithRootSpan} />);
+    it('renders no .SpanTreeOffset--indentGuide if array is empty', () => {
+      const propsWithNoAncestors = { ...props, ancestors: [] };
+      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithNoAncestors} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(0);
     });
@@ -117,38 +97,25 @@ describe('SpanTreeOffset', () => {
     });
 
     describe('is-last class (last-child span)', () => {
-      it('adds is-last to immediate parent guide when span is last child and isDetailRow is false', () => {
-        // ownSpan is the only (last) child of parentSpan
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+      it('adds is-last to immediate parent guide when isLastChild is true and isDetailRow is false', () => {
+        const { container } = render(<UnconnectedSpanTreeOffset {...props} isLastChild />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
       });
 
-      it('adds is-terminated (not is-last) to immediate parent guide when span is last child and isDetailRow is true', () => {
-        // ownSpan is the only (last) child of parentSpan
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} isDetailRow />);
+      it('adds is-terminated (not is-last) to immediate parent guide when isLastChild is true and isDetailRow is true', () => {
+        const { container } = render(<UnconnectedSpanTreeOffset {...props} isLastChild isDetailRow />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).toHaveClass('is-terminated');
       });
 
-      it('does not add is-last or is-terminated to immediate parent guide when span is not the last child', () => {
-        const siblingSpan = {
-          spanID: 'siblingSpanID',
-          hasChildren: false,
-          childSpans: [],
-          parentSpan,
-          resource: { serviceName: 'sibling-service' },
-        };
-        // ownSpan is no longer the last child
-        parentSpan.childSpans = [ownSpan, siblingSpan];
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+      it('does not add is-last or is-terminated to immediate parent guide when not the last child', () => {
+        const { container } = render(<UnconnectedSpanTreeOffset {...props} isLastChild={false} />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
-        // restore
-        parentSpan.childSpans = [ownSpan];
       });
     });
 
@@ -174,15 +141,11 @@ describe('SpanTreeOffset', () => {
 
     describe('self-guide in detail row (parent span)', () => {
       it('renders a self-guide when isDetailRow is true and span has children', () => {
-        const parentWithChildren = {
-          ...ownSpan,
-          hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
-        };
         const { getByTestId } = render(
           <UnconnectedSpanTreeOffset
             {...props}
-            span={parentWithChildren}
+            hasChildren
+            childCount={1}
             isDetailRow
             showChildrenIcon={false}
           />
@@ -194,20 +157,15 @@ describe('SpanTreeOffset', () => {
       });
 
       it('does not render a self-guide when isDetailRow is false', () => {
-        const parentWithChildren = {
-          ...ownSpan,
-          hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
-        };
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={parentWithChildren} showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset {...props} hasChildren childCount={1} showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
 
       it('does not render a self-guide when span has no children', () => {
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={ownSpan} isDetailRow showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset {...props} isDetailRow showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
@@ -215,44 +173,38 @@ describe('SpanTreeOffset', () => {
   });
 
   describe('icon', () => {
-    let renderResult;
-    let spanWithChildren;
-
-    beforeEach(() => {
-      spanWithChildren = { ...ownSpan, hasChildren: true, childSpans: [{}] };
-      const updatedProps = { ...props, span: spanWithChildren };
-      renderResult = render(<UnconnectedSpanTreeOffset {...updatedProps} />);
-    });
-
-    it('renders icon wrapper with dot if props.span.hasChildren is false', () => {
-      const propsWithoutChildren = { ...props, span: ownSpan };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithoutChildren} />);
+    it('renders icon wrapper with dot if hasChildren is false', () => {
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(container.querySelector('.SpanTreeOffset--dot')).not.toBeNull();
     });
 
-    it('does not render icon wrapper if props.span.hasChildren is true and showChildrenIcon is false', () => {
+    it('does not render icon wrapper if hasChildren is true and showChildrenIcon is false', () => {
       const propsWithIconDisabled = {
         ...props,
-        span: spanWithChildren,
+        hasChildren: true,
+        childCount: 1,
         showChildrenIcon: false,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithIconDisabled} />);
       expect(container.querySelector('.SpanTreeOffset--iconWrapper')).toBeNull();
     });
 
-    it('renders icon wrapper with child count if props.span.hasChildren is true and props.childrenVisible is false', () => {
-      const { container } = renderResult;
+    it('renders icon wrapper with child count if hasChildren is true and childrenVisible is false', () => {
+      const { container } = render(
+        <UnconnectedSpanTreeOffset {...props} hasChildren childCount={1} childrenVisible={false} />
+      );
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(iconWrapper.textContent).toBe('1'); // One child
     });
 
-    it('renders icon wrapper if props.span.hasChildren is true and props.childrenVisible is true', () => {
+    it('renders icon wrapper if hasChildren is true and childrenVisible is true', () => {
       const propsWithVisibleChildren = {
         ...props,
-        span: spanWithChildren,
+        hasChildren: true,
+        childCount: 1,
         childrenVisible: true,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithVisibleChildren} />);
@@ -260,7 +212,7 @@ describe('SpanTreeOffset', () => {
     });
 
     it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      const { container } = renderResult;
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       fireEvent.mouseEnter(iconWrapper, {});
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
@@ -268,7 +220,7 @@ describe('SpanTreeOffset', () => {
     });
 
     it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      const { container } = renderResult;
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       fireEvent.mouseLeave(iconWrapper, {});
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -15,49 +15,28 @@ describe('SpanTreeOffset', () => {
   const parentSpanID = 'parentSpanID';
   const rootSpanID = 'rootSpanID';
   let props;
-  let rootSpan;
-  let parentSpan;
-  let ownSpan;
 
   beforeEach(() => {
-    // Create span chain with parentSpan references
-    rootSpan = {
-      spanID: rootSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: null,
-      resource: { serviceName: 'root-service' },
-    };
-    parentSpan = {
-      spanID: parentSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: rootSpan,
-      resource: { serviceName: 'parent-service' },
-    };
-    ownSpan = {
+    props = {
+      addHoverIndentGuideId: vi.fn(),
+      hoverIndentGuideIds: new Set(),
+      removeHoverIndentGuideId: vi.fn(),
+      color: '#000000',
       spanID: ownSpanID,
       hasChildren: false,
-      childSpans: [],
-      parentSpan,
-      resource: { serviceName: 'own-service' },
-    };
-    rootSpan.childSpans = [parentSpan];
-    parentSpan.childSpans = [ownSpan];
-
-    props = {
-      addHoverIndentGuideId: jest.fn(),
-      hoverIndentGuideIds: new Set(),
-      removeHoverIndentGuideId: jest.fn(),
-      color: '#000000',
-      span: ownSpan,
+      childCount: 0,
+      isLastChild: true,
+      ancestors: [
+        { spanID: rootSpanID, color: '#ff0000', isTerminated: false },
+        { spanID: parentSpanID, color: '#00ff00', isTerminated: false },
+      ],
     };
   });
 
   describe('.SpanTreeOffset--indentGuide', () => {
-    it('renders no .SpanTreeOffset--indentGuide if span has no ancestors', () => {
-      const propsWithRootSpan = { ...props, span: rootSpan };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithRootSpan} />);
+    it('renders no .SpanTreeOffset--indentGuide if array is empty', () => {
+      const propsWithNoAncestors = { ...props, ancestors: [] };
+      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithNoAncestors} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(0);
     });
@@ -117,38 +96,25 @@ describe('SpanTreeOffset', () => {
     });
 
     describe('is-last class (last-child span)', () => {
-      it('adds is-last to immediate parent guide when span is last child and isDetailRow is false', () => {
-        // ownSpan is the only (last) child of parentSpan
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+      it('adds is-last to immediate parent guide when isLastChild is true and isDetailRow is false', () => {
+        const { container } = render(<UnconnectedSpanTreeOffset {...props} isLastChild />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
       });
 
-      it('adds is-terminated (not is-last) to immediate parent guide when span is last child and isDetailRow is true', () => {
-        // ownSpan is the only (last) child of parentSpan
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} isDetailRow />);
+      it('adds is-terminated (not is-last) to immediate parent guide when isLastChild is true and isDetailRow is true', () => {
+        const { container } = render(<UnconnectedSpanTreeOffset {...props} isLastChild isDetailRow />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).toHaveClass('is-terminated');
       });
 
-      it('does not add is-last or is-terminated to immediate parent guide when span is not the last child', () => {
-        const siblingSpan = {
-          spanID: 'siblingSpanID',
-          hasChildren: false,
-          childSpans: [],
-          parentSpan,
-          resource: { serviceName: 'sibling-service' },
-        };
-        // ownSpan is no longer the last child
-        parentSpan.childSpans = [ownSpan, siblingSpan];
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+      it('does not add is-last or is-terminated to immediate parent guide when not the last child', () => {
+        const { container } = render(<UnconnectedSpanTreeOffset {...props} isLastChild={false} />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
-        // restore
-        parentSpan.childSpans = [ownSpan];
       });
     });
 
@@ -174,15 +140,11 @@ describe('SpanTreeOffset', () => {
 
     describe('self-guide in detail row (parent span)', () => {
       it('renders a self-guide when isDetailRow is true and span has children', () => {
-        const parentWithChildren = {
-          ...ownSpan,
-          hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
-        };
         const { getByTestId } = render(
           <UnconnectedSpanTreeOffset
             {...props}
-            span={parentWithChildren}
+            hasChildren
+            childCount={1}
             isDetailRow
             showChildrenIcon={false}
           />
@@ -194,20 +156,15 @@ describe('SpanTreeOffset', () => {
       });
 
       it('does not render a self-guide when isDetailRow is false', () => {
-        const parentWithChildren = {
-          ...ownSpan,
-          hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
-        };
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={parentWithChildren} showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset {...props} hasChildren childCount={1} showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
 
       it('does not render a self-guide when span has no children', () => {
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={ownSpan} isDetailRow showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset {...props} isDetailRow showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
@@ -215,44 +172,38 @@ describe('SpanTreeOffset', () => {
   });
 
   describe('icon', () => {
-    let renderResult;
-    let spanWithChildren;
-
-    beforeEach(() => {
-      spanWithChildren = { ...ownSpan, hasChildren: true, childSpans: [{}] };
-      const updatedProps = { ...props, span: spanWithChildren };
-      renderResult = render(<UnconnectedSpanTreeOffset {...updatedProps} />);
-    });
-
-    it('renders icon wrapper with dot if props.span.hasChildren is false', () => {
-      const propsWithoutChildren = { ...props, span: ownSpan };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithoutChildren} />);
+    it('renders icon wrapper with dot if hasChildren is false', () => {
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(container.querySelector('.SpanTreeOffset--dot')).not.toBeNull();
     });
 
-    it('does not render icon wrapper if props.span.hasChildren is true and showChildrenIcon is false', () => {
+    it('does not render icon wrapper if hasChildren is true and showChildrenIcon is false', () => {
       const propsWithIconDisabled = {
         ...props,
-        span: spanWithChildren,
+        hasChildren: true,
+        childCount: 1,
         showChildrenIcon: false,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithIconDisabled} />);
       expect(container.querySelector('.SpanTreeOffset--iconWrapper')).toBeNull();
     });
 
-    it('renders icon wrapper with child count if props.span.hasChildren is true and props.childrenVisible is false', () => {
-      const { container } = renderResult;
+    it('renders icon wrapper with child count if hasChildren is true and childrenVisible is false', () => {
+      const { container } = render(
+        <UnconnectedSpanTreeOffset {...props} hasChildren childCount={1} childrenVisible={false} />
+      );
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(iconWrapper.textContent).toBe('1'); // One child
     });
 
-    it('renders icon wrapper if props.span.hasChildren is true and props.childrenVisible is true', () => {
+    it('renders icon wrapper if hasChildren is true and childrenVisible is true', () => {
       const propsWithVisibleChildren = {
         ...props,
-        span: spanWithChildren,
+        hasChildren: true,
+        childCount: 1,
         childrenVisible: true,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithVisibleChildren} />);
@@ -260,7 +211,7 @@ describe('SpanTreeOffset', () => {
     });
 
     it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      const { container } = renderResult;
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       fireEvent.mouseEnter(iconWrapper, {});
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
@@ -268,7 +219,7 @@ describe('SpanTreeOffset', () => {
     });
 
     it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      const { container } = renderResult;
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       fireEvent.mouseLeave(iconWrapper, {});
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
@@ -278,7 +229,7 @@ describe('SpanTreeOffset', () => {
     it('calls onClick when Enter is pressed on the span wrapper', () => {
       const onClick = jest.fn();
       const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
+        <UnconnectedSpanTreeOffset {...props} hasChildren={true} onClick={onClick} />
       );
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: 'Enter' });
@@ -288,7 +239,7 @@ describe('SpanTreeOffset', () => {
     it('calls onClick when Space is pressed on the span wrapper', () => {
       const onClick = jest.fn();
       const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
+        <UnconnectedSpanTreeOffset {...props} hasChildren={true} onClick={onClick} />
       );
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: ' ' });
@@ -298,7 +249,7 @@ describe('SpanTreeOffset', () => {
     it('does not call onClick for other keys on the span wrapper', () => {
       const onClick = jest.fn();
       const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
+        <UnconnectedSpanTreeOffset {...props} hasChildren={true} onClick={onClick} />
       );
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: 'Tab' });
@@ -308,7 +259,7 @@ describe('SpanTreeOffset', () => {
     it('sets tabIndex on the span wrapper when onClick is provided', () => {
       const onClick = jest.fn();
       const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
+        <UnconnectedSpanTreeOffset {...props} hasChildren={true} onClick={onClick} />
       );
       const wrapper = container.querySelector('.SpanTreeOffset');
       expect(wrapper).toHaveAttribute('tabindex', '0');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import cx from 'classnames';
 import _get from 'lodash/get';
 import { connect } from 'react-redux';
@@ -9,14 +9,18 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { actions } from './duck';
 import { ReduxState } from '../../../types';
-import { IOtelSpan } from '../../../types/otel';
-import colorGenerator from '../../../utils/color-generator';
 
 import './SpanTreeOffset.css';
 
 type TDispatchProps = {
   addHoverIndentGuideId: (spanID: string) => void;
   removeHoverIndentGuideId: (spanID: string) => void;
+};
+
+export type SpanTreeOffsetAncestor = {
+  spanID: string;
+  color: string;
+  isTerminated: boolean;
 };
 
 type TProps = {
@@ -27,8 +31,13 @@ type TProps = {
   onClick?: () => void;
   showChildrenIcon?: boolean;
   isDetailRow?: boolean;
-  span: IOtelSpan;
+  spanID: string;
+  hasChildren: boolean;
+  childCount: number;
+  ancestors: SpanTreeOffsetAncestor[];
+  isLastChild: boolean;
   color: string;
+  parentColor: string | null;
 };
 
 export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
@@ -36,22 +45,16 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   onClick = undefined,
   showChildrenIcon = true,
   isDetailRow = false,
-  span,
+  spanID,
+  hasChildren,
+  childCount,
+  ancestors,
+  isLastChild,
+  color,
+  parentColor,
   addHoverIndentGuideId,
   removeHoverIndentGuideId,
-  color,
 }) => {
-  // Build ancestor chain directly from span.parentSpan
-  const ancestors = useMemo(() => {
-    const chain: IOtelSpan[] = [];
-    let current = span.parentSpan;
-    while (current) {
-      chain.unshift(current);
-      current = current.parentSpan;
-    }
-    return chain;
-  }, [span]);
-
   /**
    * If the mouse leaves to anywhere except another span with the same ancestor id, this span's ancestor id is
    * removed from the set of hoverIndentGuideIds.
@@ -86,42 +89,15 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     }
   };
 
-  const { hasChildren, spanID, childSpans } = span;
   const wrapperProps = hasChildren ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
-
-  // Get parent color for horizontal line
-  const parentSpan = span.parentSpan;
-  const parentColor = parentSpan ? colorGenerator.getColorByKey(parentSpan.resource.serviceName) : color;
-
-  // Check if this span is the last child of its parent
-  const isLastChild = parentSpan
-    ? parentSpan.childSpans[parentSpan.childSpans.length - 1]?.spanID === spanID
-    : false;
 
   return (
     <span className={`SpanTreeOffset ${hasChildren ? 'is-parent' : ''}`} {...wrapperProps}>
       {ancestors.map((ancestor, index) => {
         // Determine the color for this indent guide based on the ancestor
-        const guideColor = colorGenerator.getColorByKey(ancestor.resource.serviceName);
+        const guideColor = ancestor.color;
         const isLastAncestor = index === ancestors.length - 1;
-
-        // For the immediate parent: check if current span is last child
-        // For non-immediate ancestors: check if the ancestor's branch has terminated
-        // (i.e., the descendant of this ancestor in the chain is the last child of its parent)
-        let shouldTerminate = false;
-
-        if (isLastAncestor) {
-          // For immediate parent, check if current span is last child
-          shouldTerminate = isLastChild;
-        } else {
-          // For non-immediate ancestors, check if their descendant in the chain is the last child
-          // The descendant of this ancestor in the chain is at index + 1
-          const descendantInChain = ancestors[index + 1];
-          if (descendantInChain && descendantInChain.parentSpan) {
-            const parentChildren = descendantInChain.parentSpan.childSpans;
-            shouldTerminate = parentChildren[parentChildren.length - 1]?.spanID === descendantInChain.spanID;
-          }
-        }
+        const shouldTerminate = ancestor.isTerminated;
 
         return (
           <span
@@ -142,7 +118,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
             onMouseEnter={event => handleMouseEnter(event, ancestor.spanID)}
             onMouseLeave={event => handleMouseLeave(event, ancestor.spanID)}
           >
-            {isLastAncestor && !isDetailRow && (
+            {isLastAncestor && !isDetailRow && parentColor && (
               <span className="SpanTreeOffset--horizontalLine" style={{ backgroundColor: parentColor }} />
             )}
           </span>
@@ -170,7 +146,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
                 backgroundColor: !childrenVisible ? color : undefined,
               }}
             >
-              {childSpans.length}
+              {childCount}
             </span>
           ) : (
             <span className="SpanTreeOffset--dot" style={{ backgroundColor: color }} />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import cx from 'classnames';
 import _get from 'lodash/get';
 import { connect } from 'react-redux';
@@ -9,8 +9,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { actions } from './duck';
 import { ReduxState } from '../../../types';
-import { IOtelSpan } from '../../../types/otel';
-import colorGenerator from '../../../utils/color-generator';
+import type { SpanTreeOffsetAncestor } from './utils';
 
 import './SpanTreeOffset.css';
 
@@ -18,6 +17,8 @@ type TDispatchProps = {
   addHoverIndentGuideId: (spanID: string) => void;
   removeHoverIndentGuideId: (spanID: string) => void;
 };
+
+export type { SpanTreeOffsetAncestor };
 
 type TProps = {
   addHoverIndentGuideId: (spanID: string) => void;
@@ -27,7 +28,11 @@ type TProps = {
   onClick?: () => void;
   showChildrenIcon?: boolean;
   isDetailRow?: boolean;
-  span: IOtelSpan;
+  spanID: string;
+  hasChildren: boolean;
+  childCount: number;
+  ancestors: SpanTreeOffsetAncestor[];
+  isLastChild: boolean;
   color: string;
 };
 
@@ -36,22 +41,15 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   onClick = undefined,
   showChildrenIcon = true,
   isDetailRow = false,
-  span,
+  spanID,
+  hasChildren,
+  childCount,
+  ancestors,
+  isLastChild,
+  color,
   addHoverIndentGuideId,
   removeHoverIndentGuideId,
-  color,
 }) => {
-  // Build ancestor chain directly from span.parentSpan
-  const ancestors = useMemo(() => {
-    const chain: IOtelSpan[] = [];
-    let current = span.parentSpan;
-    while (current) {
-      chain.unshift(current);
-      current = current.parentSpan;
-    }
-    return chain;
-  }, [span]);
-
   /**
    * If the mouse leaves to anywhere except another span with the same ancestor id, this span's ancestor id is
    * removed from the set of hoverIndentGuideIds.
@@ -86,7 +84,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     }
   };
 
-  const { hasChildren, spanID, childSpans } = span;
   const _childrenToggleKeyDown = (e: React.KeyboardEvent) => {
     if ((e.key === 'Enter' || e.key === ' ') && onClick) {
       e.preventDefault();
@@ -107,47 +104,21 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
       }
     : null;
 
-  // Get parent color for horizontal line
-  const parentSpan = span.parentSpan;
-  const parentColor = parentSpan ? colorGenerator.getColorByKey(parentSpan.resource.serviceName) : color;
-
-  // Check if this span is the last child of its parent
-  const isLastChild = parentSpan
-    ? parentSpan.childSpans[parentSpan.childSpans.length - 1]?.spanID === spanID
-    : false;
-
   return (
     <span className={`SpanTreeOffset ${hasChildren ? 'is-parent' : ''}`} {...wrapperProps}>
       {ancestors.map((ancestor, index) => {
         // Determine the color for this indent guide based on the ancestor
-        const guideColor = colorGenerator.getColorByKey(ancestor.resource.serviceName);
+        const guideColor = ancestor.color;
         const isLastAncestor = index === ancestors.length - 1;
-
-        // For the immediate parent: check if current span is last child
-        // For non-immediate ancestors: check if the ancestor's branch has terminated
-        // (i.e., the descendant of this ancestor in the chain is the last child of its parent)
-        let shouldTerminate = false;
-
-        if (isLastAncestor) {
-          // For immediate parent, check if current span is last child
-          shouldTerminate = isLastChild;
-        } else {
-          // For non-immediate ancestors, check if their descendant in the chain is the last child
-          // The descendant of this ancestor in the chain is at index + 1
-          const descendantInChain = ancestors[index + 1];
-          if (descendantInChain && descendantInChain.parentSpan) {
-            const parentChildren = descendantInChain.parentSpan.childSpans;
-            shouldTerminate = parentChildren[parentChildren.length - 1]?.spanID === descendantInChain.spanID;
-          }
-        }
+        const shouldTerminate = ancestor.isTerminated;
 
         return (
           <span
             key={ancestor.spanID}
             className={cx('SpanTreeOffset--indentGuide', {
-              // In a span bar row: show top-half line to connect to the horizontal bar
-              // In a detail row: treat the same case as terminated (no line) since the
-              // branch already terminated at the span row above
+              // Half-height connector on the last ancestor guide for non-detail rows.
+              // isTerminated only suppresses the *full-height* bar for non-immediate
+              // ancestors; the immediate-parent connector is controlled by isLastChild alone.
               'is-last': !isDetailRow && isLastAncestor && isLastChild,
               'is-terminated':
                 (!isLastAncestor && shouldTerminate) || (isDetailRow && isLastAncestor && isLastChild),
@@ -161,7 +132,10 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
             onMouseLeave={event => handleMouseLeave(event, ancestor.spanID)}
           >
             {isLastAncestor && !isDetailRow && (
-              <span className="SpanTreeOffset--horizontalLine" style={{ backgroundColor: parentColor }} />
+              <span
+                className="SpanTreeOffset--horizontalLine"
+                style={{ backgroundColor: ancestors.at(-1)?.color ?? color }}
+              />
             )}
           </span>
         );
@@ -188,7 +162,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
                 backgroundColor: !childrenVisible ? color : undefined,
               }}
             >
-              {childSpans.length}
+              {childCount}
             </span>
           ) : (
             <span className="SpanTreeOffset--dot" style={{ backgroundColor: color }} />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -25,6 +25,8 @@ import {
   isKindClient,
   isKindProducer,
   spanContainsErredSpan,
+  buildTreeOffsetMap,
+  SpanTreeOffsetState,
 } from './utils';
 import { Accessors } from '../ScrollManager';
 import { extractUiFindFromState, TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
@@ -212,10 +214,26 @@ const memoizedPrunedCriticalPaths = memoizeOne(
 // export from tests
 export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceViewProps> {
   listView: ListView | TNil;
+
+  // Instance-level cache for the tree-offset map. Scoped per instance so
+  // multiple mounted VirtualizedTraceViews don't thrash a shared module-level
+  // memoization slot. Rebuilt only when trace.spans reference changes.
+  private _treeOffsetMap: Map<string, SpanTreeOffsetState> | null = null;
+  private _treeOffsetMapSpans: IOtelTrace['spans'] | null = null;
+
   constructor(props: VirtualizedTraceViewProps) {
     super(props);
     const { setTrace, trace, uiFind } = props;
     setTrace(trace, uiFind);
+  }
+
+  getTreeOffsetMap(): Map<string, SpanTreeOffsetState> {
+    const { spans } = this.props.trace;
+    if (this._treeOffsetMapSpans !== spans || this._treeOffsetMap === null) {
+      this._treeOffsetMapSpans = spans;
+      this._treeOffsetMap = buildTreeOffsetMap(spans);
+    }
+    return this._treeOffsetMap;
   }
 
   componentDidMount(): void {
@@ -425,11 +443,13 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
 
   renderRow = (key: string, style: React.CSSProperties, index: number, attrs: object) => {
     const row = this.getRowStates()[index];
+    const treeOffsetMap = this.getTreeOffsetMap();
     if ('isPrunedPlaceholder' in row) {
       return this.renderPrunedSpanRow(
         row.span,
         row.prunedChildrenCount,
         row.prunedErrorCount,
+        treeOffsetMap,
         key,
         style,
         attrs
@@ -437,8 +457,8 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     }
     const { isDetail, span, spanIndex } = row;
     return isDetail
-      ? this.renderSpanDetailRow(span, key, style, attrs)
-      : this.renderSpanBarRow(span, spanIndex, key, style, attrs);
+      ? this.renderSpanDetailRow(span, treeOffsetMap, key, style, attrs)
+      : this.renderSpanBarRow(span, spanIndex, treeOffsetMap, key, style, attrs);
   };
 
   /**
@@ -482,6 +502,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     parentSpan: IOtelSpan,
     prunedChildrenCount: number,
     prunedErrorCount: number,
+    treeOffsetMap: Map<string, SpanTreeOffsetState>,
     key: string,
     style: React.CSSProperties,
     attrs: object
@@ -495,6 +516,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           prunedErrorCount={prunedErrorCount}
           nameColumnWidth={nameColumnWidth}
           timelineBarsVisible={timelineBarsVisible}
+          treeOffsetMap={treeOffsetMap}
         />
       </div>
     );
@@ -503,6 +525,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
   renderSpanBarRow(
     span: IOtelSpan,
     spanIndex: number,
+    treeOffsetMap: Map<string, SpanTreeOffsetState>,
     key: string,
     style: React.CSSProperties,
     attrs: object
@@ -595,6 +618,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           getViewedBounds={this.getViewedBounds()}
           traceStartTime={trace.startTime}
           span={span}
+          treeOffsetMap={treeOffsetMap}
           focusSpan={this.focusSpan}
           traceDuration={trace.duration}
           useOtelTerms={useOtelTerms}
@@ -603,7 +627,13 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     );
   }
 
-  renderSpanDetailRow(span: IOtelSpan, key: string, style: React.CSSProperties, attrs: object) {
+  renderSpanDetailRow(
+    span: IOtelSpan,
+    treeOffsetMap: Map<string, SpanTreeOffsetState>,
+    key: string,
+    style: React.CSSProperties,
+    attrs: object
+  ) {
     const { spanID } = span;
     const { serviceName } = span.resource;
     const {
@@ -648,6 +678,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           currentViewRangeTime={currentViewRangeTime}
           traceDuration={trace.duration}
           useOtelTerms={useOtelTerms}
+          treeOffsetMap={treeOffsetMap}
         />
       </div>
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
@@ -8,6 +8,7 @@ import {
   spanContainsErredSpan,
   isKindClient,
   isKindProducer,
+  buildTreeOffsetMap,
 } from './utils';
 
 import traceGenerator from '../../../demo/trace-generators';
@@ -157,6 +158,116 @@ describe('TraceTimelineViewer/utils', () => {
     it('returns false when span kind is not PRODUCER', () => {
       const span = { kind: SpanKind.CLIENT };
       expect(isKindProducer(span)).toBe(false);
+    });
+  });
+
+  describe('buildTreeOffsetMap()', () => {
+    // Minimal span factory — only the fields touched by buildTreeOffsetMap.
+    const makeSpan = (spanID, depth, parentSpan, childSpans, serviceName = 'svc') => ({
+      spanID,
+      depth,
+      parentSpan: parentSpan ?? null,
+      childSpans: childSpans ?? [],
+      resource: { serviceName },
+    });
+
+    it('returns empty map for empty span array', () => {
+      const result = buildTreeOffsetMap([]);
+      expect(result.size).toBe(0);
+    });
+
+    it('root span gets empty ancestors and isLastChild=false', () => {
+      const root = makeSpan('root', 0, null, []);
+      const map = buildTreeOffsetMap([root]);
+      expect(map.get('root')).toEqual({
+        ancestors: [],
+        isLastChild: false,
+      });
+    });
+
+    it('single child gets one ancestor entry and isLastChild=true', () => {
+      const root = makeSpan('root', 0, null, [], 'root-svc');
+      const child = makeSpan('child', 1, root, [], 'child-svc');
+      root.childSpans = [child];
+      const map = buildTreeOffsetMap([root, child]);
+      const childState = map.get('child');
+      expect(childState.ancestors).toHaveLength(1);
+      expect(childState.ancestors[0].spanID).toBe('root');
+      expect(childState.isLastChild).toBe(true);
+    });
+
+    it('siblings share the same ancestors array object (referential equality)', () => {
+      const root = makeSpan('root', 0, null, [], 'root-svc');
+      const c1 = makeSpan('c1', 1, root, [], 'svc');
+      const c2 = makeSpan('c2', 1, root, [], 'svc');
+      root.childSpans = [c1, c2];
+      const map = buildTreeOffsetMap([root, c1, c2]);
+      // Both children have root as their only ancestor. The array should be the
+      // same object (shared, not re-allocated per sibling).
+      expect(map.get('c1').ancestors).toBe(map.get('c2').ancestors);
+    });
+
+    it('first sibling has isLastChild=false, last sibling has isLastChild=true', () => {
+      const root = makeSpan('root', 0, null, [], 'root-svc');
+      const c1 = makeSpan('c1', 1, root, [], 'svc');
+      const c2 = makeSpan('c2', 1, root, [], 'svc');
+      root.childSpans = [c1, c2];
+      const map = buildTreeOffsetMap([root, c1, c2]);
+      expect(map.get('c1').isLastChild).toBe(false);
+      expect(map.get('c2').isLastChild).toBe(true);
+    });
+
+    it('ancestor isTerminated reflects whether that ancestor was the last child of its parent', () => {
+      // Tree: root -> [c1, c2];  c1 -> [gc1]
+      // c1 is NOT last child of root (c2 is). So when rendering gc1,
+      // the ancestor entry for root should have isTerminated=false (bar continues down).
+      const root = makeSpan('root', 0, null, [], 'root-svc');
+      const c1 = makeSpan('c1', 1, root, [], 'svc');
+      const c2 = makeSpan('c2', 1, root, [], 'svc');
+      const gc1 = makeSpan('gc1', 2, c1, [], 'svc');
+      root.childSpans = [c1, c2];
+      c1.childSpans = [gc1];
+      const map = buildTreeOffsetMap([root, c1, gc1, c2]);
+      const gc1State = map.get('gc1');
+      // ancestors for gc1: [root, c1]
+      expect(gc1State.ancestors).toHaveLength(2);
+      // root is not terminated (c2 comes after c1 under root)
+      expect(gc1State.ancestors[0].spanID).toBe('root');
+      expect(gc1State.ancestors[0].isTerminated).toBe(false);
+      expect(gc1State.isLastChild).toBe(true); // gc1 is last child of c1
+    });
+
+    it('ancestor isTerminated is true for a descendant under the last sibling', () => {
+      // Tree: root -> [c1, c2]; c2 -> [gc2]
+      // c2 IS the last child of root. When rendering gc2 the ancestor entry
+      // for root must have isTerminated=true (bar stops — no more siblings).
+      const root = makeSpan('root', 0, null, [], 'root-svc');
+      const c1 = makeSpan('c1', 1, root, [], 'svc');
+      const c2 = makeSpan('c2', 1, root, [], 'svc');
+      const gc2 = makeSpan('gc2', 2, c2, [], 'svc');
+      root.childSpans = [c1, c2];
+      c2.childSpans = [gc2];
+      const map = buildTreeOffsetMap([root, c1, c2, gc2]);
+      const gc2State = map.get('gc2');
+      // ancestors for gc2: [root, c2]
+      expect(gc2State.ancestors).toHaveLength(2);
+      // root.isTerminated must be true — c2 is root's last child
+      expect(gc2State.ancestors[0].spanID).toBe('root');
+      expect(gc2State.ancestors[0].isTerminated).toBe(true);
+      // c2.isTerminated must be true — gc2 is c2's last child
+      expect(gc2State.ancestors[1].spanID).toBe('c2');
+      expect(gc2State.ancestors[1].isTerminated).toBe(true);
+      expect(gc2State.isLastChild).toBe(true);
+    });
+
+    it('grandchild depth produces correct ancestor chain length', () => {
+      const root = makeSpan('root', 0, null, [], 'svc');
+      const child = makeSpan('child', 1, root, [], 'svc');
+      const grandchild = makeSpan('gc', 2, child, [], 'svc');
+      root.childSpans = [child];
+      child.childSpans = [grandchild];
+      const map = buildTreeOffsetMap([root, child, grandchild]);
+      expect(map.get('gc').ancestors).toHaveLength(2);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { IOtelSpan, SpanKind, StatusCode } from '../../../types/otel';
+import colorGenerator from '../../../utils/color-generator';
+import { SpanTreeOffsetAncestor } from './SpanTreeOffset';
 
 export type ViewedBoundsFunctionType = (start: number, end: number) => { start: number; end: number };
 /**
@@ -97,5 +99,51 @@ export function findServerChildSpan(spans: ReadonlyArray<IOtelSpan>): IOtelSpan 
 export const isKindClient = (span: IOtelSpan): boolean => span.kind === SpanKind.CLIENT;
 
 export const isKindProducer = (span: IOtelSpan): boolean => span.kind === SpanKind.PRODUCER;
+
+type SpanTreeOffsetState = {
+  ancestors: SpanTreeOffsetAncestor[];
+  isLastChild: boolean;
+  parentColor: string | null;
+};
+
+export function buildSpanTreeOffsetState(span: IOtelSpan): SpanTreeOffsetState {
+  const ancestorsArr: IOtelSpan[] = [];
+  let current = span.parentSpan;
+  while (current) {
+    ancestorsArr.unshift(current);
+    current = current.parentSpan;
+  }
+
+  const isLastChild = span.parentSpan
+    ? span.parentSpan.childSpans[span.parentSpan.childSpans.length - 1]?.spanID === span.spanID
+    : false;
+
+  const parentColor = span.parentSpan
+    ? colorGenerator.getColorByKey(span.parentSpan.resource.serviceName)
+    : null;
+
+  const ancestors = ancestorsArr.map((ancestor, index) => {
+    const isLastAncestor = index === ancestorsArr.length - 1;
+    let shouldTerminate = false;
+
+    if (isLastAncestor) {
+      shouldTerminate = isLastChild;
+    } else {
+      const descendantInChain = ancestorsArr[index + 1];
+      if (descendantInChain && descendantInChain.parentSpan) {
+        const parentChildren = descendantInChain.parentSpan.childSpans;
+        shouldTerminate = parentChildren[parentChildren.length - 1]?.spanID === descendantInChain.spanID;
+      }
+    }
+
+    return {
+      spanID: ancestor.spanID,
+      color: colorGenerator.getColorByKey(ancestor.resource.serviceName),
+      isTerminated: shouldTerminate,
+    };
+  });
+
+  return { ancestors, isLastChild, parentColor };
+}
 
 export { formatDuration } from '../../../utils/date';

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
@@ -2,6 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { IOtelSpan, SpanKind, StatusCode } from '../../../types/otel';
+import colorGenerator from '../../../utils/color-generator';
+
+/**
+ * Describes one ancestor level rendered as an indent-guide stripe.
+ * Shared across all siblings at the same depth (allocated once per parent).
+ */
+export type SpanTreeOffsetAncestor = {
+  spanID: string;
+  color: string;
+  isTerminated: boolean;
+};
+
+export type SpanTreeOffsetState = {
+  ancestors: SpanTreeOffsetAncestor[];
+  isLastChild: boolean;
+  // parentColor is intentionally omitted — consumers derive it as
+  // `ancestors.at(-1)?.color ?? ownColor`, eliminating one source of
+  // caller/callee inconsistency.
+};
 
 export type ViewedBoundsFunctionType = (start: number, end: number) => { start: number; end: number };
 /**
@@ -97,5 +116,104 @@ export function findServerChildSpan(spans: ReadonlyArray<IOtelSpan>): IOtelSpan 
 export const isKindClient = (span: IOtelSpan): boolean => span.kind === SpanKind.CLIENT;
 
 export const isKindProducer = (span: IOtelSpan): boolean => span.kind === SpanKind.PRODUCER;
+/**
+ * Build the tree-offset state for every span in a single O(n) DFS pass.
+ *
+ * Spans must be in pre-order DFS order (parent before children, siblings
+ * sorted by startTime) — the same order guaranteed by trace normalization and
+ * relied on by generateRowStates.ts.
+ *
+ * Key optimisation (from code-review feedback): all siblings at the same depth
+ * share one `ancestors` array (allocated once per parent during the DFS).
+ * The only per-span variation is `isLastChild` (one bool). This keeps the
+ * total allocation O(max_depth) rather than O(n · depth).
+ *
+ * Mutable-snapshot invariant: `cachedAncestors[d]` is always rebuilt from the
+ * live stack when we enter the *first child* of a new subtree (i.e. when the
+ * cache entry is `undefined`). Mutations to live stack entries (isTerminated)
+ * happen *before* the next snapshot is taken, so every snapshot reflects the
+ * correct DFS state at that point.
+ *
+ * @param spans - Pre-order DFS array of spans from a normalised trace.
+ * @returns Map from spanID → SpanTreeOffsetState, looked up O(1) per row.
+ */
+export function buildTreeOffsetMap(spans: ReadonlyArray<IOtelSpan>): Map<string, SpanTreeOffsetState> {
+  const result = new Map<string, SpanTreeOffsetState>();
+
+  // stack[d] holds the ancestor entry for depth d that is currently open.
+  const stack: SpanTreeOffsetAncestor[] = [];
+
+  // cachedAncestors[d] is the shared ancestors array for all children of the
+  // span currently open at depth d-1. It is invalidated whenever we move to
+  // a new subtree so the next first-child gets a fresh live snapshot.
+  const cachedAncestors: (SpanTreeOffsetAncestor[] | undefined)[] = [];
+
+  for (const span of spans) {
+    const { depth } = span;
+
+    // Pop entries that are deeper than the current span's depth.
+    // Only invalidate cached ancestors for depths that are deeper than where
+    // we are landing — siblings at the same depth share the same snapshot.
+    while (stack.length > depth) {
+      stack.pop();
+      // Invalidate the cache for depths strictly above the current span's
+      // depth so descendent-level caches get rebuilt for the new subtree.
+      if (stack.length > depth) {
+        cachedAncestors[stack.length] = undefined;
+      }
+    }
+
+    // Determine whether this span is the last child of its parent.
+    const parentEntry = depth > 0 ? stack[depth - 1] : null;
+    const parentSpan = span.parentSpan;
+    const isLastChild = parentSpan
+      ? parentSpan.childSpans[parentSpan.childSpans.length - 1]?.spanID === span.spanID
+      : false;
+
+    // Build (or reuse) the shared ancestors array for this span.
+    // All children of the same parent share the same prefix — we only
+    // need to snapshot the stack once per parent, not once per child.
+    if (cachedAncestors[depth] === undefined) {
+      // Snapshot the live stack as the ancestors array for spans at this depth.
+      // We must use the live stack values (not a previously cached prefix) because
+      // ancestor.isTerminated is mutated as later siblings are processed.  A
+      // cached prefix from when the first sibling was built would carry stale
+      // isTerminated values for grandparent entries, causing descendants of the
+      // last sibling to incorrectly show grandparent guide-bars as continuing.
+      cachedAncestors[depth] = stack.map(entry => ({
+        spanID: entry.spanID,
+        color: entry.color,
+        isTerminated: entry.isTerminated,
+      }));
+    }
+    const ancestors = cachedAncestors[depth]!;
+
+    result.set(span.spanID, { ancestors, isLastChild });
+
+    // Push this span onto the stack so it becomes an ancestor for its children.
+    // isTerminated here reflects whether *this* span is the last child of its
+    // parent (the vertical bar drawn for this span terminates at this row).
+    const selfEntry: SpanTreeOffsetAncestor = {
+      spanID: span.spanID,
+      color: colorGenerator.getColorByKey(span.resource.serviceName),
+      isTerminated: isLastChild,
+    };
+    // Mutable-snapshot invariant: mutations to parentEntry.isTerminated happen
+    // here, *after* this span's ancestors snapshot is taken but *before* the
+    // next sibling enters the loop. When that sibling triggers a new snapshot
+    // (cachedAncestors[depth] === undefined, because we invalidate on pop),
+    // it sees the updated isTerminated value from the live stack. This is why
+    // the snapshot must read from the live stack and not from a cached prefix.
+    if (parentEntry !== null) {
+      parentEntry.isTerminated = isLastChild;
+    }
+    stack.push(selfEntry);
+    // Invalidate the cache for children of *this* span so they get a fresh
+    // ancestors snapshot including this span as their immediate parent.
+    cachedAncestors[depth + 1] = undefined;
+  }
+
+  return result;
+}
 
 export { formatDuration, formatDurationCompact } from '../../../utils/date';


### PR DESCRIPTION
Unifies the tree hierarchy calculation in a central utility function and makes SpanTreeOffset a pure rendering component. This eliminates the need for complex prototype hacks to render synthetic spans.



## Which problem is this PR solving?
Resolves #3770

## Description of the changes
refactored the SpanTreeOffset component to be a pure rendering widget and eliminated the internal tree traversal and dependency on the IOtelSpan model



## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
