### PR TITLE
feat(genai): add GenAI span iconography in trace timeline

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { GenAISpanIcon } from './GenAISpanIcon';
+import { IOtelSpan, SpanKind, StatusCode } from '../../../types/otel';
+
+function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
+  return {
+    traceID: 'trace-1',
+    spanID: 'span-1',
+    name: 'test',
+    kind: SpanKind.INTERNAL,
+    startTime: 0 as IOtelSpan['startTime'],
+    endTime: 1 as IOtelSpan['endTime'],
+    duration: 1 as IOtelSpan['duration'],
+    attributes: Object.entries(attrs).map(([key, value]) => ({ key, value })),
+    events: [],
+    links: [],
+    inboundLinks: [],
+    status: { code: StatusCode.OK },
+    resource: { attributes: [], serviceName: 'svc' },
+    instrumentationScope: { name: 'test' },
+    depth: 0,
+    hasChildren: false,
+    childSpans: [],
+    relativeStartTime: 0 as IOtelSpan['relativeStartTime'],
+    warnings: null,
+  };
+}
+
+describe('GenAISpanIcon', () => {
+  it('renders nothing for a standard span', () => {
+    const { container } = render(<GenAISpanIcon span={makeSpan({ 'http.method': 'GET' })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders robot icon with "AI Agent" label for invoke_agent span', () => {
+    const { getByLabelText } = render(
+      <GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'invoke_agent' })} />
+    );
+    expect(getByLabelText('AI Agent')).toBeInTheDocument();
+  });
+
+  it('renders bolt icon with "LLM Call" label for chat span', () => {
+    const { getByLabelText } = render(<GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'chat' })} />);
+    expect(getByLabelText('LLM Call')).toBeInTheDocument();
+  });
+
+  it('renders wrench icon with "Tool Call" label for execute_tool span', () => {
+    const { getByLabelText } = render(
+      <GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'execute_tool' })} />
+    );
+    expect(getByLabelText('Tool Call')).toBeInTheDocument();
+  });
+
+  it('renders storage icon with "RAG Retrieval" label for retrieval span', () => {
+    const { getByLabelText } = render(
+      <GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'retrieval' })} />
+    );
+    expect(getByLabelText('RAG Retrieval')).toBeInTheDocument();
+  });
+
+  it('renders sparkle icon with "GenAI Span" label for unknown gen_ai span', () => {
+    const { getByLabelText } = render(<GenAISpanIcon span={makeSpan({ 'gen_ai.provider.name': 'acme' })} />);
+    expect(getByLabelText('GenAI Span')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
@@ -7,7 +7,7 @@ import { MdSmartToy, MdBolt, MdBuild, MdStorage, MdAutoAwesome } from 'react-ico
 import { classifySpan, GenAISpanKind } from '../../../utils/genai/detect';
 import { IOtelSpan } from '../../../types/otel';
 
-type IconComponent = React.ComponentType<{ size?: number; title?: string; 'aria-label'?: string }>;
+type IconComponent = React.ComponentType<{ size?: number; title?: string; 'aria-label'?: string; className?: string }>;
 
 const KIND_ICONS: Record<Exclude<GenAISpanKind, 'STANDARD'>, IconComponent> = {
   AGENT: MdSmartToy,
@@ -28,12 +28,13 @@ const KIND_TITLES: Record<Exclude<GenAISpanKind, 'STANDARD'>, string> = {
 type Props = {
   span: IOtelSpan;
   size?: number;
+  className?: string;
 };
 
-export function GenAISpanIcon({ span, size = 14 }: Props): React.ReactElement | null {
+export function GenAISpanIcon({ span, size = 14, className }: Props): React.ReactElement | null {
   const kind = classifySpan(span);
   if (kind === 'STANDARD') return null;
   const Icon = KIND_ICONS[kind];
   const title = KIND_TITLES[kind];
-  return <Icon size={size} title={title} aria-label={title} />;
+  return <Icon size={size} title={title} aria-label={title} className={className} />;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { MdSmartToy, MdBolt, MdBuild, MdStorage, MdAutoAwesome } from 'react-icons/md';
+
+import { classifySpan, GenAISpanKind } from '../../../utils/genai/detect';
+import { IOtelSpan } from '../../../types/otel';
+
+type IconComponent = React.ComponentType<{ size?: number; title?: string; 'aria-label'?: string }>;
+
+const KIND_ICONS: Record<Exclude<GenAISpanKind, 'STANDARD'>, IconComponent> = {
+  AGENT: MdSmartToy,
+  LLM_CALL: MdBolt,
+  TOOL_CALL: MdBuild,
+  RETRIEVAL: MdStorage,
+  UNKNOWN_GENAI: MdAutoAwesome,
+};
+
+const KIND_TITLES: Record<Exclude<GenAISpanKind, 'STANDARD'>, string> = {
+  AGENT: 'AI Agent',
+  LLM_CALL: 'LLM Call',
+  TOOL_CALL: 'Tool Call',
+  RETRIEVAL: 'RAG Retrieval',
+  UNKNOWN_GENAI: 'GenAI Span',
+};
+
+type Props = {
+  span: IOtelSpan;
+  size?: number;
+};
+
+export function GenAISpanIcon({ span, size = 14 }: Props): React.ReactElement | null {
+  const kind = classifySpan(span);
+  if (kind === 'STANDARD') return null;
+  const Icon = KIND_ICONS[kind];
+  const title = KIND_TITLES[kind];
+  return <Icon size={size} title={title} aria-label={title} />;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -208,3 +208,9 @@ SPDX-License-Identifier: Apache-2.0
 .SpanBarRow--arrowForwardIcon {
   vertical-align: middle;
 }
+
+.SpanBarRow--genAIIcon {
+  font-size: 0.85em;
+  margin-right: 0.25rem;
+  vertical-align: middle;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -13,6 +13,7 @@ import Ticks from './Ticks';
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
+import { GenAISpanIcon } from './GenAISpanIcon';
 
 import './SpanBarRow.css';
 
@@ -164,6 +165,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               {!hasOwnError && hasChildError && (
                 <IoAlert className="SpanBarRow--errorIcon SpanBarRow--errorIcon--hollow" />
               )}
+              <GenAISpanIcon span={span} size={14} />
               {serviceName}{' '}
               {rpc && (
                 <span>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -165,7 +165,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               {!hasOwnError && hasChildError && (
                 <IoAlert className="SpanBarRow--errorIcon SpanBarRow--errorIcon--hollow" />
               )}
-              <GenAISpanIcon span={span} size={14} />
+              <GenAISpanIcon span={span} size={14} className="SpanBarRow--genAIIcon" />
               {serviceName}{' '}
               {rpc && (
                 <span>

--- a/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
@@ -72,6 +72,26 @@ describe('OtelTraceFacade', () => {
     expect(facade.services).toEqual([{ name: 'test-service', numberOfSpans: 1 }]);
   });
 
+  it('isGenAITrace is false when spans have no gen_ai.* attributes', () => {
+    expect(facade.isGenAITrace).toBe(false);
+  });
+
+  it('isGenAITrace is true when at least one span has gen_ai.* attributes', () => {
+    const genAISpan: Span = {
+      ...mockSpan,
+      spanID: 'genai-span',
+      tags: [{ key: 'gen_ai.operation.name', value: 'chat' }],
+    };
+    const genAITrace: Trace = {
+      ...mockLegacyTrace,
+      spans: [genAISpan],
+      spanMap: new Map([['genai-span', genAISpan]]),
+      rootSpans: [genAISpan],
+    };
+    const genAIFacade = new OtelTraceFacade(genAITrace);
+    expect(genAIFacade.isGenAITrace).toBe(true);
+  });
+
   describe('span wiring', () => {
     const parentSpan: Span = { ...mockSpan, spanID: 'parent', hasChildren: true };
     const childSpan: Span = {

--- a/packages/jaeger-ui/src/model/OtelTraceFacade.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.ts
@@ -4,6 +4,7 @@
 import { Trace } from '../types/trace';
 import { IOtelTrace, IOtelSpan } from '../types/otel';
 import OtelSpanFacade from './OtelSpanFacade';
+import { isGenAITrace } from '../utils/genai/detect';
 
 export default class OtelTraceFacade implements IOtelTrace {
   private legacyTrace: Trace;
@@ -11,6 +12,7 @@ export default class OtelTraceFacade implements IOtelTrace {
   private _spanMap: Map<string, IOtelSpan>;
   private _rootSpans: IOtelSpan[];
   private _orphanSpanCount: number;
+  readonly isGenAITrace: boolean;
 
   constructor(legacyTrace: Trace) {
     this.legacyTrace = legacyTrace;
@@ -36,6 +38,8 @@ export default class OtelTraceFacade implements IOtelTrace {
     this._orphanSpanCount = this._spans.filter(
       s => s.parentSpanID && !this._spanMap.has(s.parentSpanID)
     ).length;
+
+    this.isGenAITrace = isGenAITrace(this);
 
     // Wire up parentSpan, childSpans, and link span references
     this._spans.forEach(span => {

--- a/packages/jaeger-ui/src/types/otel.ts
+++ b/packages/jaeger-ui/src/types/otel.ts
@@ -118,6 +118,9 @@ export interface IOtelTrace {
   // Number of orphan spans (spans with parent references to spans not in the trace)
   orphanSpanCount: number;
 
+  // True when at least one span carries gen_ai.* attributes (OpenTelemetry GenAI semconv).
+  readonly isGenAITrace: boolean;
+
   // Helper methods
   hasErrors(): boolean;
 }

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { classifySpan, isGenAITrace, GenAISpanKind } from './detect';
-import { IOtelSpan, IOtelTrace, SpanKind, StatusCode } from '../../types/otel';
+import { IOtelSpan, SpanKind, StatusCode } from '../../types/otel';
 
 function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
   return {
@@ -28,24 +28,8 @@ function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
   };
 }
 
-function makeTrace(spans: IOtelSpan[]): IOtelTrace {
-  const trace: Omit<IOtelTrace, 'isGenAITrace'> & { isGenAITrace: boolean } = {
-    traceID: 'trace-1',
-    spans,
-    duration: 1 as IOtelTrace['duration'],
-    startTime: 0 as IOtelTrace['startTime'],
-    endTime: 1 as IOtelTrace['endTime'],
-    traceName: 'test',
-    tracePageTitle: 'test',
-    traceEmoji: '',
-    services: [],
-    spanMap: new Map(spans.map(s => [s.spanID, s])),
-    rootSpans: spans.slice(0, 1),
-    orphanSpanCount: 0,
-    isGenAITrace: false,
-    hasErrors: () => false,
-  };
-  return trace;
+function makeTrace(spans: IOtelSpan[]) {
+  return { spans };
 }
 
 describe('classifySpan', () => {

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { classifySpan, isGenAITrace, GenAISpanKind } from './detect';
+import { IOtelSpan, IOtelTrace, SpanKind, StatusCode } from '../../types/otel';
+
+function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
+  return {
+    traceID: 'trace-1',
+    spanID: 'span-1',
+    name: 'test',
+    kind: SpanKind.INTERNAL,
+    startTime: 0 as IOtelSpan['startTime'],
+    endTime: 1 as IOtelSpan['endTime'],
+    duration: 1 as IOtelSpan['duration'],
+    attributes: Object.entries(attrs).map(([key, value]) => ({ key, value })),
+    events: [],
+    links: [],
+    inboundLinks: [],
+    status: { code: StatusCode.OK },
+    resource: { attributes: [], serviceName: 'svc' },
+    instrumentationScope: { name: 'test' },
+    depth: 0,
+    hasChildren: false,
+    childSpans: [],
+    relativeStartTime: 0 as IOtelSpan['relativeStartTime'],
+    warnings: null,
+  };
+}
+
+function makeTrace(spans: IOtelSpan[]): IOtelTrace {
+  return {
+    traceID: 'trace-1',
+    spans,
+    duration: 1 as IOtelTrace['duration'],
+    startTime: 0 as IOtelTrace['startTime'],
+    endTime: 1 as IOtelTrace['endTime'],
+    traceName: 'test',
+    tracePageTitle: 'test',
+    traceEmoji: '',
+    services: [],
+    spanMap: new Map(spans.map(s => [s.spanID, s])),
+    rootSpans: spans.slice(0, 1),
+    orphanSpanCount: 0,
+    hasErrors: () => false,
+  };
+}
+
+describe('classifySpan', () => {
+  it.each<[string, GenAISpanKind]>([
+    ['chat', 'LLM_CALL'],
+    ['text_completion', 'LLM_CALL'],
+    ['execute_tool', 'TOOL_CALL'],
+    ['invoke_agent', 'AGENT'],
+    ['retrieval', 'RETRIEVAL'],
+  ])('classifies gen_ai.operation.name=%s as %s', (opName, expected) => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': opName }))).toBe(expected);
+  });
+
+  it('returns UNKNOWN_GENAI for unrecognized gen_ai.operation.name with other gen_ai.* attrs', () => {
+    expect(
+      classifySpan(makeSpan({ 'gen_ai.operation.name': 'future_op', 'gen_ai.provider.name': 'acme' }))
+    ).toBe('UNKNOWN_GENAI');
+  });
+
+  it('returns UNKNOWN_GENAI when gen_ai.* attrs exist but no operation.name', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.provider.name': 'acme' }))).toBe('UNKNOWN_GENAI');
+  });
+
+  it('returns STANDARD when no gen_ai.* attrs exist', () => {
+    expect(classifySpan(makeSpan({ 'http.method': 'GET' }))).toBe('STANDARD');
+  });
+
+  it('returns STANDARD for span with no attributes', () => {
+    expect(classifySpan(makeSpan())).toBe('STANDARD');
+  });
+});
+
+describe('isGenAITrace', () => {
+  it('returns true when at least one span has gen_ai.* attributes', () => {
+    const spans = [makeSpan({ 'http.method': 'GET' }), makeSpan({ 'gen_ai.operation.name': 'chat' })];
+    expect(isGenAITrace(makeTrace(spans))).toBe(true);
+  });
+
+  it('returns false when all spans are STANDARD', () => {
+    const spans = [makeSpan({ 'http.method': 'GET' }), makeSpan({ 'db.system': 'postgresql' })];
+    expect(isGenAITrace(makeTrace(spans))).toBe(false);
+  });
+
+  it('returns false for an empty trace', () => {
+    expect(isGenAITrace(makeTrace([]))).toBe(false);
+  });
+});

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -29,7 +29,7 @@ function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
 }
 
 function makeTrace(spans: IOtelSpan[]): IOtelTrace {
-  return {
+  const trace: Omit<IOtelTrace, 'isGenAITrace'> & { isGenAITrace: boolean } = {
     traceID: 'trace-1',
     spans,
     duration: 1 as IOtelTrace['duration'],
@@ -42,8 +42,10 @@ function makeTrace(spans: IOtelSpan[]): IOtelTrace {
     spanMap: new Map(spans.map(s => [s.spanID, s])),
     rootSpans: spans.slice(0, 1),
     orphanSpanCount: 0,
+    isGenAITrace: false,
     hasErrors: () => false,
   };
+  return trace;
 }
 
 describe('classifySpan', () => {

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 import { classifySpan, isGenAITrace, GenAISpanKind } from './detect';

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 The Jaeger Authors.
+// Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 import { IOtelSpan, IOtelTrace } from '../../types/otel';
@@ -14,11 +14,16 @@ const OPERATION_NAME_MAP: Record<string, GenAISpanKind> = {
 };
 
 export function classifySpan(span: IOtelSpan): GenAISpanKind {
-  const opAttr = span.attributes.find(a => a.key === 'gen_ai.operation.name');
-  if (opAttr) {
-    return OPERATION_NAME_MAP[String(opAttr.value)] ?? 'UNKNOWN_GENAI';
+  let hasGenAI = false;
+  for (const attr of span.attributes) {
+    if (attr.key === 'gen_ai.operation.name') {
+      return OPERATION_NAME_MAP[String(attr.value)] ?? 'UNKNOWN_GENAI';
+    }
+    if (!hasGenAI && attr.key.startsWith('gen_ai.')) {
+      hasGenAI = true;
+    }
   }
-  return span.attributes.some(a => a.key.startsWith('gen_ai.')) ? 'UNKNOWN_GENAI' : 'STANDARD';
+  return hasGenAI ? 'UNKNOWN_GENAI' : 'STANDARD';
 }
 
 export function isGenAITrace(trace: Pick<IOtelTrace, 'spans'>): boolean {

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -21,12 +21,12 @@ export function classifySpan(span: IOtelSpan): GenAISpanKind {
   return span.attributes.some(a => a.key.startsWith('gen_ai.')) ? 'UNKNOWN_GENAI' : 'STANDARD';
 }
 
-export function isGenAITrace(trace: IOtelTrace): boolean {
+export function isGenAITrace(trace: Pick<IOtelTrace, 'spans'>): boolean {
   return trace.spans.some(s => classifySpan(s) !== 'STANDARD');
 }
 
 // Attribute keys that carry structured GenAI content and deserve richer rendering.
-export const RICH_MEDIA_ATTRIBUTE_KEYS: Readonly<Record<string, 'markdown' | 'json'>> = {
+export const RICH_MEDIA_ATTRIBUTE_KEYS = {
   'gen_ai.input.messages': 'markdown',
   'gen_ai.output.messages': 'markdown',
   'gen_ai.system_instructions': 'markdown',
@@ -34,4 +34,6 @@ export const RICH_MEDIA_ATTRIBUTE_KEYS: Readonly<Record<string, 'markdown' | 'js
   'gen_ai.tool.call.result': 'json',
   'gen_ai.tool.definitions': 'json',
   'gen_ai.retrieval.documents': 'json',
-};
+} as const satisfies Readonly<Record<string, 'markdown' | 'json'>>;
+
+export type RichMediaAttributeKey = keyof typeof RICH_MEDIA_ATTRIBUTE_KEYS;

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IOtelSpan, IOtelTrace } from '../../types/otel';
+
+export type GenAISpanKind = 'LLM_CALL' | 'TOOL_CALL' | 'AGENT' | 'RETRIEVAL' | 'UNKNOWN_GENAI' | 'STANDARD';
+
+const OPERATION_NAME_MAP: Record<string, GenAISpanKind> = {
+  chat: 'LLM_CALL',
+  text_completion: 'LLM_CALL',
+  execute_tool: 'TOOL_CALL',
+  invoke_agent: 'AGENT',
+  retrieval: 'RETRIEVAL',
+};
+
+export function classifySpan(span: IOtelSpan): GenAISpanKind {
+  const opAttr = span.attributes.find(a => a.key === 'gen_ai.operation.name');
+  if (opAttr) {
+    return OPERATION_NAME_MAP[String(opAttr.value)] ?? 'UNKNOWN_GENAI';
+  }
+  return span.attributes.some(a => a.key.startsWith('gen_ai.')) ? 'UNKNOWN_GENAI' : 'STANDARD';
+}
+
+export function isGenAITrace(trace: IOtelTrace): boolean {
+  return trace.spans.some(s => classifySpan(s) !== 'STANDARD');
+}

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -24,3 +24,14 @@ export function classifySpan(span: IOtelSpan): GenAISpanKind {
 export function isGenAITrace(trace: IOtelTrace): boolean {
   return trace.spans.some(s => classifySpan(s) !== 'STANDARD');
 }
+
+// Attribute keys that carry structured GenAI content and deserve richer rendering.
+export const RICH_MEDIA_ATTRIBUTE_KEYS: Readonly<Record<string, 'markdown' | 'json'>> = {
+  'gen_ai.input.messages': 'markdown',
+  'gen_ai.output.messages': 'markdown',
+  'gen_ai.system_instructions': 'markdown',
+  'gen_ai.tool.call.arguments': 'json',
+  'gen_ai.tool.call.result': 'json',
+  'gen_ai.tool.definitions': 'json',
+  'gen_ai.retrieval.documents': 'json',
+};


### PR DESCRIPTION
## Which problem is this PR solving?

Part of jaegertracing/jaeger#8401 (Deliverable 2 — Span Iconography). Closes #3825.

GenAI traces built on [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) mix agent invocations, LLM calls, tool executions, and retrieval steps in a single waterfall. Every span looks identical, making it hard to scan the AI reasoning flow at a glance.

## Description of the changes

- **`src/utils/genai/detect.ts`**
  - `isGenAITrace` param narrowed from `IOtelTrace` to `Pick<IOtelTrace, 'spans'>` to remove the circular dependency (IOtelTrace now contains `isGenAITrace: boolean`)
  - `RICH_MEDIA_ATTRIBUTE_KEYS` declared `as const satisfies Readonly<Record<string, 'markdown' | 'json'>>` so the exact key union is preserved; exports `RichMediaAttributeKey = keyof typeof RICH_MEDIA_ATTRIBUTE_KEYS` for type-safe downstream checks (groundwork for Deliverable 3)

- **`src/types/otel.ts`** — adds `readonly isGenAITrace: boolean` to `IOtelTrace` so all consumers access it without casting to `OtelTraceFacade`

- **`src/model/OtelTraceFacade.ts`** — computes `isGenAITrace` once at construction by calling `isGenAITrace(this)`

- **`src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx`** (new) — maps each `GenAISpanKind` to a `react-icons/md` icon (no new dependency); accepts `className?` forwarded to the icon for caller-controlled spacing; returns `null` for `STANDARD` spans with zero layout impact:

  | Kind | Icon | aria-label |
  |---|---|---|
  | `AGENT` | `MdSmartToy` | AI Agent |
  | `LLM_CALL` | `MdBolt` | LLM Call |
  | `TOOL_CALL` | `MdBuild` | Tool Call |
  | `RETRIEVAL` | `MdStorage` | RAG Retrieval |
  | `UNKNOWN_GENAI` | `MdAutoAwesome` | GenAI Span |

- **`src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx`** — renders `<GenAISpanIcon span={span} size={14} className="SpanBarRow--genAIIcon" />` alongside the existing error icons

- **`src/components/TracePage/TraceTimelineViewer/SpanBarRow.css`** — adds `.SpanBarRow--genAIIcon` with `font-size: 0.85em`, `margin-right: 0.25rem`, and `vertical-align: middle` to match existing icon spacing

## Test plan

- [x] `GenAISpanIcon.test.tsx` (6 tests) — null return for standard span; correct `aria-label` for each `GenAISpanKind`
- [x] `detect.test.ts` — `isGenAITrace` tests simplified to `{ spans }` now that `Pick<IOtelTrace, 'spans'>` removes the `Omit<...> & { isGenAITrace: boolean }` workaround
- [x] `OtelTraceFacade.test.ts` — `isGenAITrace` false/true for non-GenAI/GenAI traces
- [ ] Manual: load a GenAI trace; verify `invoke_agent`, `chat`, and `execute_tool` spans show the correct icon; load a standard trace and confirm no icons appear