### PR TITLE
feat(trace): Add URL utilities for layout settings

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -48,9 +48,17 @@ describe('TracePage/url', () => {
       expect(stripLayoutSettings(search)).toBe('?uiFind=foo');
     });
 
+    it('removes all layout params from a raw query string (no leading ?)', () => {
+      expect(stripLayoutSettings('uiFind=foo&timeline=on&sidebar=sidepanel')).toBe('uiFind=foo');
+    });
+
     it('returns empty string if only layout params were present', () => {
       const search = '?timeline=on&sidebar=sidepanel';
       expect(stripLayoutSettings(search)).toBe('');
+    });
+
+    it('returns empty string for raw query with only layout params (no leading ?)', () => {
+      expect(stripLayoutSettings('timeline=on&sidebar=sidepanel')).toBe('');
     });
 
     it('is a no-op when no layout params are present', () => {
@@ -68,8 +76,21 @@ describe('TracePage/url', () => {
       expect(queryString.parse(result)).toEqual({ sidebar: 'sidepanel', uiFind: 'foo' });
     });
 
+    it('strips timeline from a raw query string (no leading ?)', () => {
+      const result = stripLayoutSettingParam(
+        'uiFind=foo&timeline=on&sidebar=sidepanel',
+        'timelineBarsVisible'
+      );
+      expect(queryString.parse(result)).toEqual({ sidebar: 'sidepanel', uiFind: 'foo' });
+    });
+
     it('strips only the sidebar param, leaving timeline and uiFind intact', () => {
       const result = stripLayoutSettingParam('?uiFind=foo&timeline=on&sidebar=sidepanel', 'detailPanelMode');
+      expect(queryString.parse(result)).toEqual({ timeline: 'on', uiFind: 'foo' });
+    });
+
+    it('strips sidebar from a raw query string (no leading ?)', () => {
+      const result = stripLayoutSettingParam('uiFind=foo&timeline=on&sidebar=sidepanel', 'detailPanelMode');
       expect(queryString.parse(result)).toEqual({ timeline: 'on', uiFind: 'foo' });
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -1,19 +1,123 @@
 // Copyright (c) 2020 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getTracePageLink, getUrl } from '.';
+import queryString from 'query-string';
+
+import {
+  getTracePageLink,
+  getUrl,
+  stringifyLayoutSettings,
+  stripLayoutSettings,
+  stripLayoutSettingParam,
+  parseLayoutSettingsFromUrl,
+} from '.';
+import prefixUrl from '../../../utils/prefix-url';
 
 describe('TracePage/url', () => {
   const traceID = 'trace-id';
   const uiFind = 'ui-find';
 
-  describe('getUrl', () => {
-    it('includes traceID without uiFind', () => {
-      expect(getUrl(traceID)).toBe(`/trace/${traceID}`);
+  describe('stringifyLayoutSettings', () => {
+    it('handles empty settings', () => {
+      expect(stringifyLayoutSettings({})).toEqual({});
     });
 
-    it('includes traceID and uiFind', () => {
-      expect(getUrl(traceID, uiFind)).toBe(`/trace/${traceID}?uiFind=${uiFind}`);
+    it('handles timeline settings', () => {
+      expect(stringifyLayoutSettings({ timelineBarsVisible: true })).toEqual({ timeline: 'on' });
+      expect(stringifyLayoutSettings({ timelineBarsVisible: false })).toEqual({ timeline: 'off' });
+      expect(stringifyLayoutSettings({ timelineBarsVisible: null })).toEqual({});
+    });
+
+    it('handles sidebar settings', () => {
+      expect(stringifyLayoutSettings({ detailPanelMode: 'sidepanel' })).toEqual({ sidebar: 'sidepanel' });
+      expect(stringifyLayoutSettings({ detailPanelMode: 'inline' })).toEqual({ sidebar: 'inline' });
+      expect(stringifyLayoutSettings({ detailPanelMode: null })).toEqual({});
+    });
+
+    it('handles combined settings', () => {
+      expect(stringifyLayoutSettings({ timelineBarsVisible: true, detailPanelMode: 'sidepanel' })).toEqual({
+        timeline: 'on',
+        sidebar: 'sidepanel',
+      });
+    });
+  });
+
+  describe('stripLayoutSettings', () => {
+    it('removes all layout params while preserving others', () => {
+      const search = '?uiFind=foo&timeline=on&sidebar=sidepanel';
+      expect(stripLayoutSettings(search)).toBe('?uiFind=foo');
+    });
+
+    it('returns empty string if only layout params were present', () => {
+      const search = '?timeline=on&sidebar=sidepanel';
+      expect(stripLayoutSettings(search)).toBe('');
+    });
+
+    it('is a no-op when no layout params are present', () => {
+      const search = '?uiFind=foo';
+      expect(stripLayoutSettings(search)).toBe('?uiFind=foo');
+    });
+  });
+
+  describe('stripLayoutSettingParam', () => {
+    it('strips only the timeline param, leaving sidebar and uiFind intact', () => {
+      const result = stripLayoutSettingParam(
+        '?uiFind=foo&timeline=on&sidebar=sidepanel',
+        'timelineBarsVisible'
+      );
+      expect(queryString.parse(result)).toEqual({ sidebar: 'sidepanel', uiFind: 'foo' });
+    });
+
+    it('strips only the sidebar param, leaving timeline and uiFind intact', () => {
+      const result = stripLayoutSettingParam('?uiFind=foo&timeline=on&sidebar=sidepanel', 'detailPanelMode');
+      expect(queryString.parse(result)).toEqual({ timeline: 'on', uiFind: 'foo' });
+    });
+
+    it('returns empty string if only that param was present', () => {
+      expect(stripLayoutSettingParam('?timeline=on', 'timelineBarsVisible')).toBe('');
+    });
+
+    it('returns the original search string unchanged when the targeted param is absent', () => {
+      const search = '?uiFind=foo';
+      expect(stripLayoutSettingParam(search, 'timelineBarsVisible')).toBe(search);
+    });
+  });
+
+  describe('getUrl', () => {
+    it('includes traceID without uiFind', () => {
+      expect(getUrl(traceID)).toBe(prefixUrl(`/trace/${traceID}`));
+    });
+
+    it('includes traceID and uiFind (positional)', () => {
+      expect(getUrl(traceID, uiFind)).toBe(`${prefixUrl(`/trace/${traceID}`)}?uiFind=${uiFind}`);
+    });
+
+    it('includes traceID and uiFind (options)', () => {
+      expect(getUrl(traceID, { uiFind })).toBe(`${prefixUrl(`/trace/${traceID}`)}?uiFind=${uiFind}`);
+    });
+
+    it('includes settings (positional)', () => {
+      expect(getUrl(traceID, undefined, { timelineBarsVisible: true })).toBe(
+        `${prefixUrl(`/trace/${traceID}`)}?timeline=on`
+      );
+    });
+
+    it('includes settings (options)', () => {
+      expect(getUrl(traceID, { settings: { timelineBarsVisible: true } })).toBe(
+        `${prefixUrl(`/trace/${traceID}`)}?timeline=on`
+      );
+    });
+
+    it('includes both uiFind and settings (positional)', () => {
+      const url = getUrl(traceID, uiFind, { detailPanelMode: 'sidepanel' });
+      expect(url).toContain('uiFind=ui-find');
+      expect(url).toContain('sidebar=sidepanel');
+    });
+
+    it('includes both uiFind and settings (options)', () => {
+      const url = getUrl(traceID, { uiFind, settings: { detailPanelMode: 'sidepanel' } });
+      expect(url).toContain('uiFind=ui-find');
+      expect(url).toContain('sidebar=sidepanel');
     });
   });
 
@@ -22,18 +126,112 @@ describe('TracePage/url', () => {
       fromSearch: 'some-url',
     };
 
-    it('passes provided state with correct pathname, without uiFind', () => {
+    it('passes provided state with correct pathname, without uiFind (positional)', () => {
       expect(getTracePageLink(traceID, state)).toEqual({
         state,
-        pathname: getUrl(traceID),
+        pathname: prefixUrl(`/trace/${traceID}`),
       });
     });
 
-    it('passes provided state with correct pathname with uiFind', () => {
+    it('passes provided state with correct pathname, without uiFind (options)', () => {
+      expect(getTracePageLink(traceID, { state })).toEqual({
+        state,
+        pathname: prefixUrl(`/trace/${traceID}`),
+      });
+    });
+
+    it('treats an empty options object {} as an options bag, not as LocationState', () => {
+      expect(getTracePageLink(traceID, {})).toEqual({
+        state: undefined,
+        pathname: prefixUrl(`/trace/${traceID}`),
+      });
+    });
+
+    it('passes provided state with correct pathname with uiFind (positional)', () => {
       expect(getTracePageLink(traceID, state, uiFind)).toEqual({
         state,
-        pathname: getUrl(traceID),
+        pathname: prefixUrl(`/trace/${traceID}`),
         search: `uiFind=${uiFind}`,
+      });
+    });
+
+    it('passes provided state with correct pathname with uiFind (options)', () => {
+      expect(getTracePageLink(traceID, { state, uiFind })).toEqual({
+        state,
+        pathname: prefixUrl(`/trace/${traceID}`),
+        search: `uiFind=${uiFind}`,
+      });
+    });
+
+    it('includes settings (positional)', () => {
+      expect(getTracePageLink(traceID, state, undefined, { timelineBarsVisible: false })).toEqual({
+        state,
+        pathname: prefixUrl(`/trace/${traceID}`),
+        search: 'timeline=off',
+      });
+    });
+
+    it('includes settings (options)', () => {
+      expect(getTracePageLink(traceID, { state, settings: { timelineBarsVisible: false } })).toEqual({
+        state,
+        pathname: prefixUrl(`/trace/${traceID}`),
+        search: 'timeline=off',
+      });
+    });
+  });
+
+  describe('parseLayoutSettingsFromUrl', () => {
+    it('parses timeline=off and sidebar=sidepanel', () => {
+      const search = '?timeline=off&sidebar=sidepanel';
+      expect(parseLayoutSettingsFromUrl(search)).toEqual({
+        timelineBarsVisible: false,
+        detailPanelMode: 'sidepanel',
+      });
+    });
+
+    it('parses timeline=on and sidebar=inline', () => {
+      const search = '?timeline=on&sidebar=inline';
+      expect(parseLayoutSettingsFromUrl(search)).toEqual({
+        timelineBarsVisible: true,
+        detailPanelMode: 'inline',
+      });
+    });
+
+    it('handles missing settings', () => {
+      expect(parseLayoutSettingsFromUrl('')).toEqual({
+        timelineBarsVisible: null,
+        detailPanelMode: null,
+      });
+    });
+
+    it('handles unrecognized values by falling back to null', () => {
+      const search = '?timeline=maybe&sidebar=bottom';
+      expect(parseLayoutSettingsFromUrl(search)).toEqual({
+        timelineBarsVisible: null,
+        detailPanelMode: null,
+      });
+    });
+
+    it('picks the first occurrence of a duplicate key (the module always uses index [0])', () => {
+      const search = '?timeline=off&timeline=on&sidebar=sidepanel&sidebar=inline';
+      expect(parseLayoutSettingsFromUrl(search)).toEqual({
+        timelineBarsVisible: false,
+        detailPanelMode: 'sidepanel',
+      });
+    });
+
+    it('falls back to null when a param is present but empty (?timeline=)', () => {
+      expect(parseLayoutSettingsFromUrl('?timeline=&sidebar=')).toEqual({
+        timelineBarsVisible: null,
+        detailPanelMode: null,
+      });
+    });
+
+    it('handles sidebar duplicate keys independently of timeline', () => {
+      const search = '?sidebar=inline&sidebar=sidepanel';
+      expect(parseLayoutSettingsFromUrl(search)).toEqual({
+        timelineBarsVisible: null,
+        detailPanelMode: 'inline',
       });
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/url/index.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.test.js
@@ -113,6 +113,10 @@ describe('TracePage/url', () => {
       expect(getUrl(traceID, uiFind)).toBe(`${prefixUrl(`/trace/${traceID}`)}?uiFind=${uiFind}`);
     });
 
+    it('coerces String objects to primitive string (positional)', () => {
+      expect(getUrl(traceID, new String('foo'))).toBe(`${prefixUrl(`/trace/${traceID}`)}?uiFind=foo`);
+    });
+
     it('includes traceID and uiFind (options)', () => {
       expect(getUrl(traceID, { uiFind })).toBe(`${prefixUrl(`/trace/${traceID}`)}?uiFind=${uiFind}`);
     });
@@ -161,9 +165,9 @@ describe('TracePage/url', () => {
       });
     });
 
-    it('treats an empty options object {} as an options bag, not as LocationState', () => {
+    it('treats an empty options object {} as LocationState, preserving backward compatibility', () => {
       expect(getTracePageLink(traceID, {})).toEqual({
-        state: undefined,
+        state: {},
         pathname: prefixUrl(`/trace/${traceID}`),
       });
     });
@@ -197,6 +201,22 @@ describe('TracePage/url', () => {
         state,
         pathname: prefixUrl(`/trace/${traceID}`),
         search: 'timeline=off',
+      });
+    });
+
+    it('includes both uiFind and settings (positional)', () => {
+      expect(getTracePageLink(traceID, state, uiFind, { timelineBarsVisible: false })).toEqual({
+        state,
+        pathname: prefixUrl(`/trace/${traceID}`),
+        search: `timeline=off&uiFind=${uiFind}`,
+      });
+    });
+
+    it('includes both uiFind and settings (options)', () => {
+      expect(getTracePageLink(traceID, { state, uiFind, settings: { timelineBarsVisible: false } })).toEqual({
+        state,
+        pathname: prefixUrl(`/trace/${traceID}`),
+        search: `timeline=off&uiFind=${uiFind}`,
       });
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -132,11 +132,18 @@ export function getUrl(
   let uiFind: string | undefined;
   let layoutSettings: Partial<UrlLayoutSettings> | undefined = settings;
 
-  if (typeof uiFindOrOptions === 'object' && uiFindOrOptions !== null) {
+  // Only treat the second argument as an options bag when it carries at least one known
+  // key. This avoids silently swallowing a mistakenly-passed settings object or a
+  // String wrapper object (new String('foo')) when the caller meant to pass a uiFind string.
+  if (
+    uiFindOrOptions !== null &&
+    typeof uiFindOrOptions === 'object' &&
+    ('uiFind' in uiFindOrOptions || 'settings' in uiFindOrOptions)
+  ) {
     uiFind = uiFindOrOptions.uiFind;
     layoutSettings = uiFindOrOptions.settings;
   } else {
-    uiFind = uiFindOrOptions;
+    uiFind = uiFindOrOptions !== undefined && uiFindOrOptions !== null ? String(uiFindOrOptions) : undefined;
   }
 
   const traceUrl = prefixUrl(`/trace/${id}`);
@@ -166,16 +173,12 @@ type TracePageLinkOptions = {
 
 /**
  * Type guard that distinguishes a plain options bag from a LocationState object.
- * An argument is treated as options when it carries at least one known option key
- * OR when it is an empty object {} (caller omitted all optional args).
- * All checks are allocation-free: `in` for property existence, a short-circuiting
- * for..in loop (no array created) for the empty-object case.
+ * An argument qualifies as an options bag only when it carries at least one of the
+ * three known option keys. An empty object {} or an object with unrecognised keys
+ * is treated as a LocationState, preserving backward-compatible positional behaviour.
  */
 function isTracePageLinkOptions(arg: object): arg is TracePageLinkOptions {
-  if ('state' in arg || 'uiFind' in arg || 'settings' in arg) return true;
-  // for..in exits immediately on the first own-enumerable property — zero allocation.
-  for (const _ in arg) return false; // eslint-disable-line no-unreachable-loop
-  return true; // empty object — treat as options bag
+  return 'state' in arg || 'uiFind' in arg || 'settings' in arg;
 }
 
 export function getTracePageLink(

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -60,7 +60,10 @@ export function stringifyLayoutSettings(settings: Partial<UrlLayoutSettings>): R
   if (settings.timelineBarsVisible === true) params[URL_PARAM_TIMELINE] = 'on';
   if (settings.timelineBarsVisible === false) params[URL_PARAM_TIMELINE] = 'off';
   if (settings.detailPanelMode) {
-    params[URL_PARAM_SIDEBAR] = SIDEBAR_PARAM_VALUES[settings.detailPanelMode];
+    // Guard the lookup: a non-enum value (e.g. from JS callers or stale persisted data)
+    // would produce undefined, which must not be written into the Record<string, string>.
+    const sidebarValue = SIDEBAR_PARAM_VALUES[settings.detailPanelMode];
+    if (typeof sidebarValue === 'string') params[URL_PARAM_SIDEBAR] = sidebarValue;
   }
   return params;
 }
@@ -74,7 +77,9 @@ export function stringifyLayoutSettings(settings: Partial<UrlLayoutSettings>): R
  * Used when a caller needs a clean base URL without any layout overrides.
  */
 export function stripLayoutSettings(search: string): string {
-  const params = queryString.parse(search);
+  // Strip a leading '?' before parsing so keys are never prefixed with it,
+  // regardless of the query-string version in use.
+  const params = queryString.parse(search.replace(/^\?/, ''));
   if (!LAYOUT_PARAM_NAMES.some(p => p in params)) return search; // no layout params — no churn
   for (const p of LAYOUT_PARAM_NAMES) delete params[p];
   const newSearch = queryString.stringify(params);
@@ -92,7 +97,9 @@ export function stripLayoutSettings(search: string): string {
  */
 export function stripLayoutSettingParam(search: string, key: keyof UrlLayoutSettings): string {
   const paramName = SETTINGS_PARAM_NAMES[key];
-  const params = queryString.parse(search);
+  // Strip a leading '?' before parsing so keys are never prefixed with it,
+  // regardless of the query-string version in use.
+  const params = queryString.parse(search.replace(/^\?/, ''));
   if (!(paramName in params)) return search; // param absent — no change, no stringify churn
   delete params[paramName];
   const newSearch = queryString.stringify(params);
@@ -150,6 +157,27 @@ export type TracePageLink = {
   state?: LocationState;
 };
 
+/** Options-bag shape accepted by the getTracePageLink overload. */
+type TracePageLinkOptions = {
+  state?: LocationState;
+  uiFind?: string;
+  settings?: Partial<UrlLayoutSettings>;
+};
+
+/**
+ * Type guard that distinguishes a plain options bag from a LocationState object.
+ * An argument is treated as options when it carries at least one known option key
+ * OR when it is an empty object {} (caller omitted all optional args).
+ * All checks are allocation-free: `in` for property existence, a short-circuiting
+ * for..in loop (no array created) for the empty-object case.
+ */
+function isTracePageLinkOptions(arg: object): arg is TracePageLinkOptions {
+  if ('state' in arg || 'uiFind' in arg || 'settings' in arg) return true;
+  // for..in exits immediately on the first own-enumerable property — zero allocation.
+  for (const _ in arg) return false; // eslint-disable-line no-unreachable-loop
+  return true; // empty object — treat as options bag
+}
+
 export function getTracePageLink(
   id: string,
   state?: LocationState,
@@ -173,29 +201,10 @@ export function getTracePageLink(
   let layoutSettings: Partial<UrlLayoutSettings> | undefined = settings;
 
   if (stateOrOptions && typeof stateOrOptions === 'object') {
-    // Classify the argument as an options bag when it carries at least one known key,
-    // OR when it is an empty object {} (caller passed no extra args).
-    // All checks are allocation-free: `in` for property existence, a short-circuiting
-    // for..in loop (no array created) for the empty-object case.
-    const isOptions =
-      'state' in stateOrOptions ||
-      'uiFind' in stateOrOptions ||
-      'settings' in stateOrOptions ||
-      // for..in exits on the very first own-enumerable property — zero allocation.
-      (() => {
-        for (const _ in stateOrOptions) return false;
-        return true;
-      })();
-
-    if (isOptions) {
-      const opts = stateOrOptions as {
-        state?: LocationState;
-        uiFind?: string;
-        settings?: Partial<UrlLayoutSettings>;
-      };
-      state = opts.state;
-      resolvedUiFind = opts.uiFind;
-      layoutSettings = opts.settings;
+    if (isTracePageLinkOptions(stateOrOptions)) {
+      state = stateOrOptions.state;
+      resolvedUiFind = stateOrOptions.uiFind;
+      layoutSettings = stateOrOptions.settings;
     } else {
       state = stateOrOptions as LocationState;
     }
@@ -213,7 +222,9 @@ export function getTracePageLink(
  * including when the corresponding query parameter is absent or unrecognized.
  */
 export function parseLayoutSettingsFromUrl(search: string): UrlLayoutSettings {
-  const params = queryString.parse(search);
+  // Strip a leading '?' before parsing so keys are never prefixed with it,
+  // regardless of the query-string version in use.
+  const params = queryString.parse(search.replace(/^\?/, ''));
 
   let timelineBarsVisible: boolean | null = null;
   const timelineParamRaw = params[URL_PARAM_TIMELINE];

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -6,14 +6,135 @@ import queryString from 'query-string';
 import prefixUrl from '../../../utils/prefix-url';
 
 import type { LocationState } from '../../../types';
+import type { SpanDetailPanelMode } from '../../../types/config';
 
 export const ROUTE_PATH = prefixUrl('/trace/:id');
 
-export function getUrl(id: string, uiFind?: string): string {
-  const traceUrl = prefixUrl(`/trace/${id}`);
-  if (!uiFind) return traceUrl;
+const URL_PARAM_TIMELINE = 'timeline';
+const URL_PARAM_SIDEBAR = 'sidebar';
 
-  return `${traceUrl}?${queryString.stringify({ uiFind })}`;
+/** @public */
+export type UrlLayoutSettings = {
+  timelineBarsVisible: boolean | null;
+  detailPanelMode: SpanDetailPanelMode | null;
+};
+
+/**
+ * Maps each UrlLayoutSettings key to its URL query-parameter name.
+ * Using an explicit Record ensures a compile-time error if a new key is added
+ * to UrlLayoutSettings without also adding it here.
+ */
+const SETTINGS_PARAM_NAMES: Record<keyof UrlLayoutSettings, string> = {
+  timelineBarsVisible: URL_PARAM_TIMELINE,
+  detailPanelMode: URL_PARAM_SIDEBAR,
+};
+
+const LAYOUT_PARAM_NAMES = [URL_PARAM_TIMELINE, URL_PARAM_SIDEBAR];
+
+/**
+ * Maps each valid SpanDetailPanelMode to its URL query-parameter value.
+ * Typed as Record<SpanDetailPanelMode, string> so that adding a new mode
+ * to the type produces a compile-time error here, preventing silent drops
+ * in both stringifyLayoutSettings (write) and parseLayoutSettingsFromUrl (read).
+ */
+const SIDEBAR_PARAM_VALUES: Record<SpanDetailPanelMode, string> = {
+  inline: 'inline',
+  sidepanel: 'sidepanel',
+};
+
+/**
+ * Reverse lookup: URL param value → SpanDetailPanelMode.
+ * Built with Object.create(null) (null prototype) so that the `in` operator is safe:
+ * prototype-inherited names like toString/hasOwnProperty can never match a real mode.
+ */
+const SIDEBAR_URL_VALUE_TO_MODE: Record<string, SpanDetailPanelMode> = Object.create(null);
+for (const [mode, urlValue] of Object.entries(SIDEBAR_PARAM_VALUES) as [SpanDetailPanelMode, string][]) {
+  SIDEBAR_URL_VALUE_TO_MODE[urlValue] = mode;
+}
+
+/**
+ * Converts layout settings into URL query parameters.
+ */
+export function stringifyLayoutSettings(settings: Partial<UrlLayoutSettings>): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (settings.timelineBarsVisible === true) params[URL_PARAM_TIMELINE] = 'on';
+  if (settings.timelineBarsVisible === false) params[URL_PARAM_TIMELINE] = 'off';
+  if (settings.detailPanelMode) {
+    params[URL_PARAM_SIDEBAR] = SIDEBAR_PARAM_VALUES[settings.detailPanelMode];
+  }
+  return params;
+}
+
+/**
+ * Strips all layout setting params (?timeline, ?sidebar) from a URL search string,
+ * preserving unrelated params such as ?uiFind.
+ * Parses and stringifies the query string once regardless of how many layout
+ * params are present. The output is canonicalized (param order and encoding
+ * may differ from the original string).
+ * Used when a caller needs a clean base URL without any layout overrides.
+ */
+export function stripLayoutSettings(search: string): string {
+  const params = queryString.parse(search);
+  if (!LAYOUT_PARAM_NAMES.some(p => p in params)) return search; // no layout params — no churn
+  for (const p of LAYOUT_PARAM_NAMES) delete params[p];
+  const newSearch = queryString.stringify(params);
+  if (!newSearch) return '';
+  return search.startsWith('?') ? `?${newSearch}` : newSearch;
+}
+
+/**
+ * Removes a single layout setting param from a search string, preserving all others.
+ * Used when the user toggles a setting — only the acted-on param is stripped,
+ * so other URL overrides (e.g. ?sidebar=sidepanel) remain intact.
+ * Note: when a param is removed the output is canonicalized — param order and
+ * percent-encoding may differ from the original string. Callers doing textual
+ * URL comparison (e.g. history dedup) should compare parsed representations, not strings.
+ */
+export function stripLayoutSettingParam(search: string, key: keyof UrlLayoutSettings): string {
+  const paramName = SETTINGS_PARAM_NAMES[key];
+  const params = queryString.parse(search);
+  if (!(paramName in params)) return search; // param absent — no change, no stringify churn
+  delete params[paramName];
+  const newSearch = queryString.stringify(params);
+  if (!newSearch) return '';
+  // Preserve the leading '?' only if the input had one.
+  return search.startsWith('?') ? `?${newSearch}` : newSearch;
+}
+
+/** Builds the shared query-param object for trace page URLs. */
+function buildTraceQueryParams(
+  uiFind?: string,
+  settings?: Partial<UrlLayoutSettings>
+): Record<string, string> {
+  return {
+    ...(uiFind ? { uiFind } : {}),
+    ...(settings ? stringifyLayoutSettings(settings) : {}),
+  };
+}
+
+export function getUrl(id: string, uiFind?: string, settings?: Partial<UrlLayoutSettings>): string;
+export function getUrl(
+  id: string,
+  options?: { uiFind?: string; settings?: Partial<UrlLayoutSettings> }
+): string;
+export function getUrl(
+  id: string,
+  uiFindOrOptions?: string | { uiFind?: string; settings?: Partial<UrlLayoutSettings> },
+  settings?: Partial<UrlLayoutSettings>
+): string {
+  let uiFind: string | undefined;
+  let layoutSettings: Partial<UrlLayoutSettings> | undefined = settings;
+
+  if (typeof uiFindOrOptions === 'object' && uiFindOrOptions !== null) {
+    uiFind = uiFindOrOptions.uiFind;
+    layoutSettings = uiFindOrOptions.settings;
+  } else {
+    uiFind = uiFindOrOptions;
+  }
+
+  const traceUrl = prefixUrl(`/trace/${id}`);
+  const search = queryString.stringify(buildTraceQueryParams(uiFind, layoutSettings));
+  return search ? `${traceUrl}?${search}` : traceUrl;
 }
 
 // Navigation descriptor for links that point to the trace page.
@@ -21,15 +142,85 @@ export function getUrl(id: string, uiFind?: string): string {
 export type TracePageLink = {
   // URL path to the trace page, e.g. /trace/abc123
   pathname: string;
-  // Raw query string without the leading '?', e.g. 'uiFind=foo'. Absent when not filtering spans.
+  // Raw query string without the leading '?', e.g. 'uiFind=foo&timeline=off'.
+  // Present when filtering spans (uiFind) or when layout settings are encoded in the link.
   search?: string;
   // Out-of-band router state, not visible in the URL.
   // Currently carries fromSearch so TracePageHeader can render the back-to-search button.
   state?: LocationState;
 };
 
-export function getTracePageLink(id: string, state?: LocationState, uiFind?: string): TracePageLink {
-  const link: TracePageLink = { state, pathname: getUrl(id) };
-  if (uiFind) link.search = queryString.stringify({ uiFind });
-  return link;
+export function getTracePageLink(
+  id: string,
+  state?: LocationState,
+  uiFind?: string,
+  settings?: Partial<UrlLayoutSettings>
+): TracePageLink;
+export function getTracePageLink(
+  id: string,
+  options?: { state?: LocationState; uiFind?: string; settings?: Partial<UrlLayoutSettings> }
+): TracePageLink;
+export function getTracePageLink(
+  id: string,
+  stateOrOptions?:
+    | LocationState
+    | { state?: LocationState; uiFind?: string; settings?: Partial<UrlLayoutSettings> },
+  uiFind?: string,
+  settings?: Partial<UrlLayoutSettings>
+): TracePageLink {
+  let state: LocationState | undefined;
+  let resolvedUiFind: string | undefined = uiFind;
+  let layoutSettings: Partial<UrlLayoutSettings> | undefined = settings;
+
+  if (stateOrOptions && typeof stateOrOptions === 'object') {
+    // Treat the argument as an options bag when it carries at least one known option key,
+    // OR when it is an empty object {} (i.e. caller passed no positional args at all).
+    // Use the `in` operator throughout — no Object.keys() allocation on every call.
+    if (
+      'state' in stateOrOptions ||
+      'uiFind' in stateOrOptions ||
+      'settings' in stateOrOptions ||
+      !Object.keys(stateOrOptions).length
+    ) {
+      const opts = stateOrOptions as {
+        state?: LocationState;
+        uiFind?: string;
+        settings?: Partial<UrlLayoutSettings>;
+      };
+      state = opts.state;
+      resolvedUiFind = opts.uiFind;
+      layoutSettings = opts.settings;
+    } else {
+      state = stateOrOptions as LocationState;
+    }
+  }
+
+  const pathname = prefixUrl(`/trace/${id}`);
+  const search = queryString.stringify(buildTraceQueryParams(resolvedUiFind, layoutSettings));
+  return { state, pathname, ...(search ? { search } : {}) };
+}
+
+/**
+ * Parses URL query parameters into layout settings.
+ * Always returns both fields in the result object.
+ * A field is null when no valid override could be derived from the URL,
+ * including when the corresponding query parameter is absent or unrecognized.
+ */
+export function parseLayoutSettingsFromUrl(search: string): UrlLayoutSettings {
+  const params = queryString.parse(search);
+
+  let timelineBarsVisible: boolean | null = null;
+  const timelineParamRaw = params[URL_PARAM_TIMELINE];
+  const timelineParam = Array.isArray(timelineParamRaw) ? timelineParamRaw[0] : timelineParamRaw;
+  if (timelineParam === 'off') timelineBarsVisible = false;
+  else if (timelineParam === 'on') timelineBarsVisible = true;
+
+  let detailPanelMode: SpanDetailPanelMode | null = null;
+  const sidebarParamRaw = params[URL_PARAM_SIDEBAR];
+  const sidebarParam = Array.isArray(sidebarParamRaw) ? sidebarParamRaw[0] : sidebarParamRaw;
+  if (sidebarParam && sidebarParam in SIDEBAR_URL_VALUE_TO_MODE) {
+    detailPanelMode = SIDEBAR_URL_VALUE_TO_MODE[sidebarParam];
+  }
+
+  return { timelineBarsVisible, detailPanelMode };
 }

--- a/packages/jaeger-ui/src/components/TracePage/url/index.ts
+++ b/packages/jaeger-ui/src/components/TracePage/url/index.ts
@@ -29,7 +29,7 @@ const SETTINGS_PARAM_NAMES: Record<keyof UrlLayoutSettings, string> = {
   detailPanelMode: URL_PARAM_SIDEBAR,
 };
 
-const LAYOUT_PARAM_NAMES = [URL_PARAM_TIMELINE, URL_PARAM_SIDEBAR];
+const LAYOUT_PARAM_NAMES = [URL_PARAM_TIMELINE, URL_PARAM_SIDEBAR] as const;
 
 /**
  * Maps each valid SpanDetailPanelMode to its URL query-parameter value.
@@ -173,15 +173,21 @@ export function getTracePageLink(
   let layoutSettings: Partial<UrlLayoutSettings> | undefined = settings;
 
   if (stateOrOptions && typeof stateOrOptions === 'object') {
-    // Treat the argument as an options bag when it carries at least one known option key,
-    // OR when it is an empty object {} (i.e. caller passed no positional args at all).
-    // Use the `in` operator throughout — no Object.keys() allocation on every call.
-    if (
+    // Classify the argument as an options bag when it carries at least one known key,
+    // OR when it is an empty object {} (caller passed no extra args).
+    // All checks are allocation-free: `in` for property existence, a short-circuiting
+    // for..in loop (no array created) for the empty-object case.
+    const isOptions =
       'state' in stateOrOptions ||
       'uiFind' in stateOrOptions ||
       'settings' in stateOrOptions ||
-      !Object.keys(stateOrOptions).length
-    ) {
+      // for..in exits on the very first own-enumerable property — zero allocation.
+      (() => {
+        for (const _ in stateOrOptions) return false;
+        return true;
+      })();
+
+    if (isOptions) {
       const opts = stateOrOptions as {
         state?: LocationState;
         uiFind?: string;


### PR DESCRIPTION
## Which problem is this PR solving?
- PR 1 of 5 implementing [ADR-0010: Layout Settings Priority Stack](https://github.com/jaegertracing/jaeger-ui/blob/main/docs/adr/0010-layout-settings-priority-stack.md).

## Description of the changes
- Adds pure URL utility functions for reading and writing layout settings (`timelineBarsVisible`, `detailPanelMode`) from/to the URL query string. No React dependency; no UI changes.

**New exports in `TracePage/url/index.ts`:**
- `parseLayoutSettingsFromUrl(search)` — parses `?timeline=on|off` and `?sidebar=inline|sidepanel` into typed nullable values (`null` when absent or unrecognized)
- `stringifyLayoutSettings(settings)` — converts typed settings back into query param key/value pairs
- `stripLayoutSettings(search)` — strips all layout params from a URL while preserving unrelated params (e.g. `uiFind`)
- `stripLayoutSettingParam(search, key)` — strips only the single acted-on param; toggling the timeline switch does not silently drop an active `?sidebar=` override
- `getUrl` / `getTracePageLink` — extended with an optional `settings` argument

## How was this change tested?
- 20 unit tests covering all new functions: round-trip encoding, partial settings, `stripSettingParam` isolation (toggling timeline leaves sidebar param intact and vice versa), early-return when param is already absent, and edge cases with no params

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
