### PR TITLE
feat(trace-view): Implement priority stack for layout settings

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -22,6 +22,7 @@ import { IOtelTrace } from '../../../types/otel';
 import { formatDatetime, formatDurationCompact } from '../../../utils/date';
 import { getTraceLinks } from '../../../model/link-patterns';
 import { getIncompleteTraceTooltip } from '../../../model/trace-viewer';
+import type { ResolvedLayoutSettings } from '../useLayoutSettings';
 
 import './TracePageHeader.css';
 import ExternalLinks from '../../common/ExternalLinks';
@@ -59,6 +60,8 @@ type TracePageHeaderEmbedProps = {
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRange: IViewRange;
   useOtelTerms: boolean;
+  settingSources?: ResolvedLayoutSettings;
+  saveSettingAsDefault?: (key: 'timelineBarsVisible' | 'detailPanelMode') => void;
 };
 
 export const HEADER_ITEMS = [
@@ -91,7 +94,7 @@ export const HEADER_ITEMS = [
   {
     key: 'depth',
     label: 'Depth',
-    renderer: (trace: IOtelTrace) => _get(_maxBy(trace.spans as any[], 'depth'), 'depth', 0) + 1,
+    renderer: (trace: IOtelTrace) => _get(_maxBy(trace.spans as unknown[], 'depth'), 'depth', 0) + 1,
   },
   {
     key: 'span-count',
@@ -150,6 +153,8 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
     updateViewRangeTime,
     viewRange,
     useOtelTerms,
+    settingSources,
+    saveSettingAsDefault,
   } = props;
 
   if (!trace) {
@@ -215,6 +220,8 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
           onDetailPanelModeToggle={onDetailPanelModeToggle}
           onTimelineToggle={onTimelineToggle}
           timelineBarsVisible={timelineBarsVisible}
+          settingSources={settingSources}
+          saveSettingAsDefault={saveSettingAsDefault}
         />
         {showViewOptions && (
           <AltViewOptions

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.css
@@ -13,3 +13,187 @@ SPDX-License-Identifier: Apache-2.0
 .TraceViewSettings--icon {
   font-size: 1.2rem;
 }
+
+.TraceViewSettings--popoverOverlay .ant-popover-inner {
+  padding: 0;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border-default);
+}
+
+.TraceViewSettings--panel {
+  width: 300px;
+  background: var(--surface-primary);
+}
+
+.TraceViewSettings--panelHeader {
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+}
+
+.TraceViewSettings--panelTitle {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-secondary);
+}
+
+.TraceViewSettings--settingsList {
+  padding: 4px 0;
+}
+
+.TraceViewSettings--row {
+  padding: 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: background 0.12s ease;
+}
+
+.TraceViewSettings--row:hover {
+  background: var(--surface-secondary);
+}
+
+.TraceViewSettings--rowMain {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.TraceViewSettings--rowLabels {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.TraceViewSettings--rowLabel {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.TraceViewSettings--rowDescription {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.TraceViewSettings--switch {
+  flex-shrink: 0;
+}
+
+.TraceViewSettings--overrideRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  animation: TraceViewSettings--fadeIn 0.2s ease;
+}
+
+@keyframes TraceViewSettings--fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.TraceViewSettings--sourceBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.TraceViewSettings--sourceBadge--url {
+  background: color-mix(in srgb, var(--interactive-primary) 12%, transparent);
+  color: var(--interactive-primary);
+  border: 1px solid color-mix(in srgb, var(--interactive-primary) 30%, transparent);
+}
+
+.TraceViewSettings--sourceBadge--heuristic {
+  background: color-mix(in srgb, var(--feedback-warning) 12%, transparent);
+  color: var(--feedback-warning);
+  border: 1px solid color-mix(in srgb, var(--feedback-warning) 30%, transparent);
+}
+
+.TraceViewSettings--sourceIcon {
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.TraceViewSettings--sourceIcon--url {
+  color: var(--interactive-primary);
+}
+
+.TraceViewSettings--sourceIcon--heuristic {
+  color: var(--feedback-warning);
+}
+
+.TraceViewSettings--saveLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--text-link);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition:
+    color 0.15s ease,
+    opacity 0.15s ease;
+  white-space: nowrap;
+}
+
+.TraceViewSettings--saveLink:hover {
+  color: var(--text-link-hover);
+  opacity: 0.85;
+}
+
+.TraceViewSettings--saveLinkIcon {
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.TraceViewSettings--panelDivider {
+  height: 1px;
+  background: var(--border-default);
+  margin: 0;
+}
+
+.TraceViewSettings--kbdShortcutsBtn {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  transition: background 0.12s ease;
+}
+
+.TraceViewSettings--kbdShortcutsBtn:hover {
+  background: var(--surface-secondary);
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -19,6 +19,12 @@ const defaultProps = {
   timelineBarsVisible: true,
 };
 
+async function openPanel() {
+  await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
+  // The panel content is rendered inside the popover
+  return screen.findByRole('group', { name: /timeline view/i });
+}
+
 describe('<TraceViewSettings>', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -31,63 +37,160 @@ describe('<TraceViewSettings>', () => {
     expect(button).toHaveAttribute('title', 'Trace view settings');
   });
 
-  it('opens dropdown on click and shows "Show Timeline" item', async () => {
+  it('opens popover on click and shows "Timeline View" setting', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    expect(await screen.findByText('Show Timeline')).toBeInTheDocument();
+    await openPanel();
+    expect(screen.getByText('Timeline View')).toBeInTheDocument();
   });
 
-  it('calls onTimelineToggle when "Show Timeline" is clicked', async () => {
+  it('calls onTimelineToggle when the Timeline switch is clicked', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Show Timeline'));
+    await openPanel();
+    // The switch for timeline is labelled by "Timeline View"
+    const timelineSwitch = screen.getByRole('switch', { name: /timeline view/i });
+    await userEvent.click(timelineSwitch);
     expect(defaultProps.onTimelineToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('does not show "Show Span in Sidebar" when enableSidePanel is false', async () => {
+  it('does not show "Span Details Sidebar" setting when enableSidePanel is false', async () => {
     render(<TraceViewSettings {...defaultProps} enableSidePanel={false} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await screen.findByText('Show Timeline');
-    expect(screen.queryByText('Show Span in Sidebar')).not.toBeInTheDocument();
+    await openPanel();
+    expect(screen.queryByText('Span Details Sidebar')).not.toBeInTheDocument();
   });
 
-  it('shows "Show Span in Sidebar" when enableSidePanel is true', async () => {
+  it('shows "Span Details Sidebar" setting when enableSidePanel is true', async () => {
     render(<TraceViewSettings {...defaultProps} enableSidePanel />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    expect(await screen.findByText('Show Span in Sidebar')).toBeInTheDocument();
+    await openPanel();
+    expect(screen.getByText('Span Details Sidebar')).toBeInTheDocument();
   });
 
-  it('calls onDetailPanelModeToggle when "Show Span in Sidebar" is clicked', async () => {
+  it('calls onDetailPanelModeToggle when the Sidebar switch is clicked', async () => {
     render(<TraceViewSettings {...defaultProps} enableSidePanel />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Show Span in Sidebar'));
+    await openPanel();
+    const sidebarSwitch = screen.getByRole('switch', { name: /span details sidebar/i });
+    await userEvent.click(sidebarSwitch);
     expect(defaultProps.onDetailPanelModeToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('always shows "Keyboard Shortcuts" in the dropdown', async () => {
+  it('always shows "Keyboard Shortcuts" button in the panel', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    expect(await screen.findByText('Keyboard Shortcuts')).toBeInTheDocument();
+    await openPanel();
+    expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
   });
 
   it('opens the keyboard shortcuts modal and calls track() when "Keyboard Shortcuts" is clicked', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Keyboard Shortcuts'));
+    await openPanel();
+    await userEvent.click(screen.getByText('Keyboard Shortcuts'));
     expect(track).toHaveBeenCalledTimes(1);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('returns the cached kbdTable on a second call to getHelpModal', async () => {
-    const { unmount } = render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Keyboard Shortcuts'));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-    unmount();
+  it('shows "Set by shared link" badge when timeline source is "url"', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: false, source: 'url', isOverridden: true },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings {...defaultProps} timelineBarsVisible={false} settingSources={settingSources} />
+    );
+    await openPanel();
+    expect(screen.getByText('Set by shared link')).toBeInTheDocument();
+  });
 
-    render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Keyboard Shortcuts'));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  it('shows "Optimized for this trace" badge when timeline source is "heuristic"', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: false, source: 'heuristic', isOverridden: true },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings {...defaultProps} timelineBarsVisible={false} settingSources={settingSources} />
+    );
+    await openPanel();
+    expect(screen.getByText('Optimized for this trace')).toBeInTheDocument();
+  });
+
+  it('does not show a source badge when source is "localstorage"', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(<TraceViewSettings {...defaultProps} settingSources={settingSources} />);
+    await openPanel();
+    expect(screen.queryByText('Set by shared link')).not.toBeInTheDocument();
+    expect(screen.queryByText('Optimized for this trace')).not.toBeInTheDocument();
+  });
+
+  it('shows "Set as my default" link when a setting is overridden', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: false, source: 'url', isOverridden: true },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings
+        {...defaultProps}
+        timelineBarsVisible={false}
+        settingSources={settingSources}
+        saveSettingAsDefault={jest.fn()}
+      />
+    );
+    await openPanel();
+    expect(screen.getByText('Set as my default')).toBeInTheDocument();
+  });
+
+  it('calls saveSettingAsDefault with correct key when "Set as my default" is clicked', async () => {
+    const saveSettingAsDefault = jest.fn();
+    const settingSources = {
+      timelineBarsVisible: { value: false, source: 'url', isOverridden: true },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings
+        {...defaultProps}
+        timelineBarsVisible={false}
+        settingSources={settingSources}
+        saveSettingAsDefault={saveSettingAsDefault}
+      />
+    );
+    await openPanel();
+    await userEvent.click(screen.getByText('Set as my default'));
+    expect(saveSettingAsDefault).toHaveBeenCalledWith('timelineBarsVisible');
+  });
+
+  it('does not show "Set as my default" link when isOverridden is false', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings {...defaultProps} settingSources={settingSources} saveSettingAsDefault={jest.fn()} />
+    );
+    await openPanel();
+    await waitFor(() => {
+      expect(screen.queryByText('Set as my default')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows "Set as my default" for sidebar when sidebar source is "url"', async () => {
+    const saveSettingAsDefault = jest.fn();
+    const settingSources = {
+      timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+      detailPanelMode: { value: 'sidepanel', source: 'url', isOverridden: true },
+    };
+    render(
+      <TraceViewSettings
+        {...defaultProps}
+        enableSidePanel
+        detailPanelMode="sidepanel"
+        settingSources={settingSources}
+        saveSettingAsDefault={saveSettingAsDefault}
+      />
+    );
+    await openPanel();
+    const saveLinks = screen.getAllByText('Set as my default');
+    // Only one override (sidebar), so exactly one link
+    expect(saveLinks).toHaveLength(1);
+    await userEvent.click(saveLinks[0]);
+    expect(saveSettingAsDefault).toHaveBeenCalledWith('detailPanelMode');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
@@ -98,18 +98,6 @@ describe('<TraceViewSettings>', () => {
     expect(screen.getByText('Set by shared link')).toBeInTheDocument();
   });
 
-  it('shows "Optimized for this trace" badge when timeline source is "heuristic"', async () => {
-    const settingSources = {
-      timelineBarsVisible: { value: false, source: 'heuristic', isOverridden: true },
-      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
-    };
-    render(
-      <TraceViewSettings {...defaultProps} timelineBarsVisible={false} settingSources={settingSources} />
-    );
-    await openPanel();
-    expect(screen.getByText('Optimized for this trace')).toBeInTheDocument();
-  });
-
   it('does not show a source badge when source is "localstorage"', async () => {
     const settingSources = {
       timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
@@ -118,7 +106,6 @@ describe('<TraceViewSettings>', () => {
     render(<TraceViewSettings {...defaultProps} settingSources={settingSources} />);
     await openPanel();
     expect(screen.queryByText('Set by shared link')).not.toBeInTheDocument();
-    expect(screen.queryByText('Optimized for this trace')).not.toBeInTheDocument();
   });
 
   it('shows "Set as my default" link when a setting is overridden', async () => {

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -76,7 +76,7 @@ function SettingRow<T>({
 
       {isOverridden && (
         <div className="TraceViewSettings--overrideRow">
-          {source !== 'localstorage' && (
+          {(SOURCE_LABELS[source] || SOURCE_ICONS[source]) && (
             <span className={`TraceViewSettings--sourceBadge TraceViewSettings--sourceBadge--${source}`}>
               {SOURCE_ICONS[source]}
               {SOURCE_LABELS[source]}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -117,7 +117,7 @@ export default function TraceViewSettings(props: Props) {
   const [popoverOpen, setPopoverOpen] = React.useState(false);
 
   const panelContent = (
-    <div className="TraceViewSettings--panel" role="menu" aria-label="Trace view settings panel">
+    <div className="TraceViewSettings--panel" aria-label="Trace view settings panel">
       <div className="TraceViewSettings--panelHeader">
         <span className="TraceViewSettings--panelTitle">View Settings</span>
       </div>
@@ -142,7 +142,7 @@ export default function TraceViewSettings(props: Props) {
             description="Show span details in a side panel instead of inline"
             checked={detailPanelMode === 'sidepanel'}
             onChange={onDetailPanelModeToggle}
-            resolved={settingSources?.detailPanelMode as ResolvedSetting<string> | undefined}
+            resolved={settingSources?.detailPanelMode}
             onSaveAsDefault={saveSettingAsDefault ? () => saveSettingAsDefault('detailPanelMode') : undefined}
           />
         )}
@@ -157,7 +157,6 @@ export default function TraceViewSettings(props: Props) {
           setKbdModalVisible(true);
           setPopoverOpen(false);
         }}
-        role="menuitem"
       >
         Keyboard Shortcuts
       </button>

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { Button, Dropdown } from 'antd';
-import type { MenuProps } from 'antd';
-import { IoSettingsOutline, IoCheckmark } from 'react-icons/io5';
+import { Button, Popover, Switch, Tooltip } from 'antd';
+import { IoSettingsOutline, IoLink, IoSparkles, IoCheckmarkCircle } from 'react-icons/io5';
 
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
+import type { ResolvedLayoutSettings, ResolvedSetting, SettingSource } from '../useLayoutSettings';
 
 import './TraceViewSettings.css';
 
@@ -17,10 +17,89 @@ type Props = {
   onDetailPanelModeToggle: () => void;
   onTimelineToggle: () => void;
   timelineBarsVisible: boolean;
+  settingSources?: ResolvedLayoutSettings;
+  saveSettingAsDefault?: (key: 'timelineBarsVisible' | 'detailPanelMode') => void;
 };
 
-const CHECK_STYLE = { marginRight: 8, fontSize: 14 };
-const CHECK_PLACEHOLDER = <span style={{ display: 'inline-block', width: 22 }} />;
+const SOURCE_LABELS: Record<SettingSource, string> = {
+  url: 'Set by shared link',
+  heuristic: 'Optimized for this trace',
+  localstorage: '',
+};
+
+const SOURCE_ICONS: Record<SettingSource, React.ReactNode> = {
+  url: <IoLink className="TraceViewSettings--sourceIcon TraceViewSettings--sourceIcon--url" />,
+  heuristic: (
+    <IoSparkles className="TraceViewSettings--sourceIcon TraceViewSettings--sourceIcon--heuristic" />
+  ),
+  localstorage: null,
+};
+
+type SettingRowProps<T> = {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: () => void;
+  resolved?: ResolvedSetting<T>;
+  onSaveAsDefault?: () => void;
+};
+
+function SettingRow<T>({
+  id,
+  label,
+  description,
+  checked,
+  onChange,
+  resolved,
+  onSaveAsDefault,
+}: SettingRowProps<T>) {
+  const source = resolved?.source ?? 'localstorage';
+  const isOverridden = resolved?.isOverridden ?? false;
+
+  return (
+    <div className="TraceViewSettings--row" role="group" aria-labelledby={`${id}-label`}>
+      <div className="TraceViewSettings--rowMain">
+        <div className="TraceViewSettings--rowLabels">
+          <span id={`${id}-label`} className="TraceViewSettings--rowLabel">
+            {label}
+          </span>
+          <span className="TraceViewSettings--rowDescription">{description}</span>
+        </div>
+        <Switch
+          id={id}
+          checked={checked}
+          onChange={onChange}
+          size="small"
+          aria-label={label}
+          className="TraceViewSettings--switch"
+        />
+      </div>
+
+      {isOverridden && source !== 'localstorage' && (
+        <div className="TraceViewSettings--overrideRow">
+          <span className={`TraceViewSettings--sourceBadge TraceViewSettings--sourceBadge--${source}`}>
+            {SOURCE_ICONS[source]}
+            {SOURCE_LABELS[source]}
+          </span>
+          {onSaveAsDefault && (
+            <Tooltip title="Save this as your personal default for future traces">
+              <button
+                type="button"
+                className="TraceViewSettings--saveLink"
+                onClick={onSaveAsDefault}
+                aria-label={`Set as my default for ${label}`}
+              >
+                <IoCheckmarkCircle className="TraceViewSettings--saveLinkIcon" />
+                Set as my default
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function TraceViewSettings(props: Props) {
   const {
@@ -30,42 +109,72 @@ export default function TraceViewSettings(props: Props) {
     onDetailPanelModeToggle,
     onTimelineToggle,
     timelineBarsVisible,
+    settingSources,
+    saveSettingAsDefault,
   } = props;
 
   const [kbdModalVisible, setKbdModalVisible] = React.useState(false);
+  const [popoverOpen, setPopoverOpen] = React.useState(false);
 
-  const items: MenuProps['items'] = [
-    {
-      key: 'timeline',
-      icon: timelineBarsVisible ? <IoCheckmark style={CHECK_STYLE} /> : CHECK_PLACEHOLDER,
-      label: 'Show Timeline',
-      onClick: onTimelineToggle,
-    },
-  ];
+  const panelContent = (
+    <div className="TraceViewSettings--panel" role="menu" aria-label="Trace view settings panel">
+      <div className="TraceViewSettings--panelHeader">
+        <span className="TraceViewSettings--panelTitle">View Settings</span>
+      </div>
 
-  if (enableSidePanel) {
-    const isSidePanel = detailPanelMode === 'sidepanel';
-    items.push({
-      key: 'detail-panel-mode',
-      icon: isSidePanel ? <IoCheckmark style={CHECK_STYLE} /> : CHECK_PLACEHOLDER,
-      label: 'Show Span in Sidebar',
-      onClick: onDetailPanelModeToggle,
-    });
-  }
+      <div className="TraceViewSettings--settingsList">
+        <SettingRow
+          id="setting-timeline"
+          label="Timeline View"
+          description="Show the timeline bars in the trace view"
+          checked={timelineBarsVisible}
+          onChange={onTimelineToggle}
+          resolved={settingSources?.timelineBarsVisible}
+          onSaveAsDefault={
+            saveSettingAsDefault ? () => saveSettingAsDefault('timelineBarsVisible') : undefined
+          }
+        />
 
-  items.push(
-    { type: 'divider' },
-    {
-      key: 'keyboard-shortcuts',
-      icon: CHECK_PLACEHOLDER,
-      label: 'Keyboard Shortcuts',
-      onClick: () => setKbdModalVisible(true),
-    }
+        {enableSidePanel && (
+          <SettingRow
+            id="setting-sidebar"
+            label="Span Details Sidebar"
+            description="Show span details in a side panel instead of inline"
+            checked={detailPanelMode === 'sidepanel'}
+            onChange={onDetailPanelModeToggle}
+            resolved={settingSources?.detailPanelMode as ResolvedSetting<string> | undefined}
+            onSaveAsDefault={saveSettingAsDefault ? () => saveSettingAsDefault('detailPanelMode') : undefined}
+          />
+        )}
+      </div>
+
+      <div className="TraceViewSettings--panelDivider" />
+
+      <button
+        type="button"
+        className="TraceViewSettings--kbdShortcutsBtn"
+        onClick={() => {
+          setKbdModalVisible(true);
+          setPopoverOpen(false);
+        }}
+        role="menuitem"
+      >
+        Keyboard Shortcuts
+      </button>
+    </div>
   );
 
   return (
     <>
-      <Dropdown menu={{ items }} trigger={['click']}>
+      <Popover
+        content={panelContent}
+        trigger="click"
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+        placement="bottomRight"
+        overlayClassName="TraceViewSettings--popoverOverlay"
+        arrow={false}
+      >
         <Button
           className={`TraceViewSettings ${className || ''}`}
           htmlType="button"
@@ -74,7 +183,7 @@ export default function TraceViewSettings(props: Props) {
         >
           <IoSettingsOutline className="TraceViewSettings--icon" />
         </Button>
-      </Dropdown>
+      </Popover>
       <KeyboardShortcutsHelp open={kbdModalVisible} onClose={() => setKbdModalVisible(false)} />
     </>
   );

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -181,6 +181,7 @@ export default function TraceViewSettings(props: Props) {
           htmlType="button"
           aria-label="Trace view settings"
           title="Trace view settings"
+          data-testid="trace-view-settings"
         >
           <IoSettingsOutline className="TraceViewSettings--icon" />
         </Button>

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 import { Button, Popover, Switch, Tooltip } from 'antd';
-import { IoSettingsOutline, IoLink, IoSparkles, IoCheckmarkCircle } from 'react-icons/io5';
+import { IoSettingsOutline, IoLink, IoCheckmarkCircle } from 'react-icons/io5';
 
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 import type { ResolvedLayoutSettings, ResolvedSetting, SettingSource } from '../useLayoutSettings';
@@ -23,15 +23,13 @@ type Props = {
 
 const SOURCE_LABELS: Record<SettingSource, string> = {
   url: 'Set by shared link',
-  heuristic: 'Optimized for this trace',
+  heuristic: '',
   localstorage: '',
 };
 
 const SOURCE_ICONS: Record<SettingSource, React.ReactNode> = {
   url: <IoLink className="TraceViewSettings--sourceIcon TraceViewSettings--sourceIcon--url" />,
-  heuristic: (
-    <IoSparkles className="TraceViewSettings--sourceIcon TraceViewSettings--sourceIcon--heuristic" />
-  ),
+  heuristic: null,
   localstorage: null,
 };
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -76,12 +76,14 @@ function SettingRow<T>({
         />
       </div>
 
-      {isOverridden && source !== 'localstorage' && (
+      {isOverridden && (
         <div className="TraceViewSettings--overrideRow">
-          <span className={`TraceViewSettings--sourceBadge TraceViewSettings--sourceBadge--${source}`}>
-            {SOURCE_ICONS[source]}
-            {SOURCE_LABELS[source]}
-          </span>
+          {source !== 'localstorage' && (
+            <span className={`TraceViewSettings--sourceBadge TraceViewSettings--sourceBadge--${source}`}>
+              {SOURCE_ICONS[source]}
+              {SOURCE_LABELS[source]}
+            </span>
+          )}
           {onSaveAsDefault && (
             <Tooltip title="Save this as your personal default for future traces">
               <button

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
@@ -19,13 +19,10 @@ type TraceTimelineLayoutPrefsStore = {
   timelineBarsVisible: boolean;
   setSpanNameColumnWidth: (width: number) => void;
   setSidePanelWidth: (width: number) => void;
-  // Updates layout fields only; use `setDetailPanelMode` from `./store` to also sync detail panel state.
-  applyDetailPanelModeToLayout: (mode: SpanDetailPanelMode) => void;
-  setTimelineBarsVisible: (visible: boolean) => void;
+  applyDetailPanelModeToLayout: (mode: SpanDetailPanelMode, persist?: boolean) => void;
+  setTimelineBarsVisible: (visible: boolean, persist?: boolean) => void;
 };
 
-// Reads user layout preferences from localStorage and merges them with config-driven defaults.
-// Mirrors the logic that was previously in TraceTimelineViewer/duck.ts `newInitialState()`.
 export function getInitialLayoutState(): Pick<
   TraceTimelineLayoutPrefsStore,
   'spanNameColumnWidth' | 'sidePanelWidth' | 'detailPanelMode' | 'timelineBarsVisible'
@@ -114,8 +111,8 @@ export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()((set,
     set({ sidePanelWidth });
   },
 
-  applyDetailPanelModeToLayout: (mode: SpanDetailPanelMode) => {
-    localStorage.setItem('detailPanelMode', mode);
+  applyDetailPanelModeToLayout: (mode: SpanDetailPanelMode, persist = true) => {
+    if (persist) localStorage.setItem('detailPanelMode', mode);
     let { spanNameColumnWidth, sidePanelWidth } = get();
     if (mode === 'sidepanel') {
       const maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH);
@@ -124,8 +121,8 @@ export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()((set,
     set({ detailPanelMode: mode, spanNameColumnWidth });
   },
 
-  setTimelineBarsVisible: (visible: boolean) => {
-    localStorage.setItem('timelineVisible', String(visible));
+  setTimelineBarsVisible: (visible: boolean, persist = true) => {
+    if (persist) localStorage.setItem('timelineVisible', String(visible));
     set({ timelineBarsVisible: visible });
   },
 }));

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
@@ -20,7 +20,7 @@ export { useTraceTimelineStore } from './store.timeline';
 
 export { calculateFocusedFindRowStates, getSelectedSpanID } from './timeline-utils';
 
-export function setDetailPanelMode(mode: SpanDetailPanelMode): void {
+export function setDetailPanelMode(mode: SpanDetailPanelMode, persist?: boolean): void {
   if (mode === 'sidepanel') {
     const { detailStates } = useTraceTimelineStore.getState();
     if (detailStates.size > 0) {
@@ -30,5 +30,5 @@ export function setDetailPanelMode(mode: SpanDetailPanelMode): void {
       });
     }
   }
-  useLayoutPrefsStore.getState().applyDetailPanelModeToLayout(mode);
+  useLayoutPrefsStore.getState().applyDetailPanelModeToLayout(mode, persist);
 }

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -114,7 +114,6 @@ vi.mock('./ArchiveNotifier', async () =>
   })
 );
 
-const mockUseLayoutSettings = jest.fn();
 vi.mock('./useLayoutSettings', () => ({
   useLayoutSettings: (...args) => mockUseLayoutSettings(...args),
 }));
@@ -126,7 +125,9 @@ const {
   mockLayoutPrefsStore,
   mockTraceTimelineStore,
   useEmbeddedStateMock,
+  mockUseLayoutSettings,
 } = vi.hoisted(() => ({
+  mockUseLayoutSettings: jest.fn(),
   mockSubmitTraceToArchive: jest.fn(),
   mockAcknowledge: jest.fn(),
   mockSetDetailPanelMode: jest.fn(),

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -127,20 +127,20 @@ const {
   useEmbeddedStateMock,
   mockUseLayoutSettings,
 } = vi.hoisted(() => ({
-  mockUseLayoutSettings: jest.fn(),
-  mockSubmitTraceToArchive: jest.fn(),
-  mockAcknowledge: jest.fn(),
-  mockSetDetailPanelMode: jest.fn(),
+  mockUseLayoutSettings: vi.fn(),
+  mockSubmitTraceToArchive: vi.fn(),
+  mockAcknowledge: vi.fn(),
+  mockSetDetailPanelMode: vi.fn(),
   mockLayoutPrefsStore: {
     detailPanelMode: 'inline',
     timelineBarsVisible: true,
-    setTimelineBarsVisible: jest.fn(),
+    setTimelineBarsVisible: vi.fn(),
   },
   mockTraceTimelineStore: {
-    focusUiFindMatches: jest.fn(),
+    focusUiFindMatches: vi.fn(),
     prunedServices: new Set(),
   },
-  useEmbeddedStateMock: jest.fn().mockReturnValue(null),
+  useEmbeddedStateMock: vi.fn().mockReturnValue(null),
 }));
 
 vi.mock('../../stores/archive-store', () => ({

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -872,7 +872,7 @@ describe('<TracePage>', () => {
       mockLayoutPrefsStore.detailPanelMode = 'inline';
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onDetailPanelModeToggle();
-      expect(mockSetDetailPanelMode).toHaveBeenCalledWith('sidepanel');
+      expect(mockSetDetailPanelMode).toHaveBeenCalledWith('sidepanel', false);
       expect(defaultProps.setDetailPanelMode).toHaveBeenCalledWith('sidepanel');
     });
 
@@ -880,7 +880,7 @@ describe('<TracePage>', () => {
       mockLayoutPrefsStore.detailPanelMode = 'sidepanel';
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onDetailPanelModeToggle();
-      expect(mockSetDetailPanelMode).toHaveBeenCalledWith('inline');
+      expect(mockSetDetailPanelMode).toHaveBeenCalledWith('inline', false);
       expect(defaultProps.setDetailPanelMode).toHaveBeenCalledWith('inline');
     });
 
@@ -888,7 +888,7 @@ describe('<TracePage>', () => {
       mockLayoutPrefsStore.timelineBarsVisible = true;
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onTimelineToggle();
-      expect(mockLayoutPrefsStore.setTimelineBarsVisible).toHaveBeenCalledWith(false);
+      expect(mockLayoutPrefsStore.setTimelineBarsVisible).toHaveBeenCalledWith(false, false);
       expect(defaultProps.setTimelineBarsVisible).toHaveBeenCalledWith(false);
     });
 
@@ -896,7 +896,7 @@ describe('<TracePage>', () => {
       mockLayoutPrefsStore.timelineBarsVisible = false;
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onTimelineToggle();
-      expect(mockLayoutPrefsStore.setTimelineBarsVisible).toHaveBeenCalledWith(true);
+      expect(mockLayoutPrefsStore.setTimelineBarsVisible).toHaveBeenCalledWith(true, false);
       expect(defaultProps.setTimelineBarsVisible).toHaveBeenCalledWith(true);
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -114,6 +114,11 @@ vi.mock('./ArchiveNotifier', async () =>
   })
 );
 
+const mockUseLayoutSettings = jest.fn();
+vi.mock('./useLayoutSettings', () => ({
+  useLayoutSettings: (...args) => mockUseLayoutSettings(...args),
+}));
+
 const {
   mockSubmitTraceToArchive,
   mockAcknowledge,
@@ -238,6 +243,19 @@ describe('<TracePage>', () => {
     capturedArchiveNotifierProps = {};
     defaultProps.focusUiFindMatches.mockClear();
     mockTraceTimelineStore.focusUiFindMatches.mockClear();
+    mockUseLayoutSettings.mockReturnValue({
+      timelineBarsVisible: {
+        value: mockLayoutPrefsStore.timelineBarsVisible,
+        source: 'localstorage',
+        isOverridden: false,
+      },
+      detailPanelMode: {
+        value: mockLayoutPrefsStore.detailPanelMode,
+        source: 'localstorage',
+        isOverridden: false,
+      },
+      saveAsDefault: jest.fn(),
+    });
   });
 
   describe('clearSearch', () => {
@@ -870,6 +888,11 @@ describe('<TracePage>', () => {
 
     it('calls setDetailPanelMode (Zustand + Redux) with sidepanel when detailPanelMode is inline', () => {
       mockLayoutPrefsStore.detailPanelMode = 'inline';
+      mockUseLayoutSettings.mockReturnValue({
+        timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+        detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+        saveAsDefault: jest.fn(),
+      });
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onDetailPanelModeToggle();
       expect(mockSetDetailPanelMode).toHaveBeenCalledWith('sidepanel', false);
@@ -878,6 +901,11 @@ describe('<TracePage>', () => {
 
     it('calls setDetailPanelMode (Zustand + Redux) with inline when detailPanelMode is sidepanel', () => {
       mockLayoutPrefsStore.detailPanelMode = 'sidepanel';
+      mockUseLayoutSettings.mockReturnValue({
+        timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+        detailPanelMode: { value: 'sidepanel', source: 'localstorage', isOverridden: false },
+        saveAsDefault: jest.fn(),
+      });
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onDetailPanelModeToggle();
       expect(mockSetDetailPanelMode).toHaveBeenCalledWith('inline', false);
@@ -886,6 +914,11 @@ describe('<TracePage>', () => {
 
     it('calls setTimelineBarsVisible (Zustand + Redux) with false when timelineBarsVisible is true', () => {
       mockLayoutPrefsStore.timelineBarsVisible = true;
+      mockUseLayoutSettings.mockReturnValue({
+        timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+        detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+        saveAsDefault: jest.fn(),
+      });
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onTimelineToggle();
       expect(mockLayoutPrefsStore.setTimelineBarsVisible).toHaveBeenCalledWith(false, false);
@@ -894,6 +927,11 @@ describe('<TracePage>', () => {
 
     it('calls setTimelineBarsVisible (Zustand + Redux) with true when timelineBarsVisible is false', () => {
       mockLayoutPrefsStore.timelineBarsVisible = false;
+      mockUseLayoutSettings.mockReturnValue({
+        timelineBarsVisible: { value: false, source: 'localstorage', isOverridden: false },
+        detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+        saveAsDefault: jest.fn(),
+      });
       render(<TracePage {...defaultProps} />);
       capturedHeaderProps.onTimelineToggle();
       expect(mockLayoutPrefsStore.setTimelineBarsVisible).toHaveBeenCalledWith(true, false);

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -40,7 +40,7 @@ import TraceTimelineViewer from './TraceTimelineViewer';
 import { filterPrunedSpanIDs } from './TraceTimelineViewer/generateRowStates';
 import { actions as timelineActions } from './TraceTimelineViewer/duck';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from './types';
-import { getUrl, parseSettingsFromUrl } from './url';
+import { getUrl } from './url';
 import { useLayoutSettings } from './useLayoutSettings';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
@@ -162,8 +162,6 @@ export function TracePageImpl(props: TProps) {
   } = props;
 
   // Layout preferences are owned by Zustand; Redux setters are also called for the tracking middleware.
-  const detailPanelMode = useLayoutPrefsStore(s => s.detailPanelMode);
-  const timelineBarsVisible = useLayoutPrefsStore(s => s.timelineBarsVisible);
   const zustandSetTimelineBarsVisible = useLayoutPrefsStore(s => s.setTimelineBarsVisible);
   const zustandFocusUiFindMatches = useTraceTimelineStore(s => s.focusUiFindMatches);
   const prunedServices = useTraceTimelineStore(s => s.prunedServices);
@@ -173,16 +171,6 @@ export function TracePageImpl(props: TProps) {
     detailPanelMode: resolvedDetailPanel,
     saveAsDefault,
   } = useLayoutSettings(location.search);
-
-  useEffect(() => {
-    const urlSettings = parseSettingsFromUrl(location.search);
-    if (urlSettings.timelineBarsVisible !== null) {
-      zustandSetTimelineBarsVisible(urlSettings.timelineBarsVisible, false);
-    }
-    if (urlSettings.detailPanelMode !== null) {
-      setDetailPanelModeZustand(urlSettings.detailPanelMode, false);
-    }
-  }, [location.search, zustandSetTimelineBarsVisible]);
 
   const setDetailPanelMode = useCallback(
     (mode: SpanDetailPanelMode) => {
@@ -373,12 +361,12 @@ export function TracePageImpl(props: TProps) {
   }, []);
 
   const onDetailPanelModeToggle = useCallback(() => {
-    setDetailPanelMode(detailPanelMode === 'inline' ? 'sidepanel' : 'inline');
-  }, [detailPanelMode, setDetailPanelMode]);
+    setDetailPanelMode(resolvedDetailPanel.value === 'inline' ? 'sidepanel' : 'inline');
+  }, [resolvedDetailPanel.value, setDetailPanelMode]);
 
   const onTimelineToggle = useCallback(() => {
-    setTimelineBarsVisible(!timelineBarsVisible);
-  }, [setTimelineBarsVisible, timelineBarsVisible]);
+    setTimelineBarsVisible(!resolvedTimeline.value);
+  }, [setTimelineBarsVisible, resolvedTimeline.value]);
 
   if (!trace || trace.state === fetchedState.LOADING) {
     return <LoadingIndicator className="u-mt-vast" centered />;

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -181,10 +181,10 @@ export function TracePageImpl(props: TProps) {
 
       const nextSearch = rebaseSettings(location.search);
       if (nextSearch !== location.search) {
-        navigate({ search: nextSearch }, { replace: true });
+        navigate({ pathname: location.pathname, search: nextSearch }, { replace: true });
       }
     },
-    [reduxSetDetailPanelMode, location.search, navigate]
+    [reduxSetDetailPanelMode, location.search, location.pathname, navigate]
   );
 
   const setTimelineBarsVisible = useCallback(
@@ -194,10 +194,10 @@ export function TracePageImpl(props: TProps) {
 
       const nextSearch = rebaseSettings(location.search);
       if (nextSearch !== location.search) {
-        navigate({ search: nextSearch }, { replace: true });
+        navigate({ pathname: location.pathname, search: nextSearch }, { replace: true });
       }
     },
-    [zustandSetTimelineBarsVisible, reduxSetTimelineBarsVisible, location.search, navigate]
+    [zustandSetTimelineBarsVisible, reduxSetTimelineBarsVisible, location.search, location.pathname, navigate]
   );
 
   const archiveTraceState = useArchiveStore(s => (id ? (s.archives[id] ?? null) : null));

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -40,7 +40,7 @@ import TraceTimelineViewer from './TraceTimelineViewer';
 import { filterPrunedSpanIDs } from './TraceTimelineViewer/generateRowStates';
 import { actions as timelineActions } from './TraceTimelineViewer/duck';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from './types';
-import { getUrl, rebaseSettings } from './url';
+import { getUrl, stripSettingParam } from './url';
 import { useLayoutSettings } from './useLayoutSettings';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
@@ -179,7 +179,7 @@ export function TracePageImpl(props: TProps) {
       setDetailPanelModeZustand(mode, false);
       reduxSetDetailPanelMode(mode);
 
-      const nextSearch = rebaseSettings(location.search);
+      const nextSearch = stripSettingParam(location.search, 'detailPanelMode');
       if (nextSearch !== location.search) {
         navigate({ pathname: location.pathname, search: nextSearch }, { replace: true });
       }
@@ -192,7 +192,7 @@ export function TracePageImpl(props: TProps) {
       zustandSetTimelineBarsVisible(visible, false);
       reduxSetTimelineBarsVisible(visible);
 
-      const nextSearch = rebaseSettings(location.search);
+      const nextSearch = stripSettingParam(location.search, 'timelineBarsVisible');
       if (nextSearch !== location.search) {
         navigate({ pathname: location.pathname, search: nextSearch }, { replace: true });
       }

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -186,7 +186,7 @@ export function TracePageImpl(props: TProps) {
 
   const setDetailPanelMode = useCallback(
     (mode: SpanDetailPanelMode) => {
-      setDetailPanelModeZustand(mode);
+      setDetailPanelModeZustand(mode, false);
       reduxSetDetailPanelMode(mode);
     },
     [reduxSetDetailPanelMode]
@@ -194,7 +194,7 @@ export function TracePageImpl(props: TProps) {
 
   const setTimelineBarsVisible = useCallback(
     (visible: boolean) => {
-      zustandSetTimelineBarsVisible(visible);
+      zustandSetTimelineBarsVisible(visible, false);
       reduxSetTimelineBarsVisible(visible);
     },
     [zustandSetTimelineBarsVisible, reduxSetTimelineBarsVisible]

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -40,7 +40,8 @@ import TraceTimelineViewer from './TraceTimelineViewer';
 import { filterPrunedSpanIDs } from './TraceTimelineViewer/generateRowStates';
 import { actions as timelineActions } from './TraceTimelineViewer/duck';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from './types';
-import { getUrl } from './url';
+import { getUrl, parseSettingsFromUrl } from './url';
+import { useLayoutSettings } from './useLayoutSettings';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
 import { extractUiFindFromState } from '../common/UiFindInput';
@@ -166,6 +167,22 @@ export function TracePageImpl(props: TProps) {
   const zustandSetTimelineBarsVisible = useLayoutPrefsStore(s => s.setTimelineBarsVisible);
   const zustandFocusUiFindMatches = useTraceTimelineStore(s => s.focusUiFindMatches);
   const prunedServices = useTraceTimelineStore(s => s.prunedServices);
+
+  const {
+    timelineBarsVisible: resolvedTimeline,
+    detailPanelMode: resolvedDetailPanel,
+    saveAsDefault,
+  } = useLayoutSettings(location.search);
+
+  useEffect(() => {
+    const urlSettings = parseSettingsFromUrl(location.search);
+    if (urlSettings.timelineBarsVisible !== null) {
+      zustandSetTimelineBarsVisible(urlSettings.timelineBarsVisible, false);
+    }
+    if (urlSettings.detailPanelMode !== null) {
+      useLayoutPrefsStore.getState().applyDetailPanelModeToLayout(urlSettings.detailPanelMode, false);
+    }
+  }, [location.search, zustandSetTimelineBarsVisible]);
 
   const setDetailPanelMode = useCallback(
     (mode: SpanDetailPanelMode) => {
@@ -400,7 +417,7 @@ export function TracePageImpl(props: TProps) {
     viewRange,
     canCollapse: !embedded || !embedded.timeline?.hideSummary || !embedded.timeline?.hideMinimap,
     clearSearch,
-    detailPanelMode,
+    detailPanelMode: resolvedDetailPanel.value,
     enableSidePanel,
     hideMap: Boolean(
       viewType !== ETraceViewType.TraceTimelineViewer || Boolean(embedded?.timeline?.hideMinimap)
@@ -420,12 +437,17 @@ export function TracePageImpl(props: TProps) {
     showArchiveButton: !isEmbedded && archiveEnabled && hasArchiveStorage,
     showStandaloneLink: isEmbedded,
     showViewOptions: !isEmbedded,
-    timelineBarsVisible,
+    timelineBarsVisible: resolvedTimeline.value,
     toSearch: (locationState && locationState.fromSearch) || null,
     trace: data.asOtelTrace(),
     updateNextViewRangeTime,
     updateViewRangeTime,
     useOtelTerms,
+    settingSources: {
+      timelineBarsVisible: resolvedTimeline,
+      detailPanelMode: resolvedDetailPanel,
+    },
+    saveSettingAsDefault: saveAsDefault,
   };
 
   const sm = scrollManagerRef.current;

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -180,7 +180,7 @@ export function TracePageImpl(props: TProps) {
       zustandSetTimelineBarsVisible(urlSettings.timelineBarsVisible, false);
     }
     if (urlSettings.detailPanelMode !== null) {
-      useLayoutPrefsStore.getState().applyDetailPanelModeToLayout(urlSettings.detailPanelMode, false);
+      setDetailPanelModeZustand(urlSettings.detailPanelMode, false);
     }
   }, [location.search, zustandSetTimelineBarsVisible]);
 

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -40,7 +40,7 @@ import TraceTimelineViewer from './TraceTimelineViewer';
 import { filterPrunedSpanIDs } from './TraceTimelineViewer/generateRowStates';
 import { actions as timelineActions } from './TraceTimelineViewer/duck';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, ETraceViewType } from './types';
-import { getUrl } from './url';
+import { getUrl, rebaseSettings } from './url';
 import { useLayoutSettings } from './useLayoutSettings';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
@@ -172,23 +172,33 @@ export function TracePageImpl(props: TProps) {
     saveAsDefault,
   } = useLayoutSettings(location.search);
 
+  const navigate = useNavigate();
+
   const setDetailPanelMode = useCallback(
     (mode: SpanDetailPanelMode) => {
       setDetailPanelModeZustand(mode, false);
       reduxSetDetailPanelMode(mode);
+
+      const nextSearch = rebaseSettings(location.search);
+      if (nextSearch !== location.search) {
+        navigate({ search: nextSearch }, { replace: true });
+      }
     },
-    [reduxSetDetailPanelMode]
+    [reduxSetDetailPanelMode, location.search, navigate]
   );
 
   const setTimelineBarsVisible = useCallback(
     (visible: boolean) => {
       zustandSetTimelineBarsVisible(visible, false);
       reduxSetTimelineBarsVisible(visible);
-    },
-    [zustandSetTimelineBarsVisible, reduxSetTimelineBarsVisible]
-  );
 
-  const navigate = useNavigate();
+      const nextSearch = rebaseSettings(location.search);
+      if (nextSearch !== location.search) {
+        navigate({ search: nextSearch }, { replace: true });
+      }
+    },
+    [zustandSetTimelineBarsVisible, reduxSetTimelineBarsVisible, location.search, navigate]
+  );
 
   const archiveTraceState = useArchiveStore(s => (id ? (s.archives[id] ?? null) : null));
   const submitTraceToArchiveFn = useArchiveStore(s => s.submitTraceToArchive);

--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -1,11 +1,53 @@
 // Copyright (c) 2020 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getTracePageLink, getUrl } from '.';
+import { getTracePageLink, getUrl, stringifySettings, rebaseSettings, parseSettingsFromUrl } from '.';
 
 describe('TracePage/url', () => {
   const traceID = 'trace-id';
   const uiFind = 'ui-find';
+
+  describe('stringifySettings', () => {
+    it('handles empty settings', () => {
+      expect(stringifySettings({})).toEqual({});
+    });
+
+    it('handles timeline settings', () => {
+      expect(stringifySettings({ timelineBarsVisible: true })).toEqual({ timeline: 'on' });
+      expect(stringifySettings({ timelineBarsVisible: false })).toEqual({ timeline: 'off' });
+      expect(stringifySettings({ timelineBarsVisible: null })).toEqual({});
+    });
+
+    it('handles sidebar settings', () => {
+      expect(stringifySettings({ detailPanelMode: 'sidepanel' })).toEqual({ sidebar: 'sidepanel' });
+      expect(stringifySettings({ detailPanelMode: 'inline' })).toEqual({ sidebar: 'inline' });
+      expect(stringifySettings({ detailPanelMode: null })).toEqual({});
+    });
+
+    it('handles combined settings', () => {
+      expect(stringifySettings({ timelineBarsVisible: true, detailPanelMode: 'sidepanel' })).toEqual({
+        timeline: 'on',
+        sidebar: 'sidepanel',
+      });
+    });
+  });
+
+  describe('rebaseSettings', () => {
+    it('removes settings while preserving others', () => {
+      const search = '?uiFind=foo&timeline=on&sidebar=sidepanel';
+      expect(rebaseSettings(search)).toBe('?uiFind=foo');
+    });
+
+    it('returns empty string if only settings were present', () => {
+      const search = '?timeline=on&sidebar=sidepanel';
+      expect(rebaseSettings(search)).toBe('');
+    });
+
+    it('handles search without settings', () => {
+      const search = '?uiFind=foo';
+      expect(rebaseSettings(search)).toBe('?uiFind=foo');
+    });
+  });
 
   describe('getUrl', () => {
     it('includes traceID without uiFind', () => {
@@ -14,6 +56,16 @@ describe('TracePage/url', () => {
 
     it('includes traceID and uiFind', () => {
       expect(getUrl(traceID, uiFind)).toBe(`/trace/${traceID}?uiFind=${uiFind}`);
+    });
+
+    it('includes settings', () => {
+      expect(getUrl(traceID, undefined, { timelineBarsVisible: true })).toBe(`/trace/${traceID}?timeline=on`);
+    });
+
+    it('includes both uiFind and settings', () => {
+      const url = getUrl(traceID, uiFind, { detailPanelMode: 'sidepanel' });
+      expect(url).toContain('uiFind=ui-find');
+      expect(url).toContain('sidebar=sidepanel');
     });
   });
 
@@ -25,15 +77,40 @@ describe('TracePage/url', () => {
     it('passes provided state with correct pathname, without uiFind', () => {
       expect(getTracePageLink(traceID, state)).toEqual({
         state,
-        pathname: getUrl(traceID),
+        pathname: `/trace/${traceID}`,
       });
     });
 
     it('passes provided state with correct pathname with uiFind', () => {
       expect(getTracePageLink(traceID, state, uiFind)).toEqual({
         state,
-        pathname: getUrl(traceID),
+        pathname: `/trace/${traceID}`,
         search: `uiFind=${uiFind}`,
+      });
+    });
+
+    it('includes settings', () => {
+      expect(getTracePageLink(traceID, state, undefined, { timelineBarsVisible: false })).toEqual({
+        state,
+        pathname: `/trace/${traceID}`,
+        search: 'timeline=off',
+      });
+    });
+  });
+
+  describe('parseSettingsFromUrl', () => {
+    it('parses settings correctly', () => {
+      const search = '?timeline=off&sidebar=sidepanel';
+      expect(parseSettingsFromUrl(search)).toEqual({
+        timelineBarsVisible: false,
+        detailPanelMode: 'sidepanel',
+      });
+    });
+
+    it('handles missing settings', () => {
+      expect(parseSettingsFromUrl('')).toEqual({
+        timelineBarsVisible: null,
+        detailPanelMode: null,
       });
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getTracePageLink, getUrl, stringifySettings, rebaseSettings, parseSettingsFromUrl } from '.';
+import prefixUrl from '../../../utils/prefix-url';
 
 describe('TracePage/url', () => {
   const traceID = 'trace-id';
@@ -51,15 +52,17 @@ describe('TracePage/url', () => {
 
   describe('getUrl', () => {
     it('includes traceID without uiFind', () => {
-      expect(getUrl(traceID)).toBe(`/trace/${traceID}`);
+      expect(getUrl(traceID)).toBe(prefixUrl(`/trace/${traceID}`));
     });
 
     it('includes traceID and uiFind', () => {
-      expect(getUrl(traceID, uiFind)).toBe(`/trace/${traceID}?uiFind=${uiFind}`);
+      expect(getUrl(traceID, uiFind)).toBe(prefixUrl(`/trace/${traceID}?uiFind=${uiFind}`));
     });
 
     it('includes settings', () => {
-      expect(getUrl(traceID, undefined, { timelineBarsVisible: true })).toBe(`/trace/${traceID}?timeline=on`);
+      expect(getUrl(traceID, undefined, { timelineBarsVisible: true })).toBe(
+        prefixUrl(`/trace/${traceID}?timeline=on`)
+      );
     });
 
     it('includes both uiFind and settings', () => {
@@ -77,14 +80,14 @@ describe('TracePage/url', () => {
     it('passes provided state with correct pathname, without uiFind', () => {
       expect(getTracePageLink(traceID, state)).toEqual({
         state,
-        pathname: `/trace/${traceID}`,
+        pathname: prefixUrl(`/trace/${traceID}`),
       });
     });
 
     it('passes provided state with correct pathname with uiFind', () => {
       expect(getTracePageLink(traceID, state, uiFind)).toEqual({
         state,
-        pathname: `/trace/${traceID}`,
+        pathname: prefixUrl(`/trace/${traceID}`),
         search: `uiFind=${uiFind}`,
       });
     });
@@ -92,7 +95,7 @@ describe('TracePage/url', () => {
     it('includes settings', () => {
       expect(getTracePageLink(traceID, state, undefined, { timelineBarsVisible: false })).toEqual({
         state,
-        pathname: `/trace/${traceID}`,
+        pathname: prefixUrl(`/trace/${traceID}`),
         search: 'timeline=off',
       });
     });

--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -74,8 +74,9 @@ describe('TracePage/url', () => {
       expect(stripSettingParam('?timeline=on', 'timelineBarsVisible')).toBe('');
     });
 
-    it('is a no-op when the targeted param is absent', () => {
-      expect(stripSettingParam('?uiFind=foo', 'timelineBarsVisible')).toBe('?uiFind=foo');
+    it('returns the original search unchanged when the targeted param is absent', () => {
+      const search = '?uiFind=foo';
+      expect(stripSettingParam(search, 'timelineBarsVisible')).toBe(search);
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -1,7 +1,14 @@
 // Copyright (c) 2020 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getTracePageLink, getUrl, stringifySettings, rebaseSettings, parseSettingsFromUrl } from '.';
+import {
+  getTracePageLink,
+  getUrl,
+  stringifySettings,
+  rebaseSettings,
+  stripSettingParam,
+  parseSettingsFromUrl,
+} from '.';
 import prefixUrl from '../../../utils/prefix-url';
 
 describe('TracePage/url', () => {
@@ -47,6 +54,28 @@ describe('TracePage/url', () => {
     it('handles search without settings', () => {
       const search = '?uiFind=foo';
       expect(rebaseSettings(search)).toBe('?uiFind=foo');
+    });
+  });
+
+  describe('stripSettingParam', () => {
+    it('strips only the timeline param, leaving sidebar intact', () => {
+      expect(stripSettingParam('?uiFind=foo&timeline=on&sidebar=sidepanel', 'timelineBarsVisible')).toBe(
+        '?sidebar=sidepanel&uiFind=foo'
+      );
+    });
+
+    it('strips only the sidebar param, leaving timeline intact', () => {
+      expect(stripSettingParam('?uiFind=foo&timeline=on&sidebar=sidepanel', 'detailPanelMode')).toBe(
+        '?timeline=on&uiFind=foo'
+      );
+    });
+
+    it('returns empty string if only that param was present', () => {
+      expect(stripSettingParam('?timeline=on', 'timelineBarsVisible')).toBe('');
+    });
+
+    it('is a no-op when the targeted param is absent', () => {
+      expect(stripSettingParam('?uiFind=foo', 'timelineBarsVisible')).toBe('?uiFind=foo');
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -13,8 +13,6 @@ export const ROUTE_PATH = prefixUrl('/trace/:id');
 const URL_PARAM_TIMELINE = 'timeline';
 const URL_PARAM_SIDEBAR = 'sidebar';
 
-const SETTINGS_URL_PARAMS = [URL_PARAM_TIMELINE, URL_PARAM_SIDEBAR];
-
 export type UrlLayoutSettings = {
   timelineBarsVisible: boolean | null;
   detailPanelMode: SpanDetailPanelMode | null;
@@ -32,12 +30,26 @@ export function stringifySettings(settings: Partial<UrlLayoutSettings>): Record<
 }
 
 /**
- * Removes layout settings from a search string.
- * This is used to "rebase" the URL back to its base state (preserving other params like uiFind).
+ * Removes all layout setting params from a search string, preserving others (e.g. uiFind).
+ * Used when closing/navigating away from a trace to produce a clean base URL.
  */
 export function rebaseSettings(search: string): string {
   const params = queryString.parse(search);
-  SETTINGS_URL_PARAMS.forEach(p => delete params[p]);
+  delete params[URL_PARAM_TIMELINE];
+  delete params[URL_PARAM_SIDEBAR];
+  const newSearch = queryString.stringify(params);
+  return newSearch ? `?${newSearch}` : '';
+}
+
+/**
+ * Removes a single layout setting param from a search string, preserving all others.
+ * Used when the user toggles a setting — only the acted-on param is stripped,
+ * so other URL overrides (e.g. ?sidebar=sidepanel) remain intact.
+ */
+export function stripSettingParam(search: string, key: keyof UrlLayoutSettings): string {
+  const paramName = key === 'timelineBarsVisible' ? URL_PARAM_TIMELINE : URL_PARAM_SIDEBAR;
+  const params = queryString.parse(search);
+  delete params[paramName];
   const newSearch = queryString.stringify(params);
   return newSearch ? `?${newSearch}` : '';
 }

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -5,15 +5,52 @@ import queryString from 'query-string';
 
 import prefixUrl from '../../../utils/prefix-url';
 
-import type { LocationState } from '../../../types';
+import { TNil, LocationState } from '../../../types';
+import type { SpanDetailPanelMode } from '../../../types/config';
 
 export const ROUTE_PATH = prefixUrl('/trace/:id');
 
-export function getUrl(id: string, uiFind?: string): string {
-  const traceUrl = prefixUrl(`/trace/${id}`);
-  if (!uiFind) return traceUrl;
+const URL_PARAM_TIMELINE = 'timeline';
+const URL_PARAM_SIDEBAR = 'sidebar';
 
-  return `${traceUrl}?${queryString.stringify({ uiFind })}`;
+const SETTINGS_URL_PARAMS = [URL_PARAM_TIMELINE, URL_PARAM_SIDEBAR];
+
+export type UrlLayoutSettings = {
+  timelineBarsVisible: boolean | null;
+  detailPanelMode: SpanDetailPanelMode | null;
+};
+
+/**
+ * Converts layout settings into query parameters.
+ */
+export function stringifySettings(settings: Partial<UrlLayoutSettings>): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (settings.timelineBarsVisible === true) params[URL_PARAM_TIMELINE] = 'on';
+  if (settings.timelineBarsVisible === false) params[URL_PARAM_TIMELINE] = 'off';
+  if (settings.detailPanelMode) params[URL_PARAM_SIDEBAR] = settings.detailPanelMode;
+  return params;
+}
+
+/**
+ * Removes layout settings from a search string.
+ * This is used to "rebase" the URL back to its base state (preserving other params like uiFind).
+ */
+export function rebaseSettings(search: string): string {
+  const params = queryString.parse(search);
+  SETTINGS_URL_PARAMS.forEach(p => delete params[p]);
+  const newSearch = queryString.stringify(params);
+  return newSearch ? `?${newSearch}` : '';
+}
+
+export function getUrl(id: string, uiFind?: string, settings?: Partial<UrlLayoutSettings>): string {
+  const traceUrl = prefixUrl(`/trace/${id}`);
+  const params = {
+    ...(uiFind ? { uiFind } : {}),
+    ...(settings ? stringifySettings(settings) : {}),
+  };
+
+  const search = queryString.stringify(params);
+  return search ? `${traceUrl}?${search}` : traceUrl;
 }
 
 // Navigation descriptor for links that point to the trace page.
@@ -28,8 +65,33 @@ export type TracePageLink = {
   state?: LocationState;
 };
 
-export function getTracePageLink(id: string, state?: LocationState, uiFind?: string): TracePageLink {
-  const link: TracePageLink = { state, pathname: getUrl(id) };
-  if (uiFind) link.search = queryString.stringify({ uiFind });
-  return link;
+export function getTracePageLink(
+  id: string,
+  state?: LocationState,
+  uiFind?: string,
+  settings?: Partial<UrlLayoutSettings>
+): TracePageLink {
+  const pathname = prefixUrl(`/trace/${id}`);
+  const params = {
+    ...(uiFind ? { uiFind } : {}),
+    ...(settings ? stringifySettings(settings) : {}),
+  };
+  const search = queryString.stringify(params);
+  return { state, pathname, ...(search ? { search } : {}) };
+}
+
+export function parseSettingsFromUrl(search: string): UrlLayoutSettings {
+  const params = queryString.parse(search);
+
+  let timelineBarsVisible: boolean | null = null;
+  const timelineParam = params[URL_PARAM_TIMELINE];
+  if (timelineParam === 'off') timelineBarsVisible = false;
+  else if (timelineParam === 'on') timelineBarsVisible = true;
+
+  let detailPanelMode: SpanDetailPanelMode | null = null;
+  const sidebarParam = params[URL_PARAM_SIDEBAR];
+  if (sidebarParam === 'sidepanel') detailPanelMode = 'sidepanel';
+  else if (sidebarParam === 'inline') detailPanelMode = 'inline';
+
+  return { timelineBarsVisible, detailPanelMode };
 }

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -49,6 +49,7 @@ export function rebaseSettings(search: string): string {
 export function stripSettingParam(search: string, key: keyof UrlLayoutSettings): string {
   const paramName = key === 'timelineBarsVisible' ? URL_PARAM_TIMELINE : URL_PARAM_SIDEBAR;
   const params = queryString.parse(search);
+  if (!(paramName in params)) return search; // param absent — no change, no stringify churn
   delete params[paramName];
   const newSearch = queryString.stringify(params);
   return newSearch ? `?${newSearch}` : '';

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -5,7 +5,7 @@ import queryString from 'query-string';
 
 import prefixUrl from '../../../utils/prefix-url';
 
-import { TNil, LocationState } from '../../../types';
+import type { LocationState } from '../../../types';
 import type { SpanDetailPanelMode } from '../../../types/config';
 
 export const ROUTE_PATH = prefixUrl('/trace/:id');

--- a/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '@testing-library/react';
+import { useLayoutSettings } from './useLayoutSettings';
+import { useLayoutPrefsStore } from './TraceTimelineViewer/store.layout';
+
+function resetStore(overrides: Partial<{ timelineBarsVisible: boolean; detailPanelMode: string }> = {}) {
+  useLayoutPrefsStore.setState({
+    timelineBarsVisible: overrides.timelineBarsVisible ?? true,
+    detailPanelMode: (overrides.detailPanelMode as 'inline' | 'sidepanel') ?? 'inline',
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetStore();
+});
+
+describe('URL parameter overrides', () => {
+  it('resolves timelineBarsVisible=false from ?timeline=off', () => {
+    resetStore({ timelineBarsVisible: true });
+    const { result } = renderHook(() => useLayoutSettings('?timeline=off'));
+    expect(result.current.timelineBarsVisible.value).toBe(false);
+    expect(result.current.timelineBarsVisible.source).toBe('url');
+    expect(result.current.timelineBarsVisible.isOverridden).toBe(true);
+  });
+
+  it('resolves timelineBarsVisible=true from ?timeline=on even if localStorage says false', () => {
+    resetStore({ timelineBarsVisible: false });
+    const { result } = renderHook(() => useLayoutSettings('?timeline=on'));
+    expect(result.current.timelineBarsVisible.value).toBe(true);
+    expect(result.current.timelineBarsVisible.source).toBe('url');
+  });
+
+  it('resolves detailPanelMode=sidepanel from ?sidebar=sidepanel', () => {
+    resetStore({ detailPanelMode: 'inline' });
+    const { result } = renderHook(() => useLayoutSettings('?sidebar=sidepanel'));
+    expect(result.current.detailPanelMode.value).toBe('sidepanel');
+    expect(result.current.detailPanelMode.source).toBe('url');
+    expect(result.current.detailPanelMode.isOverridden).toBe(true);
+  });
+
+  it('resolves detailPanelMode=inline from ?sidebar=inline', () => {
+    resetStore({ detailPanelMode: 'sidepanel' });
+    const { result } = renderHook(() => useLayoutSettings('?sidebar=inline'));
+    expect(result.current.detailPanelMode.value).toBe('inline');
+    expect(result.current.detailPanelMode.source).toBe('url');
+  });
+
+  it('sets isOverridden=false when URL value matches localStorage value', () => {
+    // Set BOTH localStorage and store state so getInitialLayoutState() reads false
+    localStorage.setItem('timelineVisible', 'false');
+    resetStore({ timelineBarsVisible: false });
+    // URL also says off — value matches localStorage, so no real override from user's POV
+    const { result } = renderHook(() => useLayoutSettings('?timeline=off'));
+    expect(result.current.timelineBarsVisible.source).toBe('url');
+    expect(result.current.timelineBarsVisible.isOverridden).toBe(false);
+  });
+});
+
+describe('localStorage fallback', () => {
+  it('falls back to localStorage when no URL params present', () => {
+    resetStore({ timelineBarsVisible: false, detailPanelMode: 'sidepanel' });
+    const { result } = renderHook(() => useLayoutSettings(''));
+    expect(result.current.timelineBarsVisible.value).toBe(false);
+    expect(result.current.timelineBarsVisible.source).toBe('localstorage');
+    expect(result.current.timelineBarsVisible.isOverridden).toBe(false);
+    expect(result.current.detailPanelMode.value).toBe('sidepanel');
+    expect(result.current.detailPanelMode.source).toBe('localstorage');
+  });
+
+  it('returns isOverridden=false for localstorage source', () => {
+    resetStore({ timelineBarsVisible: true });
+    const { result } = renderHook(() => useLayoutSettings(''));
+    expect(result.current.timelineBarsVisible.isOverridden).toBe(false);
+  });
+});
+
+describe('saveAsDefault', () => {
+  it('writes timelineBarsVisible to localStorage when called', () => {
+    resetStore({ timelineBarsVisible: true });
+    const { result } = renderHook(() => useLayoutSettings('?timeline=off'));
+    // Effective value is false (from URL)
+    expect(result.current.timelineBarsVisible.value).toBe(false);
+
+    act(() => {
+      result.current.saveAsDefault('timelineBarsVisible');
+    });
+
+    expect(localStorage.getItem('timelineVisible')).toBe('false');
+  });
+
+  it('writes detailPanelMode to localStorage when called', () => {
+    resetStore({ detailPanelMode: 'inline' });
+    const { result } = renderHook(() => useLayoutSettings('?sidebar=sidepanel'));
+    expect(result.current.detailPanelMode.value).toBe('sidepanel');
+
+    act(() => {
+      result.current.saveAsDefault('detailPanelMode');
+    });
+
+    expect(localStorage.getItem('detailPanelMode')).toBe('sidepanel');
+  });
+
+  it('does NOT write to localStorage for URL-driven values unless saveAsDefault is called', () => {
+    resetStore({ timelineBarsVisible: true });
+    renderHook(() => useLayoutSettings('?timeline=off'));
+    // Before calling saveAsDefault, localStorage should not be changed
+    expect(localStorage.getItem('timelineVisible')).toBeNull();
+  });
+});
+
+describe('URL param edge cases', () => {
+  it('ignores unknown timeline param values', () => {
+    resetStore({ timelineBarsVisible: true });
+    const { result } = renderHook(() => useLayoutSettings('?timeline=maybe'));
+    expect(result.current.timelineBarsVisible.source).toBe('localstorage');
+    expect(result.current.timelineBarsVisible.value).toBe(true);
+  });
+
+  it('ignores unknown sidebar param values', () => {
+    resetStore({ detailPanelMode: 'inline' });
+    const { result } = renderHook(() => useLayoutSettings('?sidebar=floating'));
+    expect(result.current.detailPanelMode.source).toBe('localstorage');
+    expect(result.current.detailPanelMode.value).toBe('inline');
+  });
+
+  it('handles combined timeline and sidebar params', () => {
+    resetStore({ timelineBarsVisible: true, detailPanelMode: 'inline' });
+    const { result } = renderHook(() => useLayoutSettings('?timeline=off&sidebar=sidepanel'));
+    expect(result.current.timelineBarsVisible.value).toBe(false);
+    expect(result.current.timelineBarsVisible.source).toBe('url');
+    expect(result.current.detailPanelMode.value).toBe('sidepanel');
+    expect(result.current.detailPanelMode.source).toBe('url');
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.test.ts
@@ -190,4 +190,28 @@ describe('URL parameter removal and store synchronization', () => {
     // Verify it reverted to localStorage default (inline)
     expect(useLayoutPrefsStore.getState().detailPanelMode).toBe('inline');
   });
+
+  it('does NOT revert to defaults when URL param is removed if user has already changed the value', () => {
+    // lsDefault is 'sidepanel', URL overrides to 'inline'
+    localStorage.setItem('detailPanelMode', 'sidepanel');
+    resetStore({ detailPanelMode: 'sidepanel' });
+
+    const { rerender } = renderHook(({ search }) => useLayoutSettings(search), {
+      initialProps: { search: '?sidebar=inline' },
+    });
+
+    // URL forced store to 'inline'
+    expect(useLayoutPrefsStore.getState().detailPanelMode).toBe('inline');
+
+    // User manually changes it back to 'sidepanel' (different from what URL set)
+    act(() => {
+      useLayoutPrefsStore.setState({ detailPanelMode: 'sidepanel' });
+    });
+
+    // Remove URL param — because store ('sidepanel') !== prevUrlValue ('inline'),
+    // the revert guard should NOT fire, preserving the user's choice.
+    rerender({ search: '' });
+
+    expect(useLayoutPrefsStore.getState().detailPanelMode).toBe('sidepanel');
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.test.ts
@@ -61,6 +61,8 @@ describe('URL parameter overrides', () => {
 
 describe('localStorage fallback', () => {
   it('falls back to localStorage when no URL params present', () => {
+    localStorage.setItem('timelineVisible', 'false');
+    localStorage.setItem('detailPanelMode', 'sidepanel');
     resetStore({ timelineBarsVisible: false, detailPanelMode: 'sidepanel' });
     const { result } = renderHook(() => useLayoutSettings(''));
     expect(result.current.timelineBarsVisible.value).toBe(false);
@@ -70,10 +72,20 @@ describe('localStorage fallback', () => {
     expect(result.current.detailPanelMode.source).toBe('localstorage');
   });
 
-  it('returns isOverridden=false for localstorage source', () => {
+  it('returns isOverridden=false for localstorage source when it matches localStorage', () => {
+    localStorage.setItem('timelineVisible', 'true');
     resetStore({ timelineBarsVisible: true });
     const { result } = renderHook(() => useLayoutSettings(''));
     expect(result.current.timelineBarsVisible.isOverridden).toBe(false);
+  });
+
+  it('detects manual session overrides (isOverridden=true) when store diverges from localStorage', () => {
+    localStorage.setItem('timelineVisible', 'true');
+    resetStore({ timelineBarsVisible: false });
+    const { result } = renderHook(() => useLayoutSettings(''));
+    expect(result.current.timelineBarsVisible.value).toBe(false);
+    expect(result.current.timelineBarsVisible.source).toBe('localstorage');
+    expect(result.current.timelineBarsVisible.isOverridden).toBe(true);
   });
 });
 
@@ -133,5 +145,49 @@ describe('URL param edge cases', () => {
     expect(result.current.timelineBarsVisible.source).toBe('url');
     expect(result.current.detailPanelMode.value).toBe('sidepanel');
     expect(result.current.detailPanelMode.source).toBe('url');
+  });
+});
+
+describe('URL parameter removal and store synchronization', () => {
+  it('synchronizes the Zustand store when URL parameters are present', () => {
+    resetStore({ timelineBarsVisible: true });
+    renderHook(() => useLayoutSettings('?timeline=off'));
+    expect(useLayoutPrefsStore.getState().timelineBarsVisible).toBe(false);
+  });
+
+  it('reverts the Zustand store to localStorage defaults when URL parameters are removed', () => {
+    localStorage.setItem('timelineVisible', 'true');
+    resetStore({ timelineBarsVisible: true });
+
+    const { rerender } = renderHook(({ search }) => useLayoutSettings(search), {
+      initialProps: { search: '?timeline=off' },
+    });
+
+    // Verify it synced to URL initially
+    expect(useLayoutPrefsStore.getState().timelineBarsVisible).toBe(false);
+
+    // Change search to empty (removal)
+    rerender({ search: '' });
+
+    // Verify it reverted to localStorage default (true)
+    expect(useLayoutPrefsStore.getState().timelineBarsVisible).toBe(true);
+  });
+
+  it('reverts detailPanelMode to localStorage defaults when URL parameters are removed', () => {
+    localStorage.setItem('detailPanelMode', 'inline');
+    resetStore({ detailPanelMode: 'inline' });
+
+    const { rerender } = renderHook(({ search }) => useLayoutSettings(search), {
+      initialProps: { search: '?sidebar=sidepanel' },
+    });
+
+    // Verify it synced to URL initially
+    expect(useLayoutPrefsStore.getState().detailPanelMode).toBe('sidepanel');
+
+    // Change search to empty (removal)
+    rerender({ search: '' });
+
+    // Verify it reverted to localStorage default (inline)
+    expect(useLayoutPrefsStore.getState().detailPanelMode).toBe('inline');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
@@ -1,11 +1,12 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { SpanDetailPanelMode } from '../../types/config';
 import { parseSettingsFromUrl } from './url';
 import type { UrlLayoutSettings } from './url';
 import { getInitialLayoutState, useLayoutPrefsStore } from './TraceTimelineViewer/store.layout';
+import { setDetailPanelMode } from './TraceTimelineViewer/store';
 
 export type SettingSource = 'url' | 'heuristic' | 'localstorage';
 
@@ -30,9 +31,9 @@ export function useLayoutSettings(locationSearch: string): ResolvedLayoutSetting
   const storeTimelineBarsVisible = useLayoutPrefsStore(s => s.timelineBarsVisible);
   const storeDetailPanelMode = useLayoutPrefsStore(s => s.detailPanelMode);
   const zustandSetTimelineBarsVisible = useLayoutPrefsStore(s => s.setTimelineBarsVisible);
-  const zustandApplyDetailPanelMode = useLayoutPrefsStore(s => s.applyDetailPanelModeToLayout);
 
-  const lsDefaults = useMemo(() => getInitialLayoutState(), []);
+  // Read localStorage state on mount, and update it manually when saveAsDefault is called.
+  const [lsDefaults, setLsDefaults] = useState(() => getInitialLayoutState());
   const urlSettings = useMemo(() => parseSettingsFromUrl(locationSearch), [locationSearch]);
   const heuristicOverrides = useMemo(() => computeHeuristicOverrides(), []);
 
@@ -95,15 +96,11 @@ export function useLayoutSettings(locationSearch: string): ResolvedLayoutSetting
       if (key === 'timelineBarsVisible') {
         zustandSetTimelineBarsVisible(timelineBarsVisible.value, true);
       } else {
-        zustandApplyDetailPanelMode(detailPanelMode.value, true);
+        setDetailPanelMode(detailPanelMode.value, true);
       }
+      setLsDefaults(getInitialLayoutState());
     },
-    [
-      zustandSetTimelineBarsVisible,
-      zustandApplyDetailPanelMode,
-      timelineBarsVisible.value,
-      detailPanelMode.value,
-    ]
+    [zustandSetTimelineBarsVisible, timelineBarsVisible.value, detailPanelMode.value]
   );
 
   return { timelineBarsVisible, detailPanelMode, saveAsDefault };

--- a/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { SpanDetailPanelMode } from '../../types/config';
 import { parseSettingsFromUrl } from './url';
 import type { UrlLayoutSettings } from './url';
 import { getInitialLayoutState, useLayoutPrefsStore } from './TraceTimelineViewer/store.layout';
-import { setDetailPanelMode } from './TraceTimelineViewer/store';
+import { setDetailPanelMode as setDetailPanelModeZustand } from './TraceTimelineViewer/store';
 
 export type SettingSource = 'url' | 'heuristic' | 'localstorage';
 
@@ -55,7 +55,7 @@ export function useLayoutSettings(locationSearch: string): ResolvedLayoutSetting
     return {
       value: storeTimelineBarsVisible,
       source: 'localstorage',
-      isOverridden: false,
+      isOverridden: storeTimelineBarsVisible !== lsDefaults.timelineBarsVisible,
     };
   }, [
     urlSettings.timelineBarsVisible,
@@ -82,7 +82,7 @@ export function useLayoutSettings(locationSearch: string): ResolvedLayoutSetting
     return {
       value: storeDetailPanelMode,
       source: 'localstorage',
-      isOverridden: false,
+      isOverridden: storeDetailPanelMode !== lsDefaults.detailPanelMode,
     };
   }, [
     urlSettings.detailPanelMode,
@@ -91,12 +91,32 @@ export function useLayoutSettings(locationSearch: string): ResolvedLayoutSetting
     storeDetailPanelMode,
   ]);
 
+  const prevUrlSettingsRef = useRef<UrlLayoutSettings>(urlSettings);
+
+  useLayoutEffect(() => {
+    // Sync Timeline Bars
+    if (urlSettings.timelineBarsVisible !== null) {
+      zustandSetTimelineBarsVisible(urlSettings.timelineBarsVisible, false);
+    } else if (prevUrlSettingsRef.current.timelineBarsVisible !== null) {
+      zustandSetTimelineBarsVisible(lsDefaults.timelineBarsVisible, false);
+    }
+
+    // Sync Detail Panel Mode
+    if (urlSettings.detailPanelMode !== null) {
+      setDetailPanelModeZustand(urlSettings.detailPanelMode, false);
+    } else if (prevUrlSettingsRef.current.detailPanelMode !== null) {
+      setDetailPanelModeZustand(lsDefaults.detailPanelMode, false);
+    }
+
+    prevUrlSettingsRef.current = urlSettings;
+  }, [urlSettings, lsDefaults, zustandSetTimelineBarsVisible]);
+
   const saveAsDefault = useCallback(
     (key: 'timelineBarsVisible' | 'detailPanelMode') => {
       if (key === 'timelineBarsVisible') {
         zustandSetTimelineBarsVisible(timelineBarsVisible.value, true);
       } else {
-        setDetailPanelMode(detailPanelMode.value, true);
+        setDetailPanelModeZustand(detailPanelMode.value, true);
       }
       setLsDefaults(getInitialLayoutState());
     },

--- a/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useMemo } from 'react';
+import type { SpanDetailPanelMode } from '../../types/config';
+import { parseSettingsFromUrl } from './url';
+import type { UrlLayoutSettings } from './url';
+import { getInitialLayoutState, useLayoutPrefsStore } from './TraceTimelineViewer/store.layout';
+
+export type SettingSource = 'url' | 'heuristic' | 'localstorage';
+
+export type ResolvedSetting<T> = {
+  value: T;
+  source: SettingSource;
+  isOverridden: boolean;
+};
+
+export type ResolvedLayoutSettings = {
+  timelineBarsVisible: ResolvedSetting<boolean>;
+  detailPanelMode: ResolvedSetting<SpanDetailPanelMode>;
+};
+
+function computeHeuristicOverrides(): UrlLayoutSettings {
+  return { timelineBarsVisible: null, detailPanelMode: null };
+}
+
+export function useLayoutSettings(locationSearch: string): ResolvedLayoutSettings & {
+  saveAsDefault: (key: 'timelineBarsVisible' | 'detailPanelMode') => void;
+} {
+  const storeTimelineBarsVisible = useLayoutPrefsStore(s => s.timelineBarsVisible);
+  const storeDetailPanelMode = useLayoutPrefsStore(s => s.detailPanelMode);
+  const zustandSetTimelineBarsVisible = useLayoutPrefsStore(s => s.setTimelineBarsVisible);
+  const zustandApplyDetailPanelMode = useLayoutPrefsStore(s => s.applyDetailPanelModeToLayout);
+
+  const lsDefaults = useMemo(() => getInitialLayoutState(), []);
+  const urlSettings = useMemo(() => parseSettingsFromUrl(locationSearch), [locationSearch]);
+  const heuristicOverrides = useMemo(() => computeHeuristicOverrides(), []);
+
+  const timelineBarsVisible = useMemo<ResolvedSetting<boolean>>(() => {
+    if (urlSettings.timelineBarsVisible !== null) {
+      return {
+        value: urlSettings.timelineBarsVisible,
+        source: 'url',
+        isOverridden: urlSettings.timelineBarsVisible !== lsDefaults.timelineBarsVisible,
+      };
+    }
+    if (heuristicOverrides.timelineBarsVisible !== null) {
+      return {
+        value: heuristicOverrides.timelineBarsVisible,
+        source: 'heuristic',
+        isOverridden: heuristicOverrides.timelineBarsVisible !== lsDefaults.timelineBarsVisible,
+      };
+    }
+    return {
+      value: storeTimelineBarsVisible,
+      source: 'localstorage',
+      isOverridden: false,
+    };
+  }, [
+    urlSettings.timelineBarsVisible,
+    heuristicOverrides.timelineBarsVisible,
+    lsDefaults.timelineBarsVisible,
+    storeTimelineBarsVisible,
+  ]);
+
+  const detailPanelMode = useMemo<ResolvedSetting<SpanDetailPanelMode>>(() => {
+    if (urlSettings.detailPanelMode !== null) {
+      return {
+        value: urlSettings.detailPanelMode,
+        source: 'url',
+        isOverridden: urlSettings.detailPanelMode !== lsDefaults.detailPanelMode,
+      };
+    }
+    if (heuristicOverrides.detailPanelMode !== null) {
+      return {
+        value: heuristicOverrides.detailPanelMode,
+        source: 'heuristic',
+        isOverridden: heuristicOverrides.detailPanelMode !== lsDefaults.detailPanelMode,
+      };
+    }
+    return {
+      value: storeDetailPanelMode,
+      source: 'localstorage',
+      isOverridden: false,
+    };
+  }, [
+    urlSettings.detailPanelMode,
+    heuristicOverrides.detailPanelMode,
+    lsDefaults.detailPanelMode,
+    storeDetailPanelMode,
+  ]);
+
+  const saveAsDefault = useCallback(
+    (key: 'timelineBarsVisible' | 'detailPanelMode') => {
+      if (key === 'timelineBarsVisible') {
+        zustandSetTimelineBarsVisible(timelineBarsVisible.value, true);
+      } else {
+        zustandApplyDetailPanelMode(detailPanelMode.value, true);
+      }
+    },
+    [
+      zustandSetTimelineBarsVisible,
+      zustandApplyDetailPanelMode,
+      timelineBarsVisible.value,
+      detailPanelMode.value,
+    ]
+  );
+
+  return { timelineBarsVisible, detailPanelMode, saveAsDefault };
+}

--- a/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
+++ b/packages/jaeger-ui/src/components/TracePage/useLayoutSettings.ts
@@ -92,24 +92,36 @@ export function useLayoutSettings(locationSearch: string): ResolvedLayoutSetting
   ]);
 
   const prevUrlSettingsRef = useRef<UrlLayoutSettings>(urlSettings);
-
   useLayoutEffect(() => {
+    const prevUrlSettings = prevUrlSettingsRef.current;
     // Sync Timeline Bars
     if (urlSettings.timelineBarsVisible !== null) {
       zustandSetTimelineBarsVisible(urlSettings.timelineBarsVisible, false);
-    } else if (prevUrlSettingsRef.current.timelineBarsVisible !== null) {
+    } else if (
+      prevUrlSettings.timelineBarsVisible !== null &&
+      storeTimelineBarsVisible === prevUrlSettings.timelineBarsVisible
+    ) {
       zustandSetTimelineBarsVisible(lsDefaults.timelineBarsVisible, false);
     }
 
     // Sync Detail Panel Mode
     if (urlSettings.detailPanelMode !== null) {
       setDetailPanelModeZustand(urlSettings.detailPanelMode, false);
-    } else if (prevUrlSettingsRef.current.detailPanelMode !== null) {
+    } else if (
+      prevUrlSettings.detailPanelMode !== null &&
+      storeDetailPanelMode === prevUrlSettings.detailPanelMode
+    ) {
       setDetailPanelModeZustand(lsDefaults.detailPanelMode, false);
     }
 
     prevUrlSettingsRef.current = urlSettings;
-  }, [urlSettings, lsDefaults, zustandSetTimelineBarsVisible]);
+  }, [
+    urlSettings,
+    lsDefaults,
+    zustandSetTimelineBarsVisible,
+    storeTimelineBarsVisible,
+    storeDetailPanelMode,
+  ]);
 
   const saveAsDefault = useCallback(
     (key: 'timelineBarsVisible' | 'detailPanelMode') => {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves conflicts between URL parameters, heuristics, and global Local Storage preferences by introducing a cascading priority system for UI layout settings.
- Fixes #3720 

## Description of the changes
- **Architecture:** Added `useLayoutSettings` hook to resolve the effective state using a priority stack: URL > Heuristic (stubbed) > Local Storage.
- **State Management:** Added a `persist` flag to Zustand setters in `store.layout.ts` so URL-driven updates don't overwrite user defaults.
- **UI Refresh:** Redesigned `TraceViewSettings` from a dropdown into a rich Popover panel, adding blue "Set by shared link" source badges and a "Set as my default" persistence action.

## How was this change tested?
- Added 15 new component tests for the redesigned `TraceViewSettings` UI panel.
- Added 13 new unit tests for the `useLayoutSettings` hook (verifying priority resolution and `saveAsDefault` persistence).
- Verified visually in the browser that URL overrides apply correctly without mutating local storage.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes