### PR TITLE
refactor(stats): Migrate TraceStatisticsHeader to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
@@ -23,6 +23,7 @@ vi.mock('./generateDropdownValue', () => ({
 
 import TraceStatisticsHeader from './TraceStatisticsHeader';
 import { getColumnValues, getColumnValuesSecondDropdown } from './tableValues';
+import generateColor from './generateColor';
 
 const baseProps = () => ({
   trace: { traceID: 't', spans: [] },
@@ -111,11 +112,14 @@ describe('<TraceStatisticsHeader>', () => {
     const props = baseProps();
     render(<TraceStatisticsHeader {...props} />);
     props.handler.mockClear();
+    generateColor.mockClear();
 
     const colorBy = screen.getAllByRole('combobox')[2];
     await userEvent.click(colorBy);
-    fireEvent.click(await screen.findByText('Total'));
+    fireEvent.click(await screen.findByText('ST in Duration'));
 
+    expect(generateColor).toHaveBeenCalledWith(props.tableValue, 'percent', false);
+    expect(generateColor).toHaveBeenCalledWith(props.wholeTable, 'percent', false);
     expect(props.handler).toHaveBeenLastCalledWith(
       expect.any(Array),
       expect.any(Array),
@@ -152,21 +156,13 @@ describe('<TraceStatisticsHeader>', () => {
 
     props.handler.mockClear();
 
-    // antd renders the clear icon as .ant-select-clear next to the populated select
     const clearIcons = container.querySelectorAll('.ant-select-clear');
     expect(clearIcons.length).toBeGreaterThan(0);
     fireEvent.mouseDown(clearIcons[0]);
     fireEvent.click(clearIcons[0]);
 
-    // antd's allowClear fires onChange(undefined) and onClear back-to-back.
-    // setValueNameSelector2 ignores the undefined and clearValue handles the
-    // reset, so handler must only see null (never undefined) for the sub-group.
-    expect(props.handler).toHaveBeenLastCalledWith(
-      expect.any(Array),
-      expect.any(Array),
-      'service.name',
-      null
-    );
+    expect(props.handler).toHaveBeenCalledTimes(1);
+    expect(props.handler).toHaveBeenCalledWith(expect.any(Array), expect.any(Array), 'service.name', null);
     const subGroupArgs = props.handler.mock.calls.map(call => call[3]);
     expect(subGroupArgs).not.toContain(undefined);
     expect(getColumnValues).toHaveBeenCalledWith('service.name', props.trace, props.useOtelTerms);

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
@@ -158,10 +158,17 @@ describe('<TraceStatisticsHeader>', () => {
     fireEvent.mouseDown(clearIcons[0]);
     fireEvent.click(clearIcons[0]);
 
-    // antd's allowClear fires both onChange(undefined) and onClear; clearValue
-    // is the onClear branch and is the only path that re-fetches getColumnValues
-    // for the first selector and passes null for the sub-group.
-    expect(props.handler).toHaveBeenCalledWith(expect.any(Array), expect.any(Array), 'service.name', null);
+    // antd's allowClear fires onChange(undefined) and onClear back-to-back.
+    // setValueNameSelector2 ignores the undefined and clearValue handles the
+    // reset, so handler must only see null (never undefined) for the sub-group.
+    expect(props.handler).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      'service.name',
+      null
+    );
+    const subGroupArgs = props.handler.mock.calls.map(call => call[3]);
+    expect(subGroupArgs).not.toContain(undefined);
     expect(getColumnValues).toHaveBeenCalledWith('service.name', props.trace, props.useOtelTerms);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+vi.mock('./tableValues', () => ({
+  getServiceName: vi.fn(() => 'service.name'),
+  getColumnValues: vi.fn((name, _trace, _useOtel) => [{ name: `cols-for-${name}` }]),
+  getColumnValuesSecondDropdown: vi.fn((rows, n1, n2) => [{ name: `sub-${n1}-${n2}-from-${rows.length}` }]),
+}));
+
+vi.mock('./generateColor', () => ({
+  default: vi.fn(rows => rows),
+}));
+
+vi.mock('./generateDropdownValue', () => ({
+  generateDropdownValue: vi.fn(() => ['service.name', 'operation', 'kind']),
+  generateSecondDropdownValue: vi.fn(() => ['operation', 'kind']),
+}));
+
+import TraceStatisticsHeader from './TraceStatisticsHeader';
+import { getColumnValues, getColumnValuesSecondDropdown } from './tableValues';
+
+const baseProps = () => ({
+  trace: { traceID: 't', spans: [] },
+  tableValue: [{ name: 'a' }, { name: 'b' }],
+  wholeTable: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+  handler: vi.fn(),
+  useOtelTerms: false,
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('<TraceStatisticsHeader>', () => {
+  it('renders the three select boxes and the checkbox', () => {
+    const props = baseProps();
+    render(<TraceStatisticsHeader {...props} />);
+    expect(screen.getByText('Group By:')).toBeInTheDocument();
+    expect(screen.getByText('Sub-Group:')).toBeInTheDocument();
+    expect(screen.getByText('Color by:')).toBeInTheDocument();
+  });
+
+  it('calls handler once on mount with the initial service name', () => {
+    const props = baseProps();
+    render(<TraceStatisticsHeader {...props} />);
+    expect(props.handler).toHaveBeenCalledTimes(1);
+    const [tableArg, wholeArg, name1, name2] = props.handler.mock.calls[0];
+    expect(name1).toBe('service.name');
+    expect(name2).toBeNull();
+    expect(tableArg).toEqual([{ name: 'cols-for-service.name' }]);
+    expect(wholeArg).toEqual([{ name: 'cols-for-service.name' }]);
+  });
+
+  it('does not re-invoke the on-mount handler when props change', () => {
+    const props = baseProps();
+    const { rerender } = render(<TraceStatisticsHeader {...props} />);
+    expect(props.handler).toHaveBeenCalledTimes(1);
+    rerender(<TraceStatisticsHeader {...props} useOtelTerms />);
+    expect(props.handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handler with the new value when the first dropdown changes, resetting the second', async () => {
+    const props = baseProps();
+    render(<TraceStatisticsHeader {...props} />);
+    props.handler.mockClear();
+
+    const groupBy = screen.getAllByRole('combobox')[0];
+    await userEvent.click(groupBy);
+    fireEvent.click(await screen.findByText('operation'));
+
+    expect(props.handler).toHaveBeenCalledWith(
+      [{ name: 'cols-for-operation' }],
+      [{ name: 'cols-for-operation' }],
+      'operation',
+      null
+    );
+    expect(getColumnValues).toHaveBeenCalledWith('operation', props.trace, props.useOtelTerms);
+  });
+
+  it('calls handler with both names when the second dropdown changes', async () => {
+    const props = baseProps();
+    render(<TraceStatisticsHeader {...props} />);
+    props.handler.mockClear();
+
+    const subGroup = screen.getAllByRole('combobox')[1];
+    await userEvent.click(subGroup);
+    fireEvent.click(await screen.findByText('kind'));
+
+    expect(props.handler).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      'service.name',
+      'kind'
+    );
+    expect(getColumnValuesSecondDropdown).toHaveBeenCalledWith(
+      props.tableValue,
+      'service.name',
+      'kind',
+      props.trace,
+      props.useOtelTerms
+    );
+  });
+
+  it('calls handler when the third dropdown changes the color metric', async () => {
+    const props = baseProps();
+    render(<TraceStatisticsHeader {...props} />);
+    props.handler.mockClear();
+
+    const colorBy = screen.getAllByRole('combobox')[2];
+    await userEvent.click(colorBy);
+    fireEvent.click(await screen.findByText('Total'));
+
+    expect(props.handler).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      'service.name',
+      null
+    );
+  });
+
+  it('calls handler when the checkbox toggles', () => {
+    const props = baseProps();
+    const { container } = render(<TraceStatisticsHeader {...props} />);
+    props.handler.mockClear();
+
+    const checkbox = container.querySelector('.TraceStatisticsHeader--checkbox input');
+    fireEvent.click(checkbox);
+
+    expect(props.handler).toHaveBeenCalledTimes(1);
+    expect(props.handler).toHaveBeenLastCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      'service.name',
+      null
+    );
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.test.jsx
@@ -140,4 +140,28 @@ describe('<TraceStatisticsHeader>', () => {
       null
     );
   });
+
+  it('calls handler with a null sub-group when the second dropdown is cleared', async () => {
+    const props = baseProps();
+    const { container } = render(<TraceStatisticsHeader {...props} />);
+
+    // populate the second dropdown so the clear icon appears
+    const subGroup = screen.getAllByRole('combobox')[1];
+    await userEvent.click(subGroup);
+    fireEvent.click(await screen.findByText('kind'));
+
+    props.handler.mockClear();
+
+    // antd renders the clear icon as .ant-select-clear next to the populated select
+    const clearIcons = container.querySelectorAll('.ant-select-clear');
+    expect(clearIcons.length).toBeGreaterThan(0);
+    fireEvent.mouseDown(clearIcons[0]);
+    fireEvent.click(clearIcons[0]);
+
+    // antd's allowClear fires both onChange(undefined) and onClear; clearValue
+    // is the onClear branch and is the only path that re-fetches getColumnValues
+    // for the first selector and passes null for the sub-group.
+    expect(props.handler).toHaveBeenCalledWith(expect.any(Array), expect.any(Array), 'service.name', null);
+    expect(getColumnValues).toHaveBeenCalledWith('service.name', props.trace, props.useOtelTerms);
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -3,7 +3,7 @@
 
 import { Checkbox, Select } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { IOtelTrace } from '../../../types/otel';
 import { ITableSpan } from './types';
 import { generateDropdownValue, generateSecondDropdownValue } from './generateDropdownValue';
@@ -45,7 +45,7 @@ export default function TraceStatisticsHeader(props: Props) {
   const [valueNameSelector3, setValueNameSelector3State] = useState<string>('Count');
   const [checkboxStatus, setCheckboxStatus] = useState<boolean>(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     handler(
       getColumnValues(valueNameSelector1, trace, useOtelTerms),
       getColumnValues(valueNameSelector1, trace, useOtelTerms),

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -3,7 +3,7 @@
 
 import { Checkbox, Select } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IOtelTrace } from '../../../types/otel';
 import { ITableSpan } from './types';
 import { generateDropdownValue, generateSecondDropdownValue } from './generateDropdownValue';
@@ -40,21 +40,16 @@ const optionsNameSelector3 = new Map([
 
 export default function TraceStatisticsHeader(props: Props) {
   const { trace, tableValue, wholeTable, handler, useOtelTerms } = props;
-  const [initialServiceName] = useState(() => getServiceName());
-  const [valueNameSelector1, setValueNameSelector1State] = useState<string>(initialServiceName);
+  const [valueNameSelector1, setValueNameSelector1State] = useState<string>(getServiceName);
   const [valueNameSelector2, setValueNameSelector2State] = useState<string | null>(null);
   const [valueNameSelector3, setValueNameSelector3State] = useState<string>('Count');
   const [checkboxStatus, setCheckboxStatus] = useState<boolean>(false);
 
-  // Mirrors the constructor's one-shot handler call. useLayoutEffect (rather
-  // than useEffect) preserves the original timing: the class constructor ran
-  // before first paint, so the parent could populate the table state before
-  // the user saw an empty view. Mount-only on purpose, matching the class.
-  useLayoutEffect(() => {
+  useEffect(() => {
     handler(
-      getColumnValues(initialServiceName, trace, useOtelTerms),
-      getColumnValues(initialServiceName, trace, useOtelTerms),
-      initialServiceName,
+      getColumnValues(valueNameSelector1, trace, useOtelTerms),
+      getColumnValues(valueNameSelector1, trace, useOtelTerms),
+      valueNameSelector1,
       null
     );
     // eslint-disable-next-line react-x/exhaustive-deps
@@ -82,25 +77,20 @@ export default function TraceStatisticsHeader(props: Props) {
       getValue(),
       checkboxStatus
     );
-    const newWohleTable = generateColor(
+    const newWholeTable = generateColor(
       getColumnValues(value, trace, useOtelTerms),
       getValue(),
       checkboxStatus
     );
-    handler(newTableValue, newWohleTable, value, null);
+    handler(newTableValue, newWholeTable, value, null);
   };
 
   /**
    * Is called after a value from the second dropdown is selected.
-   *
-   * antd's `allowClear` fires `onChange(undefined)` when the clear icon is
-   * clicked, just before `onClear`. Forwarding that undefined into
-   * `getColumnValuesSecondDropdown(...)` would corrupt the row keys and
-   * leave `handler(...)` called with an undefined sub-group, violating its
-   * `string | null` contract. Let `onClear`/`clearValue` own the reset path
-   * and ignore the undefined onChange.
    */
   const setValueNameSelector2 = (value: string | null | undefined) => {
+    // antd's allowClear fires onChange(undefined) before onClear; ignore it
+    // and let clearValue own the reset path.
     if (value == null) return;
     setValueNameSelector2State(value);
     const newTableValue = generateColor(
@@ -108,12 +98,12 @@ export default function TraceStatisticsHeader(props: Props) {
       getValue(),
       checkboxStatus
     );
-    const newWohleTable = generateColor(
+    const newWholeTable = generateColor(
       getColumnValuesSecondDropdown(wholeTable, valueNameSelector1, value, trace, useOtelTerms),
       getValue(),
       checkboxStatus
     );
-    handler(newTableValue, newWohleTable, valueNameSelector1, value);
+    handler(newTableValue, newWholeTable, valueNameSelector1, value);
   };
 
   /**
@@ -127,8 +117,8 @@ export default function TraceStatisticsHeader(props: Props) {
       toColor = '';
     }
     const newTableValue = generateColor(tableValue, toColor, checkboxStatus);
-    const newWohleTable = generateColor(wholeTable, toColor, checkboxStatus);
-    handler(newTableValue, newWohleTable, valueNameSelector1, valueNameSelector2);
+    const newWholeTable = generateColor(wholeTable, toColor, checkboxStatus);
+    handler(newTableValue, newWholeTable, valueNameSelector1, valueNameSelector2);
   };
 
   /**

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2020 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Checkbox, CheckboxChangeEvent, Select } from 'antd';
+import { Checkbox, Select } from 'antd';
+import type { CheckboxChangeEvent } from 'antd/es/checkbox';
 import { useLayoutEffect, useState } from 'react';
 import { IOtelTrace } from '../../../types/otel';
 import { ITableSpan } from './types';

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Checkbox, Select } from 'antd';
-import React, { Component } from 'react';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { IOtelTrace } from '../../../types/otel';
 import { ITableSpan } from './types';
 import { generateDropdownValue, generateSecondDropdownValue } from './generateDropdownValue';
@@ -24,14 +25,6 @@ type Props = {
   useOtelTerms: boolean;
 };
 
-type State = {
-  valueNameSelector1: string;
-  valueNameSelector2: string | null;
-  valueNameSelector3: string;
-
-  checkboxStatus: boolean;
-};
-
 const optionsNameSelector3 = new Map([
   ['Count', 'count'],
   ['Total', 'total'],
@@ -45,220 +38,178 @@ const optionsNameSelector3 = new Map([
   ['ST in Duration', 'percent'],
 ]);
 
-export default class TraceStatisticsHeader extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    const serviceName = getServiceName();
-    this.props.handler(
-      getColumnValues(serviceName, this.props.trace, this.props.useOtelTerms),
-      getColumnValues(serviceName, this.props.trace, this.props.useOtelTerms),
-      serviceName,
+export default function TraceStatisticsHeader(props: Props) {
+  const { trace, tableValue, wholeTable, handler, useOtelTerms } = props;
+  const initialServiceName = React.useMemo(() => getServiceName(), []);
+  const [valueNameSelector1, setValueNameSelector1State] = useState<string>(initialServiceName);
+  const [valueNameSelector2, setValueNameSelector2State] = useState<string | null>(null);
+  const [valueNameSelector3, setValueNameSelector3State] = useState<string>('Count');
+  const [checkboxStatus, setCheckboxStatus] = useState<boolean>(false);
+
+  // Mirrors the constructor's one-shot handler call. Mount-only on purpose:
+  // the class component only invoked this in its constructor and never again.
+  useEffect(() => {
+    handler(
+      getColumnValues(initialServiceName, trace, useOtelTerms),
+      getColumnValues(initialServiceName, trace, useOtelTerms),
+      initialServiceName,
       null
     );
-
-    this.state = {
-      valueNameSelector1: serviceName,
-      valueNameSelector2: null,
-      valueNameSelector3: 'Count',
-      checkboxStatus: false,
-    };
-    this.setValueNameSelector1 = this.setValueNameSelector1.bind(this);
-    this.setValueNameSelector2 = this.setValueNameSelector2.bind(this);
-    this.setValueNameSelector3 = this.setValueNameSelector3.bind(this);
-    this.checkboxButton = this.checkboxButton.bind(this);
-    this.clearValue = this.clearValue.bind(this);
-  }
+    // eslint-disable-next-line react-x/exhaustive-deps
+  }, []);
 
   /**
    * Returns the value of optionsNameSelector3.
    */
-  getValue() {
-    let toColor = optionsNameSelector3.get(this.state.valueNameSelector3);
+  const getValue = () => {
+    let toColor = optionsNameSelector3.get(valueNameSelector3);
     if (toColor === undefined) {
       toColor = '';
     }
     return toColor;
-  }
+  };
 
   /**
    * Is called after a value from the first dropdown is selected.
    */
-  setValueNameSelector1(value: string) {
-    this.setState({
-      valueNameSelector1: value,
-      valueNameSelector2: null,
-    });
+  const setValueNameSelector1 = (value: string) => {
+    setValueNameSelector1State(value);
+    setValueNameSelector2State(null);
     const newTableValue = generateColor(
-      getColumnValues(value, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValues(value, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
     const newWohleTable = generateColor(
-      getColumnValues(value, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValues(value, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
-    this.props.handler(newTableValue, newWohleTable, value, null);
-  }
+    handler(newTableValue, newWohleTable, value, null);
+  };
 
   /**
    * Is called after a value from the second dropdown is selected.
    */
-  setValueNameSelector2(value: string) {
-    this.setState({
-      valueNameSelector2: value,
-    });
+  const setValueNameSelector2 = (value: string) => {
+    setValueNameSelector2State(value);
     const newTableValue = generateColor(
-      getColumnValuesSecondDropdown(
-        this.props.tableValue,
-        this.state.valueNameSelector1,
-        value,
-        this.props.trace,
-        this.props.useOtelTerms
-      ),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValuesSecondDropdown(tableValue, valueNameSelector1, value, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
     const newWohleTable = generateColor(
-      getColumnValuesSecondDropdown(
-        this.props.wholeTable,
-        this.state.valueNameSelector1,
-        value,
-        this.props.trace,
-        this.props.useOtelTerms
-      ),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValuesSecondDropdown(wholeTable, valueNameSelector1, value, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
-    this.props.handler(newTableValue, newWohleTable, this.state.valueNameSelector1, value);
-  }
+    handler(newTableValue, newWohleTable, valueNameSelector1, value);
+  };
 
   /**
    * Is called after a value from the third dropdown is selected.
    */
-  setValueNameSelector3(value: string) {
-    this.setState({
-      valueNameSelector3: value,
-    });
+  const setValueNameSelector3 = (value: string) => {
+    setValueNameSelector3State(value);
 
     let toColor = optionsNameSelector3.get(value);
     if (toColor === undefined) {
       toColor = '';
     }
-    const newTableValue = generateColor(this.props.tableValue, toColor, this.state.checkboxStatus);
-    const newWohleTable = generateColor(this.props.wholeTable, toColor, this.state.checkboxStatus);
-    this.props.handler(
-      newTableValue,
-      newWohleTable,
-      this.state.valueNameSelector1,
-      this.state.valueNameSelector2
-    );
-  }
+    const newTableValue = generateColor(tableValue, toColor, checkboxStatus);
+    const newWohleTable = generateColor(wholeTable, toColor, checkboxStatus);
+    handler(newTableValue, newWohleTable, valueNameSelector1, valueNameSelector2);
+  };
 
   /**
    * Is called after the checkbox changes its status.
    */
-  checkboxButton(e: any) {
-    this.setState({
-      checkboxStatus: e.target.checked,
-    });
+  const checkboxButton = (e: any) => {
+    setCheckboxStatus(e.target.checked);
 
-    const newTableValue = generateColor(this.props.tableValue, this.getValue(), e.target.checked);
-    const newWholeTable = generateColor(this.props.wholeTable, this.getValue(), e.target.checked);
-    this.props.handler(
-      newTableValue,
-      newWholeTable,
-      this.state.valueNameSelector1,
-      this.state.valueNameSelector2
-    );
-  }
+    const newTableValue = generateColor(tableValue, getValue(), e.target.checked);
+    const newWholeTable = generateColor(wholeTable, getValue(), e.target.checked);
+    handler(newTableValue, newWholeTable, valueNameSelector1, valueNameSelector2);
+  };
 
   /**
    * Sets the second dropdown to "No Item selected" and sets the table to the values after the first dropdown.
    */
-  clearValue() {
-    this.setState({
-      valueNameSelector2: null,
-    });
+  const clearValue = () => {
+    setValueNameSelector2State(null);
 
     const newTableValue = generateColor(
-      getColumnValues(this.state.valueNameSelector1, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValues(valueNameSelector1, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
     const newWholeTable = generateColor(
-      getColumnValues(this.state.valueNameSelector1, this.props.trace, this.props.useOtelTerms),
-      this.getValue(),
-      this.state.checkboxStatus
+      getColumnValues(valueNameSelector1, trace, useOtelTerms),
+      getValue(),
+      checkboxStatus
     );
-    this.props.handler(newTableValue, newWholeTable, this.state.valueNameSelector1, null);
-  }
+    handler(newTableValue, newWholeTable, valueNameSelector1, null);
+  };
 
-  render() {
-    const optionsNameSelector1 = generateDropdownValue(this.props.trace, this.props.useOtelTerms);
-    const optionsNameSelector2 = generateSecondDropdownValue(
-      this.props.trace,
-      this.state.valueNameSelector1,
-      this.props.useOtelTerms
-    );
+  const optionsNameSelector1 = generateDropdownValue(trace, useOtelTerms);
+  const optionsNameSelector2 = generateSecondDropdownValue(trace, valueNameSelector1, useOtelTerms);
 
-    return (
-      <div className="TraceStatisticsHeader">
+  return (
+    <div className="TraceStatisticsHeader">
+      <label className="TraceStatisticsHeader--label">
+        <span className="TraceStatisticsHeader--labelText">Group By:</span>
+        <SearchableSelect
+          className="TraceStatisticsHeader--select"
+          value={valueNameSelector1}
+          onChange={setValueNameSelector1}
+          popupMatchSelectWidth={false}
+          fuzzy
+        >
+          {optionsNameSelector1.map(opt => (
+            <Select.Option key={opt} value={opt}>
+              {opt}
+            </Select.Option>
+          ))}
+        </SearchableSelect>
+      </label>
+      <label className="TraceStatisticsHeader--label">
+        <span className="TraceStatisticsHeader--labelText">Sub-Group:</span>
+        <SearchableSelect
+          className="TraceStatisticsHeader--select"
+          value={valueNameSelector2}
+          onChange={setValueNameSelector2}
+          allowClear
+          onClear={clearValue}
+          placeholder="No item selected"
+          popupMatchSelectWidth={false}
+          fuzzy
+        >
+          {optionsNameSelector2.map(opt => (
+            <Select.Option key={opt} value={opt}>
+              {opt}
+            </Select.Option>
+          ))}
+        </SearchableSelect>
+      </label>
+      <div className="TraceStatisticsHeader--colorByWrapper">
+        <Checkbox className="TraceStatisticsHeader--checkbox" onChange={checkboxButton} />
         <label className="TraceStatisticsHeader--label">
-          <span className="TraceStatisticsHeader--labelText">Group By:</span>
+          <span className="TraceStatisticsHeader--labelText">Color by:</span>
           <SearchableSelect
             className="TraceStatisticsHeader--select"
-            value={this.state.valueNameSelector1}
-            onChange={this.setValueNameSelector1}
+            value={valueNameSelector3}
+            onChange={setValueNameSelector3}
             popupMatchSelectWidth={false}
             fuzzy
           >
-            {optionsNameSelector1.map(opt => (
+            {Array.from(optionsNameSelector3.keys()).map(opt => (
               <Select.Option key={opt} value={opt}>
                 {opt}
               </Select.Option>
             ))}
           </SearchableSelect>
         </label>
-        <label className="TraceStatisticsHeader--label">
-          <span className="TraceStatisticsHeader--labelText">Sub-Group:</span>
-          <SearchableSelect
-            className="TraceStatisticsHeader--select"
-            value={this.state.valueNameSelector2}
-            onChange={this.setValueNameSelector2}
-            allowClear
-            onClear={this.clearValue}
-            placeholder="No item selected"
-            popupMatchSelectWidth={false}
-            fuzzy
-          >
-            {optionsNameSelector2.map(opt => (
-              <Select.Option key={opt} value={opt}>
-                {opt}
-              </Select.Option>
-            ))}
-          </SearchableSelect>
-        </label>
-        <div className="TraceStatisticsHeader--colorByWrapper">
-          <Checkbox className="TraceStatisticsHeader--checkbox" onChange={this.checkboxButton} />
-          <label className="TraceStatisticsHeader--label">
-            <span className="TraceStatisticsHeader--labelText">Color by:</span>
-            <SearchableSelect
-              className="TraceStatisticsHeader--select"
-              value={this.state.valueNameSelector3}
-              onChange={this.setValueNameSelector3}
-              popupMatchSelectWidth={false}
-              fuzzy
-            >
-              {Array.from(optionsNameSelector3.keys()).map(opt => (
-                <Select.Option key={opt} value={opt}>
-                  {opt}
-                </Select.Option>
-              ))}
-            </SearchableSelect>
-          </label>
-        </div>
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) 2020 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Checkbox, Select } from 'antd';
-import * as React from 'react';
+import { Checkbox, CheckboxChangeEvent, Select } from 'antd';
 import { useLayoutEffect, useState } from 'react';
 import { IOtelTrace } from '../../../types/otel';
 import { ITableSpan } from './types';
@@ -40,7 +39,7 @@ const optionsNameSelector3 = new Map([
 
 export default function TraceStatisticsHeader(props: Props) {
   const { trace, tableValue, wholeTable, handler, useOtelTerms } = props;
-  const initialServiceName = React.useMemo(() => getServiceName(), []);
+  const [initialServiceName] = useState(() => getServiceName());
   const [valueNameSelector1, setValueNameSelector1State] = useState<string>(initialServiceName);
   const [valueNameSelector2, setValueNameSelector2State] = useState<string | null>(null);
   const [valueNameSelector3, setValueNameSelector3State] = useState<string>('Count');
@@ -134,7 +133,7 @@ export default function TraceStatisticsHeader(props: Props) {
   /**
    * Is called after the checkbox changes its status.
    */
-  const checkboxButton = (e: any) => {
+  const checkboxButton = (e: CheckboxChangeEvent) => {
     setCheckboxStatus(e.target.checked);
 
     const newTableValue = generateColor(tableValue, getValue(), e.target.checked);

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -92,8 +92,16 @@ export default function TraceStatisticsHeader(props: Props) {
 
   /**
    * Is called after a value from the second dropdown is selected.
+   *
+   * antd's `allowClear` fires `onChange(undefined)` when the clear icon is
+   * clicked, just before `onClear`. Forwarding that undefined into
+   * `getColumnValuesSecondDropdown(...)` would corrupt the row keys and
+   * leave `handler(...)` called with an undefined sub-group, violating its
+   * `string | null` contract. Let `onClear`/`clearValue` own the reset path
+   * and ignore the undefined onChange.
    */
-  const setValueNameSelector2 = (value: string) => {
+  const setValueNameSelector2 = (value: string | null | undefined) => {
+    if (value == null) return;
     setValueNameSelector2State(value);
     const newTableValue = generateColor(
       getColumnValuesSecondDropdown(tableValue, valueNameSelector1, value, trace, useOtelTerms),

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/TraceStatisticsHeader.tsx
@@ -3,7 +3,7 @@
 
 import { Checkbox, Select } from 'antd';
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { IOtelTrace } from '../../../types/otel';
 import { ITableSpan } from './types';
 import { generateDropdownValue, generateSecondDropdownValue } from './generateDropdownValue';
@@ -46,9 +46,11 @@ export default function TraceStatisticsHeader(props: Props) {
   const [valueNameSelector3, setValueNameSelector3State] = useState<string>('Count');
   const [checkboxStatus, setCheckboxStatus] = useState<boolean>(false);
 
-  // Mirrors the constructor's one-shot handler call. Mount-only on purpose:
-  // the class component only invoked this in its constructor and never again.
-  useEffect(() => {
+  // Mirrors the constructor's one-shot handler call. useLayoutEffect (rather
+  // than useEffect) preserves the original timing: the class constructor ran
+  // before first paint, so the parent could populate the table state before
+  // the user saw an empty view. Mount-only on purpose, matching the class.
+  useLayoutEffect(() => {
     handler(
       getColumnValues(initialServiceName, trace, useOtelTerms),
       getColumnValues(initialServiceName, trace, useOtelTerms),


### PR DESCRIPTION
## Problem

`TraceStatisticsHeader` is one of the remaining class components tracked by #2610 / #3370. The previous attempt (#3479) was auto-closed by the stale bot.

## Fix

Straight migration to a functional component using hooks:

- `useState` for the four state fields (`valueNameSelector1/2/3`, `checkboxStatus`).
- Mount-only `useEffect` for the constructor's one-shot `props.handler(...)` call.
- The five bound instance methods become plain functions inside the component, reading state via closure so the class's batched-setState semantics in event handlers are preserved.
- Original is plain `Component` not `PureComponent`, so no `React.memo` wrap.

## Testing

No tests existed for this file. Added a small React Testing Library suite covering:

- on-mount `handler` invocation with the initial service name
- the no-re-invoke-on-prop-change guard
- each of the three dropdown change paths
- the checkbox toggle

`npm run lint`, `npm run tsc-lint`, `npm test`, `npm run build` green locally on Node 24.

## Screenshots

### Before
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 54 04 PM" src="https://github.com/user-attachments/assets/bb8064ab-9e3f-4d93-9750-59de2527f837" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 53 40 PM" src="https://github.com/user-attachments/assets/8fa7594c-80f3-41ca-9519-50742a133ee8" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 52 09 PM" src="https://github.com/user-attachments/assets/5ff969b3-1c25-4dee-9113-40c56cc8a4df" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 51 46 PM" src="https://github.com/user-attachments/assets/cbaf45e5-6ef0-46df-886c-1b79cbf8ed3d" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 50 48 PM" src="https://github.com/user-attachments/assets/f085f5b3-621d-4c70-8ed1-730884f0b349" />

###After
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 55 52 PM" src="https://github.com/user-attachments/assets/f074ea71-7995-42d1-a826-7713fe89e451" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 55 50 PM" src="https://github.com/user-attachments/assets/a934441b-962c-4129-87cc-f6fb49340ed2" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 55 45 PM" src="https://github.com/user-attachments/assets/ef5e2ffb-c58e-4602-8694-2306d9f9c046" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 55 36 PM" src="https://github.com/user-attachments/assets/9db28ab0-569d-4f7e-8e60-a84f72615dd8" />
<img width="1470" height="956" alt="Screenshot 2026-05-10 at 2 55 32 PM" src="https://github.com/user-attachments/assets/d50f347d-b4f2-4019-8eb4-a8ddb4a8a40a" />



Fixes #3370

## AI Usage in this PR

- [x] **Specific parts**: AI assisted with code generation on parts of the change, reviewed and verified before submission.