### PR TITLE
feat(SpanDetail): add rich-media rendering for GenAI attributes

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.test.jsx
@@ -123,4 +123,14 @@ describe('<AccordionAttributes />', () => {
     fireEvent.click(header);
     expect(defaultProps.onToggle).toHaveBeenCalledTimes(1);
   });
+
+  it('applies is-empty styling when data is empty and hasAdditionalContent is not set', () => {
+    const { container } = render(<AccordionAttributes {...defaultProps} data={[]} />);
+    expect(container.querySelector('.AccordionAttributes--header')).toHaveClass('is-empty');
+  });
+
+  it('does not apply is-empty styling when data is empty but hasAdditionalContent is true', () => {
+    const { container } = render(<AccordionAttributes {...defaultProps} data={[]} hasAdditionalContent />);
+    expect(container.querySelector('.AccordionAttributes--header')).not.toHaveClass('is-empty');
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.tsx
@@ -42,6 +42,7 @@ export default function AccordionAttributes({
   label,
   linksGetter,
   onToggle = null,
+  hasAdditionalContent = false,
 }: {
   className?: string | TNil;
   data: ReadonlyArray<IAttribute>;
@@ -51,8 +52,12 @@ export default function AccordionAttributes({
   label: string;
   linksGetter: ((pairs: ReadonlyArray<IAttribute>, index: number) => Hyperlink[]) | TNil;
   onToggle?: null | (() => void);
+  // True when the caller renders extra content (e.g. GenAI rich-media attributes) alongside
+  // this table under the same header. Keeps the header looking active/expandable even when
+  // `data` itself is empty, since the header still controls a non-empty section.
+  hasAdditionalContent?: boolean;
 }) {
-  const isEmpty = !Array.isArray(data) || !data.length;
+  const isEmpty = (!Array.isArray(data) || !data.length) && !hasAdditionalContent;
   const iconCls = cx('u-align-icon', { 'AccordionAttributes--emptyIcon': isEmpty });
   let arrow: React.ReactNode | null = null;
   let headerProps: object | null = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.test.tsx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import GenAIAttributeRenderer from './GenAIAttributeRenderer';
+import type { IAttribute } from '../../../../types/otel';
+
+function makeAttr(key: string, value: string): IAttribute {
+  return { key, value };
+}
+
+describe('GenAIAttributeRenderer', () => {
+  it('returns null for a non-rich-media gen_ai attribute', () => {
+    const { container } = render(
+      <GenAIAttributeRenderer attribute={makeAttr('gen_ai.operation.name', 'chat')} isOpen />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null for a standard non-genai attribute', () => {
+    const { container } = render(
+      <GenAIAttributeRenderer attribute={makeAttr('http.method', 'GET')} isOpen />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when isOpen is false (lazy load)', () => {
+    const { container } = render(
+      <GenAIAttributeRenderer
+        attribute={makeAttr('gen_ai.tool.call.arguments', '{"query":"test"}')}
+        isOpen={false}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders JSON view for gen_ai.tool.call.arguments when open', () => {
+    render(
+      <GenAIAttributeRenderer
+        attribute={makeAttr('gen_ai.tool.call.arguments', '{"query":"Paris"}')}
+        isOpen
+      />
+    );
+    expect(screen.getByText('gen_ai.tool.call.arguments')).toBeInTheDocument();
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+  });
+
+  it('renders JSON view for gen_ai.tool.call.result when open', () => {
+    render(
+      <GenAIAttributeRenderer attribute={makeAttr('gen_ai.tool.call.result', '{"answer":"Paris"}')} isOpen />
+    );
+    expect(screen.getByText('gen_ai.tool.call.result')).toBeInTheDocument();
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+  });
+
+  it('renders pre block for gen_ai.input.messages when open', () => {
+    const messages = JSON.stringify([{ role: 'user', content: 'What is the capital of France?' }]);
+    render(<GenAIAttributeRenderer attribute={makeAttr('gen_ai.input.messages', messages)} isOpen />);
+    expect(screen.getByText('gen_ai.input.messages')).toBeInTheDocument();
+    expect(screen.getByText(/What is the capital of France/)).toBeInTheDocument();
+  });
+
+  it('renders pre block for gen_ai.output.messages when open', () => {
+    const messages = JSON.stringify([{ role: 'assistant', content: 'The capital is **Paris**.' }]);
+    render(<GenAIAttributeRenderer attribute={makeAttr('gen_ai.output.messages', messages)} isOpen />);
+    expect(screen.getByText(/The capital is/)).toBeInTheDocument();
+  });
+
+  it('falls back to raw string when JSON parse fails for a json-type key', () => {
+    render(
+      <GenAIAttributeRenderer attribute={makeAttr('gen_ai.tool.call.arguments', 'not-valid-json')} isOpen />
+    );
+    expect(screen.getByText('not-valid-json')).toBeInTheDocument();
+  });
+
+  it('renders JSON view for gen_ai.retrieval.documents when open', () => {
+    const docs = JSON.stringify([{ title: 'Paris', snippet: 'Capital of France' }]);
+    render(<GenAIAttributeRenderer attribute={makeAttr('gen_ai.retrieval.documents', docs)} isOpen />);
+    expect(screen.getByText('gen_ai.retrieval.documents')).toBeInTheDocument();
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.test.tsx
@@ -82,4 +82,47 @@ describe('GenAIAttributeRenderer', () => {
     expect(screen.getByText('gen_ai.retrieval.documents')).toBeInTheDocument();
     expect(screen.getByRole('tree')).toBeInTheDocument();
   });
+
+  it('renders JSON view when attribute value is already a native object', () => {
+    render(
+      <GenAIAttributeRenderer
+        attribute={{ key: 'gen_ai.tool.call.arguments', value: { query: 'Paris' } }}
+        isOpen
+      />
+    );
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+  });
+
+  it('uses collapseAllNested for large JSON objects (more than 10 keys)', () => {
+    const large = Object.fromEntries(Array.from({ length: 12 }, (_, i) => [`key${i}`, i]));
+    render(
+      <GenAIAttributeRenderer
+        attribute={makeAttr('gen_ai.tool.call.arguments', JSON.stringify(large))}
+        isOpen
+      />
+    );
+    expect(screen.getByRole('tree')).toBeInTheDocument();
+  });
+
+  it('renders messages without a role without a leading blank line', () => {
+    const messages = JSON.stringify([{ content: 'roleless message' }]);
+    render(<GenAIAttributeRenderer attribute={makeAttr('gen_ai.input.messages', messages)} isOpen />);
+    expect(screen.getByText('roleless message')).toBeInTheDocument();
+  });
+
+  it('handles array messages with non-object elements via String() fallback', () => {
+    const messages = JSON.stringify(['plain string', 42]);
+    render(<GenAIAttributeRenderer attribute={makeAttr('gen_ai.input.messages', messages)} isOpen />);
+    expect(screen.getByText(/plain string/)).toBeInTheDocument();
+  });
+
+  it('renders JSON.stringify fallback when message value is a non-array object', () => {
+    render(
+      <GenAIAttributeRenderer
+        attribute={{ key: 'gen_ai.output.messages', value: { role: 'assistant', content: 'hi' } }}
+        isOpen
+      />
+    );
+    expect(screen.getByText(/assistant/)).toBeInTheDocument();
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
@@ -53,8 +53,8 @@ type JsonRendererProps = { value: unknown };
 
 function JsonRenderer({ value }: JsonRendererProps) {
   const parsed = tryParseJson(value);
-  if (parsed !== null) {
-    const isSmall = typeof parsed === 'object' && parsed !== null && Object.keys(parsed).length <= 10;
+  if (typeof parsed === 'object' && parsed !== null) {
+    const isSmall = Object.keys(parsed).length <= 10;
     return (
       <div className="GenAIAttributeRenderer--json">
         <JsonView

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+import { JsonView, allExpanded, defaultStyles } from 'react-json-view-lite';
+import 'react-json-view-lite/dist/index.css';
+
+import { RICH_MEDIA_ATTRIBUTE_KEYS } from '../../../../utils/genai/detect';
+import type { IAttribute } from '../../../../types/otel';
+
+type Props = {
+  attribute: IAttribute;
+  isOpen: boolean;
+};
+
+function tryParseJson(value: unknown): unknown | null {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof value === 'object' && value !== null) {
+    return value;
+  }
+  return null;
+}
+
+/**
+ * Extracts human-readable text from a gen_ai messages attribute value.
+ * The OTel GenAI spec stores messages as a JSON array of objects with
+ * a 'content' field. Falls back to the raw string if parsing fails.
+ */
+function extractMessageText(value: unknown): string {
+  const parsed = tryParseJson(value);
+  if (Array.isArray(parsed)) {
+    return parsed
+      .map(msg => {
+        if (typeof msg === 'object' && msg !== null && 'content' in msg) {
+          const role = 'role' in msg ? `[${msg.role}]` : '';
+          return `${role}\n${String((msg as Record<string, unknown>).content)}`;
+        }
+        return String(msg);
+      })
+      .join('\n\n');
+  }
+  return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+}
+
+type JsonRendererProps = { value: unknown };
+
+function JsonRenderer({ value }: JsonRendererProps) {
+  const parsed = tryParseJson(value);
+  if (parsed !== null) {
+    return (
+      <div className="GenAIAttributeRenderer--json">
+        <JsonView data={parsed} shouldExpandNode={allExpanded} style={defaultStyles} />
+      </div>
+    );
+  }
+  // Fallback: raw string if JSON parse fails
+  return <pre className="GenAIAttributeRenderer--pre">{String(value)}</pre>;
+}
+
+type MarkdownRendererProps = { value: unknown };
+
+function MarkdownRenderer({ value }: MarkdownRendererProps) {
+  const text = extractMessageText(value);
+  return <pre className="GenAIAttributeRenderer--pre">{text}</pre>;
+}
+
+/**
+ * Renders rich content for specific OTel GenAI attributes when the
+ * containing accordion section is open. Returns null for any attribute
+ * key not in RICH_MEDIA_ATTRIBUTE_KEYS, ensuring zero cost for
+ * non-GenAI spans.
+ */
+export default function GenAIAttributeRenderer({ attribute, isOpen }: Props): React.ReactElement | null {
+  const renderKind = RICH_MEDIA_ATTRIBUTE_KEYS[attribute.key];
+  if (renderKind === undefined) return null;
+
+  // Lazy: do not parse or render when the section is collapsed
+  if (!isOpen) return null;
+
+  return (
+    <div className="GenAIAttributeRenderer">
+      <span className="GenAIAttributeRenderer--key">{attribute.key}</span>
+      {renderKind === 'json' ? (
+        <JsonRenderer value={attribute.value} />
+      ) : (
+        <MarkdownRenderer value={attribute.value} />
+      )}
+    </div>
+  );
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { JsonView, allExpanded, collapseAllNested, defaultStyles } from 'react-json-view-lite';
-import 'react-json-view-lite/dist/index.css';
+import { JsonView, allExpanded, collapseAllNested } from 'react-json-view-lite';
 
 import { RICH_MEDIA_ATTRIBUTE_KEYS } from '../../../../utils/genai/detect';
+import jsonViewStyles from '../../../../utils/jsonViewStyles';
 import type { IAttribute } from '../../../../types/otel';
 
 type Props = {
@@ -38,8 +38,9 @@ function extractMessageText(value: unknown): string {
     return parsed
       .map(msg => {
         if (typeof msg === 'object' && msg !== null && 'content' in msg) {
-          const role = 'role' in msg ? `[${msg.role}]` : '';
-          return `${role}\n${String((msg as Record<string, unknown>).content)}`;
+          const rec = msg as Record<string, unknown>;
+          const roleStr = typeof rec.role === 'string' && rec.role ? `[${rec.role}]\n` : '';
+          return `${roleStr}${String(rec.content)}`;
         }
         return String(msg);
       })
@@ -59,7 +60,7 @@ function JsonRenderer({ value }: JsonRendererProps) {
         <JsonView
           data={parsed}
           shouldExpandNode={isSmall ? allExpanded : collapseAllNested}
-          style={defaultStyles}
+          style={jsonViewStyles}
         />
       </div>
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
@@ -56,7 +56,11 @@ function JsonRenderer({ value }: JsonRendererProps) {
     const isSmall = typeof parsed === 'object' && parsed !== null && Object.keys(parsed).length <= 10;
     return (
       <div className="GenAIAttributeRenderer--json">
-        <JsonView data={parsed} shouldExpandNode={isSmall ? allExpanded : collapseAllNested} style={defaultStyles} />
+        <JsonView
+          data={parsed}
+          shouldExpandNode={isSmall ? allExpanded : collapseAllNested}
+          style={defaultStyles}
+        />
       </div>
     );
   }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState } from 'react';
-import { JsonView, allExpanded, defaultStyles } from 'react-json-view-lite';
+import React from 'react';
+import { JsonView, allExpanded, collapseAllNested, defaultStyles } from 'react-json-view-lite';
 import 'react-json-view-lite/dist/index.css';
 
 import { RICH_MEDIA_ATTRIBUTE_KEYS } from '../../../../utils/genai/detect';
@@ -53,9 +53,10 @@ type JsonRendererProps = { value: unknown };
 function JsonRenderer({ value }: JsonRendererProps) {
   const parsed = tryParseJson(value);
   if (parsed !== null) {
+    const isSmall = typeof parsed === 'object' && parsed !== null && Object.keys(parsed).length <= 10;
     return (
       <div className="GenAIAttributeRenderer--json">
-        <JsonView data={parsed} shouldExpandNode={allExpanded} style={defaultStyles} />
+        <JsonView data={parsed} shouldExpandNode={isSmall ? allExpanded : collapseAllNested} style={defaultStyles} />
       </div>
     );
   }
@@ -77,8 +78,8 @@ function MarkdownRenderer({ value }: MarkdownRendererProps) {
  * non-GenAI spans.
  */
 export default function GenAIAttributeRenderer({ attribute, isOpen }: Props): React.ReactElement | null {
+  if (!Object.hasOwn(RICH_MEDIA_ATTRIBUTE_KEYS, attribute.key)) return null;
   const renderKind = RICH_MEDIA_ATTRIBUTE_KEYS[attribute.key];
-  if (renderKind === undefined) return null;
 
   // Lazy: do not parse or render when the section is collapsed
   if (!isOpen) return null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .GenAIAttributeRenderer--pre {
-  background: var(--surface-secondary, #f5f5f5);
+  background: var(--surface-secondary);
   border-radius: 2px;
   font-size: 0.85em;
   margin: 0;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
@@ -52,3 +52,38 @@ SPDX-License-Identifier: Apache-2.0
 .AccordianWarnings--label {
   color: var(--feedback-warning);
 }
+
+.SpanDetail--genAISection {
+  margin-bottom: 0.25rem;
+}
+
+.GenAIAttributeRenderer {
+  border: 1px solid var(--border-default);
+  margin-bottom: 0.25rem;
+  padding: 0.5rem;
+}
+
+.GenAIAttributeRenderer--key {
+  color: var(--text-muted);
+  display: block;
+  font-size: 0.85em;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.GenAIAttributeRenderer--pre {
+  background: var(--surface-secondary, #f5f5f5);
+  border-radius: 2px;
+  font-size: 0.85em;
+  margin: 0;
+  max-height: 400px;
+  overflow: auto;
+  padding: 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.GenAIAttributeRenderer--json {
+  max-height: 400px;
+  overflow: auto;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -344,9 +344,12 @@ describe('<SpanDetail>', () => {
       isGenAISpanMock.mockReturnValue(false);
       const richAttr = { key: 'gen_ai.input.messages', value: '[{"role":"user","content":"hi"}]' };
       props.span.attributes.push(richAttr);
-      render(<SpanDetail {...props} />);
-      expect(screen.getByTestId('genai-renderer-gen_ai.input.messages')).toBeInTheDocument();
-      props.span.attributes.pop();
+      try {
+        render(<SpanDetail {...props} />);
+        expect(screen.getByTestId('genai-renderer-gen_ai.input.messages')).toBeInTheDocument();
+      } finally {
+        props.span.attributes.pop();
+      }
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -338,6 +338,10 @@ describe('<SpanDetail>', () => {
 
   describe('rich-media GenAI attribute section', () => {
     it('renders GenAIAttributeRenderer for rich-media attributes when accordion is open', () => {
+      // isGenAISpan is unrelated to whether a span carries rich-media attributes
+      // (it drives the separate GenAI *tab*) -- force it false here so
+      // detailsContent renders directly instead of behind a lazily-mounted tab pane.
+      isGenAISpanMock.mockReturnValue(false);
       const richAttr = { key: 'gen_ai.input.messages', value: '[{"role":"user","content":"hi"}]' };
       props.span.attributes.push(richAttr);
       render(<SpanDetail {...props} />);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -94,6 +94,12 @@ vi.mock('./GenAITab', () => {
   });
 });
 
+vi.mock('./GenAIAttributeRenderer', () => {
+  return mockDefault(function MockGenAIAttributeRenderer({ attribute }) {
+    return <div data-testid={`genai-renderer-${attribute.key}`}>{attribute.key}</div>;
+  });
+});
+
 const { isGenAISpanMock } = vi.hoisted(() => ({
   isGenAISpanMock: vi.fn(() => false),
 }));
@@ -327,6 +333,16 @@ describe('<SpanDetail>', () => {
       render(<SpanDetail {...props} />);
       expect(screen.getByRole('tab', { name: 'GenAI' })).toHaveAttribute('aria-selected', 'true');
       expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('rich-media GenAI attribute section', () => {
+    it('renders GenAIAttributeRenderer for rich-media attributes when accordion is open', () => {
+      const richAttr = { key: 'gen_ai.input.messages', value: '[{"role":"user","content":"hi"}]' };
+      props.span.attributes.push(richAttr);
+      render(<SpanDetail {...props} />);
+      expect(screen.getByTestId('genai-renderer-gen_ai.input.messages')).toBeInTheDocument();
+      props.span.attributes.pop();
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -106,6 +106,7 @@ export default function SpanDetail(props: SpanDetailProps) {
           linksGetter={linksGetter}
           isOpen={isAttributesOpen}
           onToggle={() => attributesToggle(span.spanID)}
+          hasAdditionalContent={richMediaAttrs.length > 0}
         />
         {richMediaAttrs.length > 0 && isAttributesOpen && (
           <div className="SpanDetail--genAISection">

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -10,6 +10,7 @@ import AccordionEvents from './AccordionEvents';
 import AccordionLinks from './AccordionLinks';
 import AccordionText from './AccordionText';
 import DetailState from './DetailState';
+import GenAIAttributeRenderer from './GenAIAttributeRenderer';
 import GenAITab from './GenAITab';
 import { formatDuration, formatDurationCompact } from '../utils';
 import CopyIcon from '../../../common/CopyIcon';
@@ -19,6 +20,7 @@ import { isGenAISpan } from '../../../../utils/genai';
 import { TNil } from '../../../../types';
 import { Hyperlink } from '../../../../types/hyperlink';
 import { IOtelSpan, IAttribute, IEvent } from '../../../../types/otel';
+import { RICH_MEDIA_ATTRIBUTE_KEYS } from '../../../../utils/genai/detect';
 
 import './index.css';
 
@@ -65,6 +67,11 @@ export default function SpanDetail(props: SpanDetailProps) {
   // Get links for display in AccordionLinks
   const links = span.links || [];
 
+  // Split attributes: rich-media GenAI attributes rendered by GenAIAttributeRenderer;
+  // all others passed to AccordionAttributes unchanged.
+  const richMediaAttrs = span.attributes.filter(a => Object.hasOwn(RICH_MEDIA_ATTRIBUTE_KEYS, a.key));
+  const standardAttrs = span.attributes.filter(a => !Object.hasOwn(RICH_MEDIA_ATTRIBUTE_KEYS, a.key));
+
   // Display labels based on terminology flag
   const attributesLabel = useOtelTerms ? 'Attributes' : 'Tags';
   const resourceLabel = useOtelTerms ? 'Resource' : 'Process';
@@ -94,12 +101,19 @@ export default function SpanDetail(props: SpanDetailProps) {
     <div>
       <div>
         <AccordionAttributes
-          data={span.attributes}
+          data={isAttributesOpen ? standardAttrs : span.attributes}
           label={attributesLabel}
           linksGetter={linksGetter}
           isOpen={isAttributesOpen}
           onToggle={() => attributesToggle(span.spanID)}
         />
+        {richMediaAttrs.length > 0 && isAttributesOpen && (
+          <div className="SpanDetail--genAISection">
+            {richMediaAttrs.map((attr, i) => (
+              <GenAIAttributeRenderer key={`${attr.key}-${i}`} attribute={attr} isOpen={isAttributesOpen} />
+            ))}
+          </div>
+        )}
         {span.resource.attributes && span.resource.attributes.length > 0 && (
           <AccordionAttributes
             className="ub-mb1"

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -1,117 +1,142 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { classifySpan, isGenAISpan, isGenAITrace } from './detect';
-import type { IAttribute } from '../../types/otel';
+import { describe, it, expect } from 'vitest';
+import { classifySpan, hasGenAIAttributes, isGenAISpan, isGenAITrace, RICH_MEDIA_ATTRIBUTE_KEYS } from './detect';
+import type { IAttribute, IOtelSpan, IOtelTrace } from '../../types/otel';
 
-function makeSpan(attrs: IAttribute[]): { attributes: IAttribute[] } {
-  return { attributes: attrs };
+function makeSpan(attrs: Record<string, string>): IOtelSpan {
+  const attributes: IAttribute[] = Object.entries(attrs).map(([key, value]) => ({ key, value }));
+  return { attributes } as unknown as IOtelSpan;
 }
 
+function makeTrace(spans: IOtelSpan[]): IOtelTrace {
+  return { spans } as unknown as IOtelTrace;
+}
+
+describe('hasGenAIAttributes', () => {
+  it('returns true when any attribute key starts with gen_ai.', () => {
+    expect(hasGenAIAttributes([{ key: 'gen_ai.operation.name', value: 'chat' }])).toBe(true);
+  });
+
+  it('returns false when no attribute key starts with gen_ai.', () => {
+    expect(hasGenAIAttributes([{ key: 'http.method', value: 'GET' }])).toBe(false);
+  });
+
+  it('returns false for empty attributes array', () => {
+    expect(hasGenAIAttributes([])).toBe(false);
+  });
+});
+
 describe('classifySpan', () => {
-  it('classifies chat as LLM_CALL', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }]))).toBe('LLM_CALL');
+  it('returns STANDARD for span with no gen_ai.* attributes', () => {
+    expect(classifySpan(makeSpan({ 'http.method': 'GET' }))).toBe('STANDARD');
   });
 
-  it('classifies text_completion as LLM_CALL', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'text_completion' }]))).toBe(
-      'LLM_CALL'
-    );
+  it('returns LLM_CALL for gen_ai.operation.name = chat', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'chat' }))).toBe('LLM_CALL');
   });
 
-  it('classifies generate_content as LLM_CALL', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'generate_content' }]))).toBe(
-      'LLM_CALL'
-    );
+  it('returns LLM_CALL for gen_ai.operation.name = text_completion', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'text_completion' }))).toBe('LLM_CALL');
   });
 
-  it('classifies embeddings as LLM_CALL', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'embeddings' }]))).toBe('LLM_CALL');
+  it('returns LLM_CALL for gen_ai.operation.name = generate_content', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'generate_content' }))).toBe('LLM_CALL');
   });
 
-  it('classifies execute_tool as TOOL_CALL', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'execute_tool' }]))).toBe(
-      'TOOL_CALL'
-    );
+  it('returns LLM_CALL for gen_ai.operation.name = embeddings', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'embeddings' }))).toBe('LLM_CALL');
   });
 
-  it('classifies invoke_agent as AGENT', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'invoke_agent' }]))).toBe('AGENT');
+  it('returns TOOL_CALL for gen_ai.operation.name = execute_tool', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'execute_tool' }))).toBe('TOOL_CALL');
   });
 
-  it('classifies create_agent as AGENT', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'create_agent' }]))).toBe('AGENT');
+  it('returns AGENT for gen_ai.operation.name = invoke_agent', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'invoke_agent' }))).toBe('AGENT');
   });
 
