### PR TITLE
refactor(spanview): Extract RelativeBar component from TraceSpanView

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.css
@@ -32,11 +32,6 @@ SPDX-License-Identifier: Apache-2.0
   padding: 8px 12px;
 }
 
-/* Make duration bar background more visible in dark theme */
-[data-theme='dark'] .span-view-table .duration-bar-background {
-  background: rgba(255, 255, 255, 0.15) !important;
-}
-
 /* Monospace font for Span ID column */
 .span-view-table .span-id-cell {
   font-family: monospace;

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -8,6 +8,7 @@ import { ColumnProps } from 'antd/es/table';
 import './index.css';
 import { TNil } from '../../../types';
 import { IOtelSpan, IOtelTrace } from '../../../types/otel';
+import RelativeBar from '../../common/RelativeBar';
 import { formatDuration, formatDurationCompact } from '../../../utils/date';
 import prefixUrl from '../../../utils/prefix-url';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
@@ -144,7 +145,6 @@ export default function TraceSpanView(props: Props) {
       title: 'Duration',
       sorter: (a, b) => a.duration - b.duration,
       render: (_, span) => {
-        const percentage = (span.duration / maxDuration) * 100;
         const preciseValue = formatDuration(span.duration);
         const compactValue = formatDurationCompact(span.duration);
 
@@ -158,26 +158,7 @@ export default function TraceSpanView(props: Props) {
                 width: '100%',
               }}
             >
-              <div
-                className="duration-bar-background"
-                style={{
-                  flexGrow: 1,
-                  height: '6px',
-                  background: 'var(--surface-tertiary)',
-                  marginRight: '12px',
-                  position: 'relative',
-                  borderRadius: '2px',
-                }}
-              >
-                <div
-                  style={{
-                    width: `${Math.max(percentage, 2)}%`,
-                    height: '100%',
-                    background: 'var(--interactive-primary)',
-                    borderRadius: '2px',
-                  }}
-                />
-              </div>
+              <RelativeBar value={span.duration} maxValue={maxDuration} />
               <div
                 style={{
                   whiteSpace: 'nowrap',

--- a/packages/jaeger-ui/src/components/common/RelativeBar.css
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.css
@@ -15,11 +15,6 @@ SPDX-License-Identifier: Apache-2.0
   border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.1));
 }
 
-[data-theme='dark'] .RelativeBar {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
 .RelativeBar--fill {
   height: 100%;
   background: var(--interactive-primary, #1890ff);

--- a/packages/jaeger-ui/src/components/common/RelativeBar.css
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.css
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2026 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+.RelativeBar {
+  flex-grow: 1;
+  min-width: 60px;
+  height: 10px;
+  background: var(--surface-tertiary, rgba(255, 255, 255, 0.1));
+  margin-right: 12px;
+  position: relative;
+  border-radius: 5px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.1));
+}
+
+[data-theme='dark'] .RelativeBar {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.RelativeBar--fill {
+  height: 100%;
+  background: var(--interactive-primary, #1890ff);
+  border-radius: 5px;
+  transition: width 0.3s ease;
+}

--- a/packages/jaeger-ui/src/components/common/RelativeBar.css
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.css
@@ -7,17 +7,17 @@ SPDX-License-Identifier: Apache-2.0
   flex-grow: 1;
   min-width: 60px;
   height: 10px;
-  background: var(--surface-tertiary, rgba(255, 255, 255, 0.1));
+  background: var(--surface-tertiary);
   margin-right: 12px;
   position: relative;
   border-radius: 5px;
   overflow: hidden;
-  border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.1));
+  border: 1px solid var(--border-strong);
 }
 
 .RelativeBar--fill {
   height: 100%;
-  background: var(--interactive-primary, #1890ff);
+  background: var(--interactive-primary);
   border-radius: 5px;
   transition: width 0.3s ease;
 }

--- a/packages/jaeger-ui/src/components/common/RelativeBar.test.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.test.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from '@testing-library/react';
+import RelativeBar from './RelativeBar';
+
+function getFillWidth(container: HTMLElement): string {
+  const fill = container.querySelector('.RelativeBar--fill') as HTMLElement;
+  return fill.style.width;
+}
+
+describe('RelativeBar', () => {
+  it('renders 100% fill when value equals maxValue', () => {
+    const { container } = render(<RelativeBar value={100} maxValue={100} />);
+    expect(getFillWidth(container)).toBe('100%');
+  });
+
+  it('renders proportional fill', () => {
+    const { container } = render(<RelativeBar value={50} maxValue={100} />);
+    expect(getFillWidth(container)).toBe('50%');
+  });
+
+  it('clamps fill to minimum 2% when value is 0', () => {
+    const { container } = render(<RelativeBar value={0} maxValue={100} />);
+    expect(getFillWidth(container)).toBe('2%');
+  });
+
+  it('clamps fill to 100% when value exceeds maxValue', () => {
+    const { container } = render(<RelativeBar value={200} maxValue={100} />);
+    expect(getFillWidth(container)).toBe('100%');
+  });
+
+  it('handles maxValue of 0 without error', () => {
+    const { container } = render(<RelativeBar value={50} maxValue={0} />);
+    expect(getFillWidth(container)).toBe('100%');
+  });
+
+  it('handles non-finite maxValue by falling back to maxValue=1', () => {
+    const { container } = render(<RelativeBar value={50} maxValue={Infinity} />);
+    expect(getFillWidth(container)).toBe('100%');
+  });
+
+  it('handles negative value', () => {
+    const { container } = render(<RelativeBar value={-10} maxValue={100} />);
+    expect(getFillWidth(container)).toBe('2%');
+  });
+});

--- a/packages/jaeger-ui/src/components/common/RelativeBar.test.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.test.tsx
@@ -44,4 +44,9 @@ describe('RelativeBar', () => {
     const { container } = render(<RelativeBar value={-10} maxValue={100} />);
     expect(getFillWidth(container)).toBe('2%');
   });
+
+  it('handles NaN value without producing invalid CSS', () => {
+    const { container } = render(<RelativeBar value={NaN} maxValue={100} />);
+    expect(getFillWidth(container)).toBe('2%');
+  });
 });

