### PR TITLE
fix(AttributesTable): Add aria-labels to external links for accessibility

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
@@ -40,6 +40,7 @@ describe('LinkValue', () => {
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', href);
     expect(link).toHaveAttribute('title', title);
+    expect(link).toHaveAttribute('aria-label', title);
     expect(link).toHaveTextContent(childrenText);
   });
 
@@ -185,6 +186,7 @@ describe('<AttributesTable>', () => {
 
     const dropdownTrigger = container.querySelector('a');
     expect(dropdownTrigger).toBeInTheDocument();
+    expect(dropdownTrigger).toHaveAttribute('aria-label', 'View multiple links');
 
     const row = dropdownTrigger.closest('tr');
     const keyCell = row.querySelector('.KeyValueTable--keyColumn');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -105,7 +105,13 @@ function formatValue(key: string, value: any) {
 }
 
 export const LinkValue = (props: { href: string; title?: string; children: React.ReactNode }) => (
-  <a href={props.href} title={props.title || ''} target="_blank" rel="noopener noreferrer">
+  <a
+    href={props.href}
+    title={props.title || ''}
+    aria-label={props.title || 'View link'}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
     {props.children} <IoOpenOutline className="KeyValueTable--linkIcon" />
   </a>
 );
@@ -151,7 +157,7 @@ export default function AttributesTable(props: AttributesTableProps) {
                     placement="bottomRight"
                     trigger={['click']}
                   >
-                    <a>
+                    <a aria-label="View multiple links">
                       {jsonTable} <IoList className="KeyValueTable--linkIcon" />
                     </a>
                   </Dropdown>


### PR DESCRIPTION
### Description
This PR improves the accessibility of the `AttributesTable` by adding `aria-label` attributes to external links and dropdown triggers. 

### Changes
- Added `aria-label` to the `LinkValue` component to describe the destination of external links.
- Added `aria-label="View multiple links"` to the dropdown trigger when multiple links are available for an attribute.
- Added unit tests to verify that these accessibility labels are correctly rendered.

### Linked Issue
Fixes jaegertracing/jaeger#8456
