### PR TITLE
fix: Correct typos in SpanDetail components and tests

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.css
@@ -48,3 +48,7 @@ SPDX-License-Identifier: Apache-2.0
 .SpanReference--debugLabel {
   margin: 0 5px 0 5px;
 }
+
+.AccordionLinks--emptyIcon {
+  color: var(--text-muted);
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -68,7 +68,7 @@ function AccordionLinks({
   useOtelTerms,
 }: AccordionLinksProps) {
   const isEmpty = !Array.isArray(data) || !data.length;
-  const iconCls = cx('u-align-icon', { 'AccordianKReferences--emptyIcon': isEmpty });
+  const iconCls = cx('u-align-icon', { 'AccordionLinks--emptyIcon': isEmpty });
 
   let arrow: React.ReactNode | null = null;
   let headerProps: object | null = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -92,7 +92,7 @@ function formatValue(key: string, value: any) {
           nullValue: 'json-markup-null',
           undefinedValue: 'json-markup-undefined',
           basicChildStyle: 'json-markup-child',
-          punctuation: 'json-markup-puncuation',
+          punctuation: 'json-markup-punctuation',
           otherValue: 'json-markup-other',
         }}
       />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
@@ -30,25 +30,25 @@ SPDX-License-Identifier: Apache-2.0
   color: var(--text-primary);
 }
 