-  it('classifies invoke_workflow as AGENT', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'invoke_workflow' }]))).toBe(
-      'AGENT'
-    );
+  it('returns AGENT for gen_ai.operation.name = create_agent', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'create_agent' }))).toBe('AGENT');
   });
 
-  it('classifies retrieval as RETRIEVAL', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'retrieval' }]))).toBe('RETRIEVAL');
+  it('returns AGENT for gen_ai.operation.name = invoke_workflow', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'invoke_workflow' }))).toBe('AGENT');
   });
 
-  it('returns UNKNOWN_GENAI for an unrecognized gen_ai.operation.name', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'some_new_op' }]))).toBe(
-      'UNKNOWN_GENAI'
-    );
+  it('returns RETRIEVAL for gen_ai.operation.name = retrieval', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'retrieval' }))).toBe('RETRIEVAL');
   });
 
-  it('returns UNKNOWN_GENAI for a span with gen_ai.* attrs but no operation.name', () => {
-    expect(classifySpan(makeSpan([{ key: 'gen_ai.system', value: 'openai' }]))).toBe('UNKNOWN_GENAI');
+  it('returns UNKNOWN_GENAI for span with gen_ai.* attrs but no operation.name', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.provider.name': 'openai' }))).toBe('UNKNOWN_GENAI');
   });
 
-  it('returns undefined for a span with no gen_ai.* attrs', () => {
-    expect(classifySpan(makeSpan([{ key: 'http.method', value: 'GET' }]))).toBeUndefined();
-  });
-
-  it('returns undefined for a span with empty attributes', () => {
-    expect(classifySpan(makeSpan([]))).toBeUndefined();
+  it('returns UNKNOWN_GENAI for unrecognized gen_ai.operation.name value', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'future_unknown_op' }))).toBe('UNKNOWN_GENAI');
   });
 });
 
 describe('isGenAISpan', () => {
   it('returns true for a span with a gen_ai.* attribute', () => {
-    expect(isGenAISpan(makeSpan([{ key: 'gen_ai.system', value: 'openai' }]))).toBe(true);
+    expect(isGenAISpan(makeSpan({ 'gen_ai.provider.name': 'openai' }))).toBe(true);
   });
 
   it('returns true for a span with gen_ai.operation.name', () => {
-    expect(isGenAISpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }]))).toBe(true);
+    expect(isGenAISpan(makeSpan({ 'gen_ai.operation.name': 'chat' }))).toBe(true);
   });
 
   it('returns false for a span with no gen_ai.* attribute', () => {
-    expect(isGenAISpan(makeSpan([{ key: 'http.method', value: 'GET' }]))).toBe(false);
+    expect(isGenAISpan(makeSpan({ 'http.method': 'GET' }))).toBe(false);
   });
 
