### PR TITLE
feat(trace-view): add decorative icons to span tree view

### DIFF
--- a/packages/jaeger-ui/docs/span-decorations.md
+++ b/packages/jaeger-ui/docs/span-decorations.md
@@ -1,0 +1,67 @@
+# Span Decorations
+
+Span decorations allow visual icons to be displayed next to spans in the trace timeline view based on span attributes (tags). This helps users quickly identify different types of operations, such as database calls, messaging, or AI-related spans.
+
+## Configuration
+
+Span decorations are configured via the `spanDecorations` property in the Jaeger UI configuration.
+
+```json
+{
+  "spanDecorations": [
+    {
+      "entries": [
+        { "key": "db.system", "value": ".*" }
+      ],
+      "icon": "io.Database",
+      "tooltip": "Database Call"
+    },
+    {
+      "entries": [
+        { "key": "http.method", "value": "GET|POST" }
+      ],
+      "icon": "https://example.com/icons/http.svg",
+      "tooltip": "HTTP Request"
+    }
+  ]
+}
+```
+
+### Rule Evaluation
+
+The span decoration engine follows these rules:
+
+1.  **Order of Evaluation:** Rules are evaluated in the order they appear in the `spanDecorations` array.
+2.  **First Match Wins:** The first rule that matches a span is used, and subsequent rules are ignored.
+3.  **All Criteria Must Match (AND):** A rule matches a span only if **all** of its `entries` match.
+4.  **Regex Matching:** Both the `key` and `value` in an entry are treated as regular expressions.
+5.  **Attribute Search:** The engine searches for matches in both span attributes and resource attributes.
+
+### Icons
+
+The `icon` property can be one of:
+
+1.  **Built-in Tokens:** Pre-defined icons bundled with Jaeger UI (e.g., `io.Database`, `io.Server`, `io.Cloud`).
+2.  **External URLs:** A full URL starting with `http://` or `https://` pointing to an image (SVG, PNG, etc.).
+3.  **Local Paths:** A path starting with `/` pointing to an asset served by the Jaeger UI server.
+
+#### Supported Built-in Tokens
+
+- `io.Server`: General server operation.
+- `io.Database`: Database operations.
+- `io.Cloud`: Cloud/External services.
+- `io.Globe`: Web/HTTP requests.
+- `io.PaperPlane`: Messaging/PubSub.
+- `io.Swap`: RPC/Inter-service communication.
+- `io.HardwareChip`: AI/Compute intensive tasks.
+- `io.Shield`: Security/Auth operations.
+- `io.Terminal`: CLI/System commands.
+- `io.Settings`: Configuration/Internal tasks.
+
+## Extensibility
+
+Users can extend the span decorations purely via configuration by:
+- Adding new rules to match custom attribute patterns.
+- Using external URLs for custom icons not included in the built-in set.
+
+For more complex heuristics, the Jaeger UI can be built with custom icons added to the internal registry in `IconProvider.tsx`.

--- a/packages/jaeger-ui/docs/span-decorations.md
+++ b/packages/jaeger-ui/docs/span-decorations.md
@@ -6,21 +6,36 @@ Span decorations allow visual icons to be displayed next to spans in the trace t
 
 Span decorations are configured via the `spanDecorations` property in the Jaeger UI configuration.
 
+### Where to define the configuration
+
+The exact location of your configuration depends on how you are running the Jaeger UI:
+
+- **Production (Jaeger Backend):** When running the Jaeger Query or Jaeger All-in-One binaries, you can provide a UI configuration file using the `--query.ui-config` command-line flag. This file must be valid JSON.
+  ```bash
+  jaeger-all-in-one --query.ui-config=/path/to/jaeger-ui.config.json
+  ```
+
+- **Local Development (Vite):** If you are running the UI standalone for frontend development (e.g., using `npm start`), the Vite dev server automatically reads from a `jaeger-ui.config.json` file located in the `packages/jaeger-ui/` directory. You can copy the provided `jaeger-ui.config.example.json` to create your own configuration.
+
+### Configuration Schema
+
+Once you have located or created your configuration file, you can add or modify the `spanDecorations` array at the top level:
+
 ```json
 {
   "spanDecorations": [
     {
-      "entries": [
-        { "key": "db.system", "value": ".*" }
+      "attributes": [
+        { "key": "^(?:db\\.system)$", "value": ".*" }
       ],
       "icon": "io.Database",
       "tooltip": "Database Call"
     },
     {
-      "entries": [
-        { "key": "http.method", "value": "GET|POST" }
+      "attributes": [
+        { "key": "^(?:http\\.method)$", "value": "GET|POST" }
       ],
-      "icon": "https://example.com/icons/http.svg",
+      "icon": "https://example.com/icons/http.png",
       "tooltip": "HTTP Request"
     }
   ]
@@ -31,32 +46,23 @@ Span decorations are configured via the `spanDecorations` property in the Jaeger
 
 The span decoration engine follows these rules:
 
-1.  **Order of Evaluation:** Rules are evaluated in the order they appear in the `spanDecorations` array.
-2.  **First Match Wins:** The first rule that matches a span is used, and subsequent rules are ignored.
-3.  **All Criteria Must Match (AND):** A rule matches a span only if **all** of its `entries` match.
-4.  **Regex Matching:** Both the `key` and `value` in an entry are treated as regular expressions.
+1.  **Order of Evaluation:** Rules are evaluated in the order they appear in the `spanDecorations` array. User-defined config rules are evaluated *before* the built-in default rules.
+2.  **First Match Wins:** The first rule that matches a span is used, and subsequent rules are ignored. This allows you to easily override a built-in default icon.
+3.  **All Criteria Must Match (AND):** A rule matches a span only if **all** of its `attributes` match.
+4.  **Regex Matching:** Both the `key` and `value` in an attribute definition are treated as regular expressions.
 5.  **Attribute Search:** The engine searches for matches in both span attributes and resource attributes.
 
 ### Icons
 
 The `icon` property can be one of:
 
-1.  **Built-in Tokens:** Pre-defined icons bundled with Jaeger UI (e.g., `io.Database`, `io.Server`, `io.Cloud`).
-2.  **External URLs:** A full URL starting with `http://` or `https://` pointing to an image (SVG, PNG, etc.).
+1.  **Built-in Tokens:** Pre-defined icons bundled with Jaeger UI (e.g., `io.Database`, `io.Server`, `si.Redis`).
+2.  **External URLs:** A full URL starting with `http://` or `https://` pointing to an image (e.g., SVG, PNG).
 3.  **Local Paths:** A path starting with `/` pointing to an asset served by the Jaeger UI server.
 
 #### Supported Built-in Tokens
 
