### PR TITLE
fix(search): Restore time picker options broken by #3781

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../../hooks/useConfig', () => ({
     search: {
       maxLookback: { label: '2 Days', value: '2d' },
       adjustEndTime: '1m',
+      maxLimit: 1500,
     },
   }),
 }));
@@ -532,22 +533,9 @@ describe('<SearchForm>', () => {
   });
 
   it('uses config.search.maxLimit', () => {
-    const maxLimit = 6789;
-    const config = {
-      search: {
-        maxLimit,
-      },
-    };
-
-    const originalGetConfig = window.getJaegerUiConfig;
-    window.getJaegerUiConfig = jest.fn(() => config);
-
     const { container } = renderForm(<SearchForm {...defaultProps} />);
-
     const limitInput = container.querySelector('input[name="resultsLimit"]');
-    expect(limitInput).toHaveAttribute('max');
-
-    window.getJaegerUiConfig = originalGetConfig;
+    expect(limitInput).toHaveAttribute('max', '1500');
   });
 
   it('updates state when tags input changes', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -18,6 +18,10 @@ vi.mock('../common/SearchableSelect', () => {
 vi.mock('../../hooks/useConfig', () => ({
   useConfig: () => ({
     useOpenTelemetryTerms: false,
+    search: {
+      maxLookback: { label: '2 Days', value: '2d' },
+      adjustEndTime: '1m',
+    },
   }),
 }));
 vi.mock('../../hooks/useTraceDiscovery', () => ({
@@ -83,10 +87,6 @@ function makeDateParams(dateOffset = 0) {
 const defaultProps = {
   dataCenters: ['dc1'],
   handleSubmit: () => {},
-  searchMaxLookback: {
-    label: '2 Days',
-    value: '2d',
-  },
   submitFormHandler: jest.fn().mockReturnValue('/search'),
 };
 
@@ -560,9 +560,7 @@ describe('<SearchForm>', () => {
   });
 
   it('prevents default form submission behavior', async () => {
-    const { container } = renderForm(
-      <SearchForm {...defaultProps} searchAdjustEndTime="1m" initialValues={{ service: 'svcA' }} />
-    );
+    const { container } = renderForm(<SearchForm {...defaultProps} initialValues={{ service: 'svcA' }} />);
     const form = container.querySelector('form');
 
     await waitFor(() =>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -331,8 +331,6 @@ export function submitForm(
 interface ISearchFormImplProps {
   invalid?: boolean;
   submitting?: boolean;
-  searchMaxLookback?: ILookbackOption;
-  searchAdjustEndTime?: string;
   initialValues?: Partial<ISearchFormFields> & { traceIDs?: string | null };
   searchTraces: SearchTracesFunction;
   submitFormHandler: (
@@ -345,13 +343,13 @@ interface ISearchFormImplProps {
 export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   invalid = false,
   submitting = false,
-  searchMaxLookback,
-  searchAdjustEndTime,
   initialValues,
   submitFormHandler,
 }) => {
   const navigate = useNavigate();
-  const { useOpenTelemetryTerms: useOtelTerms } = useConfig();
+  const { useOpenTelemetryTerms: useOtelTerms, search } = useConfig();
+  const searchMaxLookback: ILookbackOption | undefined = search?.maxLookback;
+  const searchAdjustEndTime: string | undefined = search?.adjustEndTime;
   const [formData, setFormData] = useState<Partial<ISearchFormFields>>(() => ({
     service: initialValues?.service,
     operation: initialValues?.operation,
@@ -828,8 +826,6 @@ export function mapStateToProps(state: ReduxState, ownProps: { search?: string }
       maxDuration: (maxDuration as string | undefined) || undefined,
       traceIDs: traceIDs || null,
     },
-    searchMaxLookback: _get(state, 'config.search.maxLookback'),
-    searchAdjustEndTime: _get(state, 'config.search.adjustEndTime'),
     submitting: state.trace?.search?.state === fetchedState.LOADING,
   };
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -3,7 +3,6 @@
 
 import React, { useState, useCallback, useMemo, ComponentProps } from 'react';
 import { Input, Button, Tooltip, Select, Row, Col, Form, Switch } from 'antd';
-import _get from 'lodash/get';
 import logfmtParser from 'logfmt/lib/logfmt_parser';
 import { stringify as logfmtStringify } from 'logfmt/lib/stringify';
 import dayjs from 'dayjs';
@@ -21,7 +20,6 @@ import { trackFormInput } from './SearchForm.track';
 import * as jaegerApiActions from '../../actions/jaeger-api';
 import { formatDate, formatTime } from '../../utils/date';
 import { DEFAULT_OPERATION, DEFAULT_LIMIT, DEFAULT_LOOKBACK } from '../../constants/search-form';
-import getConfig from '../../utils/config/get-config';
 import SearchableSelect from '../common/SearchableSelect';
 import './SearchForm.css';
 import ValidatedFormField from '../../utils/ValidatedFormField';
@@ -702,7 +700,7 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
           placeholder="Limit Results"
           type="number"
           min={1}
-          max={getConfig().search?.maxLimit}
+          max={search?.maxLimit}
           onChange={e => handleChange({ resultsLimit: e.target.value })}
         />
       </FormItem>


### PR DESCRIPTION
PR #3781 removed the config Redux slice but left SearchForm reading searchMaxLookback and searchAdjustEndTime from state.config, which is now always undefined. The guard {searchMaxLookback && ...} suppressed all preset lookback options, leaving only "Custom Time Range" visible.

Read both values directly from getConfig() via useConfig(), matching the pattern established by #3781 for other config fields.

## AI Usage in this PR (choose one)

- [x] **Heavy**: AI generated most or all of the code changes
