### PR TITLE
fix: remove unnecessary span wrapper in RelativeDate component

### DIFF
--- a/packages/jaeger-ui/src/components/common/RelativeDate.tsx
+++ b/packages/jaeger-ui/src/components/common/RelativeDate.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
 import dayjs from 'dayjs';
 
 import { formatRelativeDate } from '../../utils/date';
@@ -12,12 +11,10 @@ type Props = {
   value: number | Date;
 };
 
-// TODO typescript doesn't understand text or null as react nodes
-// https://github.com/Microsoft/TypeScript/issues/21699
-export default function RelativeDate(props: Props): React.JSX.Element {
+export default function RelativeDate(props: Props): string {
   const { value, includeTime, fullMonthName } = props;
   const m = dayjs.isDayjs(value) ? value : dayjs(value);
   const dateStr = formatRelativeDate(m, Boolean(fullMonthName));
   const timeStr = includeTime ? `, ${m.format('h:mm:ss a')}` : '';
-  return <span>{`${dateStr}${timeStr}`}</span>;
+  return `${dateStr}${timeStr}`;
 }


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #3858

## Description of the changes
- Remove unnecessary `<span>` wrapper from RelativeDate component
- Remove unused `import React from 'react'`
- Update return type from `React.JSX.Element` to `string`
- Remove TODO comment that referenced the old TypeScript limitation

## How was this change tested?
Manually verified the component renders correctly in the trace search results page. No existing tests for this component the change is a straightforward type and wrapper removal with no behavioral difference.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
