### PR TITLE
Add some space below the navbar on mobile screens

### DIFF
--- a/packages/jaeger-ui/src/components/App/Page.css
+++ b/packages/jaeger-ui/src/components/App/Page.css
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 .Page--topNav {
-  height: auto;
+  height: var(--nav-height);
+  overflow: hidden;
   padding: 0;
   position: fixed;
   width: 100%;

--- a/packages/jaeger-ui/src/components/App/Page.test.jsx
+++ b/packages/jaeger-ui/src/components/App/Page.test.jsx
@@ -43,75 +43,9 @@ describe('<Page>', () => {
     useEmbeddedStateMock.mockReturnValue(null);
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('renders without exploding', () => {
     renderWithPath();
     expect(screen.getByRole('banner')).toBeInTheDocument();
-  });
-
-  const mockNavHeight = navHeight => {
-    const baseRect = { x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 };
-    return vi
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(function mockGetBoundingClientRect() {
-        const height = this.classList.contains('Page--topNav') ? navHeight : 0;
-        return { ...baseRect, height, bottom: height, toJSON: () => ({ ...baseRect, height }) };
-      });
-  };
-
-  it('sets nav height from the rendered header', () => {
-    const getBoundingClientRect = mockNavHeight(91.2);
-
-    const { container } = renderWithPath();
-
-    expect(getBoundingClientRect).toHaveBeenCalled();
-    expect(container.firstChild).toHaveStyle('--nav-height: 92px');
-  });
-
-  it('does not set nav height when the measured header is zero', () => {
-    mockNavHeight(0);
-
-    const { container } = renderWithPath();
-
-    expect(container.firstChild.style.getPropertyValue('--nav-height')).toBe('');
-  });
-
-  it('falls back to a window resize listener when ResizeObserver is unavailable', () => {
-    const originalResizeObserver = global.ResizeObserver;
-    delete global.ResizeObserver;
-    const addSpy = vi.spyOn(window, 'addEventListener');
-    const removeSpy = vi.spyOn(window, 'removeEventListener');
-    mockNavHeight(50);
-
-    try {
-      const { container, unmount } = renderWithPath();
-
-      const resizeCall = addSpy.mock.calls.find(([type]) => type === 'resize');
-      expect(resizeCall).toBeDefined();
-      const handler = resizeCall[1];
-
-      mockNavHeight(120);
-      handler();
-      expect(container.firstChild).toHaveStyle('--nav-height: 120px');
-
-      unmount();
-      expect(removeSpy).toHaveBeenCalledWith('resize', handler);
-    } finally {
-      global.ResizeObserver = originalResizeObserver;
-    }
-  });
-
-  it('does not measure nav height in embedded mode', () => {
-    useEmbeddedStateMock.mockReturnValue(embeddedV0);
-    const getBoundingClientRect = mockNavHeight(80);
-
-    const { container } = renderWithPath();
-
-    expect(getBoundingClientRect).not.toHaveBeenCalled();
-    expect(container.firstChild.style.getPropertyValue('--nav-height')).toBe('');
   });
 
   it('tracks an initial page-view using location from useLocation()', () => {

--- a/packages/jaeger-ui/src/components/App/Page.test.jsx
+++ b/packages/jaeger-ui/src/components/App/Page.test.jsx
@@ -43,9 +43,27 @@ describe('<Page>', () => {
     useEmbeddedStateMock.mockReturnValue(null);
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('renders without exploding', () => {
     renderWithPath();
     expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
+  it('sets nav height from the rendered header', () => {
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function mockGetBoundingClientRect() {
+        const height = this.classList.contains('Page--topNav') ? 91.2 : 0;
+        return { height };
+      });
+
+    const { container } = renderWithPath();
+
+    expect(getBoundingClientRect).toHaveBeenCalled();
+    expect(container.firstChild).toHaveStyle('--nav-height: 92px');
   });
 
   it('tracks an initial page-view using location from useLocation()', () => {

--- a/packages/jaeger-ui/src/components/App/Page.test.jsx
+++ b/packages/jaeger-ui/src/components/App/Page.test.jsx
@@ -52,18 +52,66 @@ describe('<Page>', () => {
     expect(screen.getByRole('banner')).toBeInTheDocument();
   });
 
-  it('sets nav height from the rendered header', () => {
-    const getBoundingClientRect = vi
+  const mockNavHeight = navHeight => {
+    const baseRect = { x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 };
+    return vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function mockGetBoundingClientRect() {
-        const height = this.classList.contains('Page--topNav') ? 91.2 : 0;
-        return { height };
+        const height = this.classList.contains('Page--topNav') ? navHeight : 0;
+        return { ...baseRect, height, bottom: height, toJSON: () => ({ ...baseRect, height }) };
       });
+  };
+
+  it('sets nav height from the rendered header', () => {
+    const getBoundingClientRect = mockNavHeight(91.2);
 
     const { container } = renderWithPath();
 
     expect(getBoundingClientRect).toHaveBeenCalled();
     expect(container.firstChild).toHaveStyle('--nav-height: 92px');
+  });
+
+  it('does not set nav height when the measured header is zero', () => {
+    mockNavHeight(0);
+
+    const { container } = renderWithPath();
+
+    expect(container.firstChild.style.getPropertyValue('--nav-height')).toBe('');
+  });
+
+  it('falls back to a window resize listener when ResizeObserver is unavailable', () => {
+    const originalResizeObserver = global.ResizeObserver;
+    delete global.ResizeObserver;
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    mockNavHeight(50);
+
+    try {
+      const { container, unmount } = renderWithPath();
+
+      const resizeCall = addSpy.mock.calls.find(([type]) => type === 'resize');
+      expect(resizeCall).toBeDefined();
+      const handler = resizeCall[1];
+
+      mockNavHeight(120);
+      handler();
+      expect(container.firstChild).toHaveStyle('--nav-height: 120px');
+
+      unmount();
+      expect(removeSpy).toHaveBeenCalledWith('resize', handler);
+    } finally {
+      global.ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  it('does not measure nav height in embedded mode', () => {
+    useEmbeddedStateMock.mockReturnValue(embeddedV0);
+    const getBoundingClientRect = mockNavHeight(80);
+
+    const { container } = renderWithPath();
+
+    expect(getBoundingClientRect).not.toHaveBeenCalled();
+    expect(container.firstChild.style.getPropertyValue('--nav-height')).toBe('');
   });
 
   it('tracks an initial page-view using location from useLocation()', () => {

--- a/packages/jaeger-ui/src/components/App/Page.tsx
+++ b/packages/jaeger-ui/src/components/App/Page.tsx
@@ -24,46 +24,19 @@ export const PageImpl: React.FC<TProps> = props => {
   const embedded = useEmbeddedState();
   const { children } = props;
   const { pathname, search } = useLocation();
-  const pageRef = React.useRef<HTMLDivElement | null>(null);
-  const headerRef = React.useRef<HTMLElement | null>(null);
 
   React.useEffect(() => {
     trackPageView(pathname, search);
   }, [pathname, search]);
 
-  React.useLayoutEffect(() => {
-    if (embedded) return undefined;
-
-    const headerEl = headerRef.current;
-    if (!headerEl) return undefined;
-
-    const updateNavHeight = () => {
-      const nextHeight = Math.ceil(headerEl.getBoundingClientRect().height);
-      if (nextHeight > 0) {
-        pageRef.current?.style.setProperty('--nav-height', `${nextHeight}px`);
-      }
-    };
-
-    updateNavHeight();
-
-    if (typeof ResizeObserver === 'function') {
-      const observer = new ResizeObserver(updateNavHeight);
-      observer.observe(headerEl);
-      return () => observer.disconnect();
-    }
-
-    window.addEventListener('resize', updateNavHeight);
-    return () => window.removeEventListener('resize', updateNavHeight);
-  }, [embedded]);
-
   const contentCls = cx({ 'Page--content': true, 'Page--content--no-embedded': !embedded });
 
   return (
-    <div ref={pageRef}>
+    <div>
       <DocumentTitle title="Jaeger UI" />
       <Layout>
         {!embedded && (
-          <Header className="Page--topNav" ref={headerRef}>
+          <Header className="Page--topNav">
             <TopNav />
           </Header>
         )}

--- a/packages/jaeger-ui/src/components/App/Page.tsx
+++ b/packages/jaeger-ui/src/components/App/Page.tsx
@@ -24,18 +24,46 @@ export const PageImpl: React.FC<TProps> = props => {
   const embedded = useEmbeddedState();
   const { children } = props;
   const { pathname, search } = useLocation();
+  const pageRef = React.useRef<HTMLDivElement | null>(null);
+  const headerRef = React.useRef<HTMLElement | null>(null);
+
   React.useEffect(() => {
     trackPageView(pathname, search);
   }, [pathname, search]);
 
+  React.useLayoutEffect(() => {
+    if (embedded) return undefined;
+
+    const headerEl = headerRef.current;
+    if (!headerEl) return undefined;
+
+    const updateNavHeight = () => {
+      const nextHeight = Math.ceil(headerEl.getBoundingClientRect().height);
+      if (nextHeight > 0) {
+        pageRef.current?.style.setProperty('--nav-height', `${nextHeight}px`);
+      }
+    };
+
+    updateNavHeight();
+
+    if (typeof ResizeObserver === 'function') {
+      const observer = new ResizeObserver(updateNavHeight);
+      observer.observe(headerEl);
+      return () => observer.disconnect();
+    }
+
+    window.addEventListener('resize', updateNavHeight);
+    return () => window.removeEventListener('resize', updateNavHeight);
+  }, [embedded]);
+
   const contentCls = cx({ 'Page--content': true, 'Page--content--no-embedded': !embedded });
 
   return (
-    <div>
+    <div ref={pageRef}>
       <DocumentTitle title="Jaeger UI" />
       <Layout>
         {!embedded && (
-          <Header className="Page--topNav">
+          <Header className="Page--topNav" ref={headerRef}>
             <TopNav />
           </Header>
         )}

--- a/packages/jaeger-ui/src/components/App/TopNav.css
+++ b/packages/jaeger-ui/src/components/App/TopNav.css
@@ -3,6 +3,13 @@ Copyright (c) 2017 Uber Technologies, Inc.
 SPDX-License-Identifier: Apache-2.0
 */
 
+.TopNav {
+  display: flex;
+  height: var(--nav-height);
+  justify-content: space-between;
+  overflow: hidden;
+}
+
 .Dropdown--icon-container {
   display: flex;
   color: var(--text-inverse);
@@ -42,4 +49,25 @@ SPDX-License-Identifier: Apache-2.0
   align-items: center;
   justify-content: center;
   height: 100%;
+}
+
+.Menu--item--left {
+  flex: 1 1 0;
+  min-width: 3rem;
+}
+
+.Menu--item--right {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .Menu--item--left {
+    flex-basis: 100%;
+    min-width: 0;
+  }
+
+  .Menu--item--right {
+    display: none;
+  }
 }

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -142,7 +142,7 @@ export function TopNavImpl(props: Props) {
   ];
 
   return (
-    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+    <div className="TopNav">
       <Menu
         theme="dark"
         items={itemsGlobalLeft?.concat(
@@ -159,21 +159,19 @@ export function TopNavImpl(props: Props) {
             };
           })
         )}
-        className="Menu--item"
+        className="Menu--item Menu--item--left"
         mode="horizontal"
         selectable={false}
         selectedKeys={[pathname]}
-        style={{ flex: '1 1 0', minWidth: '3rem' }}
       />
       <Menu
         theme="dark"
         items={itemsGlobalRight}
-        className="Menu--item"
+        className="Menu--item Menu--item--right"
         mode="horizontal"
         selectable={false}
         disabledOverflow
         selectedKeys={[pathname]}
-        style={{ flex: '0 1 auto', minWidth: 0 }}
       />
     </div>
   );

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.css
@@ -33,5 +33,7 @@ SPDX-License-Identifier: Apache-2.0
 
 .SearchTracePage--logo {
   display: block;
+  height: auto;
   margin: 13rem auto 0 auto;
+  max-width: 100%;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.css
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .SearchTracePage--column {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   flex-grow: 1;

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
@@ -22,6 +22,7 @@ SPDX-License-Identifier: Apache-2.0
   align-items: center;
   background-color: var(--surface-primary);
   display: flex;
+  flex-wrap: wrap;
 }
 
 .TracePageHeader--back {
@@ -47,6 +48,7 @@ SPDX-License-Identifier: Apache-2.0
   color: var(--text-primary);
   display: flex;
   flex: 1;
+  min-width: 0;
 }
 
 .TracePageHeader--titleLink:hover * {
@@ -74,6 +76,8 @@ SPDX-License-Identifier: Apache-2.0
   font-size: 1.7em;
   line-height: 1em;
   margin: 0 0 0 0.5em;
+  min-width: 0;
+  overflow-wrap: anywhere;
   padding: 0.5em 0;
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Addresses https://github.com/jaegertracing/jaeger-ui/issues/3480

## Description of the changes
Add a responsive gap below the navbar and to the right of the main page element. Currently, on small mobile screens, it looks like this:

<img width="1526" height="900" alt="Screenshot from 2026-05-01 23-23-32" src="https://github.com/user-attachments/assets/6d0d1315-a501-4a5a-a4d8-54ba0b6e2fc3" />

Notice the overlap of the top navbar as well as a bit of horizontal overflow to the right of the screen.

This commits turns it into:

<img width="1526" height="900" alt="Screenshot from 2026-05-02 00-28-02" src="https://github.com/user-attachments/assets/65eba39b-3d34-42a7-bca9-9cebdf0ef2c7" />

## How was this change tested?
- local dev with different UI sizes via chrome dev tools.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ x I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
