### PR TITLE
Refactor: Simplify SpanTreeOffset to use precomputed ancestor data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -322,6 +322,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -651,6 +652,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -699,6 +701,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -709,6 +712,7 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -720,6 +724,7 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -771,7 +776,6 @@
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -899,7 +903,6 @@
       "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
@@ -915,7 +918,6 @@
       "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.1"
       },
@@ -929,7 +931,6 @@
       "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -943,7 +944,6 @@
       "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
@@ -954,7 +954,6 @@
       "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
@@ -987,7 +986,6 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -998,7 +996,6 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -1013,7 +1010,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -1028,7 +1024,6 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -1149,6 +1144,7 @@
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -1283,9 +1279,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1303,9 +1296,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1323,9 +1313,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1343,9 +1330,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,9 +1347,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1383,9 +1364,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1403,9 +1381,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1423,9 +1398,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3670,6 +3642,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3882,8 +3855,7 @@
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3946,6 +3918,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3956,6 +3929,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4644,6 +4618,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4657,7 +4632,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -4668,6 +4642,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4876,6 +4851,7 @@
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4968,6 +4944,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5469,6 +5446,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5571,7 +5549,8 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5624,8 +5603,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -5928,7 +5906,6 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6028,7 +6005,6 @@
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
@@ -6061,7 +6037,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6079,7 +6054,6 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -6093,7 +6067,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -6106,8 +6079,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -6115,7 +6087,6 @@
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
@@ -6134,7 +6105,6 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -6162,7 +6132,6 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -6176,7 +6145,6 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -6190,7 +6158,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6208,7 +6175,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6261,16 +6227,14 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -6305,7 +6269,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -6344,7 +6307,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -6378,7 +6340,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -6392,8 +6353,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -6863,7 +6823,6 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -7093,6 +7052,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7124,6 +7084,7 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -7213,8 +7174,7 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -7235,8 +7195,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json2mq": {
       "version": "0.2.0",
@@ -7285,7 +7244,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -7354,6 +7312,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7377,6 +7336,7 @@
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -7403,7 +7363,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -7751,7 +7710,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -8201,8 +8159,7 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/needle": {
       "version": "3.5.0",
@@ -8379,7 +8336,8 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/openapi-zod-client": {
       "version": "1.18.3",
@@ -8439,7 +8397,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -8623,6 +8580,7 @@
       "integrity": "sha512-/Uc9TQyN1l8w9QNvXtVHYtz+SzDJHKpb5X0UnHodl0BVzijUPk0LPlDOHAvogd1UI+iy9ZSF6gQxEqfzUxCULQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "tsgolint": "bin/tsgolint.js"
       },
@@ -8641,7 +8599,6 @@
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -8658,7 +8615,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -8766,7 +8722,6 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8917,7 +8872,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -9007,6 +8961,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9025,6 +8980,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9045,7 +9001,8 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-json-view-lite": {
       "version": "2.5.0",
@@ -9064,6 +9021,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9220,7 +9178,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-actions": {
       "version": "3.0.3",
@@ -9429,44 +9388,6 @@
         "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
