### PR TITLE
fix: correct typos in AttributesTable style keys and AccordionLinks class names

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -68,7 +68,7 @@ function AccordionLinks({
   useOtelTerms,
 }: AccordionLinksProps) {
   const isEmpty = !Array.isArray(data) || !data.length;
-  const iconCls = cx('u-align-icon', { 'AccordianKReferences--emptyIcon': isEmpty });
+  const iconCls = cx('u-align-icon', { 'AccordionLinks--emptyIcon': isEmpty });
 
   let arrow: React.ReactNode | null = null;
   let headerProps: object | null = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -92,7 +92,7 @@ function formatValue(key: string, value: any) {
           nullValue: 'json-markup-null',
           undefinedValue: 'json-markup-undefined',
           basicChildStyle: 'json-markup-child',
-          punctuation: 'json-markup-puncuation',
+          punctuation: 'json-markup-punctuation',
           otherValue: 'json-markup-other',
         }}
       />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -103,6 +103,6 @@ SPDX-License-Identifier: Apache-2.0
   padding: 0;
 }
 
-.json-markup-puncuation {
+.json-markup-punctuation {
   font-weight: bold;
 }


### PR DESCRIPTION
Fixes typos identified in [jaegertracing/jaeger#8452](https://github.com/jaegertracing/jaeger/issues/8452).

## Changes

1. **`puncuation` → `punctuation`** — Renamed `.json-markup-puncuation` to `.json-markup-punctuation` in `packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css` and updated the matching reference in `AttributesTable.tsx` so the JSON viewer's punctuation styling continues to apply correctly.

2. **`AccordianKReferences--emptyIcon` → `AccordionLinks--emptyIcon`** — Renamed in `AccordionLinks.tsx` to match the project's naming convention already used by `AccordionAttributes--emptyIcon` and `AccordionEvents`/`AccordionText` siblings.

## Verification

- `grep -r 'puncuation\|AccordianK' packages/jaeger-ui/src/` returns no matches after the change.
- The CSS rule and TS reference for `json-markup-punctuation` are kept in sync.

Closes jaegertracing/jaeger#8452