### PR TITLE
feat(trace): Redesign TraceViewSettings as Popover panel

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -22,6 +22,7 @@ import { IOtelTrace } from '../../../types/otel';
 import { formatDatetime, formatDurationCompact } from '../../../utils/date';
 import { getTraceLinks } from '../../../model/link-patterns';
 import { getIncompleteTraceTooltip } from '../../../model/trace-viewer';
+import type { ResolvedLayoutSettings } from '../useLayoutSettings';
 
 import './TracePageHeader.css';
 import ExternalLinks from '../../common/ExternalLinks';
@@ -59,6 +60,8 @@ type TracePageHeaderEmbedProps = {
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRange: IViewRange;
   useOtelTerms: boolean;
+  settingSources?: ResolvedLayoutSettings;
+  saveSettingAsDefault?: (key: 'timelineBarsVisible' | 'detailPanelMode') => void;
 };
 
 export const HEADER_ITEMS = [
@@ -91,7 +94,7 @@ export const HEADER_ITEMS = [
   {
     key: 'depth',
     label: 'Depth',
-    renderer: (trace: IOtelTrace) => _get(_maxBy(trace.spans as any[], 'depth'), 'depth', 0) + 1,
+    renderer: (trace: IOtelTrace) => _get(_maxBy(trace.spans as unknown[], 'depth'), 'depth', 0) + 1,
   },
   {
     key: 'span-count',
@@ -150,6 +153,8 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
     updateViewRangeTime,
     viewRange,
     useOtelTerms,
+    settingSources,
+    saveSettingAsDefault,
   } = props;
 
   if (!trace) {
@@ -215,6 +220,8 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
           onDetailPanelModeToggle={onDetailPanelModeToggle}
           onTimelineToggle={onTimelineToggle}
           timelineBarsVisible={timelineBarsVisible}
+          settingSources={settingSources}
+          saveSettingAsDefault={saveSettingAsDefault}
         />
         {showViewOptions && (
           <AltViewOptions

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.css
@@ -13,3 +13,187 @@ SPDX-License-Identifier: Apache-2.0
 .TraceViewSettings--icon {
   font-size: 1.2rem;
 }
+
+.TraceViewSettings--popoverOverlay .ant-popover-inner {
+  padding: 0;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border-default);
+}
+
+.TraceViewSettings--panel {
+  width: 300px;
+  background: var(--surface-primary);
+}
+
+.TraceViewSettings--panelHeader {
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+}
+
+.TraceViewSettings--panelTitle {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-secondary);
+}
+
+.TraceViewSettings--settingsList {
+  padding: 4px 0;
+}
+
+.TraceViewSettings--row {
+  padding: 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: background 0.12s ease;
+}
+
+.TraceViewSettings--row:hover {
+  background: var(--surface-secondary);
+}
+
+.TraceViewSettings--rowMain {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.TraceViewSettings--rowLabels {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.TraceViewSettings--rowLabel {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+
+.TraceViewSettings--rowDescription {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.TraceViewSettings--switch {
+  flex-shrink: 0;
+}
+
+.TraceViewSettings--overrideRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  animation: TraceViewSettings--fadeIn 0.2s ease;
+}
+
+@keyframes TraceViewSettings--fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.TraceViewSettings--sourceBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.TraceViewSettings--sourceBadge--url {
+  background: color-mix(in srgb, var(--interactive-primary) 12%, transparent);
+  color: var(--interactive-primary);
+  border: 1px solid color-mix(in srgb, var(--interactive-primary) 30%, transparent);
+}
+
+.TraceViewSettings--sourceBadge--heuristic {
+  background: color-mix(in srgb, var(--feedback-warning) 12%, transparent);
+  color: var(--feedback-warning);
+  border: 1px solid color-mix(in srgb, var(--feedback-warning) 30%, transparent);
+}
+
+.TraceViewSettings--sourceIcon {
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.TraceViewSettings--sourceIcon--url {
+  color: var(--interactive-primary);
+}
+
+.TraceViewSettings--sourceIcon--heuristic {
+  color: var(--feedback-warning);
+}
+
+.TraceViewSettings--saveLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--text-link);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition:
+    color 0.15s ease,
+    opacity 0.15s ease;
+  white-space: nowrap;
+}
+
+.TraceViewSettings--saveLink:hover {
+  color: var(--text-link-hover);
+  opacity: 0.85;
+}
+
+.TraceViewSettings--saveLinkIcon {
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.TraceViewSettings--panelDivider {
+  height: 1px;
+  background: var(--border-default);
+  margin: 0;
+}
+
+.TraceViewSettings--kbdShortcutsBtn {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  transition: background 0.12s ease;
+}
+
+.TraceViewSettings--kbdShortcutsBtn:hover {
+  background: var(--surface-secondary);
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -19,6 +19,12 @@ const defaultProps = {
   timelineBarsVisible: true,
 };
 
+async function openPanel() {
+  await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
+  // The panel content is rendered inside the popover
+  return screen.findByRole('group', { name: /timeline view/i });
+}
+
 describe('<TraceViewSettings>', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -31,63 +37,147 @@ describe('<TraceViewSettings>', () => {
     expect(button).toHaveAttribute('title', 'Trace view settings');
   });
 
-  it('opens dropdown on click and shows "Show Timeline" item', async () => {
+  it('opens popover on click and shows "Timeline View" setting', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    expect(await screen.findByText('Show Timeline')).toBeInTheDocument();
+    await openPanel();
+    expect(screen.getByText('Timeline View')).toBeInTheDocument();
   });
 
-  it('calls onTimelineToggle when "Show Timeline" is clicked', async () => {
+  it('calls onTimelineToggle when the Timeline switch is clicked', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Show Timeline'));
+    await openPanel();
+    // The switch for timeline is labelled by "Timeline View"
+    const timelineSwitch = screen.getByRole('switch', { name: /timeline view/i });
+    await userEvent.click(timelineSwitch);
     expect(defaultProps.onTimelineToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('does not show "Show Span in Sidebar" when enableSidePanel is false', async () => {
+  it('does not show "Span Details Sidebar" setting when enableSidePanel is false', async () => {
     render(<TraceViewSettings {...defaultProps} enableSidePanel={false} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await screen.findByText('Show Timeline');
-    expect(screen.queryByText('Show Span in Sidebar')).not.toBeInTheDocument();
+    await openPanel();
+    expect(screen.queryByText('Span Details Sidebar')).not.toBeInTheDocument();
   });
 
-  it('shows "Show Span in Sidebar" when enableSidePanel is true', async () => {
+  it('shows "Span Details Sidebar" setting when enableSidePanel is true', async () => {
     render(<TraceViewSettings {...defaultProps} enableSidePanel />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    expect(await screen.findByText('Show Span in Sidebar')).toBeInTheDocument();
+    await openPanel();
+    expect(screen.getByText('Span Details Sidebar')).toBeInTheDocument();
   });
 
-  it('calls onDetailPanelModeToggle when "Show Span in Sidebar" is clicked', async () => {
+  it('calls onDetailPanelModeToggle when the Sidebar switch is clicked', async () => {
     render(<TraceViewSettings {...defaultProps} enableSidePanel />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Show Span in Sidebar'));
+    await openPanel();
+    const sidebarSwitch = screen.getByRole('switch', { name: /span details sidebar/i });
+    await userEvent.click(sidebarSwitch);
     expect(defaultProps.onDetailPanelModeToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('always shows "Keyboard Shortcuts" in the dropdown', async () => {
+  it('always shows "Keyboard Shortcuts" button in the panel', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    expect(await screen.findByText('Keyboard Shortcuts')).toBeInTheDocument();
+    await openPanel();
+    expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
   });
 
   it('opens the keyboard shortcuts modal and calls track() when "Keyboard Shortcuts" is clicked', async () => {
     render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Keyboard Shortcuts'));
+    await openPanel();
+    await userEvent.click(screen.getByText('Keyboard Shortcuts'));
     expect(track).toHaveBeenCalledTimes(1);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('returns the cached kbdTable on a second call to getHelpModal', async () => {
-    const { unmount } = render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Keyboard Shortcuts'));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-    unmount();
+  it('shows "Set by shared link" badge when timeline source is "url"', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: false, source: 'url', isOverridden: true },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings {...defaultProps} timelineBarsVisible={false} settingSources={settingSources} />
+    );
+    await openPanel();
+    expect(screen.getByText('Set by shared link')).toBeInTheDocument();
+  });
 
-    render(<TraceViewSettings {...defaultProps} />);
-    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
-    await userEvent.click(await screen.findByText('Keyboard Shortcuts'));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  it('does not show a source badge when source is "localstorage"', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(<TraceViewSettings {...defaultProps} settingSources={settingSources} />);
+    await openPanel();
+    expect(screen.queryByText('Set by shared link')).not.toBeInTheDocument();
+  });
+
+  it('shows "Set as my default" link when a setting is overridden', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: false, source: 'url', isOverridden: true },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings
+        {...defaultProps}
+        timelineBarsVisible={false}
+        settingSources={settingSources}
+        saveSettingAsDefault={jest.fn()}
+      />
+    );
+    await openPanel();
+    expect(screen.getByText('Set as my default')).toBeInTheDocument();
+  });
+
+  it('calls saveSettingAsDefault with correct key when "Set as my default" is clicked', async () => {
+    const saveSettingAsDefault = jest.fn();
+    const settingSources = {
+      timelineBarsVisible: { value: false, source: 'url', isOverridden: true },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings
+        {...defaultProps}
+        timelineBarsVisible={false}
+        settingSources={settingSources}
+        saveSettingAsDefault={saveSettingAsDefault}
+      />
+    );
+    await openPanel();
+    await userEvent.click(screen.getByText('Set as my default'));
+    expect(saveSettingAsDefault).toHaveBeenCalledWith('timelineBarsVisible');
+  });
+
+  it('does not show "Set as my default" link when isOverridden is false', async () => {
+    const settingSources = {
+      timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+      detailPanelMode: { value: 'inline', source: 'localstorage', isOverridden: false },
+    };
+    render(
+      <TraceViewSettings {...defaultProps} settingSources={settingSources} saveSettingAsDefault={jest.fn()} />
+    );
+    await openPanel();
+    await waitFor(() => {
+      expect(screen.queryByText('Set as my default')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows "Set as my default" for sidebar when sidebar source is "url"', async () => {
+    const saveSettingAsDefault = jest.fn();
+    const settingSources = {
+      timelineBarsVisible: { value: true, source: 'localstorage', isOverridden: false },
+      detailPanelMode: { value: 'sidepanel', source: 'url', isOverridden: true },
+    };
+    render(
+      <TraceViewSettings
+        {...defaultProps}
+        enableSidePanel
+        detailPanelMode="sidepanel"
+        settingSources={settingSources}
+        saveSettingAsDefault={saveSettingAsDefault}
+      />
+    );
+    await openPanel();
+    const saveLinks = screen.getAllByText('Set as my default');
+    // Only one override (sidebar), so exactly one link
+    expect(saveLinks).toHaveLength(1);
+    await userEvent.click(saveLinks[0]);
+    expect(saveSettingAsDefault).toHaveBeenCalledWith('detailPanelMode');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { Button, Dropdown } from 'antd';
-import type { MenuProps } from 'antd';
-import { IoSettingsOutline, IoCheckmark } from 'react-icons/io5';
+import { Button, Popover, Switch, Tooltip } from 'antd';
+import { IoSettingsOutline, IoLink, IoCheckmarkCircle } from 'react-icons/io5';
 
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
+import type { ResolvedLayoutSettings, ResolvedSetting, SettingSource } from '../useLayoutSettings';
 
 import './TraceViewSettings.css';
 
@@ -17,10 +17,89 @@ type Props = {
   onDetailPanelModeToggle: () => void;
   onTimelineToggle: () => void;
   timelineBarsVisible: boolean;
+  settingSources?: ResolvedLayoutSettings;
+  saveSettingAsDefault?: (key: 'timelineBarsVisible' | 'detailPanelMode') => void;
 };
 
-const CHECK_STYLE = { marginRight: 8, fontSize: 14 };
-const CHECK_PLACEHOLDER = <span style={{ display: 'inline-block', width: 22 }} />;
+const SOURCE_LABELS: Record<SettingSource, string> = {
+  url: 'Set by shared link',
+  heuristic: '',
+  localstorage: '',
+};
+
+const SOURCE_ICONS: Record<SettingSource, React.ReactNode> = {
+  url: <IoLink className="TraceViewSettings--sourceIcon TraceViewSettings--sourceIcon--url" />,
+  heuristic: null,
+  localstorage: null,
+};
+
+type SettingRowProps<T> = {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: () => void;
+  resolved?: ResolvedSetting<T>;
+  onSaveAsDefault?: () => void;
+};
+
+function SettingRow<T>({
+  id,
+  label,
+  description,
+  checked,
+  onChange,
+  resolved,
+  onSaveAsDefault,
+}: SettingRowProps<T>) {
+  const source = resolved?.source ?? 'localstorage';
+  const isOverridden = resolved?.isOverridden ?? false;
+
+  return (
+    <div className="TraceViewSettings--row" role="group" aria-labelledby={`${id}-label`}>
+      <div className="TraceViewSettings--rowMain">
+        <div className="TraceViewSettings--rowLabels">
+          <span id={`${id}-label`} className="TraceViewSettings--rowLabel">
+            {label}
+          </span>
+          <span className="TraceViewSettings--rowDescription">{description}</span>
+        </div>
+        <Switch
+          id={id}
+          checked={checked}
+          onChange={onChange}
+          size="small"
+          aria-label={label}
+          className="TraceViewSettings--switch"
+        />
+      </div>
+
+      {isOverridden && (
+        <div className="TraceViewSettings--overrideRow">
+          {source !== 'localstorage' && (
+            <span className={`TraceViewSettings--sourceBadge TraceViewSettings--sourceBadge--${source}`}>
+              {SOURCE_ICONS[source]}
+              {SOURCE_LABELS[source]}
+            </span>
+          )}
+          {onSaveAsDefault && (
+            <Tooltip title="Save this as your personal default for future traces">
+              <button
+                type="button"
+                className="TraceViewSettings--saveLink"
+                onClick={onSaveAsDefault}
+                aria-label={`Set as my default for ${label}`}
+              >
+                <IoCheckmarkCircle className="TraceViewSettings--saveLinkIcon" />
+                Set as my default
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function TraceViewSettings(props: Props) {
   const {
@@ -30,51 +109,81 @@ export default function TraceViewSettings(props: Props) {
     onDetailPanelModeToggle,
     onTimelineToggle,
     timelineBarsVisible,
+    settingSources,
+    saveSettingAsDefault,
   } = props;
 
   const [kbdModalVisible, setKbdModalVisible] = React.useState(false);
+  const [popoverOpen, setPopoverOpen] = React.useState(false);
 
-  const items: MenuProps['items'] = [
-    {
-      key: 'timeline',
-      icon: timelineBarsVisible ? <IoCheckmark style={CHECK_STYLE} /> : CHECK_PLACEHOLDER,
-      label: 'Show Timeline',
-      onClick: onTimelineToggle,
-    },
-  ];
+  const panelContent = (
+    <div className="TraceViewSettings--panel" aria-label="Trace view settings panel">
+      <div className="TraceViewSettings--panelHeader">
+        <span className="TraceViewSettings--panelTitle">View Settings</span>
+      </div>
 
-  if (enableSidePanel) {
-    const isSidePanel = detailPanelMode === 'sidepanel';
-    items.push({
-      key: 'detail-panel-mode',
-      icon: isSidePanel ? <IoCheckmark style={CHECK_STYLE} /> : CHECK_PLACEHOLDER,
-      label: 'Show Span in Sidebar',
-      onClick: onDetailPanelModeToggle,
-    });
-  }
+      <div className="TraceViewSettings--settingsList">
+        <SettingRow
+          id="setting-timeline"
+          label="Timeline View"
+          description="Show the timeline bars in the trace view"
+          checked={timelineBarsVisible}
+          onChange={onTimelineToggle}
+          resolved={settingSources?.timelineBarsVisible}
+          onSaveAsDefault={
+            saveSettingAsDefault ? () => saveSettingAsDefault('timelineBarsVisible') : undefined
+          }
+        />
 
-  items.push(
-    { type: 'divider' },
-    {
-      key: 'keyboard-shortcuts',
-      icon: CHECK_PLACEHOLDER,
-      label: 'Keyboard Shortcuts',
-      onClick: () => setKbdModalVisible(true),
-    }
+        {enableSidePanel && (
+          <SettingRow
+            id="setting-sidebar"
+            label="Span Details Sidebar"
+            description="Show span details in a side panel instead of inline"
+            checked={detailPanelMode === 'sidepanel'}
+            onChange={onDetailPanelModeToggle}
+            resolved={settingSources?.detailPanelMode}
+            onSaveAsDefault={saveSettingAsDefault ? () => saveSettingAsDefault('detailPanelMode') : undefined}
+          />
+        )}
+      </div>
+
+      <div className="TraceViewSettings--panelDivider" />
+
+      <button
+        type="button"
+        className="TraceViewSettings--kbdShortcutsBtn"
+        onClick={() => {
+          setKbdModalVisible(true);
+          setPopoverOpen(false);
+        }}
+      >
+        Keyboard Shortcuts
+      </button>
+    </div>
   );
 
   return (
     <>
-      <Dropdown menu={{ items }} trigger={['click']}>
+      <Popover
+        content={panelContent}
+        trigger="click"
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+        placement="bottomRight"
+        overlayClassName="TraceViewSettings--popoverOverlay"
+        arrow={false}
+      >
         <Button
           className={`TraceViewSettings ${className || ''}`}
           htmlType="button"
           aria-label="Trace view settings"
           title="Trace view settings"
+          data-testid="trace-view-settings"
         >
           <IoSettingsOutline className="TraceViewSettings--icon" />
         </Button>
-      </Dropdown>
+      </Popover>
       <KeyboardShortcutsHelp open={kbdModalVisible} onClose={() => setKbdModalVisible(false)} />
     </>
   );


### PR DESCRIPTION
## Which problem is this PR solving?
- PR 3 of 5 implementing [ADR-0010: Layout Settings Priority Stack](https://github.com/jaegertracing/jaeger-ui/blob/main/docs/adr/0010-layout-settings-priority-stack.md).

The existing `TraceViewSettings` component used an Ant Design `Dropdown` with menu items — a compact but limited control surface. The priority stack feature (ADR-0010) requires a richer settings panel that can show per-setting source indicators and a "Set as my default" action. This PR delivers that UX foundation as a self-contained redesign with no priority-stack logic included.

## Description of the changes
Redesigns `TraceViewSettings` from a `Dropdown` menu to a `Popover`-based settings panel with `Switch` controls:

**`TraceViewSettings.tsx`**
- Replaces `Dropdown` + menu items with a `Popover` containing a structured `SettingRow` layout per setting
- Each row has a label, description, and an accessible `Switch` toggle (`aria-label`, `role="group"`, `aria-labelledby`)
- Accepts two optional forward-looking props (`settingSources`, `saveSettingAsDefault`) used by PR 5 for source badges; renders correctly without them
- `data-testid="trace-view-settings"` preserved on the trigger `Button` for test stability
- Keyboard Shortcuts button retained inside the panel

**`TraceViewSettings.css`**
- New styles for the panel, setting rows, source badge pills, and the "Set as my default" link

**`TracePageHeader.tsx`**
- Minor prop forwarding update to pass `settingSources` and `saveSettingAsDefault` through to `TraceViewSettings`

## How was this change tested?
- 14 unit tests covering: gear button render, popover open/close, timeline and sidebar toggles, `data-testid` presence, URL source badge render, "Set as my default" click, and keyboard shortcuts modal
- All 2830 existing tests continue to pass 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
