### PR TITLE
fix: use DedicatedWorkerGlobalScope instead of Worker in layout.worke…

### DIFF
--- a/packages/plexus/src/LayoutManager/layout.worker.ts
+++ b/packages/plexus/src/LayoutManager/layout.worker.ts
@@ -12,10 +12,8 @@ import {
 } from './types';
 
 type TMessageErrorTarget = {
-  onmessageerror: ((this: DedicatedWorkerGlobalScope, ev: ErrorEvent) => any | void) | null;
+  onmessageerror: ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any | void) | null;
 };
-
-// TODO: Use WorkerGlobalScope instead of Worker
 
 const ctx: DedicatedWorkerGlobalScope & TMessageErrorTarget = self as any;
 

--- a/packages/plexus/src/LayoutManager/layout.worker.ts
+++ b/packages/plexus/src/LayoutManager/layout.worker.ts
@@ -12,12 +12,12 @@ import {
 } from './types';
 
 type TMessageErrorTarget = {
-  onmessageerror: ((this: Worker, ev: ErrorEvent) => any | void) | null;
+  onmessageerror: ((this: DedicatedWorkerGlobalScope, ev: ErrorEvent) => any | void) | null;
 };
 
 // TODO: Use WorkerGlobalScope instead of Worker
 
-const ctx: Worker & TMessageErrorTarget = self as any;
+const ctx: DedicatedWorkerGlobalScope & TMessageErrorTarget = self as any;
 
 let currentMeta: TLayoutWorkerMeta | null;
 


### PR DESCRIPTION


## Which problem is this PR solving?
- #3860 

## Description of the changes
- Replace `Worker` type with `DedicatedWorkerGlobalScope` in layout.worker.ts
- Update `TMessageErrorTarget` callback type from `this: Worker` to `this: DedicatedWorkerGlobalScope`
- Remove TODO comment from 2017

## How was this change tested?
All 115 existing plexus tests pass 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