-- `io.Server`: General server operation.
-- `io.Database`: Database operations.
-- `io.Cloud`: Cloud/External services.
-- `io.Globe`: Web/HTTP requests.
-- `io.PaperPlane`: Messaging/PubSub.
-- `io.Swap`: RPC/Inter-service communication.
-- `io.HardwareChip`: AI/Compute intensive tasks.
-- `io.Shield`: Security/Auth operations.
-- `io.Terminal`: CLI/System commands.
-- `io.Settings`: Configuration/Internal tasks.
+The complete list of built-in tokens is available in the [`IconProvider` source code](https://github.com/jaegertracing/jaeger-ui/blob/main/packages/jaeger-ui/src/components/common/IconProvider.tsx) under the `ICON_MAP` dictionary.
 
 ## Extensibility
 

--- a/packages/jaeger-ui/docs/span-decorations.md
+++ b/packages/jaeger-ui/docs/span-decorations.md
@@ -56,7 +56,7 @@ The span decoration engine follows these rules:
 
 The `icon` property can be one of:
 
-1.  **Built-in Tokens:** Pre-defined icons bundled with Jaeger UI (e.g., `io.Database`, `io.Server`, `si.Redis`).
+1.  **Built-in Tokens:** Pre-defined icons bundled with Jaeger UI (e.g., `io.Database`, `io.Server`, `di.Redis`).
 2.  **External URLs:** A full URL starting with `http://` or `https://` pointing to an image (e.g., SVG, PNG).
 3.  **Local Paths:** A path starting with `/` pointing to an asset served by the Jaeger UI server.
 

--- a/packages/jaeger-ui/jaeger-ui.config.example.json
+++ b/packages/jaeger-ui/jaeger-ui.config.example.json
@@ -16,6 +16,17 @@
       "text": "Information about Jaeger SDK release #{jaeger.version}"
     }
   ],