-  it('returns false for a span with empty attributes', () => {
-    expect(isGenAISpan(makeSpan([]))).toBe(false);
+  it('returns false for a span with no attributes', () => {
+    expect(isGenAISpan(makeSpan({}))).toBe(false);
   });
 
   it('does not match keys that merely contain "gen_ai" in the middle', () => {
-    expect(isGenAISpan(makeSpan([{ key: 'custom.gen_ai.tag', value: 'x' }]))).toBe(false);
+    expect(isGenAISpan(makeSpan({ 'custom.gen_ai.tag': 'x' }))).toBe(false);
   });
 });
 
 describe('isGenAITrace', () => {
-  it('returns true when at least one span has a gen_ai.* attribute', () => {
-    const spans = [
-      makeSpan([{ key: 'http.method', value: 'GET' }]),
-      makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }]),
-    ];
-    expect(isGenAITrace(spans)).toBe(true);
+  it('returns true when at least one span has gen_ai.* attributes', () => {
+    const trace = makeTrace([
+      makeSpan({ 'http.method': 'GET' }),
+      makeSpan({ 'gen_ai.operation.name': 'chat' }),
+    ]);
+    expect(isGenAITrace(trace)).toBe(true);
   });
 
-  it('returns false when no span has any gen_ai.* attribute', () => {
-    const spans = [
-      makeSpan([{ key: 'http.method', value: 'GET' }]),
-      makeSpan([{ key: 'db.system', value: 'postgresql' }]),
-    ];
-    expect(isGenAITrace(spans)).toBe(false);
+  it('returns false when no span has gen_ai.* attributes', () => {
+    const trace = makeTrace([makeSpan({ 'http.method': 'GET' }), makeSpan({ 'db.system': 'postgresql' })]);
+    expect(isGenAITrace(trace)).toBe(false);
   });
 
-  it('returns false for an empty span list', () => {
-    expect(isGenAITrace([])).toBe(false);
+  it('returns false for empty trace', () => {
+    expect(isGenAITrace(makeTrace([]))).toBe(false);
+  });
+});
+
+describe('RICH_MEDIA_ATTRIBUTE_KEYS', () => {
+  it('classifies gen_ai.input.messages as markdown', () => {
+    expect(RICH_MEDIA_ATTRIBUTE_KEYS['gen_ai.input.messages']).toBe('markdown');
+  });
+
+  it('classifies gen_ai.output.messages as markdown', () => {
+    expect(RICH_MEDIA_ATTRIBUTE_KEYS['gen_ai.output.messages']).toBe('markdown');
+  });
+
+  it('classifies gen_ai.tool.call.arguments as json', () => {
+    expect(RICH_MEDIA_ATTRIBUTE_KEYS['gen_ai.tool.call.arguments']).toBe('json');
+  });
+
+  it('classifies gen_ai.tool.call.result as json', () => {
+    expect(RICH_MEDIA_ATTRIBUTE_KEYS['gen_ai.tool.call.result']).toBe('json');
+  });
+
+  it('does not classify gen_ai.operation.name as a rich-media key', () => {
+    expect(RICH_MEDIA_ATTRIBUTE_KEYS['gen_ai.operation.name']).toBeUndefined();
   });
 });

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -1,121 +1,118 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from 'vitest';
-import { classifySpan, hasGenAIAttributes, isGenAISpan, isGenAITrace, RICH_MEDIA_ATTRIBUTE_KEYS } from './detect';
-import type { IAttribute, IOtelSpan, IOtelTrace } from '../../types/otel';
+import { classifySpan, isGenAISpan, isGenAITrace, RICH_MEDIA_ATTRIBUTE_KEYS } from './detect';
+import type { IAttribute } from '../../types/otel';
 
-function makeSpan(attrs: Record<string, string>): IOtelSpan {
-  const attributes: IAttribute[] = Object.entries(attrs).map(([key, value]) => ({ key, value }));
-  return { attributes } as unknown as IOtelSpan;
+function makeSpan(attrs: IAttribute[]): { attributes: IAttribute[] } {
+  return { attributes: attrs };
 }
-
-function makeTrace(spans: IOtelSpan[]): IOtelTrace {
-  return { spans } as unknown as IOtelTrace;
-}
-
-describe('hasGenAIAttributes', () => {
-  it('returns true when any attribute key starts with gen_ai.', () => {
-    expect(hasGenAIAttributes([{ key: 'gen_ai.operation.name', value: 'chat' }])).toBe(true);
-  });
-
-  it('returns false when no attribute key starts with gen_ai.', () => {
-    expect(hasGenAIAttributes([{ key: 'http.method', value: 'GET' }])).toBe(false);
-  });
-
-  it('returns false for empty attributes array', () => {
-    expect(hasGenAIAttributes([])).toBe(false);
-  });
-});
 
 describe('classifySpan', () => {
-  it('returns STANDARD for span with no gen_ai.* attributes', () => {
-    expect(classifySpan(makeSpan({ 'http.method': 'GET' }))).toBe('STANDARD');
+  it('classifies chat as LLM_CALL', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }]))).toBe('LLM_CALL');
   });
 
-  it('returns LLM_CALL for gen_ai.operation.name = chat', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'chat' }))).toBe('LLM_CALL');
+  it('classifies text_completion as LLM_CALL', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'text_completion' }]))).toBe(
+      'LLM_CALL'
+    );
   });
 
