### PR TITLE
feat(SearchResults): add compact table view with list/table toggle

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.css
@@ -1,0 +1,3 @@
+.TraceTable {
+  margin-top: 1rem;
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import TraceTable from './TraceTable';
+import { IOtelTrace, StatusCode, SpanKind } from '../../../types/otel';
+
+vi.mock('react-router-dom', async () => {
+  const { MemoryRouter: ActualMemoryRouter } = await vi.importActual('react-router-dom');
+  return {
+    MemoryRouter: ActualMemoryRouter,
+    Link: ({ to, children }: any) => {
+      const href = typeof to === 'string' ? to : `${to.pathname}${to.search || ''}`;
+      return <a href={href}>{children}</a>;
+    },
+  };
+});
+
+function makeTrace(overrides: Partial<IOtelTrace> = {}): IOtelTrace {
+  return {
+    traceID: 'abc123',
+    traceName: 'test-trace',
+    spans: [],
+    services: [],
+    duration: 1000000 as IOtelTrace['duration'],
+    startTime: 1748000000000000 as IOtelTrace['startTime'],
+    endTime: 1748000001000000 as IOtelTrace['endTime'],
+    spanMap: new Map(),
+    rootSpans: [],
+    orphanSpanCount: 0,
+    tracePageTitle: 'test-trace',
+    traceEmoji: '',
+    isGenAITrace: false,
+    hasErrors: () => false,
+    ...overrides,
+  } as IOtelTrace;
+}
+
+function makeSpan(hasError = false) {
+  return {
+    spanID: 'span-1',
+    traceID: 'abc123',
+    name: 'op',
+    kind: SpanKind.INTERNAL,
+    startTime: 0 as any,
+    endTime: 1 as any,
+    duration: 1 as any,
+    attributes: [],
+    events: [],
+    links: [],
+    inboundLinks: [],
+    status: { code: hasError ? StatusCode.ERROR : StatusCode.OK },
+    resource: { attributes: [], serviceName: 'svc' },
+    instrumentationScope: { name: 'test' },
+    depth: 0,
+    hasChildren: false,
+    childSpans: [],
+    relativeStartTime: 0 as any,
+    warnings: null,
+    parentSpanID: undefined,
+    parentSpan: undefined,
+  };
+}
+
+const getTraceLink = (traceID: string) => ({
+  pathname: `/trace/${traceID}`,
+  search: '',
+  state: undefined,
+});
+
+function renderTable(traces: IOtelTrace[]) {
+  return render(
+    <MemoryRouter>
+      <TraceTable traces={traces} getTraceLink={getTraceLink} />
+    </MemoryRouter>
+  );
+}
+
+describe('TraceTable', () => {
+  it('renders one row per trace', () => {
+    const traces = [
+      makeTrace({ traceID: 'aaa', traceName: 'trace-a' }),
+      makeTrace({ traceID: 'bbb', traceName: 'trace-b' }),
+      makeTrace({ traceID: 'ccc', traceName: 'trace-c' }),
+    ];
+    renderTable(traces);
+    expect(screen.getByText('trace-a')).toBeInTheDocument();
+    expect(screen.getByText('trace-b')).toBeInTheDocument();
+    expect(screen.getByText('trace-c')).toBeInTheDocument();
+  });
+
+  it('renders span count correctly', () => {
+    const spans = [makeSpan(), makeSpan()];
+    const traces = [makeTrace({ spans: spans as any })];
+    renderTable(traces);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders error count as red tag when errors exist', () => {
+    const spans = [makeSpan(true), makeSpan(false)];
+    const traces = [makeTrace({ spans: spans as any })];
+    renderTable(traces);
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders no red error tag when there are no errors', () => {
+    const traces = [makeTrace({ spans: [makeSpan(false)] as any })];
+    const { container } = renderTable(traces);
+    expect(container.querySelector('.ant-tag-red')).toBeNull();
+  });
+
+  it('renders service count', () => {
+    const traces = [
+      makeTrace({
+        services: [
+          { name: 'svc-a', numberOfSpans: 1 },
+          { name: 'svc-b', numberOfSpans: 2 },
+        ],
+      }),
+    ];
+    renderTable(traces);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('links trace name to trace detail page', () => {
+    const traces = [makeTrace({ traceID: 'xyz', traceName: 'linked-trace' })];
+    renderTable(traces);
+    const link = screen.getByText('linked-trace').closest('a');
+    expect(link).toHaveAttribute('href', '/trace/xyz');
+  });
+
+  it('falls back to truncated traceID when traceName is empty', () => {
+    const traces = [makeTrace({ traceID: 'abcdef1234567', traceName: '' })];
+    renderTable(traces);
+    expect(screen.getByText('abcdef1')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { Table, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { Link } from 'react-router-dom';
+
+import { formatDuration, formatRelativeDate } from '../../../utils/date';
+import { IOtelTrace, StatusCode } from '../../../types/otel';
+import { Microseconds } from '../../../types/units';
+import type { TracePageLink } from '../../TracePage/url/index';
+
+import './TraceTable.css';
+
+type Props = {
+  traces: IOtelTrace[];
+  getTraceLink: (traceID: string) => TracePageLink;
+};
+
+type Row = {
+  key: string;
+  traceID: string;
+  traceName: string;
+  services: number;
+  spans: number;
+  errors: number;
+  duration: number;
+  startTime: number;
+};
+
+function toRows(traces: IOtelTrace[]): Row[] {
+  return traces.map(trace => ({
+    key: trace.traceID,
+    traceID: trace.traceID,
+    traceName: trace.traceName,
+    services: trace.services.length,
+    spans: trace.spans.length,
+    errors: trace.spans.filter(s => s.status.code === StatusCode.ERROR).length,
+    duration: trace.duration,
+    startTime: trace.startTime,
+  }));
+}
+
+export default function TraceTable({ traces, getTraceLink }: Props) {
+  const columns: ColumnsType<Row> = [
+    {
+      title: 'Trace',
+      dataIndex: 'traceName',
+      render: (name: string, row: Row) => {
+        const link = getTraceLink(row.traceID);
+        return (
+          <Link to={{ pathname: link.pathname, search: link.search }} state={link.state}>
+            {name || row.traceID.slice(0, 7)}
+          </Link>
+        );
+      },
+    },
+    {
+      title: 'Services',
+      dataIndex: 'services',
+      sorter: (a: Row, b: Row) => a.services - b.services,
+      width: 90,
+    },
+    {
+      title: 'Spans',
+      dataIndex: 'spans',
+      sorter: (a: Row, b: Row) => a.spans - b.spans,
+      width: 80,
+    },
+    {
+      title: 'Errors',
+      dataIndex: 'errors',
+      render: (count: number) =>
+        count > 0 ? (
+          <Tag color="red" variant="outlined">
+            {count}
+          </Tag>
+        ) : (
+          <span>0</span>
+        ),
+      sorter: (a: Row, b: Row) => a.errors - b.errors,
+      width: 80,
+    },
+    {
+      title: 'Duration',
+      dataIndex: 'duration',
+      render: (d: number) => formatDuration(d as Microseconds),
+      sorter: (a: Row, b: Row) => a.duration - b.duration,
+      width: 110,
+    },
+    {
+      title: 'Start time',
+      dataIndex: 'startTime',
+      render: (t: number) => formatRelativeDate(t / 1000),
+      sorter: (a: Row, b: Row) => a.startTime - b.startTime,
+      defaultSortOrder: 'descend',
+      width: 160,
+    },
+  ];
+
+  return (
+    <Table<Row>
+      className="TraceTable"
+      columns={columns}
+      dataSource={toRows(traces)}
+      size="small"
+      pagination={{ pageSize: 100, hideOnSinglePage: true }}
+      rowKey="key"
+    />
+  );
+}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { useCallback } from 'react';
-import { Select } from 'antd';
+import { useCallback, useState } from 'react';
+import { Select, Button } from 'antd';
 import { Link, useNavigate } from 'react-router-dom';
 import type { Location } from 'react-router-dom';
 import queryString from 'query-string';
@@ -15,6 +15,7 @@ import * as markers from './index.markers';
 import { EAltViewActions, trackAltView } from './index.track';
 import ResultItem from './ResultItem';
 import ScatterPlot from './ScatterPlot';
+import TraceTable from './TraceTable';
 import { getUrl } from '../url';
 import LoadingIndicator from '../../common/LoadingIndicator';
 import NewWindowIcon from '../../common/NewWindowIcon';
@@ -142,6 +143,7 @@ export function UnconnectedSearchResults({
   cohortRemoveTrace,
 }: SearchResultsProps) {
   const navigate = useNavigate();
+  const [viewMode, setViewMode] = useState<'list' | 'table'>('list');
 
   const toggleComparison = useCallback(
     (traceID: string, remove?: boolean) => {
@@ -238,6 +240,24 @@ export function UnconnectedSearchResults({
             {traces.length} Trace{traces.length > 1 && 's'}
           </h2>
           {traceResultsView && <SelectSort sortBy={sortBy} handleSortChange={handleSortChange} />}
+          {traceResultsView && (
+            <Button.Group className="ub-ml2">
+              <Button
+                size="small"
+                type={viewMode === 'list' ? 'primary' : 'default'}
+                onClick={() => setViewMode('list')}
+              >
+                List
+              </Button>
+              <Button
+                size="small"
+                type={viewMode === 'table' ? 'primary' : 'default'}
+                onClick={() => setViewMode('table')}
+              >
+                Table
+              </Button>
+            </Button.Group>
+          )}
           {traceResultsView && <DownloadResults onDownloadResultsClicked={onDownloadResultsClicked} />}
           <AltViewOptions traceResultsView={traceResultsView} onDdgViewClicked={onDdgViewClicked} />
           {showStandaloneLink && (
@@ -258,7 +278,19 @@ export function UnconnectedSearchResults({
         </div>
       )}
       {traceResultsView && diffSelection}
-      {traceResultsView && (
+      {traceResultsView && viewMode === 'table' && (
+        <TraceTable
+          traces={traces}
+          getTraceLink={traceID =>
+            getTracePageLink(
+              traceID,
+              { fromSearch: searchUrl },
+              spanLinks && (spanLinks[traceID] || spanLinks[traceID.replace(/^0*/, '')])
+            )
+          }
+        />
+      )}
+      {traceResultsView && viewMode === 'list' && (
         <ul className="ub-list-reset">
           {traces.map(trace => (
             <li className="ub-my3" key={trace.traceID}>


### PR DESCRIPTION
Adds a compact table view to the search results page as an alternative to the existing card list. Users can switch between the two views using a List/Table toggle added to the results header.

The table shows one row per trace with six columns: trace name (linked to the detail page), service count, span count, error count (shown as a red tag when non-zero), duration, and start time. All columns except trace name are sortable. Pagination kicks in at 100 results.

The existing list view is completely unchanged. The toggle defaults to List so there is no visible difference for existing users until they opt in. The TraceTable component is self-contained and does not touch any shared state.

Covered by seven unit tests: row count, span count, error tag rendering, no-error case, service count, trace link href, and traceID fallback when traceName is empty. All 178 SearchTracePage tests pass with no regressions. TypeScript reports no errors.

Closes #3816