-.AccordianWarnings {
+.AccordionWarnings {
   background: var(--surface-tertiary);
   border: 1px solid var(--border-default);
   margin-bottom: 0.25rem;
 }
 
-.AccordianWarnings--header {
+.AccordionWarnings--header {
   background: var(--ant-color-warning-bg);
   padding: 0.25rem 0.5rem;
 }
 
-.AccordianWarnings--header:hover {
+.AccordionWarnings--header:hover {
   background: var(--ant-color-warning-bg-hover);
 }
 
-.AccordianWarnings--header.is-open {
+.AccordionWarnings--header.is-open {
   border-bottom: 1px solid var(--border-default);
 }
 
-.AccordianWarnings--label {
+.AccordionWarnings--label {
   color: var(--feedback-warning);
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -17,7 +17,7 @@ import OtelSpanFacade from '../../../../model/OtelSpanFacade';
 vi.mock('./AccordionAttributes', () => {
   return mockDefault(function MockAccordionAttributes({ label, onToggle }) {
     return (
-      <div data-testid={`accordian-keyvalues-${label.toLowerCase()}`}>
+      <div data-testid={`accordion-keyvalues-${label.toLowerCase()}`}>
         <button type="button" onClick={onToggle} data-testid={`toggle-${label.toLowerCase()}`}>
           Toggle {label}
         </button>
@@ -29,7 +29,7 @@ vi.mock('./AccordionAttributes', () => {
 vi.mock('./AccordionEvents', () => {
   return mockDefault(function MockAccordionEvents({ onToggle, onItemToggle }) {
     return (
-      <div data-testid="accordian-logs">
+      <div data-testid="accordion-logs">
         <button type="button" onClick={onToggle} data-testid="toggle-logs">
           Toggle Logs
         </button>
@@ -56,7 +56,7 @@ vi.mock('./AccordionLinks', () => {
 vi.mock('./AccordionText', () => {
   return mockDefault(function MockAccordionText({ onToggle }) {
     return (
-      <div data-testid="accordian-warnings">
+      <div data-testid="accordion-warnings">
         <button type="button" onClick={onToggle} data-testid="toggle-warnings">
           Toggle Warnings
         </button>
@@ -213,11 +213,11 @@ describe('<SpanDetail>', () => {
     expect(screen.getByTestId('item-start')).toHaveTextContent('Start Time:');
   });
 
-  it('renders span tags accordian and triggers toggle callback with span ID', () => {
+  it('renders span tags accordion and triggers toggle callback with span ID', () => {
     render(<SpanDetail {...props} />);
 
-    const tagsAccordian = screen.getByTestId('accordian-keyvalues-tags');
-    expect(tagsAccordian).toBeInTheDocument();
+    const tagsAccordion = screen.getByTestId('accordion-keyvalues-tags');
+    expect(tagsAccordion).toBeInTheDocument();
 
     const toggleButton = screen.getByTestId('toggle-tags');
     fireEvent.click(toggleButton);
@@ -225,11 +225,11 @@ describe('<SpanDetail>', () => {
     expect(props.attributesToggle).toHaveBeenCalledWith(span.spanID);
   });
 
-  it('renders process tags accordian and triggers toggle callback with span ID', () => {
+  it('renders process tags accordion and triggers toggle callback with span ID', () => {
     render(<SpanDetail {...props} />);
 
-    const processAccordian = screen.getByTestId('accordian-keyvalues-process');
-    expect(processAccordian).toBeInTheDocument();
+    const processAccordion = screen.getByTestId('accordion-keyvalues-process');
+    expect(processAccordion).toBeInTheDocument();
 
     const toggleButton = screen.getByTestId('toggle-process');
     fireEvent.click(toggleButton);
@@ -237,11 +237,11 @@ describe('<SpanDetail>', () => {
     expect(props.resourceToggle).toHaveBeenCalledWith(span.spanID);
   });
 
-  it('renders logs accordian and triggers both main toggle and item toggle callbacks', () => {
+  it('renders logs accordion and triggers both main toggle and item toggle callbacks', () => {
     render(<SpanDetail {...props} />);
 
-    const logsAccordian = screen.getByTestId('accordian-logs');
-    expect(logsAccordian).toBeInTheDocument();
+    const logsAccordion = screen.getByTestId('accordion-logs');
+    expect(logsAccordion).toBeInTheDocument();
 
     const toggleButton = screen.getByTestId('toggle-logs');
     fireEvent.click(toggleButton);
@@ -252,11 +252,11 @@ describe('<SpanDetail>', () => {
     expect(props.eventItemToggle).toHaveBeenCalledWith(span.spanID, 'test-log');
   });
 
-  it('renders warnings accordian and triggers toggle callback with span ID', () => {
+  it('renders warnings accordion and triggers toggle callback with span ID', () => {
     render(<SpanDetail {...props} />);
 
-    const warningsAccordian = screen.getByTestId('accordian-warnings');
-    expect(warningsAccordian).toBeInTheDocument();
+    const warningsAccordion = screen.getByTestId('accordion-warnings');
+    expect(warningsAccordion).toBeInTheDocument();
 
     const toggleButton = screen.getByTestId('toggle-warnings');
     fireEvent.click(toggleButton);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -135,9 +135,9 @@ export default function SpanDetail(props: SpanDetailProps) {
         )}
         {warnings && warnings.length > 0 && (
           <AccordionText
-            className="AccordianWarnings"
-            headerClassName="AccordianWarnings--header"
-            label={<span className="AccordianWarnings--label">Warnings</span>}
+            className="AccordionWarnings"
+            headerClassName="AccordionWarnings--header"
+            label={<span className="AccordionWarnings--label">Warnings</span>}
             data={warnings}
             isOpen={isWarningsOpen}
             onToggle={() => warningsToggle(span.spanID)}


### PR DESCRIPTION
### Description
This PR corrects several typos across the `SpanDetail` components and their associated tests to ensure consistent styling and better maintainability.

### Changes
- Corrected `puncuation` to `punctuation` in `AttributesTable` style mapping.
- Renamed `AccordianKReferences--emptyIcon` to `AccordionLinks--emptyIcon` and updated CSS.
- Corrected `AccordianWarnings` to `AccordionWarnings` in `index.tsx` and `index.css`.
- Updated all associated tests (`index.test.jsx`, etc.) to use correct spelling in descriptions and `data-testid` attributes.

### Linked Issue
Fixes jaegertracing/jaeger#8452