-  it('returns LLM_CALL for gen_ai.operation.name = text_completion', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'text_completion' }))).toBe('LLM_CALL');
+  it('classifies generate_content as LLM_CALL', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'generate_content' }]))).toBe(
+      'LLM_CALL'
+    );
   });
 
-  it('returns LLM_CALL for gen_ai.operation.name = generate_content', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'generate_content' }))).toBe('LLM_CALL');
+  it('classifies embeddings as LLM_CALL', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'embeddings' }]))).toBe('LLM_CALL');
   });
 
-  it('returns LLM_CALL for gen_ai.operation.name = embeddings', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'embeddings' }))).toBe('LLM_CALL');
+  it('classifies execute_tool as TOOL_CALL', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'execute_tool' }]))).toBe(
+      'TOOL_CALL'
+    );
   });
 
-  it('returns TOOL_CALL for gen_ai.operation.name = execute_tool', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'execute_tool' }))).toBe('TOOL_CALL');
+  it('classifies invoke_agent as AGENT', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'invoke_agent' }]))).toBe('AGENT');
   });
 
-  it('returns AGENT for gen_ai.operation.name = invoke_agent', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'invoke_agent' }))).toBe('AGENT');
+  it('classifies create_agent as AGENT', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'create_agent' }]))).toBe('AGENT');
   });
 