--- a/packages/jaeger-ui/src/components/common/RelativeBar.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import './RelativeBar.css';
+
+type Props = {
+  value: number;
+  maxValue: number;
+};
+
+const RelativeBar: React.FC<Props> = ({ value, maxValue }) => {
+  const percentage = (value / (maxValue || 1)) * 100;
+
+  return (
+    <div className="RelativeBar">
+      <div className="RelativeBar--fill" style={{ width: `${Math.max(percentage, 2)}%` }} />
+    </div>
+  );
+};
+
+export default RelativeBar;

--- a/packages/jaeger-ui/src/components/common/RelativeBar.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.tsx
@@ -11,7 +11,8 @@ type Props = {
 
 const RelativeBar: React.FC<Props> = ({ value, maxValue }) => {
   const safeMax = Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 1;
-  const percentage = Math.min(100, Math.max(0, (value / safeMax) * 100));
+  const safeValue = Number.isFinite(value) ? value : 0;
+  const percentage = Math.min(100, Math.max(0, (safeValue / safeMax) * 100));
 
   return (
     <div className="RelativeBar">

--- a/packages/jaeger-ui/src/components/common/RelativeBar.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeBar.tsx
@@ -10,7 +10,8 @@ type Props = {
 };
 
 const RelativeBar: React.FC<Props> = ({ value, maxValue }) => {
-  const percentage = (value / (maxValue || 1)) * 100;
+  const safeMax = Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 1;
+  const percentage = Math.min(100, Math.max(0, (value / safeMax) * 100));
 
   return (
     <div className="RelativeBar">


### PR DESCRIPTION
## Which problem is this PR solving?

This is a focused extraction from #3348 (by @chinmay3012), isolating the reusable `RelativeBar` component so it can be reviewed and merged independently.

## Description of the changes

- Add `RelativeBar` component (`components/common/RelativeBar.tsx` + `.css`) — a simple proportional bar that renders a fill relative to a max value, using CSS design tokens for theming (light/dark mode compatible). Original implementation by @chinmay3012.
- Refactor `TraceSpanView` duration column to use `<RelativeBar>` instead of the equivalent inline div structure.

The remaining changes from #3348 (RelativeBar integration into TraceStatistics, dark mode fixes, performance improvements) are left for the original PR.

## How was this change tested?

- All existing tests pass (`npm test`)

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully