### PR TITLE
fix(search): Surface per-trace errors in multi-trace search

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.css
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2026 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+.ResultItemError {
+  border: 1px solid var(--feedback-error);
+  background: color-mix(in srgb, var(--feedback-error) 6%, var(--surface-primary));
+  padding: 0.75rem 1rem;
+}
+
+.ResultItemError--label {
+  color: var(--feedback-error);
+  font-weight: 600;
+  margin-right: 0.4rem;
+}
+
+.ResultItemError--traceID {
+  color: var(--text-primary);
+  font-family: monospace;
+  word-break: break-all;
+}
+
+.ResultItemError--message {
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+  font-size: 0.9em;
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.test.jsx
@@ -10,7 +10,7 @@ import ResultItemError from './ResultItemError';
 describe('<ResultItemError>', () => {
   it('renders the trace ID and error label', () => {
     render(<ResultItemError traceID="abc123" message="trace not found" />);
-    expect(screen.getByText('Trace not found:')).toBeInTheDocument();
+    expect(screen.getByText('Trace fetch failed:')).toBeInTheDocument();
     expect(screen.getByText('abc123')).toBeInTheDocument();
     expect(screen.getByText('trace not found')).toBeInTheDocument();
   });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.test.jsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ResultItemError from './ResultItemError';
+
+describe('<ResultItemError>', () => {
+  it('renders the trace ID and error label', () => {
+    render(<ResultItemError traceID="abc123" message="trace not found" />);
+    expect(screen.getByText('Trace not found:')).toBeInTheDocument();
+    expect(screen.getByText('abc123')).toBeInTheDocument();
+    expect(screen.getByText('trace not found')).toBeInTheDocument();
+  });
+
+  it('omits the message paragraph when no message is provided', () => {
+    const { container } = render(<ResultItemError traceID="abc123" />);
+    expect(screen.getByText('abc123')).toBeInTheDocument();
+    expect(container.querySelector('.ResultItemError--message')).toBeNull();
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.tsx
@@ -14,7 +14,7 @@ export default function ResultItemError({ traceID, message }: Props) {
   return (
     <div className="ResultItemError" data-testid="ResultItemError">
       <h3 className="ub-m0">
-        <span className="ResultItemError--label">Trace fetch failed:</span>
+        <span className="ResultItemError--label">Trace fetch failed:</span>{' '}
         <span className="ResultItemError--traceID">{traceID}</span>
       </h3>
       {message && <div className="ResultItemError--message">{message}</div>}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.tsx
@@ -14,7 +14,7 @@ export default function ResultItemError({ traceID, message }: Props) {
   return (
     <div className="ResultItemError" data-testid="ResultItemError">
       <h3 className="ub-m0">
-        <span className="ResultItemError--label">Trace not found:</span>
+        <span className="ResultItemError--label">Trace fetch failed:</span>
         <span className="ResultItemError--traceID">{traceID}</span>
       </h3>
       {message && <div className="ResultItemError--message">{message}</div>}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemError.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+
+import './ResultItemError.css';
+
+type Props = {
+  traceID: string;
+  message?: string;
+};
+
+export default function ResultItemError({ traceID, message }: Props) {
+  return (
+    <div className="ResultItemError" data-testid="ResultItemError">
+      <h3 className="ub-m0">
+        <span className="ResultItemError--label">Trace not found:</span>
+        <span className="ResultItemError--traceID">{traceID}</span>
+      </h3>
+      {message && <div className="ResultItemError--message">{message}</div>}
+    </div>
+  );
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -178,13 +178,29 @@ describe('<SearchResults>', () => {
   });
 
   it('renders only error rows when no successful traces are present', () => {
-    const traceErrors = [
-      { id: 'only-error', error: new Error('trace not found - only-error'), state: 'FETCH_ERROR' },
-    ];
+    const traceErrors = [{ id: 'only-error', error: new Error('trace not found'), state: 'FETCH_ERROR' }];
     renderWithRouter(<SearchResults {...baseProps} traces={[]} traceErrors={traceErrors} />);
     expect(screen.getByTestId('ResultItemError')).toBeInTheDocument();
     expect(screen.getByText('only-error')).toBeInTheDocument();
     expect(screen.queryByText(/No trace results\. Try another query\./i)).not.toBeInTheDocument();
+  });
+
+  it('keeps error rows visible in DDG view alongside successful traces', () => {
+    const traceErrors = [{ id: 'missing-1', error: new Error('trace not found'), state: 'FETCH_ERROR' }];
+    renderWithRouter(
+      <SearchResults {...baseProps} traceErrors={traceErrors} location={{ search: '?view=ddg' }} />
+    );
+    expect(screen.getByTestId('ResultItemError')).toBeInTheDocument();
+    expect(screen.getByTestId('ddg')).toBeInTheDocument();
+  });
+
+  it('shows a failed count in the header when errors are present', () => {
+    const traceErrors = [
+      { id: 'missing-1', error: new Error('trace not found'), state: 'FETCH_ERROR' },
+      { id: 'missing-2', error: new Error('trace not found'), state: 'FETCH_ERROR' },
+    ];
+    renderWithRouter(<SearchResults {...baseProps} traceErrors={traceErrors} />);
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toContain('2 failed');
   });
 
   it('hide scatter plot if queryparam hideGraph', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -165,6 +165,28 @@ describe('<SearchResults>', () => {
     expect(screen.getByTestId('loading')).toBeInTheDocument();
   });
 
+  it('renders error rows for traces that could not be fetched', () => {
+    const traceErrors = [
+      { id: 'missing-1', error: new Error('trace not found - missing-1'), state: 'FETCH_ERROR' },
+      { id: 'missing-2', error: new Error('trace not found - missing-2'), state: 'FETCH_ERROR' },
+    ];
+    renderWithRouter(<SearchResults {...baseProps} traceErrors={traceErrors} />);
+    const errorCards = screen.getAllByTestId('ResultItemError');
+    expect(errorCards).toHaveLength(2);
+    expect(screen.getByText('missing-1')).toBeInTheDocument();
+    expect(screen.getByText('missing-2')).toBeInTheDocument();
+  });
+
+  it('renders only error rows when no successful traces are present', () => {
+    const traceErrors = [
+      { id: 'only-error', error: new Error('trace not found - only-error'), state: 'FETCH_ERROR' },
+    ];
+    renderWithRouter(<SearchResults {...baseProps} traces={[]} traceErrors={traceErrors} />);
+    expect(screen.getByTestId('ResultItemError')).toBeInTheDocument();
+    expect(screen.getByText('only-error')).toBeInTheDocument();
+    expect(screen.queryByText(/No trace results\. Try another query\./i)).not.toBeInTheDocument();
+  });
+
   it('hide scatter plot if queryparam hideGraph', () => {
     const { rerender } = renderWithRouter(<SearchResults {...baseProps} hideGraph={false} />);
     expect(screen.getByTestId('scatterplot')).toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -14,6 +14,7 @@ import DiffSelection from './DiffSelection';
 import * as markers from './index.markers';
 import { EAltViewActions, trackAltView } from './index.track';
 import ResultItem from './ResultItem';
+import ResultItemError from './ResultItemError';
 import ScatterPlot from './ScatterPlot';
 import { getUrl } from '../url';
 import LoadingIndicator from '../../common/LoadingIndicator';
@@ -47,6 +48,7 @@ type SearchResultsProps = {
   skipMessage?: boolean;
   spanLinks?: Record<string, string> | undefined;
   traces: IOtelTrace[];
+  traceErrors?: FetchedTrace[];
   rawTraces: any[];
   sortBy: string;
   handleSortChange: (sortBy: string) => void;
@@ -135,12 +137,20 @@ export function UnconnectedSearchResults({
   skipMessage = false,
   spanLinks,
   traces,
+  traceErrors,
   rawTraces,
   sortBy,
   handleSortChange,
   cohortAddTrace,
   cohortRemoveTrace,
 }: SearchResultsProps) {
+  const errorList = traceErrors ?? [];
+  const hasErrors = errorList.length > 0;
+  const errorMessage = (entry: FetchedTrace): string | undefined => {
+    const { error } = entry;
+    if (!error) return undefined;
+    return typeof error === 'string' ? error : error.message;
+  };
   const navigate = useNavigate();
 
   const toggleComparison = useCallback(
@@ -197,6 +207,20 @@ export function UnconnectedSearchResults({
     );
   }
   if (!Array.isArray(traces) || !traces.length) {
+    if (hasErrors) {
+      return (
+        <React.Fragment key="errors-only">
+          {diffCohort.length > 0 && diffSelection}
+          <ul className="ub-list-reset">
+            {errorList.map(err => (
+              <li className="ub-my3" key={err.id}>
+                <ResultItemError traceID={err.id} message={errorMessage(err)} />
+              </li>
+            ))}
+          </ul>
+        </React.Fragment>
+      );
+    }
     return (
       <React.Fragment key="no-results">
         {diffCohort.length > 0 && diffSelection}
@@ -260,6 +284,11 @@ export function UnconnectedSearchResults({
       {traceResultsView && diffSelection}
       {traceResultsView && (
         <ul className="ub-list-reset">
+          {errorList.map(err => (
+            <li className="ub-my3" key={`error-${err.id}`}>
+              <ResultItemError traceID={err.id} message={errorMessage(err)} />
+            </li>
+          ))}
           {traces.map(trace => (
             <li className="ub-my3" key={trace.traceID}>
               <ResultItem

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -151,6 +151,15 @@ export function UnconnectedSearchResults({
     if (!error) return undefined;
     return typeof error === 'string' ? error : error.message;
   };
+  const errorRows = hasErrors ? (
+    <ul className="ub-list-reset">
+      {errorList.map(err => (
+        <li className="ub-my3" key={err.id}>
+          <ResultItemError traceID={err.id} message={errorMessage(err)} />
+        </li>
+      ))}
+    </ul>
+  ) : null;
   const navigate = useNavigate();
 
   const toggleComparison = useCallback(
@@ -211,13 +220,7 @@ export function UnconnectedSearchResults({
       return (
         <React.Fragment key="errors-only">
           {diffCohort.length > 0 && diffSelection}
-          <ul className="ub-list-reset">
-            {errorList.map(err => (
-              <li className="ub-my3" key={err.id}>
-                <ResultItemError traceID={err.id} message={errorMessage(err)} />
-              </li>
-            ))}
-          </ul>
+          {errorRows}
         </React.Fragment>
       );
     }
@@ -277,15 +280,7 @@ export function UnconnectedSearchResults({
           )}
         </div>
       </div>
-      {hasErrors && (
-        <ul className="ub-list-reset">
-          {errorList.map(err => (
-            <li className="ub-my3" key={`error-${err.id}`}>
-              <ResultItemError traceID={err.id} message={errorMessage(err)} />
-            </li>
-          ))}
-        </ul>
-      )}
+      {errorRows}
       {!traceResultsView && (
         <div className="SearchResults--ddg-container">
           <SearchResultsDDG location={location as any} />

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -260,6 +260,7 @@ export function UnconnectedSearchResults({
         <div className="SearchResults--headerOverview">
           <h2 className="ub-m0 u-flex-1">
             {traces.length} Trace{traces.length > 1 && 's'}
+            {hasErrors && ` (${errorList.length} failed)`}
           </h2>
           {traceResultsView && <SelectSort sortBy={sortBy} handleSortChange={handleSortChange} />}
           {traceResultsView && <DownloadResults onDownloadResultsClicked={onDownloadResultsClicked} />}
@@ -276,6 +277,15 @@ export function UnconnectedSearchResults({
           )}
         </div>
       </div>
+      {hasErrors && (
+        <ul className="ub-list-reset">
+          {errorList.map(err => (
+            <li className="ub-my3" key={`error-${err.id}`}>
+              <ResultItemError traceID={err.id} message={errorMessage(err)} />
+            </li>
+          ))}
+        </ul>
+      )}
       {!traceResultsView && (
         <div className="SearchResults--ddg-container">
           <SearchResultsDDG location={location as any} />
@@ -284,11 +294,6 @@ export function UnconnectedSearchResults({
       {traceResultsView && diffSelection}
       {traceResultsView && (
         <ul className="ub-list-reset">
-          {errorList.map(err => (
-            <li className="ub-my3" key={`error-${err.id}`}>
-              <ResultItemError traceID={err.id} message={errorMessage(err)} />
-            </li>
-          ))}
           {traces.map(trace => (
             <li className="ub-my3" key={trace.traceID}>
               <ResultItem

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.test.jsx
@@ -337,6 +337,35 @@ describe('mapStateToProps()', () => {
       urlQueryParams: null,
       loadingTraces: false,
       errors: null,
+      traceErrors: [],
     });
+  });
+
+  it('splits successful and errored traces in stateTraceXformer', () => {
+    const trace = transformTraceData(traceGenerator.trace({}));
+    const erroredID = 'errored-id';
+    const erroredEntry = { id: erroredID, error: new Error('trace not found'), state: fetchedState.ERROR };
+    const stateTrace = {
+      search: {
+        results: [trace.traceID, erroredID],
+        state: fetchedState.DONE,
+      },
+      traces: {
+        [trace.traceID]: { id: trace.traceID, data: trace, state: fetchedState.DONE },
+        [erroredID]: erroredEntry,
+      },
+      rawTraces: [trace],
+    };
+    const state = {
+      trace: stateTrace,
+      services: { loading: false, services: [], operationsForService: {}, error: null },
+      config: { disableFileUploadControl: false },
+    };
+
+    const { traces, traceErrors } = mapStateToProps(state, { search: '' });
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].traceID).toBe(trace.traceID);
+    expect(traceErrors).toEqual([erroredEntry]);
   });
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
@@ -28,7 +28,7 @@ import { trackSortByChange } from './SearchForm.track';
 import { useTraceDiffStore } from '../../stores/trace-diff-store';
 import { useEmbeddedState } from '../../stores/embedded-store';
 import { useShallow } from 'zustand/react/shallow';
-import { ReduxState } from '../../types';
+import { FetchedTrace, ReduxState } from '../../types';
 import { SearchQuery } from '../../types/search';
 import { Trace } from '../../types/trace';
 import { IOtelTrace } from '../../types/otel';
@@ -50,6 +50,7 @@ interface IStateProps {
   tracesInRedux: ReduxState['trace'];
   loadingTraces: boolean;
   traces: Trace[];
+  traceErrors: FetchedTrace[];
   traceResultsToDownload: unknown[];
   errors: Array<{ message: string }> | null;
   maxTraceDuration: number;
@@ -83,6 +84,7 @@ export function SearchTracePageImpl(props: SearchTracePageImplProps) {
     urlQueryParams,
     sortedTracesXformer,
     traces,
+    traceErrors,
   } = props;
 
   // On Search: when we click “add to compare” / remove, we write that list
@@ -189,6 +191,7 @@ export function SearchTracePageImpl(props: SearchTracePageImplProps) {
               skipMessage: isHomepage,
               spanLinks: urlQueryParams && urlQueryParams.spanLinks,
               traces: traceResults,
+              traceErrors,
               rawTraces: traceResultsToDownload,
               sortBy,
               handleSortChange,
@@ -217,11 +220,21 @@ const stateTraceXformer = memoizeOne((stateTrace: ReduxState['trace']) => {
   const { query, results, state, error: traceError } = search;
 
   const loadingTraces = state === fetchedState.LOADING;
-  const traces = results.map(id => traceMap[id].data).filter((t): t is Trace => t !== undefined);
+  const traces: Trace[] = [];
+  const traceErrors: FetchedTrace[] = [];
+  results.forEach(id => {
+    const entry = traceMap[id];
+    if (!entry) return;
+    if (entry.state === fetchedState.ERROR) {
+      traceErrors.push(entry);
+    } else if (entry.data) {
+      traces.push(entry.data);
+    }
+  });
   // rawTraces is populated by the trace reducer when search results are returned
   const rawTraces = (stateTrace as any).rawTraces || [];
   const maxDuration = Math.max(0, ...traces.map(tr => tr.duration || 0));
-  return { traces, rawTraces, maxDuration, traceError, loadingTraces, query };
+  return { traces, traceErrors, rawTraces, maxDuration, traceError, loadingTraces, query };
 });
 
 export const stateTraceDiffXformer = memoizeOne(
@@ -248,6 +261,7 @@ export function mapStateToProps(
   const {
     query: queryOfResults,
     traces,
+    traceErrors,
     rawTraces,
     maxDuration,
     traceError,
@@ -265,6 +279,7 @@ export function mapStateToProps(
     isHomepage,
     loadingTraces,
     traces,
+    traceErrors,
     traceResultsToDownload: rawTraces,
     errors: errors.length ? errors : null,
     maxTraceDuration: maxDuration,

--- a/packages/jaeger-ui/src/reducers/trace.test.js
+++ b/packages/jaeger-ui/src/reducers/trace.test.js
@@ -299,6 +299,42 @@ describe('search traces', () => {
     expect(state.traces[erroredID].error.message).toBe('unknown error');
   });
 
+  it('does not overwrite a DONE entry when an error appears for the same traceID', () => {
+    const state = traceReducer(
+      { search: { query } },
+      {
+        type: `${jaegerApiActions.searchTraces}${ACTION_POSTFIX_FULFILLED}`,
+        payload: { data: [trace], errors: [{ msg: 'should be ignored', traceID: id }] },
+        meta: { query },
+      }
+    );
+
+    expect(state.search.results).toEqual([id]);
+    expect(state.traces[id].state).toBe(fetchedState.DONE);
+    expect(state.traces[id].error).toBeUndefined();
+  });
+
+  it('deduplicates repeated error entries for the same traceID', () => {
+    const erroredID = 'dup-error';
+    const state = traceReducer(
+      { search: { query } },
+      {
+        type: `${jaegerApiActions.searchTraces}${ACTION_POSTFIX_FULFILLED}`,
+        payload: {
+          data: [],
+          errors: [
+            { msg: 'first', traceID: erroredID },
+            { msg: 'second', traceID: erroredID },
+          ],
+        },
+        meta: { query },
+      }
+    );
+
+    expect(state.search.results).toEqual([erroredID]);
+    expect(state.traces[erroredID].error).toEqual({ message: 'first' });
+  });
+
   it('ignores the results with the wrong query', () => {
     const otherQuery = 'some-other-query';
     [ACTION_POSTFIX_FULFILLED, ACTION_POSTFIX_REJECTED].forEach(postfix => {

--- a/packages/jaeger-ui/src/reducers/trace.test.js
+++ b/packages/jaeger-ui/src/reducers/trace.test.js
@@ -251,11 +251,52 @@ describe('search traces', () => {
     expect(state.traces[id].state).toBe(fetchedState.DONE);
     expect(state.traces[erroredID]).toEqual({
       id: erroredID,
-      error: expect.any(Error),
+      error: { message: msg },
       state: fetchedState.ERROR,
     });
-    expect(state.traces[erroredID].error.message).toBe(msg);
     expect(state.rawTraces).toEqual([trace]);
+  });
+
+  it('skips error entries that have no traceID', () => {
+    const validID = 'valid-id';
+    const state = traceReducer(
+      { search: { query } },
+      {
+        type: `${jaegerApiActions.searchTraces}${ACTION_POSTFIX_FULFILLED}`,
+        payload: {
+          data: [],
+          errors: [
+            { msg: 'orphaned error', traceID: '' },
+            { msg: 'no id at all' },
+            null,
+            { msg: 'real failure', traceID: validID },
+          ],
+        },
+        meta: { query },
+      }
+    );
+
+    expect(state.search.results).toEqual([validID]);
+    expect(state.traces[validID]).toEqual({
+      id: validID,
+      error: { message: 'real failure' },
+      state: fetchedState.ERROR,
+    });
+    expect(Object.keys(state.traces)).toEqual([validID]);
+  });
+
+  it('falls back to a default message when the error entry has no msg', () => {
+    const erroredID = 'err-no-msg';
+    const state = traceReducer(
+      { search: { query } },
+      {
+        type: `${jaegerApiActions.searchTraces}${ACTION_POSTFIX_FULFILLED}`,
+        payload: { data: [], errors: [{ traceID: erroredID }] },
+        meta: { query },
+      }
+    );
+
+    expect(state.traces[erroredID].error.message).toBe('unknown error');
   });
 
   it('ignores the results with the wrong query', () => {

--- a/packages/jaeger-ui/src/reducers/trace.test.js
+++ b/packages/jaeger-ui/src/reducers/trace.test.js
@@ -254,8 +254,7 @@ describe('search traces', () => {
       error: expect.any(Error),
       state: fetchedState.ERROR,
     });
-    expect(state.traces[erroredID].error.message).toContain(msg);
-    expect(state.traces[erroredID].error.message).toContain(erroredID);
+    expect(state.traces[erroredID].error.message).toBe(msg);
     expect(state.rawTraces).toEqual([trace]);
   });
 

--- a/packages/jaeger-ui/src/reducers/trace.test.js
+++ b/packages/jaeger-ui/src/reducers/trace.test.js
@@ -235,6 +235,30 @@ describe('search traces', () => {
     expect(state.search).toEqual(outcome);
   });
 
+  it('preserves per-trace errors from the response', () => {
+    const erroredID = 'missing-trace-id';
+    const msg = 'trace not found';
+    const state = traceReducer(
+      { search: { query } },
+      {
+        type: `${jaegerApiActions.searchTraces}${ACTION_POSTFIX_FULFILLED}`,
+        payload: { data: [trace], errors: [{ msg, traceID: erroredID }] },
+        meta: { query },
+      }
+    );
+
+    expect(state.search.results).toEqual([id, erroredID]);
+    expect(state.traces[id].state).toBe(fetchedState.DONE);
+    expect(state.traces[erroredID]).toEqual({
+      id: erroredID,
+      error: expect.any(Error),
+      state: fetchedState.ERROR,
+    });
+    expect(state.traces[erroredID].error.message).toContain(msg);
+    expect(state.traces[erroredID].error.message).toContain(erroredID);
+    expect(state.rawTraces).toEqual([trace]);
+  });
+
   it('ignores the results with the wrong query', () => {
     const otherQuery = 'some-other-query';
     [ACTION_POSTFIX_FULFILLED, ACTION_POSTFIX_REJECTED].forEach(postfix => {

--- a/packages/jaeger-ui/src/reducers/trace.ts
+++ b/packages/jaeger-ui/src/reducers/trace.ts
@@ -106,10 +106,13 @@ function searchDone(state: TraceState, { meta, payload }: any): TraceState {
   const payloadData = payload.data;
   const processed = payloadData.map(transformTraceData);
   const resultTraces: Record<string, any> = {};
+  const seen = new Set<string>();
   const results: string[] = [];
   for (let i = 0; i < processed.length; i++) {
     const data = processed[i];
     const id = data.traceID;
+    if (seen.has(id)) continue;
+    seen.add(id);
     resultTraces[id] = { data, id, state: fetchedState.DONE };
     results.push(id);
   }
@@ -117,6 +120,11 @@ function searchDone(state: TraceState, { meta, payload }: any): TraceState {
     payload.errors.forEach((err: any) => {
       const { msg, traceID } = err || {};
       if (typeof traceID !== 'string' || !traceID) return;
+      // Don't overwrite a successfully transformed entry if the backend
+      // returns the same traceID in both data and errors.
+      if (resultTraces[traceID]?.state === fetchedState.DONE) return;
+      if (seen.has(traceID)) return;
+      seen.add(traceID);
       const error = { message: typeof msg === 'string' && msg ? msg : 'unknown error' };
       resultTraces[traceID] = { error, id: traceID, state: fetchedState.ERROR };
       results.push(traceID);

--- a/packages/jaeger-ui/src/reducers/trace.ts
+++ b/packages/jaeger-ui/src/reducers/trace.ts
@@ -113,6 +113,14 @@ function searchDone(state: TraceState, { meta, payload }: any): TraceState {
     resultTraces[id] = { data, id, state: fetchedState.DONE };
     results.push(id);
   }
+  if (payload.errors) {
+    payload.errors.forEach((err: any) => {
+      const { msg, traceID } = err;
+      const error = new Error(`Error: ${msg} - ${traceID}`);
+      resultTraces[traceID] = { error, id: traceID, state: fetchedState.ERROR };
+      results.push(traceID);
+    });
+  }
   const traces = { ...state.traces, ...resultTraces };
   const search = { ...state.search, results, state: fetchedState.DONE };
   return { ...state, search, traces, rawTraces: payloadData };

--- a/packages/jaeger-ui/src/reducers/trace.ts
+++ b/packages/jaeger-ui/src/reducers/trace.ts
@@ -106,13 +106,11 @@ function searchDone(state: TraceState, { meta, payload }: any): TraceState {
   const payloadData = payload.data;
   const processed = payloadData.map(transformTraceData);
   const resultTraces: Record<string, any> = {};
-  const seen = new Set<string>();
   const results: string[] = [];
   for (let i = 0; i < processed.length; i++) {
     const data = processed[i];
     const id = data.traceID;
-    if (seen.has(id)) continue;
-    seen.add(id);
+    if (resultTraces[id]) continue;
     resultTraces[id] = { data, id, state: fetchedState.DONE };
     results.push(id);
   }
@@ -120,11 +118,9 @@ function searchDone(state: TraceState, { meta, payload }: any): TraceState {
     payload.errors.forEach((err: any) => {
       const { msg, traceID } = err || {};
       if (typeof traceID !== 'string' || !traceID) return;
-      // Don't overwrite a successfully transformed entry if the backend
-      // returns the same traceID in both data and errors.
-      if (resultTraces[traceID]?.state === fetchedState.DONE) return;
-      if (seen.has(traceID)) return;
-      seen.add(traceID);
+      // Skip if this traceID already has an entry from `data` or an earlier
+      // error, so we never overwrite a DONE entry or push a duplicate ID.
+      if (resultTraces[traceID]) return;
       const error = { message: typeof msg === 'string' && msg ? msg : 'unknown error' };
       resultTraces[traceID] = { error, id: traceID, state: fetchedState.ERROR };
       results.push(traceID);

--- a/packages/jaeger-ui/src/reducers/trace.ts
+++ b/packages/jaeger-ui/src/reducers/trace.ts
@@ -116,7 +116,7 @@ function searchDone(state: TraceState, { meta, payload }: any): TraceState {
   if (payload.errors) {
     payload.errors.forEach((err: any) => {
       const { msg, traceID } = err;
-      const error = new Error(`Error: ${msg} - ${traceID}`);
+      const error = new Error(msg);
       resultTraces[traceID] = { error, id: traceID, state: fetchedState.ERROR };
       results.push(traceID);
     });

--- a/packages/jaeger-ui/src/reducers/trace.ts
+++ b/packages/jaeger-ui/src/reducers/trace.ts
@@ -115,8 +115,9 @@ function searchDone(state: TraceState, { meta, payload }: any): TraceState {
   }
   if (payload.errors) {
     payload.errors.forEach((err: any) => {
-      const { msg, traceID } = err;
-      const error = new Error(msg);
+      const { msg, traceID } = err || {};
+      if (typeof traceID !== 'string' || !traceID) return;
+      const error = { message: typeof msg === 'string' && msg ? msg : 'unknown error' };
       resultTraces[traceID] = { error, id: traceID, state: fetchedState.ERROR };
       results.push(traceID);
     });


### PR DESCRIPTION
## Problem

Multi-trace search (`?traceID=a,b,c`) silently drops any traceID the backend can't return. The query API answers with `{ data, errors: [{msg, traceID}] }` so the per-trace failure is on the wire, but `searchDone` in `reducers/trace.ts` only iterates `payload.data`, so failed IDs never make it into `state.traces` or `state.search.results` and the UI shows no indication. `fetchMultipleTracesDone` in the same file already ingests `payload.errors`, so this is essentially a parity gap.

## Fix

Extend `searchDone` to walk `payload.errors`, store each entry as `{id, error, state: ERROR}` in the trace map, and push the failed IDs into `search.results` so downstream selectors see them. `stateTraceXformer` in `SearchTracePage/index.tsx` now splits the IDs into successful traces and errored ones, exposing a new `traceErrors` prop that flows into `SearchResults`. The list view renders an error row per failed ID alongside the successful results, using a small new `ResultItemError` component rather than overloading `ResultItem`. Empty-state handling is updated so a search that returns only errors shows the error rows instead of "No trace results."

The trace-diff cohort path (`fetchMultipleTraces`) already handled errors and is left alone. `rawTraces` (used for the JSON download) continues to contain only successful results.

## Testing

- Reducer test in `trace.test.js` for a `searchDone` payload that mixes `data` and `errors`.
- `mapStateToProps` test in `SearchTracePage/index.test.jsx` asserting the selector returns errored IDs in `traceErrors` and excludes them from `traces`.
- `SearchResults/index.test.jsx` renders error rows for each `traceErrors` entry, including the case where no successful traces are present.
- Unit test for `ResultItemError` covering the label, trace ID, and optional message.

`npm run lint`, `npm run tsc-lint`, `npm test`, `npm run build` green locally on Node 24.

Fixes #51

## AI Usage in this PR

- [x] **Specific parts**: AI assisted with code generation on parts of the change, reviewed and verified before submission.