-      }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "engines": {
-        "node": ">=11.0.0"
       }
     },
     "node_modules/safer-buffer": {
@@ -9882,6 +9803,7 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -9992,6 +9914,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10144,7 +10067,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -10158,6 +10080,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10260,7 +10183,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -10302,6 +10224,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10722,7 +10645,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10881,6 +10803,7 @@
       "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -10955,7 +10878,6 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10969,6 +10891,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11077,6 +11000,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -11133,6 +11057,7 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
@@ -10,10 +10,44 @@ import PrunedSpanRow from './PrunedSpanRow';
 import { IOtelSpan } from '../../../types/otel';
 
 vi.mock('./SpanTreeOffset', () =>
-  mockDefault(({ span, color }: { span: IOtelSpan; color: string }) => (
-    <span data-testid="span-tree-offset" data-depth={span.depth} data-color={color} />
-  ))
+  mockDefault(
+    ({
+      spanID,
+      hasChildren,
+      childCount,
+      ancestorEntries,
+      isLastChild,
+      color,
+    }: {
+      spanID: string;
+      hasChildren: boolean;
+      childCount: number;
+      ancestorEntries: { ancestorId: string; color: string | null }[];
+      isLastChild: boolean;
+      color: string;
+    }) => (
+      <span
+        data-testid="span-tree-offset"
+        data-span-id={spanID}
+        data-has-children={String(hasChildren)}
+        data-child-count={childCount}
+        data-ancestor-count={ancestorEntries.length}
+        data-is-last-child={String(isLastChild)}
+        data-color={color}
+      />
+    )
+  )
 );
+
+vi.mock('./span-tree-utils', () => ({
+  computeAncestorEntries: vi.fn(() => [{ ancestorId: 'grandparent', color: '#aaa' }]),
+}));
+
+vi.mock('../../../utils/color-generator', () => ({
+  default: {
+    getColorByKey: vi.fn(() => '#svc-color'),
+  },
+}));
 
 function makeSpan(depth: number): IOtelSpan {
   return {
@@ -52,7 +86,7 @@ describe('PrunedSpanRow', () => {
     expect(screen.getByText('5 spans pruned')).toBeInTheDocument();
   });
 
-  it('renders SpanTreeOffset at parent depth + 1 with gray color', () => {
+  it('renders SpanTreeOffset with precomputed data and gray color', () => {
     render(
       <PrunedSpanRow
         parentSpan={makeSpan(3)}
@@ -63,8 +97,13 @@ describe('PrunedSpanRow', () => {
       />
     );
     const offset = screen.getByTestId('span-tree-offset');
-    expect(offset).toHaveAttribute('data-depth', '4');
+    // spanID should be parentSpanID--pruned
+    expect(offset).toHaveAttribute('data-span-id', 'span-1--pruned');
+    expect(offset).toHaveAttribute('data-has-children', 'false');
+    expect(offset).toHaveAttribute('data-is-last-child', 'true');
     expect(offset).toHaveAttribute('data-color', '#bbb');
+    // ancestorEntries: parent's ancestors (mocked as 1) + parent itself = 2
+    expect(offset).toHaveAttribute('data-ancestor-count', '2');
   });
 
   it('renders label inside endpoint-name (operation name font size)', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
@@ -5,8 +5,11 @@ import React, { useMemo } from 'react';
 import { IoAlert } from 'react-icons/io5';
 
 import SpanTreeOffset from './SpanTreeOffset';
+import { computeAncestorEntries } from './span-tree-utils';
+import { AncestorEntry } from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
 import { IOtelSpan } from '../../../types/otel';
+import colorGenerator from '../../../utils/color-generator';
 
 import './PrunedSpanRow.css';
 
@@ -33,34 +36,32 @@ export default function PrunedSpanRow({
     prunedErrorCount > 0 ? `, ${prunedErrorCount} ${prunedErrorCount === 1 ? 'error' : 'errors'}` : '';
   const label = `${prunedChildrenCount} ${spanWord} pruned${errorSuffix}`;
 
-  // Create a fake span so SpanTreeOffset renders proper tree lines and a dot
-  // at depth = parentSpan.depth + 1. Use a synthetic parent that appends the
-  // fake span as the last child so SpanTreeOffset correctly terminates the
-  // vertical tree line (it checks parentSpan.childSpans[last].spanID === spanID).
-  const fakeSpan = useMemo(() => {
-    const spanID = `${parentSpan.spanID}--pruned`;
-    const fake = {
-      spanID,
-      depth: parentSpan.depth + 1,
-      hasChildren: false,
-      childSpans: [],
-      parentSpan: null as unknown as IOtelSpan,
-      resource: parentSpan.resource,
-    } as unknown as IOtelSpan;
-    // Prototype-based copy: syntheticParent delegates all properties (including
-    // parentSpan for ancestor walks) to the real parentSpan, with only childSpans
-    // overridden. This lets SpanTreeOffset see the placeholder as the last child.
-    const syntheticParent = Object.create(parentSpan) as IOtelSpan;
-    (syntheticParent as unknown as { childSpans: IOtelSpan[] }).childSpans = [...parentSpan.childSpans, fake];
-    (fake as { parentSpan: IOtelSpan }).parentSpan = syntheticParent;
-    return fake;
+  // Compute ancestor entries for the pruned row. The pruned placeholder sits at
+  // parentSpan.depth + 1, so we need all of parentSpan's ancestors plus parentSpan
+  // itself as the immediate parent. The pruned placeholder is always the "last child"
+  // so that the vertical tree line terminates correctly.
+  const ancestorEntries = useMemo((): AncestorEntry[] => {
+    // Get parent's own ancestor entries (these represent depth 0 → parentSpan's parent)
+    const parentEntries = computeAncestorEntries(parentSpan);
+    // Append parentSpan itself as the immediate parent of the pruned placeholder
+    const parentColor = colorGenerator.getColorByKey(parentSpan.resource.serviceName);
+    return [...parentEntries, { ancestorId: parentSpan.spanID, color: parentColor }];
   }, [parentSpan]);
+
+  const spanID = `${parentSpan.spanID}--pruned`;
 
   return (
     <TimelineRow className="span-row PrunedSpanRow">
       <TimelineRow.Cell className="span-name-column" width={nameColumnWidth}>
         <div className="span-name-wrapper">
-          <SpanTreeOffset span={fakeSpan} color={PRUNED_DOT_COLOR} />
+          <SpanTreeOffset
+            spanID={spanID}
+            hasChildren={false}
+            childCount={0}
+            ancestorEntries={ancestorEntries}
+            isLastChild={true}
+            color={PRUNED_DOT_COLOR}
+          />
           <span className="span-name PrunedSpanRow--name">
             <span className="span-svc-name">
               {prunedErrorCount > 0 && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
@@ -6,7 +6,7 @@ import { IoAlert } from 'react-icons/io5';
 
 import SpanTreeOffset from './SpanTreeOffset';
 import { computeAncestorEntries } from './span-tree-utils';
-import { AncestorEntry } from './SpanTreeOffset';
+import type { AncestorEntry } from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
 import { IOtelSpan } from '../../../types/otel';
 import colorGenerator from '../../../utils/color-generator';

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
@@ -8,7 +8,7 @@ import SpanTreeOffset from './SpanTreeOffset';
 import { computeAncestorEntries } from './span-tree-utils';
 import type { AncestorEntry } from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
-import { IOtelSpan } from '../../../types/otel';
+import type { IOtelSpan } from '../../../types/otel';
 import colorGenerator from '../../../utils/color-generator';
 
 import './PrunedSpanRow.css';

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -9,9 +9,9 @@ import SpanBarRow from './SpanBarRow';
 import SpanBar from './SpanBar';
 
 vi.mock('./SpanTreeOffset', () => ({
-  default: jest.fn(({ span, childrenVisible, onClick }) => (
+  default: jest.fn(({ spanID, childrenVisible, onClick }) => (
     <div data-testid="span-tree-offset" onClick={onClick}>
-      SpanTreeOffset: {span.spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
+      SpanTreeOffset: {spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
     </div>
   )),
 }));
@@ -36,6 +36,11 @@ vi.mock('./SpanBar', () => ({
 vi.mock('./utils', () => ({
   formatDuration: jest.fn(d => `formatted-${d}`),
   ViewedBoundsFunctionType: {},
+}));
+
+vi.mock('./span-tree-utils', () => ({
+  computeAncestorEntries: jest.fn(() => []),
+  computeIsLastChild: jest.fn(() => false),
 }));
 
 describe('<SpanBarRow>', () => {
@@ -78,6 +83,7 @@ describe('<SpanBarRow>', () => {
       instrumentationScope: { name: 'scope' },
       depth: 0,
       hasChildren: true,
+      childSpans: [],
       relativeStartTime: 100,
       inboundLinks: [],
       warnings: null,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDuration, ViewedBoundsFunctionType } from './utils';
 import SpanTreeOffset from './SpanTreeOffset';
+import { computeAncestorEntries, computeIsLastChild } from './span-tree-utils';
 import SpanBar from './SpanBar';
 import Ticks from './Ticks';
 
@@ -121,6 +122,10 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   const hasLinks = span.links && span.links.length > 0;
   const hasInboundLinks = span.inboundLinks && span.inboundLinks.length > 0;
 
+  // Precompute ancestor data for SpanTreeOffset
+  const ancestorEntries = useMemo(() => computeAncestorEntries(span), [span]);
+  const isLastChild = useMemo(() => computeIsLastChild(span), [span]);
+
   return (
     <TimelineRow
       className={`
@@ -135,7 +140,11 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
         <div className={`span-name-wrapper ${isMatchingFilter ? 'is-matching-filter' : ''}`}>
           <SpanTreeOffset
             childrenVisible={isChildrenExpanded}
-            span={span}
+            spanID={span.spanID}
+            hasChildren={isParent}
+            childCount={span.childSpans.length}
+            ancestorEntries={ancestorEntries}
+            isLastChild={isLastChild}
             onClick={isParent ? _childrenToggle : undefined}
             color={color}
           />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
@@ -37,6 +37,7 @@ describe('<SpanDetailRow> icon behavior', () => {
     depth: 0,
     hasChildren: true,
     childSpans: [{ spanID: 'child-1' }],
+    parentSpan: null,
     attributes: [],
     events: [],
     links: [],
@@ -56,6 +57,7 @@ describe('<SpanDetailRow> icon behavior', () => {
   const props = {
     color: 'some-color',
     nameColumnWidth: 0.5,
+    timelineBarsVisible: true,
     detailState: new DetailState(),
     onDetailToggled: jest.fn(),
     linksGetter: jest.fn(),

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
@@ -8,7 +8,6 @@ import userEvent from '@testing-library/user-event';
 
 import SpanDetailRow from './SpanDetailRow';
 import DetailState from './SpanDetail/DetailState';
-import SpanTreeOffset from './SpanTreeOffset';
 
 const MockSpanDetail = jest.fn(() => <div data-testid="mocked-span-detail" />);
 vi.mock('./SpanDetail', () => ({
@@ -20,6 +19,11 @@ vi.mock('./SpanTreeOffset', () => ({
   default: props => MockSpanTreeOffset(props),
 }));
 
+vi.mock('./span-tree-utils', () => ({
+  computeAncestorEntries: jest.fn(() => []),
+  computeIsLastChild: jest.fn(() => false),
+}));
+
 describe('<SpanDetailRow>', () => {
   const spanID = 'some-id';
   const span = {
@@ -28,6 +32,8 @@ describe('<SpanDetailRow>', () => {
     name: 'op-name',
     startTimeUnixMicro: 1000n,
     durationMicros: 100n,
+    hasChildren: false,
+    childSpans: [],
     attributes: [],
     events: [],
     resource: {
@@ -86,12 +92,13 @@ describe('<SpanDetailRow>', () => {
     expect(props.onDetailToggled).toHaveBeenCalledWith(props.span.spanID);
   });
 
-  it('renders the span tree offset with isDetailRow=true', () => {
+  it('renders the span tree offset with isDetailRow=true and precomputed data', () => {
     render(<SpanDetailRow {...props} />);
     expect(MockSpanTreeOffset).toHaveBeenCalledTimes(1);
     expect(MockSpanTreeOffset).toHaveBeenCalledWith(
       expect.objectContaining({
-        span: props.span,
+        spanID: props.span.spanID,
+        hasChildren: props.span.hasChildren,
         isDetailRow: true,
       })
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import SpanDetail from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
 import SpanTreeOffset from './SpanTreeOffset';
+import { computeAncestorEntries, computeIsLastChild } from './span-tree-utils';
 import TimelineRow from './TimelineRow';
 
 import { IOtelSpan, IAttribute, IEvent } from '../../../types/otel';
@@ -58,11 +59,25 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
     eventItemToggle,
     useOtelTerms,
   } = props;
+
+  // Precompute ancestor data for SpanTreeOffset
+  const ancestorEntries = useMemo(() => computeAncestorEntries(span), [span]);
+  const isLastChild = useMemo(() => computeIsLastChild(span), [span]);
+
   return (
     <TimelineRow className="detail-row">
       {timelineBarsVisible && (
         <TimelineRow.Cell width={nameColumnWidth}>
-          <SpanTreeOffset span={span} showChildrenIcon={false} isDetailRow color={color} />
+          <SpanTreeOffset
+            spanID={span.spanID}
+            hasChildren={span.hasChildren}
+            childCount={span.childSpans.length}
+            ancestorEntries={ancestorEntries}
+            isLastChild={isLastChild}
+            showChildrenIcon={false}
+            isDetailRow
+            color={color}
+          />
           <span>
             <span
               className="detail-row-expanded-accent"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -6,57 +6,38 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
-import spanAncestorIds from '../../../utils/span-ancestor-ids';
-
-vi.mock('../../../utils/span-ancestor-ids');
 
 describe('SpanTreeOffset', () => {
   const ownSpanID = 'ownSpanID';
   const parentSpanID = 'parentSpanID';
   const rootSpanID = 'rootSpanID';
   let props;
-  let rootSpan;
-  let parentSpan;
-  let ownSpan;
 
   beforeEach(() => {
-    // Create span chain with parentSpan references
-    rootSpan = {
-      spanID: rootSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: null,
-      resource: { serviceName: 'root-service' },
-    };
-    parentSpan = {
-      spanID: parentSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: rootSpan,
-      resource: { serviceName: 'parent-service' },
-    };
-    ownSpan = {
-      spanID: ownSpanID,
-      hasChildren: false,
-      childSpans: [],
-      parentSpan,
-      resource: { serviceName: 'own-service' },
-    };
-    rootSpan.childSpans = [parentSpan];
-    parentSpan.childSpans = [ownSpan];
-
     props = {
       addHoverIndentGuideId: jest.fn(),
       hoverIndentGuideIds: new Set(),
       removeHoverIndentGuideId: jest.fn(),
       color: '#000000',
-      span: ownSpan,
+      spanID: ownSpanID,
+      hasChildren: false,
+      childCount: 0,
+      ancestorEntries: [
+        { ancestorId: rootSpanID, color: '#root-color' },
+        { ancestorId: parentSpanID, color: '#parent-color' },
+      ],
+      isLastChild: true,
     };
   });
 
   describe('.SpanTreeOffset--indentGuide', () => {
     it('renders no .SpanTreeOffset--indentGuide if span has no ancestors', () => {
-      const propsWithRootSpan = { ...props, span: rootSpan };
+      const propsWithRootSpan = {
+        ...props,
+        spanID: rootSpanID,
+        ancestorEntries: [],
+        isLastChild: false,
+      };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithRootSpan} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(0);
@@ -118,7 +99,7 @@ describe('SpanTreeOffset', () => {
 
     describe('is-last class (last-child span)', () => {
       it('adds is-last to immediate parent guide when span is last child and isDetailRow is false', () => {
-        // ownSpan is the only (last) child of parentSpan
+        // isLastChild is true in default props
         const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).toHaveClass('is-last');
@@ -126,7 +107,6 @@ describe('SpanTreeOffset', () => {
       });
 
       it('adds is-terminated (not is-last) to immediate parent guide when span is last child and isDetailRow is true', () => {
-        // ownSpan is the only (last) child of parentSpan
         const { container } = render(<UnconnectedSpanTreeOffset {...props} isDetailRow />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
@@ -134,21 +114,11 @@ describe('SpanTreeOffset', () => {
       });
 
       it('does not add is-last or is-terminated to immediate parent guide when span is not the last child', () => {
-        const siblingSpan = {
-          spanID: 'siblingSpanID',
-          hasChildren: false,
-          childSpans: [],
-          parentSpan,
-          resource: { serviceName: 'sibling-service' },
-        };
-        // ownSpan is no longer the last child
-        parentSpan.childSpans = [ownSpan, siblingSpan];
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+        const propsNotLast = { ...props, isLastChild: false };
+        const { container } = render(<UnconnectedSpanTreeOffset {...propsNotLast} />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
-        // restore
-        parentSpan.childSpans = [ownSpan];
       });
     });
 
@@ -174,18 +144,13 @@ describe('SpanTreeOffset', () => {
 
     describe('self-guide in detail row (parent span)', () => {
       it('renders a self-guide when isDetailRow is true and span has children', () => {
-        const parentWithChildren = {
-          ...ownSpan,
+        const propsWithChildren = {
+          ...props,
           hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
+          childCount: 1,
         };
         const { getByTestId } = render(
-          <UnconnectedSpanTreeOffset
-            {...props}
-            span={parentWithChildren}
-            isDetailRow
-            showChildrenIcon={false}
-          />
+          <UnconnectedSpanTreeOffset {...propsWithChildren} isDetailRow showChildrenIcon={false} />
         );
         expect(getByTestId('detail-row-self-guide')).toBeInTheDocument();
         expect(getByTestId('detail-row-self-guide')).toHaveClass('SpanTreeOffset--indentGuide');
@@ -194,65 +159,83 @@ describe('SpanTreeOffset', () => {
       });
 
       it('does not render a self-guide when isDetailRow is false', () => {
-        const parentWithChildren = {
-          ...ownSpan,
+        const propsWithChildren = {
+          ...props,
           hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
+          childCount: 1,
         };
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={parentWithChildren} showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset {...propsWithChildren} showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
 
       it('does not render a self-guide when span has no children', () => {
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={ownSpan} isDetailRow showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset {...props} isDetailRow showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
+      });
+    });
+
+    describe('terminated ancestors', () => {
+      it('applies is-terminated to non-immediate ancestors with null color', () => {
+        const propsTerminated = {
+          ...props,
+          ancestorEntries: [
+            { ancestorId: rootSpanID, color: null },
+            { ancestorId: parentSpanID, color: '#parent-color' },
+          ],
+        };
+        const { container } = render(<UnconnectedSpanTreeOffset {...propsTerminated} />);
+        const rootGuide = container.querySelector(`[data-ancestor-id="${rootSpanID}"]`);
+        expect(rootGuide).toHaveClass('is-terminated');
+      });
+
+      it('does not apply is-terminated to non-immediate ancestors with non-null color', () => {
+        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+        const rootGuide = container.querySelector(`[data-ancestor-id="${rootSpanID}"]`);
+        expect(rootGuide).not.toHaveClass('is-terminated');
       });
     });
   });
 
   describe('icon', () => {
     let renderResult;
-    let spanWithChildren;
+    let propsWithChildren;
 
     beforeEach(() => {
-      spanWithChildren = { ...ownSpan, hasChildren: true, childSpans: [{}] };
-      const updatedProps = { ...props, span: spanWithChildren };
-      renderResult = render(<UnconnectedSpanTreeOffset {...updatedProps} />);
+      propsWithChildren = { ...props, hasChildren: true, childCount: 1 };
+      renderResult = render(<UnconnectedSpanTreeOffset {...propsWithChildren} />);
     });
 
-    it('renders icon wrapper with dot if props.span.hasChildren is false', () => {
-      const propsWithoutChildren = { ...props, span: ownSpan };
+    it('renders icon wrapper with dot if hasChildren is false', () => {
+      const propsWithoutChildren = { ...props, hasChildren: false, childCount: 0 };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithoutChildren} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(container.querySelector('.SpanTreeOffset--dot')).not.toBeNull();
     });
 
-    it('does not render icon wrapper if props.span.hasChildren is true and showChildrenIcon is false', () => {
+    it('does not render icon wrapper if hasChildren is true and showChildrenIcon is false', () => {
       const propsWithIconDisabled = {
-        ...props,
-        span: spanWithChildren,
+        ...propsWithChildren,
         showChildrenIcon: false,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithIconDisabled} />);
       expect(container.querySelector('.SpanTreeOffset--iconWrapper')).toBeNull();
     });
 
-    it('renders icon wrapper with child count if props.span.hasChildren is true and props.childrenVisible is false', () => {
+    it('renders icon wrapper with child count if hasChildren is true and childrenVisible is false', () => {
       const { container } = renderResult;
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(iconWrapper.textContent).toBe('1'); // One child
     });
 
-    it('renders icon wrapper if props.span.hasChildren is true and props.childrenVisible is true', () => {
+    it('renders icon wrapper if hasChildren is true and childrenVisible is true', () => {
       const propsWithVisibleChildren = {
-        ...props,
-        span: spanWithChildren,
+        ...propsWithChildren,
         childrenVisible: true,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithVisibleChildren} />);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import cx from 'classnames';
 import _get from 'lodash/get';
 import { connect } from 'react-redux';
@@ -9,17 +9,26 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { actions } from './duck';
 import { ReduxState } from '../../../types';
-import { IOtelSpan } from '../../../types/otel';
-import colorGenerator from '../../../utils/color-generator';
 
 import './SpanTreeOffset.css';
+
+/**
+ * One entry per ancestor depth, ordered from outermost to immediate parent.
+ * - `ancestorId` is the span ID at that depth (used for hover-highlight of vertical guides).
+ * - `color` is the service color to draw a vertical bar, or `null` when the ancestor's branch
+ *   has terminated (no more siblings below) and the line should be hidden.
+ */
+export type AncestorEntry = {
+  ancestorId: string;
+  color: string | null;
+};
 
 type TDispatchProps = {
   addHoverIndentGuideId: (spanID: string) => void;
   removeHoverIndentGuideId: (spanID: string) => void;
 };
 
-type TProps = {
+export type TProps = {
   addHoverIndentGuideId: (spanID: string) => void;
   hoverIndentGuideIds: Set<string>;
   removeHoverIndentGuideId: (spanID: string) => void;
@@ -27,7 +36,19 @@ type TProps = {
   onClick?: () => void;
   showChildrenIcon?: boolean;
   isDetailRow?: boolean;
-  span: IOtelSpan;
+  // --- precomputed data (no span model knowledge) ---
+  spanID: string;
+  hasChildren: boolean;
+  childCount: number;
+  /**
+   * One entry per ancestor depth, outermost → immediate parent.
+   * The last entry's color is used for the horizontal connector line.
+   * For terminated branches, `color` is `null` (no vertical bar).
+   */
+  ancestorEntries: AncestorEntry[];
+  /** Whether this span is the last child of its immediate parent. */
+  isLastChild: boolean;
+  /** Own service color for dot/box. */
   color: string;
 };
 
@@ -36,22 +57,15 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   onClick = undefined,
   showChildrenIcon = true,
   isDetailRow = false,
-  span,
+  spanID,
+  hasChildren,
+  childCount,
+  ancestorEntries,
+  isLastChild,
   addHoverIndentGuideId,
   removeHoverIndentGuideId,
   color,
 }) => {
-  // Build ancestor chain directly from span.parentSpan
-  const ancestors = useMemo(() => {
-    const chain: IOtelSpan[] = [];
-    let current = span.parentSpan;
-    while (current) {
-      chain.unshift(current);
-      current = current.parentSpan;
-    }
-    return chain;
-  }, [span]);
-
   /**
    * If the mouse leaves to anywhere except another span with the same ancestor id, this span's ancestor id is
    * removed from the set of hoverIndentGuideIds.
@@ -86,46 +100,21 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     }
   };
 
-  const { hasChildren, spanID, childSpans } = span;
   const wrapperProps = hasChildren ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
 
-  // Get parent color for horizontal line
-  const parentSpan = span.parentSpan;
-  const parentColor = parentSpan ? colorGenerator.getColorByKey(parentSpan.resource.serviceName) : color;
-
-  // Check if this span is the last child of its parent
-  const isLastChild = parentSpan
-    ? parentSpan.childSpans[parentSpan.childSpans.length - 1]?.spanID === spanID
-    : false;
+  // The last ancestor entry is the immediate parent; its color is used for the horizontal connector.
+  const lastEntry = ancestorEntries.length > 0 ? ancestorEntries[ancestorEntries.length - 1] : null;
+  const parentColor = lastEntry ? (lastEntry.color ?? color) : color;
 
   return (
     <span className={`SpanTreeOffset ${hasChildren ? 'is-parent' : ''}`} {...wrapperProps}>
-      {ancestors.map((ancestor, index) => {
-        // Determine the color for this indent guide based on the ancestor
-        const guideColor = colorGenerator.getColorByKey(ancestor.resource.serviceName);
-        const isLastAncestor = index === ancestors.length - 1;
-
-        // For the immediate parent: check if current span is last child
-        // For non-immediate ancestors: check if the ancestor's branch has terminated
-        // (i.e., the descendant of this ancestor in the chain is the last child of its parent)
-        let shouldTerminate = false;
-
-        if (isLastAncestor) {
-          // For immediate parent, check if current span is last child
-          shouldTerminate = isLastChild;
-        } else {
-          // For non-immediate ancestors, check if their descendant in the chain is the last child
-          // The descendant of this ancestor in the chain is at index + 1
-          const descendantInChain = ancestors[index + 1];
-          if (descendantInChain && descendantInChain.parentSpan) {
-            const parentChildren = descendantInChain.parentSpan.childSpans;
-            shouldTerminate = parentChildren[parentChildren.length - 1]?.spanID === descendantInChain.spanID;
-          }
-        }
+      {ancestorEntries.map((entry, index) => {
+        const isLastAncestor = index === ancestorEntries.length - 1;
+        const shouldTerminate = entry.color === null;
 
         return (
           <span
-            key={ancestor.spanID}
+            key={entry.ancestorId}
             className={cx('SpanTreeOffset--indentGuide', {
               // In a span bar row: show top-half line to connect to the horizontal bar
               // In a detail row: treat the same case as terminated (no line) since the
@@ -135,12 +124,12 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
                 (!isLastAncestor && shouldTerminate) || (isDetailRow && isLastAncestor && isLastChild),
             })}
             style={{
-              color: guideColor,
+              color: entry.color ?? undefined,
             }}
-            data-ancestor-id={ancestor.spanID}
-            data-testid={`indent-guide-${ancestor.spanID}`}
-            onMouseEnter={event => handleMouseEnter(event, ancestor.spanID)}
-            onMouseLeave={event => handleMouseLeave(event, ancestor.spanID)}
+            data-ancestor-id={entry.ancestorId}
+            data-testid={`indent-guide-${entry.ancestorId}`}
+            onMouseEnter={event => handleMouseEnter(event, entry.ancestorId)}
+            onMouseLeave={event => handleMouseLeave(event, entry.ancestorId)}
           >
             {isLastAncestor && !isDetailRow && (
               <span className="SpanTreeOffset--horizontalLine" style={{ backgroundColor: parentColor }} />
@@ -170,7 +159,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
                 backgroundColor: !childrenVisible ? color : undefined,
               }}
             >
-              {childSpans.length}
+              {childCount}
             </span>
           ) : (
             <span className="SpanTreeOffset--dot" style={{ backgroundColor: color }} />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -100,7 +100,8 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     }
   };
 
-  const wrapperProps = hasChildren ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
+  const wrapperProps =
+    hasChildren && onClick ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
 
   // The last ancestor entry is the immediate parent; its color is used for the horizontal connector.
   const lastEntry = ancestorEntries.length > 0 ? ancestorEntries[ancestorEntries.length - 1] : null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computeAncestorEntries, computeIsLastChild } from './span-tree-utils';
+import { IOtelSpan } from '../../../types/otel';
+
+vi.mock('../../../utils/color-generator', () => ({
+  default: {
+    getColorByKey: vi.fn((svc: string) => `#color-${svc}`),
+  },
+}));
+
+function makeChain(): { root: IOtelSpan; parent: IOtelSpan; child: IOtelSpan; sibling: IOtelSpan } {
+  const root = {
+    spanID: 'root',
+    hasChildren: true,
+    childSpans: [],
+    parentSpan: null,
+    resource: { serviceName: 'root-svc' },
+  } as unknown as IOtelSpan;
+
+  const parent = {
+    spanID: 'parent',
+    hasChildren: true,
+    childSpans: [],
+    parentSpan: root,
+    resource: { serviceName: 'parent-svc' },
+  } as unknown as IOtelSpan;
+
+  const child = {
+    spanID: 'child',
+    hasChildren: false,
+    childSpans: [],
+    parentSpan: parent,
+    resource: { serviceName: 'child-svc' },
+  } as unknown as IOtelSpan;
+
+  const sibling = {
+    spanID: 'sibling',
+    hasChildren: false,
+    childSpans: [],
+    parentSpan: parent,
+    resource: { serviceName: 'sibling-svc' },
+  } as unknown as IOtelSpan;
+
+  root.childSpans = [parent];
+  parent.childSpans = [child, sibling];
+
+  return { root, parent, child, sibling };
+}
+
+describe('span-tree-utils', () => {
+  describe('computeIsLastChild', () => {
+    it('returns false for root spans (no parent)', () => {
+      const { root } = makeChain();
+      expect(computeIsLastChild(root)).toBe(false);
+    });
+
+    it('returns false when span is not the last child', () => {
+      const { child } = makeChain();
+      expect(computeIsLastChild(child)).toBe(false);
+    });
+
+    it('returns true when span is the last child', () => {
+      const { sibling } = makeChain();
+      expect(computeIsLastChild(sibling)).toBe(true);
+    });
+
+    it('returns true for an only child', () => {
+      const { parent } = makeChain();
+      // parent is the only child of root
+      expect(computeIsLastChild(parent)).toBe(true);
+    });
+  });
+
+  describe('computeAncestorEntries', () => {
+    it('returns empty array for root spans', () => {
+      const { root } = makeChain();
+      expect(computeAncestorEntries(root)).toEqual([]);
+    });
+
+    it('returns one entry for a span with one ancestor', () => {
+      const { parent } = makeChain();
+      const entries = computeAncestorEntries(parent);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].ancestorId).toBe('root');
+      // parent is the only (last) child of root, but since it is the immediate parent
+      // (isLastAncestor), its color is always preserved (never null)
+      expect(entries[0].color).toBe('#color-root-svc');
+    });
+
+    it('returns entries ordered outermost to immediate parent', () => {
+      const { child } = makeChain();
+      const entries = computeAncestorEntries(child);
+      expect(entries).toHaveLength(2);
+      expect(entries[0].ancestorId).toBe('root');
+      expect(entries[1].ancestorId).toBe('parent');
+    });
+
+    it('sets color to null for non-immediate ancestors whose branch has terminated', () => {
+      // parent is the last child of root, so root's branch terminates
+      const { child } = makeChain();
+      const entries = computeAncestorEntries(child);
+      // root's descendant in chain (parent) is the last child of root → terminated
+      expect(entries[0].color).toBeNull();
+      // parent is the immediate ancestor → always has color
+      expect(entries[1].color).toBe('#color-parent-svc');
+    });
+
+    it('preserves color for non-immediate ancestors whose branch has NOT terminated', () => {
+      const { sibling } = makeChain();
+      const entries = computeAncestorEntries(sibling);
+      // root's descendant in chain (parent) is the last child of root → terminated
+      expect(entries[0].color).toBeNull();
+      // parent is the immediate ancestor → always has color
+      expect(entries[1].color).toBe('#color-parent-svc');
+    });
+
+    it('preserves color when descendant in chain is NOT the last child', () => {
+      // Create a deeper chain where the descendant is NOT the last child
+      const root = {
+        spanID: 'root',
+        hasChildren: true,
+        childSpans: [],
+        parentSpan: null,
+        resource: { serviceName: 'root-svc' },
+      } as unknown as IOtelSpan;
+
+      const mid1 = {
+        spanID: 'mid1',
+        hasChildren: true,
+        childSpans: [],
+        parentSpan: root,
+        resource: { serviceName: 'mid1-svc' },
+      } as unknown as IOtelSpan;
+
+      const mid2 = {
+        spanID: 'mid2',
+        hasChildren: false,
+        childSpans: [],
+        parentSpan: root,
+        resource: { serviceName: 'mid2-svc' },
+      } as unknown as IOtelSpan;
+
+      const leaf = {
+        spanID: 'leaf',
+        hasChildren: false,
+        childSpans: [],
+        parentSpan: mid1,
+        resource: { serviceName: 'leaf-svc' },
+      } as unknown as IOtelSpan;
+
+      root.childSpans = [mid1, mid2]; // mid1 is NOT the last child
+      mid1.childSpans = [leaf];
+
+      const entries = computeAncestorEntries(leaf);
+      expect(entries).toHaveLength(2);
+      // root's descendant (mid1) is NOT the last child → root color preserved
+      expect(entries[0].color).toBe('#color-root-svc');
+      // mid1 is immediate parent → always has color
+      expect(entries[1].color).toBe('#color-mid1-svc');
+    });
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AncestorEntry } from './SpanTreeOffset';
+import { IOtelSpan } from '../../../types/otel';
+import colorGenerator from '../../../utils/color-generator';
+
+/**
+ * Walk `span.parentSpan` once to build the ancestor entries array for SpanTreeOffset.
+ *
+ * Each entry has:
+ * - `ancestorId`: the span ID at that depth (for hover-highlight).
+ * - `color`: the service color to draw a vertical bar, or `null` when the ancestor's branch
+ *   has terminated (the descendant in the chain is the last child of its parent, meaning no
+ *   more siblings exist below that depth).
+ *
+ * The array is ordered outermost → immediate parent.
+ */
+/**
+ * Check if a span is the last child of its parent.
+ */
+export function computeIsLastChild(span: IOtelSpan): boolean {
+  const parent = span.parentSpan;
+  if (!parent) return false;
+  return parent.childSpans[parent.childSpans.length - 1]?.spanID === span.spanID;
+}
+
+export function computeAncestorEntries(span: IOtelSpan): AncestorEntry[] {
+  // Build ancestor chain (outermost first)
+  const ancestors: IOtelSpan[] = [];
+  let current = span.parentSpan;
+  while (current) {
+    ancestors.unshift(current);
+    current = current.parentSpan;
+  }
+
+  if (ancestors.length === 0) {
+    return [];
+  }
+
+  const isLast = computeIsLastChild(span);
+
+  return ancestors.map((ancestor, index) => {
+    const guideColor = colorGenerator.getColorByKey(ancestor.resource.serviceName);
+    const isLastAncestor = index === ancestors.length - 1;
+
+    let shouldTerminate = false;
+    if (isLastAncestor) {
+      // For immediate parent, check if current span is the last child
+      shouldTerminate = isLast;
+    } else {
+      // For non-immediate ancestors, check if their descendant in the chain is the last child
+      const descendantInChain = ancestors[index + 1];
+      if (descendantInChain && descendantInChain.parentSpan) {
+        const parentChildren = descendantInChain.parentSpan.childSpans;
+        shouldTerminate = parentChildren[parentChildren.length - 1]?.spanID === descendantInChain.spanID;
+      }
+    }
+
+    return {
+      ancestorId: ancestor.spanID,
+      // For the immediate parent the color is always needed for the horizontal connector,
+      // so we never null it out. The `isLastChild` prop on SpanTreeOffset handles the
+      // half-height / terminated rendering for the immediate parent guide.
+      color: !isLastAncestor && shouldTerminate ? null : guideColor,
+    };
+  });
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
@@ -39,17 +39,12 @@ export function computeAncestorEntries(span: IOtelSpan): AncestorEntry[] {
     return [];
   }
 
-  const isLast = computeIsLastChild(span);
-
   return ancestors.map((ancestor, index) => {
     const guideColor = colorGenerator.getColorByKey(ancestor.resource.serviceName);
     const isLastAncestor = index === ancestors.length - 1;
 
     let shouldTerminate = false;
-    if (isLastAncestor) {
-      // For immediate parent, check if current span is the last child
-      shouldTerminate = isLast;
-    } else {
+    if (!isLastAncestor) {
       // For non-immediate ancestors, check if their descendant in the chain is the last child
       const descendantInChain = ancestors[index + 1];
       if (descendantInChain && descendantInChain.parentSpan) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AncestorEntry } from './SpanTreeOffset';
+import type { AncestorEntry } from './SpanTreeOffset';
 import { IOtelSpan } from '../../../types/otel';
 import colorGenerator from '../../../utils/color-generator';
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-tree-utils.ts
@@ -26,13 +26,14 @@ export function computeIsLastChild(span: IOtelSpan): boolean {
 }
 
 export function computeAncestorEntries(span: IOtelSpan): AncestorEntry[] {
-  // Build ancestor chain (outermost first)
+  // Build ancestor chain, then reverse once to get outermost first
   const ancestors: IOtelSpan[] = [];
   let current = span.parentSpan;
   while (current) {
-    ancestors.unshift(current);
+    ancestors.push(current);
     current = current.parentSpan;
   }
+  ancestors.reverse();
 
   if (ancestors.length === 0) {
     return [];


### PR DESCRIPTION
## Which problem is this PR solving?

* Fixes #3770

## Description of the changes

* Refactored `SpanTreeOffset` to remove internal parent traversal logic
* Replaced `span: IOtelSpan` with precomputed props:

  * `ancestorEntries`, `isLastChild`, `spanID`, `hasChildren`, `childCount`
* Introduced `span-tree-utils.ts` with helper functions:

  * `computeAncestorEntries`
  * `computeIsLastChild`
* Updated dependent components (`SpanBarRow`, `SpanDetailRow`) to compute and pass data using `useMemo`
* Simplified `PrunedSpanRow` by removing synthetic span construction and prototype manipulation
* Cleaned up logic to make the component purely presentational and deterministic

## How was this change tested?

* Added new unit tests for `span-tree-utils` (10 test cases)
* Rewrote `SpanTreeOffset` tests to use plain data instead of linked spans
* Updated all affected component tests to match new API
* Verified:

  * 65 tests passing across modified/new test files
  * Full test suite: 2819 passing (6 unrelated pre-existing timeouts)
  * `tsc-lint` passed
  * `fmt-lint` passed
  * `oxlint`  passed (no new issues)

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

* [x] **Moderate**: AI helped with code structuring and debugging specific parts
