### PR TITLE
feat(search): Add compact trace table

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.css
@@ -1,0 +1,36 @@
+/*
+Copyright (c) 2026 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+.TraceTable {
+  margin-bottom: 1rem;
+}
+
+.TraceTable--row {
+  cursor: pointer;
+}
+
+.TraceTable--traceLink {
+  color: inherit;
+  display: inline-flex;
+  flex-direction: column;
+  max-width: 28rem;
+}
+
+.TraceTable--traceLink:hover {
+  color: inherit;
+}
+
+.TraceTable--traceName {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.TraceTable--traceID {
+  color: var(--text-muted);
+  font-family: monospace;
+  font-size: 0.85em;
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.css
@@ -15,7 +15,8 @@ SPDX-License-Identifier: Apache-2.0
   color: inherit;
   display: inline-flex;
   flex-direction: column;
-  max-width: 28rem;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .TraceTable--traceLink:hover {
@@ -33,4 +34,42 @@ SPDX-License-Identifier: Apache-2.0
   color: var(--text-muted);
   font-family: monospace;
   font-size: 0.85em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.TraceTable--serviceTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  max-height: 4.5rem;
+  overflow: auto;
+}
+
+.TraceTable--serviceTagItem {
+  display: inline-flex;
+}
+
+.TraceTable--serviceTag {
+  align-items: center;
+  border-left-width: 15px;
+  display: flex;
+  margin: 0;
+  max-width: 18rem;
+}
+
+.TraceTable--serviceTag .ant-tag-content {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.TraceTable--errorIcon {
+  background: var(--feedback-error);
+  border-radius: 6.5px;
+  color: var(--text-inverse);
+  font-size: 0.85em;
+  margin-right: 0.25rem;
+  padding: 1px;
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.jsx
@@ -6,7 +6,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 
-import TraceTable from './TraceTable';
+import TraceTable, { getSortBy } from './TraceTable';
 import * as orderBy from '../../../model/order-by';
 import { StatusCode } from '../../../types/otel';
 
@@ -15,7 +15,7 @@ const getTracePageLink = trace => ({
   state: { fromSearch: '/search' },
 });
 
-const makeSpan = (spanID, statusCode = StatusCode.OK) => ({
+const makeSpan = (spanID, statusCode = StatusCode.OK, serviceName = 'svc') => ({
   attributes: [],
   childSpans: [],
   duration: 1,
@@ -28,7 +28,7 @@ const makeSpan = (spanID, statusCode = StatusCode.OK) => ({
   links: [],
   name: `span-${spanID}`,
   relativeStartTime: 0,
-  resource: { attributes: [], serviceName: 'svc' },
+  resource: { attributes: [], serviceName },
   spanID,
   startTime: 0,
   status: { code: statusCode },
@@ -36,13 +36,13 @@ const makeSpan = (spanID, statusCode = StatusCode.OK) => ({
   warnings: null,
 });
 
-const makeTrace = (traceID, spans = []) => ({
+const makeTrace = (traceID, spans = [], services = [{ name: 'svc', numberOfSpans: spans.length }]) => ({
   duration: 1000,
   endTime: 2000,
   hasErrors: () => spans.some(span => span.status.code === StatusCode.ERROR),
   orphanSpanCount: 0,
   rootSpans: [],
-  services: [{ name: 'svc', numberOfSpans: spans.length }],
+  services,
   spanMap: new Map(),
   spans,
   startTime: 1000,
@@ -71,7 +71,7 @@ describe('<TraceTable>', () => {
     const traces = ['a', 'b', 'c', 'd', 'e'].map(traceID => makeTrace(traceID));
     const { container } = renderTraceTable({ traces });
 
-    expect(container.querySelectorAll('tbody tr')).toHaveLength(5);
+    expect(container.querySelectorAll('tbody tr[data-row-key]')).toHaveLength(5);
   });
 
   it('shows the error count for traces with errored spans', () => {
@@ -88,12 +88,37 @@ describe('<TraceTable>', () => {
     expect(screen.getByText('2')).toBeInTheDocument();
   });
 
+  it('renders service tags with span counts', () => {
+    const services = [
+      { name: 'backend', numberOfSpans: 2 },
+      { name: 'frontend', numberOfSpans: 3 },
+    ];
+    const traces = [
+      makeTrace(
+        'services',
+        [makeSpan('1', StatusCode.OK, 'frontend'), makeSpan('2', StatusCode.ERROR, 'backend')],
+        services
+      ),
+    ];
+
+    renderTraceTable({ traces });
+
+    expect(screen.getByText('backend (2)')).toBeInTheDocument();
+    expect(screen.getByText('frontend (3)')).toBeInTheDocument();
+  });
+
   it('calls handleSortChange when a sortable table column is clicked', () => {
     const handleSortChange = jest.fn();
     renderTraceTable({ handleSortChange, traces: [makeTrace('a')] });
 
-    fireEvent.click(screen.getByText('Duration'));
+    fireEvent.click(screen.getAllByText('Duration')[0]);
 
     expect(handleSortChange).toHaveBeenCalledWith(orderBy.SHORTEST_FIRST);
+  });
+
+  it('does not map a cleared table sort to another sort value', () => {
+    expect(getSortBy('duration', null)).toBeNull();
+    expect(getSortBy('spanCount', null)).toBeNull();
+    expect(getSortBy('startTime', null)).toBeNull();
   });
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.jsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+import TraceTable from './TraceTable';
+import * as orderBy from '../../../model/order-by';
+import { StatusCode } from '../../../types/otel';
+
+const getTracePageLink = trace => ({
+  pathname: `/trace/${trace.traceID}`,
+  state: { fromSearch: '/search' },
+});
+
+const makeSpan = (spanID, statusCode = StatusCode.OK) => ({
+  attributes: [],
+  childSpans: [],
+  duration: 1,
+  endTime: 1,
+  events: [],
+  hasChildren: false,
+  inboundLinks: [],
+  instrumentationScope: { name: 'test' },
+  kind: 'INTERNAL',
+  links: [],
+  name: `span-${spanID}`,
+  relativeStartTime: 0,
+  resource: { attributes: [], serviceName: 'svc' },
+  spanID,
+  startTime: 0,
+  status: { code: statusCode },
+  traceID: 'trace',
+  warnings: null,
+});
+
+const makeTrace = (traceID, spans = []) => ({
+  duration: 1000,
+  endTime: 2000,
+  hasErrors: () => spans.some(span => span.status.code === StatusCode.ERROR),
+  orphanSpanCount: 0,
+  rootSpans: [],
+  services: [{ name: 'svc', numberOfSpans: spans.length }],
+  spanMap: new Map(),
+  spans,
+  startTime: 1000,
+  traceEmoji: '',
+  traceID,
+  traceName: `trace-${traceID}`,
+  tracePageTitle: `trace-${traceID}`,
+});
+
+const renderTraceTable = props =>
+  render(
+    <MemoryRouter>
+      <TraceTable
+        getTracePageLink={getTracePageLink}
+        handleSortChange={jest.fn()}
+        onRowClick={jest.fn()}
+        sortBy={orderBy.MOST_RECENT}
+        traces={[]}
+        {...props}
+      />
+    </MemoryRouter>
+  );
+
+describe('<TraceTable>', () => {
+  it('renders one table row for each trace', () => {
+    const traces = ['a', 'b', 'c', 'd', 'e'].map(traceID => makeTrace(traceID));
+    const { container } = renderTraceTable({ traces });
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(5);
+  });
+
+  it('shows the error count for traces with errored spans', () => {
+    const traces = [
+      makeTrace('errored', [
+        makeSpan('1', StatusCode.ERROR),
+        makeSpan('2', StatusCode.OK),
+        makeSpan('3', StatusCode.ERROR),
+      ]),
+    ];
+
+    renderTraceTable({ traces });
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('calls handleSortChange when a sortable table column is clicked', () => {
+    const handleSortChange = jest.fn();
+    renderTraceTable({ handleSortChange, traces: [makeTrace('a')] });
+
+    fireEvent.click(screen.getByText('Duration'));
+
+    expect(handleSortChange).toHaveBeenCalledWith(orderBy.SHORTEST_FIRST);
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -3,10 +3,13 @@
 
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Table } from 'antd';
+import { Table, Tag } from 'antd';
 import { ColumnProps } from 'antd/es/table';
+import _sortBy from 'lodash/sortBy';
+import { IoAlert } from 'react-icons/io5';
 
 import * as orderBy from '../../../model/order-by';
+import colorGenerator from '../../../utils/color-generator';
 import { formatDatetime, formatDuration } from '../../../utils/date';
 
 import { IOtelTrace, StatusCode } from '../../../types/otel';
@@ -28,6 +31,12 @@ function getErrorCount(trace: IOtelTrace) {
   return trace.spans.filter(span => span.status?.code === StatusCode.ERROR).length;
 }
 
+function getErroredServices(trace: IOtelTrace) {
+  return new Set(
+    trace.spans.filter(span => span.status?.code === StatusCode.ERROR).map(span => span.resource.serviceName)
+  );
+}
+
 function getSortOrder(sortBy: string, columnKey: string): SortOrder {
   if (columnKey === 'duration') {
     if (sortBy === orderBy.LONGEST_FIRST) return 'descend';
@@ -43,7 +52,10 @@ function getSortOrder(sortBy: string, columnKey: string): SortOrder {
   return null;
 }
 
-function getSortBy(columnKey: React.Key | undefined, order: SortOrder) {
+export function getSortBy(columnKey: React.Key | undefined, order: SortOrder) {
+  if (!order) {
+    return null;
+  }
   if (columnKey === 'duration') {
     return order === 'ascend' ? orderBy.SHORTEST_FIRST : orderBy.LONGEST_FIRST;
   }
@@ -67,6 +79,7 @@ export default function TraceTable({
     {
       key: 'traceName',
       title: 'Trace Name',
+      width: 320,
       render: (_value, trace) => {
         const linkTo = getTracePageLink(trace);
         return (
@@ -85,7 +98,30 @@ export default function TraceTable({
     {
       key: 'services',
       title: 'Services',
-      render: (_value, trace) => (trace.services || []).map(service => service.name).join(', '),
+      width: 360,
+      render: (_value, trace) => {
+        const erroredServices = getErroredServices(trace);
+        return (
+          <ul className="TraceTable--serviceTags ub-list-reset">
+            {_sortBy(trace.services || [], service => service.name).map(service => {
+              const { name, numberOfSpans: count } = service;
+              return (
+                <li key={name} className="TraceTable--serviceTagItem">
+                  <Tag
+                    className="TraceTable--serviceTag"
+                    style={{ borderLeftColor: colorGenerator.getColorByKey(name) }}
+                    title={`${name} (${count})`}
+                    variant="outlined"
+                  >
+                    {erroredServices.has(name) && <IoAlert className="TraceTable--errorIcon" />}
+                    {name} ({count})
+                  </Tag>
+                </li>
+              );
+            })}
+          </ul>
+        );
+      },
     },
     {
       key: 'spanCount',
@@ -93,12 +129,14 @@ export default function TraceTable({
       align: 'right',
       sorter: true,
       sortOrder: getSortOrder(sortBy, 'spanCount'),
+      width: 95,
       render: (_value, trace) => trace.spans.length,
     },
     {
       key: 'errorCount',
       title: 'Errors',
       align: 'right',
+      width: 95,
       render: (_value, trace) => getErrorCount(trace),
     },
     {
@@ -107,6 +145,7 @@ export default function TraceTable({
       align: 'right',
       sorter: true,
       sortOrder: getSortOrder(sortBy, 'duration'),
+      width: 120,
       render: (_value, trace) => formatDuration(trace.duration),
     },
     {
@@ -115,6 +154,7 @@ export default function TraceTable({
       sorter: true,
       sortDirections: ['descend'],
       sortOrder: getSortOrder(sortBy, 'startTime'),
+      width: 190,
       render: (_value, trace) => formatDatetime(trace.startTime),
     },
   ];
@@ -140,6 +180,7 @@ export default function TraceTable({
       pagination={false}
       rowClassName="TraceTable--row"
       rowKey="traceID"
+      scroll={{ x: 1080 }}
       size="small"
     />
   );

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Table } from 'antd';
+import { ColumnProps } from 'antd/es/table';
+
+import * as orderBy from '../../../model/order-by';
+import { formatDatetime, formatDuration } from '../../../utils/date';
+
+import { IOtelTrace, StatusCode } from '../../../types/otel';
+import type { TracePageLink } from '../../TracePage/url';
+
+import './TraceTable.css';
+
+type TraceTableProps = {
+  getTracePageLink: (trace: IOtelTrace) => TracePageLink;
+  handleSortChange: (sortBy: string) => void;
+  onRowClick: (traceID: string) => void;
+  sortBy: string;
+  traces: IOtelTrace[];
+};
+
+type SortOrder = 'ascend' | 'descend' | null;
+
+function getErrorCount(trace: IOtelTrace) {
+  return trace.spans.filter(span => span.status?.code === StatusCode.ERROR).length;
+}
+
+function getSortOrder(sortBy: string, columnKey: string): SortOrder {
+  if (columnKey === 'duration') {
+    if (sortBy === orderBy.LONGEST_FIRST) return 'descend';
+    if (sortBy === orderBy.SHORTEST_FIRST) return 'ascend';
+  }
+  if (columnKey === 'spanCount') {
+    if (sortBy === orderBy.MOST_SPANS) return 'descend';
+    if (sortBy === orderBy.LEAST_SPANS) return 'ascend';
+  }
+  if (columnKey === 'startTime' && sortBy === orderBy.MOST_RECENT) {
+    return 'descend';
+  }
+  return null;
+}
+
+function getSortBy(columnKey: React.Key | undefined, order: SortOrder) {
+  if (columnKey === 'duration') {
+    return order === 'ascend' ? orderBy.SHORTEST_FIRST : orderBy.LONGEST_FIRST;
+  }
+  if (columnKey === 'spanCount') {
+    return order === 'ascend' ? orderBy.LEAST_SPANS : orderBy.MOST_SPANS;
+  }
+  if (columnKey === 'startTime') {
+    return orderBy.MOST_RECENT;
+  }
+  return null;
+}
+
+export default function TraceTable({
+  getTracePageLink,
+  handleSortChange,
+  onRowClick,
+  sortBy,
+  traces,
+}: TraceTableProps) {
+  const columns: ColumnProps<IOtelTrace>[] = [
+    {
+      key: 'traceName',
+      title: 'Trace Name',
+      render: (_value, trace) => {
+        const linkTo = getTracePageLink(trace);
+        return (
+          <Link
+            className="TraceTable--traceLink"
+            onClick={event => event.stopPropagation()}
+            to={{ pathname: linkTo.pathname, search: linkTo.search }}
+            state={linkTo.state}
+          >
+            <span className="TraceTable--traceName">{trace.traceName}</span>
+            <span className="TraceTable--traceID">{trace.traceID}</span>
+          </Link>
+        );
+      },
+    },
+    {
+      key: 'services',
+      title: 'Services',
+      render: (_value, trace) => (trace.services || []).map(service => service.name).join(', '),
+    },
+    {
+      key: 'spanCount',
+      title: 'Spans',
+      align: 'right',
+      sorter: true,
+      sortOrder: getSortOrder(sortBy, 'spanCount'),
+      render: (_value, trace) => trace.spans.length,
+    },
+    {
+      key: 'errorCount',
+      title: 'Errors',
+      align: 'right',
+      render: (_value, trace) => getErrorCount(trace),
+    },
+    {
+      key: 'duration',
+      title: 'Duration',
+      align: 'right',
+      sorter: true,
+      sortOrder: getSortOrder(sortBy, 'duration'),
+      render: (_value, trace) => formatDuration(trace.duration),
+    },
+    {
+      key: 'startTime',
+      title: 'Start Time',
+      sorter: true,
+      sortDirections: ['descend'],
+      sortOrder: getSortOrder(sortBy, 'startTime'),
+      render: (_value, trace) => formatDatetime(trace.startTime),
+    },
+  ];
+
+  return (
+    <Table
+      className="TraceTable"
+      columns={columns}
+      dataSource={traces}
+      onChange={(_pagination, _filters, sorter) => {
+        const activeSorter = Array.isArray(sorter) ? sorter[0] : sorter;
+        if (!activeSorter) {
+          return;
+        }
+        const nextSortBy = getSortBy(activeSorter.columnKey, activeSorter.order as SortOrder);
+        if (nextSortBy) {
+          handleSortChange(nextSortBy);
+        }
+      }}
+      onRow={trace => ({
+        onClick: () => onRowClick(trace.traceID),
+      })}
+      pagination={false}
+      rowClassName="TraceTable--row"
+      rowKey="traceID"
+      size="small"
+    />
+  );
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.css
@@ -42,3 +42,9 @@ SPDX-License-Identifier: Apache-2.0
   flex-grow: 1;
   position: relative;
 }
+
+.SearchResults--viewOption {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.25rem;
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -14,6 +14,7 @@ import { getUrl } from '../url';
 import ResultItem from './ResultItem';
 import ScatterPlot from './ScatterPlot';
 import DiffSelection from './DiffSelection';
+import TraceTable from './TraceTable';
 import { StatusCode } from '../../../types/otel';
 
 const mockNavigate = jest.fn();
@@ -49,6 +50,8 @@ vi.mock('./ResultItem', () =>
 );
 
 vi.mock('./ScatterPlot', () => mockDefault(jest.fn(props => <div data-testid="scatterplot" {...props} />)));
+
+vi.mock('./TraceTable', () => mockDefault(jest.fn(() => <div data-testid="trace-table" />)));
 
 vi.mock('./DownloadResults', () =>
   mockDefault(
@@ -314,6 +317,20 @@ describe('<SearchResults>', () => {
     it('shows a result entry for each trace', () => {
       renderWithRouter(<SearchResults {...baseProps} />);
       expect(ResultItem.mock.calls).toHaveLength(baseTraces.length);
+    });
+
+    it('switches between list and table rendering', () => {
+      renderWithRouter(<SearchResults {...baseProps} />);
+
+      expect(ResultItem.mock.calls).toHaveLength(baseTraces.length);
+      expect(screen.queryByTestId('trace-table')).not.toBeInTheDocument();
+
+      ResultItem.mockClear();
+      fireEvent.click(screen.getByText('Table'));
+
+      expect(screen.getByTestId('trace-table')).toBeInTheDocument();
+      expect(ResultItem).not.toHaveBeenCalled();
+      expect(TraceTable.mock.calls[0][0].handleSortChange).toBe(baseProps.handleSortChange);
     });
 
     it('deep links traces', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -324,11 +324,13 @@ describe('<SearchResults>', () => {
 
       expect(ResultItem.mock.calls).toHaveLength(baseTraces.length);
       expect(screen.queryByTestId('trace-table')).not.toBeInTheDocument();
+      expect(screen.getByTestId('searchable-select')).toBeInTheDocument();
 
       ResultItem.mockClear();
       fireEvent.click(screen.getByText('Table'));
 
       expect(screen.getByTestId('trace-table')).toBeInTheDocument();
+      expect(screen.queryByTestId('searchable-select')).not.toBeInTheDocument();
       expect(ResultItem).not.toHaveBeenCalled();
       expect(TraceTable.mock.calls[0][0].handleSortChange).toBe(baseProps.handleSortChange);
     });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -3,10 +3,11 @@
 
 import * as React from 'react';
 import { useCallback } from 'react';
-import { Select } from 'antd';
+import { Segmented, Select } from 'antd';
 import { Link, useNavigate } from 'react-router-dom';
 import type { Location } from 'react-router-dom';
 import queryString from 'query-string';
+import { IoGridOutline, IoListOutline } from 'react-icons/io5';
 
 import AltViewOptions from './AltViewOptions';
 import DownloadResults from './DownloadResults';
@@ -15,6 +16,7 @@ import * as markers from './index.markers';
 import { EAltViewActions, trackAltView } from './index.track';
 import ResultItem from './ResultItem';
 import ScatterPlot from './ScatterPlot';
+import TraceTable from './TraceTable';
 import { getUrl } from '../url';
 import LoadingIndicator from '../../common/LoadingIndicator';
 import NewWindowIcon from '../../common/NewWindowIcon';
@@ -58,6 +60,7 @@ type SelectSortProps = {
 };
 
 const Option = Select.Option;
+type ViewMode = 'list' | 'table';
 
 /**
  * Contains the dropdown to sort and filter trace search results
@@ -142,6 +145,7 @@ export function UnconnectedSearchResults({
   cohortRemoveTrace,
 }: SearchResultsProps) {
   const navigate = useNavigate();
+  const [viewMode, setViewMode] = React.useState<ViewMode>('list');
 
   const toggleComparison = useCallback(
     (traceID: string, remove?: boolean) => {
@@ -184,6 +188,16 @@ export function UnconnectedSearchResults({
   }, [rawTraces]);
 
   const traceResultsView = queryString.parse(location.search).view !== 'ddg';
+  const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
+  const getTraceLink = useCallback(
+    (trace: IOtelTrace) =>
+      getTracePageLink(
+        trace.traceID,
+        { fromSearch: searchUrl },
+        spanLinks && (spanLinks[trace.traceID] || spanLinks[trace.traceID.replace(/^0*/, '')])
+      ),
+    [searchUrl, spanLinks]
+  );
 
   const diffSelection = !disableComparisons && (
     <DiffSelection toggleComparison={toggleComparison} traces={diffCohort} />
@@ -209,7 +223,6 @@ export function UnconnectedSearchResults({
     );
   }
   const cohortIds = new Set(diffCohort.map(datum => datum.id));
-  const searchUrl = queryOfResults ? getUrl(stripEmbeddedState(queryOfResults)) : getUrl();
   return (
     <div className="SearchResults">
       <div className="SearchResults--header">
@@ -238,6 +251,31 @@ export function UnconnectedSearchResults({
             {traces.length} Trace{traces.length > 1 && 's'}
           </h2>
           {traceResultsView && <SelectSort sortBy={sortBy} handleSortChange={handleSortChange} />}
+          {traceResultsView && (
+            <Segmented
+              aria-label="Search results view"
+              options={[
+                {
+                  label: (
+                    <span className="SearchResults--viewOption">
+                      <IoListOutline /> List
+                    </span>
+                  ),
+                  value: 'list',
+                },
+                {
+                  label: (
+                    <span className="SearchResults--viewOption">
+                      <IoGridOutline /> Table
+                    </span>
+                  ),
+                  value: 'table',
+                },
+              ]}
+              onChange={value => setViewMode(value as ViewMode)}
+              value={viewMode}
+            />
+          )}
           {traceResultsView && <DownloadResults onDownloadResultsClicked={onDownloadResultsClicked} />}
           <AltViewOptions traceResultsView={traceResultsView} onDdgViewClicked={onDdgViewClicked} />
           {showStandaloneLink && (
@@ -258,18 +296,23 @@ export function UnconnectedSearchResults({
         </div>
       )}
       {traceResultsView && diffSelection}
-      {traceResultsView && (
+      {traceResultsView && viewMode === 'table' && (
+        <TraceTable
+          getTracePageLink={getTraceLink}
+          handleSortChange={handleSortChange}
+          onRowClick={goToTrace}
+          sortBy={sortBy}
+          traces={traces}
+        />
+      )}
+      {traceResultsView && viewMode === 'list' && (
         <ul className="ub-list-reset">
           {traces.map(trace => (
             <li className="ub-my3" key={trace.traceID}>
               <ResultItem
                 durationPercent={getPercentageOfDuration(trace.duration, maxTraceDuration)}
                 isInDiffCohort={cohortIds.has(trace.traceID)}
-                linkTo={getTracePageLink(
-                  trace.traceID,
-                  { fromSearch: searchUrl },
-                  spanLinks && (spanLinks[trace.traceID] || spanLinks[trace.traceID.replace(/^0*/, '')])
-                )}
+                linkTo={getTraceLink(trace)}
                 toggleComparison={toggleComparison}
                 trace={trace}
                 disableComparision={disableComparisons}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -250,7 +250,9 @@ export function UnconnectedSearchResults({
           <h2 className="ub-m0 u-flex-1">
             {traces.length} Trace{traces.length > 1 && 's'}
           </h2>
-          {traceResultsView && <SelectSort sortBy={sortBy} handleSortChange={handleSortChange} />}
+          {traceResultsView && viewMode === 'list' && (
+            <SelectSort sortBy={sortBy} handleSortChange={handleSortChange} />
+          )}
           {traceResultsView && (
             <Segmented
               aria-label="Search results view"

--- a/packages/jaeger-ui/test/vitest-setup.ts
+++ b/packages/jaeger-ui/test/vitest-setup.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { vi } from 'vitest';
-import { TextEncoder } from 'util';
+import { TextEncoder } from 'node:util';
 import { polyfill as rafPolyfill } from '../src/utils/test/requestAnimationFrame';
 import '@testing-library/jest-dom/vitest';
 
@@ -10,7 +10,8 @@ import '@testing-library/jest-dom/vitest';
 rafPolyfill();
 
 // TextEncoder is not provided by JSDOM
-global.TextEncoder = TextEncoder as typeof global.TextEncoder;
+globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+window.TextEncoder = TextEncoder as typeof window.TextEncoder;
 
 // Alias jest → vi so existing test files work without modification.
 // Note: jest.mock() calls are NOT covered by this alias — they are renamed to


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves jaegertracing/jaeger-ui#3816

## Description of the changes
- Adds a compact table view for search results using Ant Design Table.
- Adds a List/Table segmented toggle while keeping List as the default view.
- Shows trace name, trace ID, services, span count, error count, duration, and start time.
- Wires table sorting to the existing `handleSortChange` flow.
- Adds tests for table rendering, error count, sorting, and switching between list/table views.
- Updates the Vitest `TextEncoder` polyfill to work with the npm/Vitest test path.

## How was this change tested?
- `npm run fmt`
- `npm run lint`
- `npm test -w packages/jaeger-ui -- src/components/SearchTracePage/SearchResults/index.test.jsx src/components/SearchTracePage/SearchResults/TraceTable.test.jsx`
- `npm test`
- `npm run build`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes

## Screenshots

Compact table view on the Search page:
<img width="1094" height="771" alt="table" src="https://github.com/user-attachments/assets/56194d5c-2876-440d-93f4-2f57deefcb9c" />