+  "spanDecorations": [
+    {
+      "entries": [
+        {
+          "key": "db.system",
+          "value": ".*"
+        }
+      ],
+      "icon": "IoServer"
+    }
+  ],
   "backendCapabilities": {
     "archiveStorage": false,
     "metricsStorage": true,

--- a/packages/jaeger-ui/jaeger-ui.config.example.json
+++ b/packages/jaeger-ui/jaeger-ui.config.example.json
@@ -18,13 +18,13 @@
   ],
   "spanDecorations": [
     {
-      "entries": [
+      "attributes": [
         {
           "key": "db.system",
           "value": ".*"
         }
       ],
-      "icon": "IoServer"
+      "icon": "io.Database"
     }
   ],
   "backendCapabilities": {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -194,6 +194,12 @@ SPDX-License-Identifier: Apache-2.0
   /* Adjust padding since border adds 1.5px */
 }
 
+.SpanBarRow--decorationIcon {
+  font-size: 1.1em;
+  margin-right: 0.25rem;
+  vertical-align: middle;
+}
+
 .SpanBarRow--rpcColorMarker {
   border-radius: 6.5px;
   display: inline-block;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -200,6 +200,12 @@ SPDX-License-Identifier: Apache-2.0
   vertical-align: middle;
 }
 
+.SpanBarRow--decorationIcon img {
+  width: 1em;
+  height: 1em;
+  object-fit: contain;
+}
+
 .SpanBarRow--rpcColorMarker {
   border-radius: 6.5px;
   display: inline-block;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -200,7 +200,7 @@ SPDX-License-Identifier: Apache-2.0
   vertical-align: middle;
 }
 
-.SpanBarRow--decorationIcon img {
+img.SpanBarRow--decorationIcon {
   width: 1em;
   height: 1em;
   object-fit: contain;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -210,6 +210,49 @@ describe('<SpanBarRow>', () => {
     expect(container.querySelector('.SpanBarRow--decorationIcon')).toBeInTheDocument();
   });
 
+  it('handles empty spanDecorations gracefully', () => {
+    getConfig.mockReturnValueOnce({ spanDecorations: [] });
+    const props = {
+      ...defaultProps,
+      span: {
+        ...defaultProps.span,
+        attributes: [{ key: 'db.system', value: 'postgresql' }],
+      },
+    };
+    const { container } = render(<SpanBarRow {...props} />);
+    expect(container.querySelector('.SpanBarRow--decorationIcon')).not.toBeInTheDocument();
+  });
+
+  it('handles invalid regex patterns gracefully', () => {
+    getConfig.mockReturnValueOnce({
+      spanDecorations: [{ entries: [{ key: 'db.system', value: '[' }], icon: 'IoServer' }],
+    });
+    const props = {
+      ...defaultProps,
+      span: {
+        ...defaultProps.span,
+        attributes: [{ key: 'db.system', value: 'postgresql' }],
+      },
+    };
+    const { container } = render(<SpanBarRow {...props} />);
+    expect(container.querySelector('.SpanBarRow--decorationIcon')).not.toBeInTheDocument();
+  });
+
+  it('handles unknown icon names gracefully', () => {
+    getConfig.mockReturnValueOnce({
+      spanDecorations: [{ entries: [{ key: 'db.system', value: '.*' }], icon: 'UnknownIcon' }],
+    });
+    const props = {
+      ...defaultProps,
+      span: {
+        ...defaultProps.span,
+        attributes: [{ key: 'db.system', value: 'postgresql' }],
+      },
+    };
+    const { container } = render(<SpanBarRow {...props} />);
+    expect(container.querySelector('.SpanBarRow--decorationIcon')).not.toBeInTheDocument();
+  });
+
   it('renders with error icon when hasOwnError is true', () => {
     const props = {
       ...defaultProps,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -8,10 +8,11 @@ import '@testing-library/jest-dom';
 import SpanBarRow from './SpanBarRow';
 import SpanBar from './SpanBar';
 import getConfig from '../../../utils/config/get-config';
+import { _clearCache } from '../../../model/span-decorations';
 
 vi.mock('../../../utils/config/get-config', () => ({
   default: jest.fn(() => ({
-    spanDecorations: [{ entries: [{ key: 'db.system', value: '.*' }], icon: 'IoServer' }],
+    spanDecorations: [{ attributes: [{ key: 'db.system', value: '.*' }], icon: 'io.Database' }],
   })),
 }));
 
@@ -97,6 +98,7 @@ describe('<SpanBarRow>', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    _clearCache();
     defaultProps.onDetailToggled.mockReset();
     defaultProps.onChildrenToggled.mockReset();
   });
@@ -225,7 +227,7 @@ describe('<SpanBarRow>', () => {
 
   it('handles invalid regex patterns gracefully', () => {
     getConfig.mockReturnValueOnce({
-      spanDecorations: [{ entries: [{ key: 'db.system', value: '[' }], icon: 'IoServer' }],
+      spanDecorations: [{ attributes: [{ key: 'db.system', value: '[' }], icon: 'io.Database' }],
     });
     const props = {
       ...defaultProps,
@@ -240,7 +242,7 @@ describe('<SpanBarRow>', () => {
 
   it('handles unknown icon names gracefully', () => {
     getConfig.mockReturnValueOnce({
-      spanDecorations: [{ entries: [{ key: 'db.system', value: '.*' }], icon: 'UnknownIcon' }],
+      spanDecorations: [{ attributes: [{ key: 'db.system', value: '.*' }], icon: 'UnknownIcon' }],
     });
     const props = {
       ...defaultProps,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -7,6 +7,13 @@ import '@testing-library/jest-dom';
 
 import SpanBarRow from './SpanBarRow';
 import SpanBar from './SpanBar';
+import getConfig from '../../../utils/config/get-config';
+
+vi.mock('../../../utils/config/get-config', () => ({
+  default: jest.fn(() => ({
+    spanDecorations: [{ entries: [{ key: 'db.system', value: '.*' }], icon: 'IoServer' }],
+  })),
+}));
 
 vi.mock('./SpanTreeOffset', () => ({
   default: jest.fn(({ span, childrenVisible, onClick }) => (
@@ -189,6 +196,18 @@ describe('<SpanBarRow>', () => {
     };
     render(<SpanBarRow {...props} />);
     expect(screen.getByText('no-instrumented-service')).toBeVisible();
+  });
+
+  it('renders decoration icon based on span attributes', () => {
+    const props = {
+      ...defaultProps,
+      span: {
+        ...defaultProps.span,
+        attributes: [{ key: 'db.system', value: 'postgresql' }],
+      },
+    };
+    const { container } = render(<SpanBarRow {...props} />);
+    expect(container.querySelector('.SpanBarRow--decorationIcon')).toBeInTheDocument();
   });
 
   it('renders with error icon when hasOwnError is true', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -1,8 +1,18 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback } from 'react';
-import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
+import React, { useCallback, useMemo } from 'react';
+import {
+  IoAlert,
+  IoGitNetwork,
+  IoCloudUploadOutline,
+  IoArrowForward,
+  IoServer,
+  IoPaperPlane,
+  IoSwapHorizontal,
+  IoGlobeOutline,
+  IoHardwareChip,
+} from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDurationCompact, ViewedBoundsFunctionType } from './utils';
@@ -13,10 +23,19 @@ import Ticks from './Ticks';
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
+import getConfig from '../../../utils/config/get-config';
 
 import { getSpanIconComponent } from './span-icons';
 
 import './SpanBarRow.css';
+
+const ICON_MAP: Record<string, React.ElementType> = {
+  IoServer,
+  IoPaperPlane,
+  IoSwapHorizontal,
+  IoGlobeOutline,
+  IoHardwareChip,
+};
 
 type SpanBarRowProps = {
   className?: string;
@@ -118,6 +137,32 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   const viewStart = viewBounds.start;
   const viewEnd = viewBounds.end;
 
+  const decorationIcon = useMemo(() => {
+    const { spanDecorations } = getConfig();
+    if (!spanDecorations || spanDecorations.length === 0) {
+      return null;
+    }
+    for (const decoration of spanDecorations) {
+      const allMatched = decoration.entries.every(entry => {
+        const attribute = span.attributes.find(attr => attr.key === entry.key);
+        if (!attribute) return false;
+        try {
+          const regex = new RegExp(entry.value);
+          return regex.test(String(attribute.value));
+        } catch {
+          return false;
+        }
+      });
+      if (allMatched) {
+        const IconComponent = ICON_MAP[decoration.icon];
+        if (IconComponent) {
+          return <IconComponent className="SpanBarRow--decorationIcon" />;
+        }
+      }
+    }
+    return null;
+  }, [span.attributes]);
+
   const labelDetail = `${serviceName}::${operationName}`;
   let longLabel;
   let hintSide;
@@ -169,6 +214,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               {!hasOwnError && hasChildError && (
                 <IoAlert className="SpanBarRow--errorIcon SpanBarRow--errorIcon--hollow" />
               )}
+              {decorationIcon}
               {serviceName}{' '}
               {rpc && (
                 <span>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -37,6 +37,20 @@ const ICON_MAP: Record<string, React.ElementType> = {
   IoHardwareChip,
 };
 
+const REGEX_CACHE = new Map<string, RegExp>();
+
+function getRegex(pattern: string): RegExp | null {
+  let regex = REGEX_CACHE.get(pattern);
+  if (regex) return regex;
+  try {
+    regex = new RegExp(pattern);
+    REGEX_CACHE.set(pattern, regex);
+    return regex;
+  } catch {
+    return null;
+  }
+}
+
 type SpanBarRowProps = {
   className?: string;
   color: string;
@@ -146,12 +160,8 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
       const allMatched = decoration.entries.every(entry => {
         const attribute = span.attributes.find(attr => attr.key === entry.key);
         if (!attribute) return false;
-        try {
-          const regex = new RegExp(entry.value);
-          return regex.test(String(attribute.value));
-        } catch {
-          return false;
-        }
+        const regex = getRegex(entry.value);
+        return regex ? regex.test(String(attribute.value)) : false;
       });
       if (allMatched) {
         const IconComponent = ICON_MAP[decoration.icon];

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -2,17 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback, useMemo } from 'react';
-import {
-  IoAlert,
-  IoGitNetwork,
-  IoCloudUploadOutline,
-  IoArrowForward,
-  IoServer,
-  IoPaperPlane,
-  IoSwapHorizontal,
-  IoGlobeOutline,
-  IoHardwareChip,
-} from 'react-icons/io5';
+import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
+import IconProvider from '../../common/IconProvider';
+import { getSpanDecoration } from '../../../model/span-decorations';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDurationCompact, ViewedBoundsFunctionType } from './utils';
@@ -23,33 +15,10 @@ import Ticks from './Ticks';
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
-import getConfig from '../../../utils/config/get-config';
 
 import { getSpanIconComponent } from './span-icons';
 
 import './SpanBarRow.css';
-
-const ICON_MAP: Record<string, React.ElementType> = {
-  IoServer,
-  IoPaperPlane,
-  IoSwapHorizontal,
-  IoGlobeOutline,
-  IoHardwareChip,
-};
-
-const REGEX_CACHE = new Map<string, RegExp>();
-
-function getRegex(pattern: string): RegExp | null {
-  let regex = REGEX_CACHE.get(pattern);
-  if (regex) return regex;
-  try {
-    regex = new RegExp(pattern);
-    REGEX_CACHE.set(pattern, regex);
-    return regex;
-  } catch {
-    return null;
-  }
-}
 
 type SpanBarRowProps = {
   className?: string;
@@ -152,26 +121,18 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   const viewEnd = viewBounds.end;
 
   const decorationIcon = useMemo(() => {
-    const { spanDecorations } = getConfig();
-    if (!spanDecorations || spanDecorations.length === 0) {
-      return null;
-    }
-    for (const decoration of spanDecorations) {
-      const allMatched = decoration.entries.every(entry => {
-        const attribute = span.attributes.find(attr => attr.key === entry.key);
-        if (!attribute) return false;
-        const regex = getRegex(entry.value);
-        return regex ? regex.test(String(attribute.value)) : false;
-      });
-      if (allMatched) {
-        const IconComponent = ICON_MAP[decoration.icon];
-        if (IconComponent) {
-          return <IconComponent className="SpanBarRow--decorationIcon" />;
-        }
-      }
+    const decoration = getSpanDecoration(span);
+    if (decoration) {
+      return (
+        <IconProvider
+          className="SpanBarRow--decorationIcon"
+          icon={decoration.icon}
+          tooltip={decoration.tooltip}
+        />
+      );
     }
     return null;
-  }, [span.attributes]);
+  }, [span]);
 
   const labelDetail = `${serviceName}::${operationName}`;
   let longLabel;

--- a/packages/jaeger-ui/src/components/common/IconProvider.tsx
+++ b/packages/jaeger-ui/src/components/common/IconProvider.tsx
@@ -33,7 +33,9 @@ import {
   SiGo,
   SiPython,
   SiNodedotjs,
-} from 'react-icons/si';
+  SiGraphql,
+  SiElasticsearch,
+} from './SiIcons';
 
 const ICON_MAP: Record<string, React.ElementType> = {
   // Formal built-in tokens
@@ -64,6 +66,8 @@ const ICON_MAP: Record<string, React.ElementType> = {
   'si.Go': SiGo,
   'si.Python': SiPython,
   'si.Nodedotjs': SiNodedotjs,
+  'si.Graphql': SiGraphql,
+  'si.Elasticsearch': SiElasticsearch,
 };
 
 type Props = {
@@ -73,18 +77,27 @@ type Props = {
 };
 
 const IconProvider: React.FC<Props> = ({ icon, className, tooltip }) => {
-  // 1. Check built-in tokens
+  // 1. Check for image URL
+  if (icon.startsWith('http://') || icon.startsWith('https://') || icon.startsWith('/')) {
+    const ariaProps = tooltip ? { alt: tooltip } : { alt: '', 'aria-hidden': true };
+    const resolvedIcon = icon.startsWith('/') ? prefixUrl(icon) : icon;
+    return (
+      <img
+        src={resolvedIcon}
+        className={className}
+        title={tooltip}
+        referrerPolicy="no-referrer"
+        crossOrigin="anonymous"
+        {...ariaProps}
+      />
+    );
+  }
+
+  // 2. Check built-in tokens
   const BuiltInIcon = ICON_MAP[icon];
   if (BuiltInIcon) {
     const ariaProps = tooltip ? { role: 'img', 'aria-label': tooltip } : { 'aria-hidden': true };
     return <BuiltInIcon className={className} title={tooltip} {...ariaProps} />;
-  }
-
-  // 2. Check for image URL
-  if (icon.startsWith('http://') || icon.startsWith('https://') || icon.startsWith('/')) {
-    const ariaProps = tooltip ? { alt: tooltip } : { alt: '', 'aria-hidden': true };
-    const resolvedIcon = icon.startsWith('/') ? prefixUrl(icon) : icon;
-    return <img src={resolvedIcon} className={className} title={tooltip} {...ariaProps} />;
   }
 
   return null;

--- a/packages/jaeger-ui/src/components/common/IconProvider.tsx
+++ b/packages/jaeger-ui/src/components/common/IconProvider.tsx
@@ -1,7 +1,8 @@
-// Copyright (c) 2024 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import prefixUrl from '../../utils/prefix-url';
 import {
   IoServer,
   IoPaperPlane,
@@ -19,14 +20,22 @@ import {
   IoFlash,
 } from 'react-icons/io5';
 
-const ICON_MAP: Record<string, React.ElementType> = {
-  // Legacy aliases (for backward compatibility with the first version of PR)
-  IoServer,
-  IoPaperPlane,
-  IoSwapHorizontal,
-  IoGlobeOutline,
-  IoHardwareChip,
+import { DiRedis } from 'react-icons/di';
+import { FaDatabase } from 'react-icons/fa';
 
+import {
+  SiPostgresql,
+  SiMysql,
+  SiMongodb,
+  SiApachekafka,
+  SiRabbitmq,
+  SiKubernetes,
+  SiGo,
+  SiPython,
+  SiNodedotjs,
+} from 'react-icons/si';
+
+const ICON_MAP: Record<string, React.ElementType> = {
   // Formal built-in tokens
   'io.Server': IoServer,
   'io.PaperPlane': IoPaperPlane,
@@ -34,7 +43,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   'io.Globe': IoGlobeOutline,
   'io.HardwareChip': IoHardwareChip,
   'io.Cloud': IoCloud,
-  'io.Database': IoServer, // Fallback to Server if Database is missing in this version
+  'io.Database': FaDatabase,
   'io.Shield': IoShieldCheckmark,
   'io.Terminal': IoTerminal,
   'io.Settings': IoSettings,
@@ -43,6 +52,18 @@ const ICON_MAP: Record<string, React.ElementType> = {
   'io.Bug': IoBug,
   'io.Cube': IoCube,
   'io.Flash': IoFlash,
+
+  // Tool-specific tokens
+  'di.Redis': DiRedis,
+  'si.Postgresql': SiPostgresql,
+  'si.Mysql': SiMysql,
+  'si.Mongodb': SiMongodb,
+  'si.Apachekafka': SiApachekafka,
+  'si.Rabbitmq': SiRabbitmq,
+  'si.Kubernetes': SiKubernetes,
+  'si.Go': SiGo,
+  'si.Python': SiPython,
+  'si.Nodedotjs': SiNodedotjs,
 };
 
 type Props = {
@@ -55,25 +76,15 @@ const IconProvider: React.FC<Props> = ({ icon, className, tooltip }) => {
   // 1. Check built-in tokens
   const BuiltInIcon = ICON_MAP[icon];
   if (BuiltInIcon) {
-    return <BuiltInIcon className={className} title={tooltip} />;
+    const ariaProps = tooltip ? { role: 'img', 'aria-label': tooltip } : { 'aria-hidden': true };
+    return <BuiltInIcon className={className} title={tooltip} {...ariaProps} />;
   }
 
   // 2. Check for image URL
   if (icon.startsWith('http://') || icon.startsWith('https://') || icon.startsWith('/')) {
-    return <img src={icon} className={className} alt={tooltip || 'decoration'} title={tooltip} />;
-  }
-
-  // 3. Check for SVG string
-  if (icon.trim().startsWith('<svg')) {
-    return (
-      <div
-        className={className}
-        title={tooltip}
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: icon }}
-        style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
-      />
-    );
+    const ariaProps = tooltip ? { alt: tooltip } : { alt: '', 'aria-hidden': true };
+    const resolvedIcon = icon.startsWith('/') ? prefixUrl(icon) : icon;
+    return <img src={resolvedIcon} className={className} title={tooltip} {...ariaProps} />;
   }
 
   return null;

--- a/packages/jaeger-ui/src/components/common/IconProvider.tsx
+++ b/packages/jaeger-ui/src/components/common/IconProvider.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import {
+  IoServer,
+  IoPaperPlane,
+  IoSwapHorizontal,
+  IoGlobeOutline,
+  IoHardwareChip,
+  IoCloud,
+  IoShieldCheckmark,
+  IoTerminal,
+  IoSettings,
+  IoSearch,
+  IoCodeWorking,
+  IoBug,
+  IoCube,
+  IoFlash,
+} from 'react-icons/io5';
+
+const ICON_MAP: Record<string, React.ElementType> = {
+  // Legacy aliases (for backward compatibility with the first version of PR)
+  IoServer,
+  IoPaperPlane,
+  IoSwapHorizontal,
+  IoGlobeOutline,
+  IoHardwareChip,
+
+  // Formal built-in tokens
+  'io.Server': IoServer,
+  'io.PaperPlane': IoPaperPlane,
+  'io.Swap': IoSwapHorizontal,
+  'io.Globe': IoGlobeOutline,
+  'io.HardwareChip': IoHardwareChip,
+  'io.Cloud': IoCloud,
+  'io.Database': IoServer, // Fallback to Server if Database is missing in this version
+  'io.Shield': IoShieldCheckmark,
+  'io.Terminal': IoTerminal,
+  'io.Settings': IoSettings,
+  'io.Search': IoSearch,
+  'io.Code': IoCodeWorking,
+  'io.Bug': IoBug,
+  'io.Cube': IoCube,
+  'io.Flash': IoFlash,
+};
+
+type Props = {
+  icon: string;
+  className?: string;
+  tooltip?: string;
+};
+
+const IconProvider: React.FC<Props> = ({ icon, className, tooltip }) => {
+  // 1. Check built-in tokens
+  const BuiltInIcon = ICON_MAP[icon];
+  if (BuiltInIcon) {
+    return <BuiltInIcon className={className} title={tooltip} />;
+  }
+
+  // 2. Check for image URL
+  if (icon.startsWith('http://') || icon.startsWith('https://') || icon.startsWith('/')) {
+    return <img src={icon} className={className} alt={tooltip || 'decoration'} title={tooltip} />;
+  }
+
+  // 3. Check for SVG string
+  if (icon.trim().startsWith('<svg')) {
+    return (
+      <div
+        className={className}
+        title={tooltip}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: icon }}
+        style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+      />
+    );
+  }
+
+  return null;
+};
+
+export default IconProvider;

--- a/packages/jaeger-ui/src/components/common/SiIcons.ts
+++ b/packages/jaeger-ui/src/components/common/SiIcons.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+export {
+  SiPostgresql,
+  SiMysql,
+  SiMongodb,
+  SiApachekafka,
+  SiRabbitmq,
+  SiKubernetes,
+  SiGo,
+  SiPython,
+  SiNodedotjs,
+  SiGraphql,
+  SiElasticsearch,
+} from 'react-icons/si';

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -100,6 +100,16 @@ const defaultConfig: Config = {
       tooltip: 'MongoDB',
     },
     {
+      attributes: [{ key: '^(?:db\\.system|peer\\.service|service\\.name)$', value: 'elasticsearch' }],
+      icon: 'si.Elasticsearch',
+      tooltip: 'Elasticsearch',
+    },
+    {
+      attributes: [{ key: '^(?:graphql\\.operation\\.name|graphql\\.operation\\.type)$', value: '.*' }],
+      icon: 'si.Graphql',
+      tooltip: 'GraphQL',
+    },
+    {
       attributes: [{ key: '^(?:db\\.system)$', value: '.*' }],
       icon: 'io.Database',
       tooltip: 'Database Call',

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -80,37 +80,62 @@ const defaultConfig: Config = {
   linkPatterns: [],
   spanDecorations: [
     {
-      entries: [{ key: 'db.system', value: '.*' }],
+      attributes: [{ key: '^(?:db\\.system|peer\\.service|service\\.name)$', value: 'redis.*' }],
+      icon: 'di.Redis',
+      tooltip: 'Redis',
+    },
+    {
+      attributes: [{ key: '^(?:db\\.system|peer\\.service|service\\.name)$', value: 'postgresql|postgres' }],
+      icon: 'si.Postgresql',
+      tooltip: 'PostgreSQL',
+    },
+    {
+      attributes: [{ key: '^(?:db\\.system|peer\\.service|service\\.name)$', value: 'mysql|mariadb' }],
+      icon: 'si.Mysql',
+      tooltip: 'MySQL',
+    },
+    {
+      attributes: [{ key: '^(?:db\\.system|peer\\.service|service\\.name)$', value: 'mongodb' }],
+      icon: 'si.Mongodb',
+      tooltip: 'MongoDB',
+    },
+    {
+      attributes: [{ key: '^(?:db\\.system)$', value: '.*' }],
       icon: 'io.Database',
       tooltip: 'Database Call',
     },
     {
-      entries: [{ key: 'db.type', value: '.*' }],
+      attributes: [{ key: '^(?:db\\.type)$', value: '.*' }],
       icon: 'io.Database',
       tooltip: 'Database Call',
     },
     {
-      entries: [{ key: 'otel.scope.name', value: 'mysql|redis|mongodb|postgres|sql' }],
-      icon: 'io.Database',
-      tooltip: 'Database Call',
-    },
-    {
-      entries: [{ key: 'http.method|http.request.method', value: '.*' }],
+      attributes: [{ key: '^(?:http\\.method|http\\.request\\.method)$', value: '.*' }],
       icon: 'io.Globe',
       tooltip: 'HTTP Request',
     },
     {
-      entries: [{ key: 'messaging.system', value: '.*' }],
+      attributes: [{ key: '^(?:messaging\\.system)$', value: 'kafka' }],
+      icon: 'si.Apachekafka',
+      tooltip: 'Apache Kafka',
+    },
+    {
+      attributes: [{ key: '^(?:messaging\\.system)$', value: 'rabbitmq' }],
+      icon: 'si.Rabbitmq',
+      tooltip: 'RabbitMQ',
+    },
+    {
+      attributes: [{ key: '^(?:messaging\\.system)$', value: '.*' }],
       icon: 'io.PaperPlane',
       tooltip: 'Messaging',
     },
     {
-      entries: [{ key: 'rpc.system|rpc.system.name', value: '.*' }],
+      attributes: [{ key: '^(?:rpc\\.system|rpc\\.system\\.name)$', value: '.*' }],
       icon: 'io.Swap',
       tooltip: 'RPC Call',
     },
     {
-      entries: [{ key: 'gen_ai.system', value: '.*' }],
+      attributes: [{ key: '^(?:gen_ai\\.system)$', value: '.*' }],
       icon: 'io.HardwareChip',
       tooltip: 'AI/ML Operation',
     },

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -80,9 +80,13 @@ const defaultConfig: Config = {
   linkPatterns: [],
   spanDecorations: [
     { entries: [{ key: 'db.system', value: '.*' }], icon: 'IoServer' },
+    { entries: [{ key: 'db.type', value: '.*' }], icon: 'IoServer' },
+    { entries: [{ key: 'otel.scope.name', value: 'mysql|redis|mongodb|postgres|sql' }], icon: 'IoServer' },
+    { entries: [{ key: 'http.method', value: '.*' }], icon: 'IoGlobeOutline' },
+    { entries: [{ key: 'http.request.method', value: '.*' }], icon: 'IoGlobeOutline' },
     { entries: [{ key: 'messaging.system', value: '.*' }], icon: 'IoPaperPlane' },
     { entries: [{ key: 'rpc.system', value: '.*' }], icon: 'IoSwapHorizontal' },
-    { entries: [{ key: 'http.method', value: '.*' }], icon: 'IoGlobeOutline' },
+    { entries: [{ key: 'rpc.system.name', value: '.*' }], icon: 'IoSwapHorizontal' },
     { entries: [{ key: 'gen_ai.system', value: '.*' }], icon: 'IoHardwareChip' },
   ],
   monitor: {

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -78,6 +78,13 @@ const defaultConfig: Config = {
     customWebAnalytics: null,
   },
   linkPatterns: [],
+  spanDecorations: [
+    { entries: [{ key: 'db.system', value: '.*' }], icon: 'IoServer' },
+    { entries: [{ key: 'messaging.system', value: '.*' }], icon: 'IoPaperPlane' },
+    { entries: [{ key: 'rpc.system', value: '.*' }], icon: 'IoSwapHorizontal' },
+    { entries: [{ key: 'http.method', value: '.*' }], icon: 'IoGlobeOutline' },
+    { entries: [{ key: 'gen_ai.system', value: '.*' }], icon: 'IoHardwareChip' },
+  ],
   monitor: {
     menuEnabled: true,
     emptyState: {

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -79,15 +79,41 @@ const defaultConfig: Config = {
   },
   linkPatterns: [],
   spanDecorations: [
-    { entries: [{ key: 'db.system', value: '.*' }], icon: 'IoServer' },
-    { entries: [{ key: 'db.type', value: '.*' }], icon: 'IoServer' },
-    { entries: [{ key: 'otel.scope.name', value: 'mysql|redis|mongodb|postgres|sql' }], icon: 'IoServer' },
-    { entries: [{ key: 'http.method', value: '.*' }], icon: 'IoGlobeOutline' },
-    { entries: [{ key: 'http.request.method', value: '.*' }], icon: 'IoGlobeOutline' },
-    { entries: [{ key: 'messaging.system', value: '.*' }], icon: 'IoPaperPlane' },
-    { entries: [{ key: 'rpc.system', value: '.*' }], icon: 'IoSwapHorizontal' },
-    { entries: [{ key: 'rpc.system.name', value: '.*' }], icon: 'IoSwapHorizontal' },
-    { entries: [{ key: 'gen_ai.system', value: '.*' }], icon: 'IoHardwareChip' },
+    {
+      entries: [{ key: 'db.system', value: '.*' }],
+      icon: 'io.Database',
+      tooltip: 'Database Call',
+    },
+    {
+      entries: [{ key: 'db.type', value: '.*' }],
+      icon: 'io.Database',
+      tooltip: 'Database Call',
+    },
+    {
+      entries: [{ key: 'otel.scope.name', value: 'mysql|redis|mongodb|postgres|sql' }],
+      icon: 'io.Database',
+      tooltip: 'Database Call',
+    },
+    {
+      entries: [{ key: 'http.method|http.request.method', value: '.*' }],
+      icon: 'io.Globe',
+      tooltip: 'HTTP Request',
+    },
+    {
+      entries: [{ key: 'messaging.system', value: '.*' }],
+      icon: 'io.PaperPlane',
+      tooltip: 'Messaging',
+    },
+    {
+      entries: [{ key: 'rpc.system|rpc.system.name', value: '.*' }],
+      icon: 'io.Swap',
+      tooltip: 'RPC Call',
+    },
+    {
+      entries: [{ key: 'gen_ai.system', value: '.*' }],
+      icon: 'io.HardwareChip',
+      tooltip: 'AI/ML Operation',
+    },
   ],
   monitor: {
     menuEnabled: true,

--- a/packages/jaeger-ui/src/model/span-decorations.ts
+++ b/packages/jaeger-ui/src/model/span-decorations.ts
@@ -1,10 +1,10 @@
-// Copyright (c) 2024 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 import getConfig from '../utils/config/get-config';
-import { IOtelSpan } from '../types/otel';
+import { IOtelSpan, IAttribute } from '../types/otel';
 
-export type SpanDecoration = {
+type SpanDecoration = {
   icon: string;
   tooltip?: string;
 };
@@ -15,12 +15,19 @@ type ProcessedEntry = {
 };
 
 type ProcessedRule = {
-  entries: ProcessedEntry[];
+  attributes: ProcessedEntry[];
   icon: string;
   tooltip?: string;
 };
 
 let processedRules: ProcessedRule[] | null = null;
+let decorationCache = new WeakMap<IOtelSpan, SpanDecoration | null>();
+
+/** @internal */
+export function _clearCache() {
+  processedRules = null;
+  decorationCache = new WeakMap<IOtelSpan, SpanDecoration | null>();
+}
 
 function getProcessedRules(): ProcessedRule[] {
   if (processedRules) return processedRules;
@@ -35,14 +42,25 @@ function getProcessedRules(): ProcessedRule[] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (spanDecorations as any[]).forEach(rule => {
     try {
+      if (typeof rule.icon !== 'string' || !rule.icon) {
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parsedAttributes = (rule.attributes || [])
+        .filter((attr: any) => typeof attr.key === 'string' && attr.key.trim().length > 0)
+        .map((attr: any) => ({
+          keyRegex: new RegExp(attr.key),
+          valueRegex: attr.value ? new RegExp(attr.value) : null,
+        }));
+
+      if (parsedAttributes.length === 0) {
+        return;
+      }
+
       rules.push({
         icon: rule.icon,
         tooltip: rule.tooltip,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        entries: rule.entries.map((entry: any) => ({
-          keyRegex: entry.key ? new RegExp(entry.key) : null,
-          valueRegex: entry.value ? new RegExp(entry.value) : null,
-        })),
+        attributes: parsedAttributes,
       });
     } catch (e) {
       // eslint-disable-next-line no-console
@@ -55,30 +73,46 @@ function getProcessedRules(): ProcessedRule[] {
 }
 
 export function getSpanDecoration(span: IOtelSpan): SpanDecoration | null {
+  if (decorationCache.has(span)) return decorationCache.get(span)!;
+
   const rules = getProcessedRules();
-  if (rules.length === 0) return null;
+  if (rules.length === 0) {
+    decorationCache.set(span, null);
+    return null;
+  }
 
   // Search in both span attributes and resource attributes
-  const allAttributes = [...(span.attributes || []), ...(span.resource?.attributes || [])];
+  const allAttributes: IAttribute[] = [...(span.attributes || []), ...(span.resource?.attributes || [])];
+
+  if (span.resource?.serviceName) {
+    allAttributes.push({ key: 'service.name', value: span.resource.serviceName });
+  }
+
+  if (span.name) {
+    allAttributes.push({ key: 'span.name', value: span.name });
+  }
 
   for (const rule of rules) {
-    const allMatched = rule.entries.every(entry => {
-      if (!entry.keyRegex) return true;
-      return allAttributes.some(attr => {
-        const keyMatches = entry.keyRegex?.test(attr.key);
+    const allMatched = rule.attributes.every(attr => {
+      if (!attr.keyRegex) return true;
+      return allAttributes.some(spanAttr => {
+        const keyMatches = attr.keyRegex?.test(spanAttr.key);
         if (!keyMatches) return false;
-        if (!entry.valueRegex) return true;
-        return entry.valueRegex.test(String(attr.value));
+        if (!attr.valueRegex) return true;
+        return attr.valueRegex.test(String(spanAttr.value));
       });
     });
 
     if (allMatched) {
-      return {
+      const result = {
         icon: rule.icon,
         tooltip: rule.tooltip,
       };
+      decorationCache.set(span, result);
+      return result;
     }
   }
 
+  decorationCache.set(span, null);
   return null;
 }

--- a/packages/jaeger-ui/src/model/span-decorations.ts
+++ b/packages/jaeger-ui/src/model/span-decorations.ts
@@ -47,10 +47,13 @@ function getProcessedRules(): ProcessedRule[] {
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const parsedAttributes = (rule.attributes || [])
-        .filter((attr: any) => typeof attr.key === 'string' && attr.key.trim().length > 0)
+        .filter(
+          (attr: any) =>
+            typeof attr.key === 'string' && attr.key.trim().length > 0 && typeof attr.value === 'string'
+        )
         .map((attr: any) => ({
           keyRegex: new RegExp(attr.key),
-          valueRegex: attr.value ? new RegExp(attr.value) : null,
+          valueRegex: new RegExp(attr.value),
         }));
 
       if (parsedAttributes.length === 0) {

--- a/packages/jaeger-ui/src/model/span-decorations.ts
+++ b/packages/jaeger-ui/src/model/span-decorations.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2024 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import getConfig from '../utils/config/get-config';
+import { IOtelSpan } from '../types/otel';
+
+export type SpanDecoration = {
+  icon: string;
+  tooltip?: string;
+};
+
+type ProcessedEntry = {
+  keyRegex: RegExp | null;
+  valueRegex: RegExp | null;
+};
+
+type ProcessedRule = {
+  entries: ProcessedEntry[];
+  icon: string;
+  tooltip?: string;
+};
+
+let processedRules: ProcessedRule[] | null = null;
+
+function getProcessedRules(): ProcessedRule[] {
+  if (processedRules) return processedRules;
+
+  const { spanDecorations } = getConfig();
+  if (!spanDecorations || !Array.isArray(spanDecorations)) {
+    processedRules = [];
+    return processedRules;
+  }
+
+  const rules: ProcessedRule[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (spanDecorations as any[]).forEach(rule => {
+    try {
+      rules.push({
+        icon: rule.icon,
+        tooltip: rule.tooltip,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        entries: rule.entries.map((entry: any) => ({
+          keyRegex: entry.key ? new RegExp(entry.key) : null,
+          valueRegex: entry.value ? new RegExp(entry.value) : null,
+        })),
+      });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('Invalid span decoration rule:', rule, e);
+    }
+  });
+
+  processedRules = rules;
+  return processedRules;
+}
+
+export function getSpanDecoration(span: IOtelSpan): SpanDecoration | null {
+  const rules = getProcessedRules();
+  if (rules.length === 0) return null;
+
+  // Search in both span attributes and resource attributes
+  const allAttributes = [...(span.attributes || []), ...(span.resource?.attributes || [])];
+
+  for (const rule of rules) {
+    const allMatched = rule.entries.every(entry => {
+      if (!entry.keyRegex) return true;
+      return allAttributes.some(attr => {
+        const keyMatches = entry.keyRegex?.test(attr.key);
+        if (!keyMatches) return false;
+        if (!entry.valueRegex) return true;
+        return entry.valueRegex.test(String(attr.value));
+      });
+    });
+
+    if (allMatched) {
+      return {
+        icon: rule.icon,
+        tooltip: rule.tooltip,
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -89,9 +89,13 @@ export type BackendCapabilities = {
 
 export type SpanDecorationConfig = {
   // A set of tag key/value regular expressions. A span matches if all entries match.
-  entries: { key: string; value: string }[];
-  // Name of the icon to render (from react-icons/io5)
+  // Both 'key' and 'value' are treated as regular expressions.
+  entries: readonly { key: string; value: string }[];
+  // Name of the icon to render. This can be a built-in token (e.g. 'io.Server')
+  // or a full URL to an external image.
   icon: string;
+  // Optional tooltip text to show on hover.
+  tooltip?: string;
 };
 
 // Default values are provided in packages/jaeger-ui/src/constants/default-config.tsx

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -87,7 +87,7 @@ export type BackendCapabilities = {
   aiAssistant?: boolean;
 };
 
-export type SpanDecorationConfig = {
+type SpanDecorationConfig = {
   // A set of tag key/value regular expressions. A span matches if all attributes match.
   // Both 'key' and 'value' are treated as regular expressions.
   attributes: readonly { key: string; value: string }[];

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -88,9 +88,9 @@ export type BackendCapabilities = {
 };
 
 export type SpanDecorationConfig = {
-  // A set of tag key/value regular expressions. A span matches if all entries match.
+  // A set of tag key/value regular expressions. A span matches if all attributes match.
   // Both 'key' and 'value' are treated as regular expressions.
-  entries: readonly { key: string; value: string }[];
+  attributes: readonly { key: string; value: string }[];
   // Name of the icon to render. This can be a built-in token (e.g. 'io.Server')
   // or a full URL to an external image.
   icon: string;
@@ -98,7 +98,7 @@ export type SpanDecorationConfig = {
   tooltip?: string;
 };
 
-// Default values are provided in packages/jaeger-ui/src/constants/default-config.tsx
+// Default values are provided in packages/jaeger-ui/src/constants/default-config.ts
 export type Config = {
   //
   // archiveEnabled enables the Archive Trace button in the trace view.

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -87,6 +87,13 @@ export type BackendCapabilities = {
   aiAssistant?: boolean;
 };
 
+export type SpanDecorationConfig = {
+  // A set of tag key/value regular expressions. A span matches if all entries match.
+  entries: { key: string; value: string }[];
+  // Name of the icon to render (from react-icons/io5)
+  icon: string;
+};
+
 // Default values are provided in packages/jaeger-ui/src/constants/default-config.tsx
 export type Config = {
   //
@@ -96,6 +103,9 @@ export type Config = {
 
   // criticalPath enables to show the criticalPath of each span in a trace view.
   criticalPathEnabled: boolean;
+
+  // spanDecorations defines icons to be shown next to spans based on their tags/attributes.
+  spanDecorations?: readonly SpanDecorationConfig[];
 
   // dependencies controls the behavior of System Architecture tab.
   dependencies?: {

--- a/packages/jaeger-ui/src/utils/config/get-config.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-config.test.js
@@ -119,12 +119,19 @@ describe('getConfig()', () => {
       describe('fields not in mergeFields', () => {
         it('gives precedence to the embedded config', () => {
           const mergeFieldsSet = new Set(mergeFields);
-          const keys = Object.keys(defaultConfig).filter(k => !mergeFieldsSet.has(k));
+          const keys = Object.keys(defaultConfig).filter(
+            k => !mergeFieldsSet.has(k) && k !== 'spanDecorations'
+          );
           embedded = {};
           keys.forEach(key => {
             embedded[key] = key;
           });
-          expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, backendCapabilities: capabilities });
+          expect(getConfig()).toEqual({
+            ...defaultConfig,
+            ...embedded,
+            backendCapabilities: capabilities,
+            spanDecorations: defaultConfig.spanDecorations || [],
+          });
         });
       });
 

--- a/packages/jaeger-ui/src/utils/config/get-config.ts
+++ b/packages/jaeger-ui/src/utils/config/get-config.ts
@@ -55,6 +55,16 @@ const getConfig = memoizeOne(function getConfig(): Config {
       rv[key] = { ...defaultConfig[key], ...embedded[key] };
     }
   });
+  if (embedded && 'spanDecorations' in embedded) {
+    if (Array.isArray(embedded.spanDecorations)) {
+      if (embedded.spanDecorations !== defaultConfig.spanDecorations) {
+        rv.spanDecorations = [...embedded.spanDecorations, ...(defaultConfig.spanDecorations || [])];
+      }
+    } else {
+      rv.spanDecorations = defaultConfig.spanDecorations || [];
+    }
+  }
+
   // backendCapabilities always comes from getJaegerBackendCapabilities(), overriding anything
   // that may be present in the UI config, so the backend remains authoritative.
   return { ...rv, backendCapabilities };

--- a/packages/jaeger-ui/test/vitest-setup.ts
+++ b/packages/jaeger-ui/test/vitest-setup.ts
@@ -95,3 +95,26 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
 //
 // See docs/adr/0007-vite-plus-migration.md §9 (PR H2c / H3) for details.
 (global as any).mockDefault = (mod: unknown) => ({ default: mod });
+
+// jsdom does not provide localStorage by default if URL is not set
+const localStorageMock = (function () {
+  let store: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return store[key] || null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+  };
+})();
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -274,10 +274,10 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    // react-icons/tb is a 4400+ icon barrel. Vite 8 / Rolldown pre-bundles it
-    // into a single 4 MB file that Rolldown's import-analysis parser can't handle.
-    // Exclude it so Vite serves the ESM entry directly without pre-bundling.
-    exclude: ['react-icons/tb'],
+    // react-icons/tb and react-icons/si are large icon barrels. Vite 8 / Rolldown pre-bundles them
+    // into single massive files that Rolldown's import-analysis parser can't handle.
+    // Exclude them so Vite serves the ESM entry directly without pre-bundling.
+    exclude: ['react-icons/tb', 'react-icons/si'],
   },
   base: './',
   build: {


### PR DESCRIPTION
Description
  This PR introduces visual icons in the trace tree view based on span attributes, addressing the requirement in #3821. This enhancement allows users to quickly identify the type of operation (e.g., database call, GenAI step, messaging) at a glance without expanding span details.

  Key Features
   - Flexible Matching Engine: Supports a rule-based system where spans are matched against specific tag/attribute key-value patterns.
   - Built-in OTel Heuristics: Provides sensible defaults out-of-the-box based on standard OpenTelemetry semantic conventions:
       - 🗄️ Database: db.system matches -> io.Database token.
       - 📬 Messaging: messaging.system matches -> io.PaperPlane token.
       - ↔️ RPC: rpc.system matches -> io.Swap token.
       - 🌐 HTTP: http.method matches -> io.Globe token.
       - 🤖 GenAI: gen_ai.system matches -> io.HardwareChip token.
       - 🔍 Elasticsearch: db.system matches -> si.Elasticsearch token.
       - 🕸️ GraphQL: graphql.operation matches -> si.Graphql token.
   - Configurable: Users can extend or override these icons via the spanDecorations field in the UI configuration (jaeger-ui.config.json).
   - Seamless Integration: Icons are rendered inline within the SpanBarRow, maintaining the existing tree view layout, alignment, and theme compatibility.

  Screenshot
  
<img width="1220" height="509" alt="image" src="https://github.com/user-attachments/assets/d9b3943e-9ac6-46be-9fed-1bbb1c5ef6d9"/>


  Testing Plan
   - Unit Tests: Added comprehensive test cases packages/jaegerui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx to verify the attribute matching and icon selection logic.
   - Manual Verification: Verified using a local Jaeger backend with OTLP-injected traces for various semantic conventions (PostgreSQL, OpenAI, etc.).
   - Regression: Confirmed that tree view offsets, error icons, and RPC arrows remain correctly aligned when decorations are present.

  Checklist
   - [x] I have signed off my commits (DCO).
   - [x] I have added unit tests for my changes.
   - [x] All existing tests pass.
   - [x] I have updated the documentation/examples if necessary.

  Closes #3821