-  it('returns AGENT for gen_ai.operation.name = create_agent', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'create_agent' }))).toBe('AGENT');
+  it('classifies invoke_workflow as AGENT', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'invoke_workflow' }]))).toBe(
+      'AGENT'
+    );
   });
 
-  it('returns AGENT for gen_ai.operation.name = invoke_workflow', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'invoke_workflow' }))).toBe('AGENT');
+  it('classifies retrieval as RETRIEVAL', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'retrieval' }]))).toBe('RETRIEVAL');
   });
 
-  it('returns RETRIEVAL for gen_ai.operation.name = retrieval', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'retrieval' }))).toBe('RETRIEVAL');
+  it('returns UNKNOWN_GENAI for an unrecognized gen_ai.operation.name', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'some_new_op' }]))).toBe(
+      'UNKNOWN_GENAI'
+    );
   });
 
-  it('returns UNKNOWN_GENAI for span with gen_ai.* attrs but no operation.name', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.provider.name': 'openai' }))).toBe('UNKNOWN_GENAI');
+  it('returns UNKNOWN_GENAI for a span with gen_ai.* attrs but no operation.name', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.system', value: 'openai' }]))).toBe('UNKNOWN_GENAI');
   });
 
-  it('returns UNKNOWN_GENAI for unrecognized gen_ai.operation.name value', () => {
-    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': 'future_unknown_op' }))).toBe('UNKNOWN_GENAI');
+  it('returns undefined for a span with no gen_ai.* attrs', () => {
+    expect(classifySpan(makeSpan([{ key: 'http.method', value: 'GET' }]))).toBeUndefined();
+  });
+
+  it('returns undefined for a span with empty attributes', () => {
+    expect(classifySpan(makeSpan([]))).toBeUndefined();
   });
 });
 
 describe('isGenAISpan', () => {
   it('returns true for a span with a gen_ai.* attribute', () => {
-    expect(isGenAISpan(makeSpan({ 'gen_ai.provider.name': 'openai' }))).toBe(true);
+    expect(isGenAISpan(makeSpan([{ key: 'gen_ai.system', value: 'openai' }]))).toBe(true);
   });
 
   it('returns true for a span with gen_ai.operation.name', () => {
-    expect(isGenAISpan(makeSpan({ 'gen_ai.operation.name': 'chat' }))).toBe(true);
+    expect(isGenAISpan(makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }]))).toBe(true);
   });
 
   it('returns false for a span with no gen_ai.* attribute', () => {
-    expect(isGenAISpan(makeSpan({ 'http.method': 'GET' }))).toBe(false);
+    expect(isGenAISpan(makeSpan([{ key: 'http.method', value: 'GET' }]))).toBe(false);
   });
 
