### PR TITLE
fix(SpanDetail): Add keyboard support for accordion headers

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.test.jsx
@@ -123,4 +123,18 @@ describe('<AccordionAttributes />', () => {
     fireEvent.click(header);
     expect(defaultProps.onToggle).toHaveBeenCalledTimes(1);
   });
+
+  it('calls onToggle when Enter key is pressed', () => {
+    render(<AccordionAttributes {...defaultProps} />);
+    const header = screen.getByText('le-label:').closest('div');
+    fireEvent.keyDown(header, { key: 'Enter' });
+    expect(defaultProps.onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onToggle when Space key is pressed', () => {
+    render(<AccordionAttributes {...defaultProps} />);
+    const header = screen.getByText('le-label:').closest('div');
+    fireEvent.keyDown(header, { key: ' ' });
+    expect(defaultProps.onToggle).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.tsx
@@ -61,7 +61,14 @@ export default function AccordionAttributes({
     headerProps = {
       'aria-checked': isOpen,
       onClick: onToggle,
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (onToggle && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onToggle();
+        }
+      },
       role: 'switch',
+      tabIndex: 0,
     };
   }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -100,6 +100,18 @@ describe('<AccordionEvents>', () => {
     expect(defaultProps.onToggle).toHaveBeenCalled();
   });
 
+  it('calls onToggle when Enter key is pressed', () => {
+    render(<AccordionEvents {...defaultProps} />);
+    fireEvent.keyDown(screen.getByRole('switch'), { key: 'Enter' });
+    expect(defaultProps.onToggle).toHaveBeenCalled();
+  });
+
+  it('calls onToggle when Space key is pressed', () => {
+    render(<AccordionEvents {...defaultProps} />);
+    fireEvent.keyDown(screen.getByRole('switch'), { key: ' ' });
+    expect(defaultProps.onToggle).toHaveBeenCalled();
+  });
+
   it('shows all events when "show all" is clicked', () => {
     render(<AccordionEvents {...defaultProps} isOpen />);
     fireEvent.click(screen.getByRole('button', { name: /show all/i }));

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
@@ -165,8 +165,18 @@ export default function AccordionEvents({
     HeaderComponent = 'a';
     headerProps = {
       'aria-checked': isOpen,
-      onClick: onToggle,
+      onClick: (e: React.MouseEvent) => {
+        e.preventDefault();
+        if (onToggle) onToggle();
+      },
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (onToggle && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onToggle();
+        }
+      },
       role: 'switch',
+      tabIndex: 0,
     };
   }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.test.jsx
@@ -110,6 +110,24 @@ describe('<AccordionLinks /> – functional component', () => {
     expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
   });
 
+  it('calls onToggle when Enter key is pressed', () => {
+    render(<AccordionLinks {...baseProps} />);
+    const header = screen.getByText('References').closest('.AccordionLinks--header');
+    if (header) {
+      fireEvent.keyDown(header, { key: 'Enter' });
+    }
+    expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onToggle when Space key is pressed', () => {
+    render(<AccordionLinks {...baseProps} />);
+    const header = screen.getByText('References').closest('.AccordionLinks--header');
+    if (header) {
+      fireEvent.keyDown(header, { key: ' ' });
+    }
+    expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
+  });
+
   it('applies high contrast class when highContrast is true', () => {
     render(<AccordionLinks {...baseProps} highContrast={true} />);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -78,7 +78,14 @@ function AccordionLinks({
     headerProps = {
       'aria-checked': isOpen,
       onClick: isEmpty ? null : onToggle,
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (!isEmpty && onToggle && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onToggle();
+        }
+      },
       role: 'switch',
+      tabIndex: isEmpty ? -1 : 0,
     };
   }
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -79,7 +79,20 @@ function AccordionLinks({
       'aria-checked': isOpen,
       onClick: isEmpty ? null : onToggle,
       onKeyDown: (e: React.KeyboardEvent) => {
-        if (!isEmpty && onToggle && (e.key === 'Enter' || e.key === ' ')) {
+        if (isEmpty || !onToggle) {
+          return;
+        }
+        if (e.key === ' ') {
+          e.preventDefault();
+          return;
+        }
+        if (e.key === 'Enter' && !e.repeat) {
+          e.preventDefault();
+          onToggle();
+        }
+      },
+      onKeyUp: (e: React.KeyboardEvent) => {
+        if (!isEmpty && onToggle && e.key === ' ' && !e.repeat) {
           e.preventDefault();
           onToggle();
         }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionText.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionText.test.jsx
@@ -63,4 +63,20 @@ describe('<AccordionText>', () => {
     expect(header.getAttribute('role')).toBeNull();
     expect(header.querySelector('.u-align-icon')).not.toBeInTheDocument();
   });
+
+  it('calls onToggle when Enter key is pressed', () => {
+    const mockToggle = jest.fn();
+    render(<AccordionText {...baseProps} onToggle={mockToggle} />);
+    const header = screen.getByRole('switch');
+    fireEvent.keyDown(header, { key: 'Enter' });
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onToggle when Space key is pressed', () => {
+    const mockToggle = jest.fn();
+    render(<AccordionText {...baseProps} onToggle={mockToggle} />);
+    const header = screen.getByRole('switch');
+    fireEvent.keyDown(header, { key: ' ' });
+    expect(mockToggle).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionText.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionText.tsx
@@ -41,7 +41,14 @@ export default function AccordionText({
     headerProps = {
       'aria-checked': isOpen,
       onClick: isEmpty ? null : onToggle,
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (!isEmpty && onToggle && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onToggle();
+        }
+      },
       role: 'switch',
+      tabIndex: isEmpty ? -1 : 0,
     };
   }
 


### PR DESCRIPTION
### Description
This PR improves the accessibility of the `SpanDetail` view by adding keyboard support to the accordion headers (Attributes, Events, Links, and Text). 

### Changes
- Added `tabIndex={0}` to interactive accordion headers to make them focusable.
- Implemented `onKeyDown` handlers to support toggling sections using the `Enter` or `Space` keys.
- Ensured headers correctly use `role="switch"` and `aria-checked` to reflect their state to screen readers.
- Added unit tests for each modified component to verify keyboard interaction.

### Linked Issue
Fixes jaegertracing/jaeger#8450