-  it('returns false for a span with no attributes', () => {
-    expect(isGenAISpan(makeSpan({}))).toBe(false);
+  it('returns false for a span with empty attributes', () => {
+    expect(isGenAISpan(makeSpan([]))).toBe(false);
   });
 
   it('does not match keys that merely contain "gen_ai" in the middle', () => {
-    expect(isGenAISpan(makeSpan({ 'custom.gen_ai.tag': 'x' }))).toBe(false);
+    expect(isGenAISpan(makeSpan([{ key: 'custom.gen_ai.tag', value: 'x' }]))).toBe(false);
   });
 });
 
 describe('isGenAITrace', () => {
-  it('returns true when at least one span has gen_ai.* attributes', () => {
-    const trace = makeTrace([
-      makeSpan({ 'http.method': 'GET' }),
-      makeSpan({ 'gen_ai.operation.name': 'chat' }),
-    ]);
-    expect(isGenAITrace(trace)).toBe(true);
+  it('returns true when at least one span has a gen_ai.* attribute', () => {
+    const spans = [
+      makeSpan([{ key: 'http.method', value: 'GET' }]),
+      makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }]),
+    ];
+    expect(isGenAITrace(spans)).toBe(true);
   });
 
-  it('returns false when no span has gen_ai.* attributes', () => {
-    const trace = makeTrace([makeSpan({ 'http.method': 'GET' }), makeSpan({ 'db.system': 'postgresql' })]);
-    expect(isGenAITrace(trace)).toBe(false);
+  it('returns false when no span has any gen_ai.* attribute', () => {
+    const spans = [
+      makeSpan([{ key: 'http.method', value: 'GET' }]),
+      makeSpan([{ key: 'db.system', value: 'postgresql' }]),
+    ];
+    expect(isGenAITrace(spans)).toBe(false);
   });
 
-  it('returns false for empty trace', () => {
-    expect(isGenAITrace(makeTrace([]))).toBe(false);
+  it('returns false for an empty span list', () => {
+    expect(isGenAITrace([])).toBe(false);
   });
 });
 

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -1,44 +1,77 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { IAttribute, GenAISpanKind } from '../../types/otel';
-import { GEN_AI_NAMESPACE, GEN_AI_OPERATION_NAME } from '../../constants/span-attributes';
+import type { IAttribute, IOtelSpan, IOtelTrace } from '../../types/otel';
 
-type SpanAttrs = { attributes: ReadonlyArray<IAttribute> };
+/**
+ * Span classification based on OTel GenAI semantic conventions.
+ * https://opentelemetry.io/docs/specs/semconv/gen-ai/
+ */
+export type GenAISpanKind = 'LLM_CALL' | 'TOOL_CALL' | 'AGENT' | 'RETRIEVAL' | 'UNKNOWN_GENAI' | 'STANDARD';
 
-const OPERATION_TO_KIND: Partial<Record<string, GenAISpanKind>> = {
-  chat: 'LLM_CALL',
-  text_completion: 'LLM_CALL',
-  generate_content: 'LLM_CALL',
-  embeddings: 'LLM_CALL',
-  execute_tool: 'TOOL_CALL',
-  invoke_agent: 'AGENT',
-  create_agent: 'AGENT',
-  invoke_workflow: 'AGENT',
-  retrieval: 'RETRIEVAL',
-};
+const LLM_OPS = new Set(['chat', 'text_completion', 'generate_content', 'embeddings']);
+const TOOL_OPS = new Set(['execute_tool']);
+const AGENT_OPS = new Set(['invoke_agent', 'create_agent', 'invoke_workflow']);
+const RETRIEVAL_OPS = new Set(['retrieval']);
 
-// Single pass over attributes: looks for gen_ai.operation.name while also
-// tracking whether any gen_ai.* attribute was seen, so a span with GenAI
-// attributes but an unrecognized (or missing) operation name still maps to
-// UNKNOWN_GENAI instead of undefined.
-export function classifySpan(span: SpanAttrs): GenAISpanKind | undefined {
-  let hasGenAI = false;
-  for (const { key, value } of span.attributes) {
-    if (key === GEN_AI_OPERATION_NAME && typeof value === 'string') {
-      return OPERATION_TO_KIND[value] ?? 'UNKNOWN_GENAI';
-    }
-    if (!hasGenAI && key.startsWith(GEN_AI_NAMESPACE)) {
-      hasGenAI = true;
-    }
+function getStringAttribute(attributes: ReadonlyArray<IAttribute>, key: string): string | undefined {
+  const attr = attributes.find(a => a.key === key);
+  return attr !== undefined && typeof attr.value === 'string' ? attr.value : undefined;
+}
+
+export function hasGenAIAttributes(attributes: ReadonlyArray<IAttribute>): boolean {
+  return attributes.some(a => a.key.startsWith('gen_ai.'));
+}
+
+/**
+ * Classifies a single span by its gen_ai.operation.name attribute.
+ * Returns 'STANDARD' for any span with no gen_ai.* attributes.
+ */
+export function classifySpan(span: IOtelSpan): GenAISpanKind {
+  if (!hasGenAIAttributes(span.attributes)) {
+    return 'STANDARD';
   }
-  return hasGenAI ? 'UNKNOWN_GENAI' : undefined;
+  const op = getStringAttribute(span.attributes, 'gen_ai.operation.name');
+  if (op === undefined) {
+    return 'UNKNOWN_GENAI';
+  }
+  if (LLM_OPS.has(op)) return 'LLM_CALL';
+  if (TOOL_OPS.has(op)) return 'TOOL_CALL';
+  if (AGENT_OPS.has(op)) return 'AGENT';
+  if (RETRIEVAL_OPS.has(op)) return 'RETRIEVAL';
+  return 'UNKNOWN_GENAI';
 }
 
-export function isGenAISpan(span: SpanAttrs): boolean {
-  return classifySpan(span) !== undefined;
+/**
+ * Returns true if the span carries any gen_ai.* attributes, i.e. it is not
+ * classified as 'STANDARD'. Used to decide whether to show GenAI-specific UI
+ * (the GenAI detail tab, rich-media attribute rendering) for a given span.
+ */
+export function isGenAISpan(span: IOtelSpan): boolean {
+  return classifySpan(span) !== 'STANDARD';
 }
 
-export function isGenAITrace(spans: ReadonlyArray<SpanAttrs>): boolean {
-  return spans.some(s => classifySpan(s) !== undefined);
+/**
+ * Returns true if any span in the trace carries gen_ai.* attributes.
+ * Result is O(n*attrs) on first call; callers should cache it.
+ */
+export function isGenAITrace(trace: IOtelTrace): boolean {
+  return trace.spans.some(span => hasGenAIAttributes(span.attributes));
 }
+
+/**
+ * Attribute keys defined by OTel GenAI semconv that carry rich content
+ * (structured JSON or human-readable text) and need specialized rendering.
+ *
+ * 'json'     - render with react-json-view-lite
+ * 'markdown' - render as preformatted text (Markdown-like prompts/completions)
+ */
+export const RICH_MEDIA_ATTRIBUTE_KEYS: Readonly<Record<string, 'json' | 'markdown'>> = {
+  'gen_ai.input.messages': 'markdown',
+  'gen_ai.output.messages': 'markdown',
+  'gen_ai.system_instructions': 'markdown',
+  'gen_ai.tool.call.arguments': 'json',
+  'gen_ai.tool.call.result': 'json',
+  'gen_ai.tool.definitions': 'json',
+  'gen_ai.retrieval.documents': 'json',
+};

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -1,62 +1,46 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { IAttribute, IOtelSpan, IOtelTrace } from '../../types/otel';
+import type { IAttribute, GenAISpanKind } from '../../types/otel';
+import { GEN_AI_NAMESPACE, GEN_AI_OPERATION_NAME } from '../../constants/span-attributes';
 
-/**
- * Span classification based on OTel GenAI semantic conventions.
- * https://opentelemetry.io/docs/specs/semconv/gen-ai/
- */
-export type GenAISpanKind = 'LLM_CALL' | 'TOOL_CALL' | 'AGENT' | 'RETRIEVAL' | 'UNKNOWN_GENAI' | 'STANDARD';
+type SpanAttrs = { attributes: ReadonlyArray<IAttribute> };
 
-const LLM_OPS = new Set(['chat', 'text_completion', 'generate_content', 'embeddings']);
-const TOOL_OPS = new Set(['execute_tool']);
-const AGENT_OPS = new Set(['invoke_agent', 'create_agent', 'invoke_workflow']);
-const RETRIEVAL_OPS = new Set(['retrieval']);
+const OPERATION_TO_KIND: Partial<Record<string, GenAISpanKind>> = {
+  chat: 'LLM_CALL',
+  text_completion: 'LLM_CALL',
+  generate_content: 'LLM_CALL',
+  embeddings: 'LLM_CALL',
+  execute_tool: 'TOOL_CALL',
+  invoke_agent: 'AGENT',
+  create_agent: 'AGENT',
+  invoke_workflow: 'AGENT',
+  retrieval: 'RETRIEVAL',
+};
 
-function getStringAttribute(attributes: ReadonlyArray<IAttribute>, key: string): string | undefined {
-  const attr = attributes.find(a => a.key === key);
-  return attr !== undefined && typeof attr.value === 'string' ? attr.value : undefined;
-}
-
-export function hasGenAIAttributes(attributes: ReadonlyArray<IAttribute>): boolean {
-  return attributes.some(a => a.key.startsWith('gen_ai.'));
-}
-
-/**
- * Classifies a single span by its gen_ai.operation.name attribute.
- * Returns 'STANDARD' for any span with no gen_ai.* attributes.
- */
-export function classifySpan(span: IOtelSpan): GenAISpanKind {
-  if (!hasGenAIAttributes(span.attributes)) {
-    return 'STANDARD';
+// Single pass over attributes: looks for gen_ai.operation.name while also
+// tracking whether any gen_ai.* attribute was seen, so a span with GenAI
+// attributes but an unrecognized (or missing) operation name still maps to
+// UNKNOWN_GENAI instead of undefined.
+export function classifySpan(span: SpanAttrs): GenAISpanKind | undefined {
+  let hasGenAI = false;
+  for (const { key, value } of span.attributes) {
+    if (key === GEN_AI_OPERATION_NAME && typeof value === 'string') {
+      return OPERATION_TO_KIND[value] ?? 'UNKNOWN_GENAI';
+    }
+    if (!hasGenAI && key.startsWith(GEN_AI_NAMESPACE)) {
+      hasGenAI = true;
+    }
   }
-  const op = getStringAttribute(span.attributes, 'gen_ai.operation.name');
-  if (op === undefined) {
-    return 'UNKNOWN_GENAI';
-  }
-  if (LLM_OPS.has(op)) return 'LLM_CALL';
-  if (TOOL_OPS.has(op)) return 'TOOL_CALL';
-  if (AGENT_OPS.has(op)) return 'AGENT';
-  if (RETRIEVAL_OPS.has(op)) return 'RETRIEVAL';
-  return 'UNKNOWN_GENAI';
+  return hasGenAI ? 'UNKNOWN_GENAI' : undefined;
 }
 
-/**
- * Returns true if the span carries any gen_ai.* attributes, i.e. it is not
- * classified as 'STANDARD'. Used to decide whether to show GenAI-specific UI
- * (the GenAI detail tab, rich-media attribute rendering) for a given span.
- */
-export function isGenAISpan(span: IOtelSpan): boolean {
-  return classifySpan(span) !== 'STANDARD';
+export function isGenAISpan(span: SpanAttrs): boolean {
+  return classifySpan(span) !== undefined;
 }
 
-/**
- * Returns true if any span in the trace carries gen_ai.* attributes.
- * Result is O(n*attrs) on first call; callers should cache it.
- */
-export function isGenAITrace(trace: IOtelTrace): boolean {
-  return trace.spans.some(span => hasGenAIAttributes(span.attributes));
+export function isGenAITrace(spans: ReadonlyArray<SpanAttrs>): boolean {
+  return spans.some(s => classifySpan(s) !== undefined);
 }
 
 /**


### PR DESCRIPTION
## Which problem is this PR solving?

GenAI spans following [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) carry large, structured payloads in attributes like `gen_ai.input.messages` and `gen_ai.tool.call.arguments`. The current `AccordionAttributes` renders every `IAttribute` as a flat key-value row, truncating these values and making them unreadable for developers debugging AI agent behavior.

Part of jaegertracing/jaeger#8401.

## Description of the changes

- **`src/utils/genai/detect.ts`** - New utility exporting:
  - `GenAISpanKind` union type (`LLM_CALL | TOOL_CALL | AGENT | RETRIEVAL | UNKNOWN_GENAI | STANDARD`)
  - `classifySpan(span)` - classifies by `gen_ai.operation.name`
  - `isGenAITrace(trace)` - true if any span carries `gen_ai.*` attributes
  - `RICH_MEDIA_ATTRIBUTE_KEYS` - maps specific attribute keys to render strategy (`'json'` or `'markdown'`)

- **`src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAIAttributeRenderer.tsx`** - New component that:
  - Guards key lookup with `Object.hasOwn(RICH_MEDIA_ATTRIBUTE_KEYS, attribute.key)` to avoid prototype-chain false positives
  - Returns `null` when `isOpen` is false (lazy - no parse cost until accordion is expanded)
  - Renders `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`, `gen_ai.tool.definitions`, `gen_ai.retrieval.documents` via `react-json-view-lite` (already in `package.json` at v2.5.0 - no new dependency); expands automatically for objects with ≤10 top-level keys, collapses deeply nested payloads otherwise
  - Renders `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions` as preformatted text, extracting `role` and `content` fields from the message JSON array

- **`src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx`** - Splits `span.attributes` before rendering using own-property checks:
  ```tsx
  const richMediaAttrs = span.attributes.filter(a => Object.hasOwn(RICH_MEDIA_ATTRIBUTE_KEYS, a.key));
  const standardAttrs  = span.attributes.filter(a => !Object.hasOwn(RICH_MEDIA_ATTRIBUTE_KEYS, a.key));
  ```
  `standardAttrs` goes to `AccordionAttributes` (unchanged behavior). `richMediaAttrs` renders via `GenAIAttributeRenderer` with index-based keys to handle duplicate attribute names.

- **`src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css`** - Adds styles for `.SpanDetail--genAISection`, `.GenAIAttributeRenderer`, `.GenAIAttributeRenderer--key`, `.GenAIAttributeRenderer--pre`, and `.GenAIAttributeRenderer--json` with `max-height` and overflow scroll for large payloads.

For any span with no `gen_ai.*` rich-media attributes, `richMediaAttrs` is empty and the new section does not mount. `AccordionAttributes` receives the full attribute list exactly as before.

## Test plan

- [x] `src/utils/genai/detect.test.ts` - covers all `GenAISpanKind` values, `isGenAITrace` true/false/empty cases, `RICH_MEDIA_ATTRIBUTE_KEYS` classification
- [x] `GenAIAttributeRenderer.test.tsx` - covers `null` returns for non-rich-media keys, lazy load (`isOpen=false`), JSON rendering with collapse strategy, preformatted text rendering, JSON parse fallback, all major attribute keys
- [ ] Manual: load a GenAI trace via FileLoader; open a `chat` span; verify `gen_ai.input.messages` renders as readable text and `gen_ai.tool.call.arguments` renders as a JSON tree
- [ ] Manual: load a standard (non-GenAI) trace; verify `SpanDetail` behavior is identical to before this PR