### PR TITLE
feat(genai): show token usage badge on LLM spans in trace timeline

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { GenAISpanIcon } from './GenAISpanIcon';
+import { IOtelSpan, SpanKind, StatusCode } from '../../../types/otel';
+
+function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
+  return {
+    traceID: 'trace-1',
+    spanID: 'span-1',
+    name: 'test',
+    kind: SpanKind.INTERNAL,
+    startTime: 0 as IOtelSpan['startTime'],
+    endTime: 1 as IOtelSpan['endTime'],
+    duration: 1 as IOtelSpan['duration'],
+    attributes: Object.entries(attrs).map(([key, value]) => ({ key, value })),
+    events: [],
+    links: [],
+    inboundLinks: [],
+    status: { code: StatusCode.OK },
+    resource: { attributes: [], serviceName: 'svc' },
+    instrumentationScope: { name: 'test' },
+    depth: 0,
+    hasChildren: false,
+    childSpans: [],
+    relativeStartTime: 0 as IOtelSpan['relativeStartTime'],
+    warnings: null,
+  };
+}
+
+describe('GenAISpanIcon', () => {
+  it('renders nothing for a standard span', () => {
+    const { container } = render(<GenAISpanIcon span={makeSpan({ 'http.method': 'GET' })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders robot icon with "AI Agent" label for invoke_agent span', () => {
+    const { getByLabelText } = render(
+      <GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'invoke_agent' })} />
+    );
+    expect(getByLabelText('AI Agent')).toBeInTheDocument();
+  });
+
+  it('renders bolt icon with "LLM Call" label for chat span', () => {
+    const { getByLabelText } = render(<GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'chat' })} />);
+    expect(getByLabelText('LLM Call')).toBeInTheDocument();
+  });
+
+  it('renders wrench icon with "Tool Call" label for execute_tool span', () => {
+    const { getByLabelText } = render(
+      <GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'execute_tool' })} />
+    );
+    expect(getByLabelText('Tool Call')).toBeInTheDocument();
+  });
+
+  it('renders storage icon with "RAG Retrieval" label for retrieval span', () => {
+    const { getByLabelText } = render(
+      <GenAISpanIcon span={makeSpan({ 'gen_ai.operation.name': 'retrieval' })} />
+    );
+    expect(getByLabelText('RAG Retrieval')).toBeInTheDocument();
+  });
+
+  it('renders sparkle icon with "GenAI Span" label for unknown gen_ai span', () => {
+    const { getByLabelText } = render(<GenAISpanIcon span={makeSpan({ 'gen_ai.provider.name': 'acme' })} />);
+    expect(getByLabelText('GenAI Span')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { MdSmartToy, MdBolt, MdBuild, MdStorage, MdAutoAwesome } from 'react-icons/md';
+
+import { classifySpan, GenAISpanKind } from '../../../utils/genai/detect';
+import { IOtelSpan } from '../../../types/otel';
+
+type IconComponent = React.ComponentType<{ size?: number; title?: string; 'aria-label'?: string }>;
+
+const KIND_ICONS: Record<Exclude<GenAISpanKind, 'STANDARD'>, IconComponent> = {
+  AGENT: MdSmartToy,
+  LLM_CALL: MdBolt,
+  TOOL_CALL: MdBuild,
+  RETRIEVAL: MdStorage,
+  UNKNOWN_GENAI: MdAutoAwesome,
+};
+
+const KIND_TITLES: Record<Exclude<GenAISpanKind, 'STANDARD'>, string> = {
+  AGENT: 'AI Agent',
+  LLM_CALL: 'LLM Call',
+  TOOL_CALL: 'Tool Call',
+  RETRIEVAL: 'RAG Retrieval',
+  UNKNOWN_GENAI: 'GenAI Span',
+};
+
+type Props = {
+  span: IOtelSpan;
+  size?: number;
+};
+
+export function GenAISpanIcon({ span, size = 14 }: Props): React.ReactElement | null {
+  const kind = classifySpan(span);
+  if (kind === 'STANDARD') return null;
+  const Icon = KIND_ICONS[kind];
+  const title = KIND_TITLES[kind];
+  return <Icon size={size} title={title} aria-label={title} />;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAITokenBadge.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAITokenBadge.test.tsx
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { GenAITokenBadge } from './GenAITokenBadge';
+import { IOtelSpan, SpanKind, StatusCode } from '../../../types/otel';
+
+function makeSpan(attrs: Record<string, string | number> = {}): IOtelSpan {
+  return {
+    traceID: 'trace-1',
+    spanID: 'span-1',
+    name: 'test',
+    kind: SpanKind.INTERNAL,
+    startTime: 0 as IOtelSpan['startTime'],
+    endTime: 1 as IOtelSpan['endTime'],
+    duration: 1 as IOtelSpan['duration'],
+    attributes: Object.entries(attrs).map(([key, value]) => ({ key, value })),
+    events: [],
+    links: [],
+    inboundLinks: [],
+    status: { code: StatusCode.OK },
+    resource: { attributes: [], serviceName: 'svc' },
+    instrumentationScope: { name: 'test' },
+    depth: 0,
+    hasChildren: false,
+    childSpans: [],
+    relativeStartTime: 0 as IOtelSpan['relativeStartTime'],
+    warnings: null,
+  };
+}
+
+describe('GenAITokenBadge', () => {
+  it('returns null for a standard span', () => {
+    const { container } = render(<GenAITokenBadge span={makeSpan({ 'http.method': 'GET' })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null for a non-LLM GenAI span (tool call)', () => {
+    const { container } = render(
+      <GenAITokenBadge span={makeSpan({ 'gen_ai.operation.name': 'execute_tool' })} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null for an LLM span with no token attributes', () => {
+    const { container } = render(<GenAITokenBadge span={makeSpan({ 'gen_ai.operation.name': 'chat' })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders both input and output tokens', () => {
+    render(
+      <GenAITokenBadge
+        span={makeSpan({
+          'gen_ai.operation.name': 'chat',
+          'gen_ai.usage.input_tokens': 512,
+          'gen_ai.usage.output_tokens': 128,
+        })}
+      />
+    );
+    expect(screen.getByText('↑512 ↓128')).toBeInTheDocument();
+  });
+
+  it('renders only input tokens when output is absent', () => {
+    render(
+      <GenAITokenBadge
+        span={makeSpan({ 'gen_ai.operation.name': 'chat', 'gen_ai.usage.input_tokens': 200 })}
+      />
+    );
+    expect(screen.getByText('↑200')).toBeInTheDocument();
+  });
+
+  it('renders only output tokens when input is absent', () => {
+    render(
+      <GenAITokenBadge
+        span={makeSpan({ 'gen_ai.operation.name': 'chat', 'gen_ai.usage.output_tokens': 75 })}
+      />
+    );
+    expect(screen.getByText('↓75')).toBeInTheDocument();
+  });
+
+  it('formats counts >= 1000 as Xk', () => {
+    render(
+      <GenAITokenBadge
+        span={makeSpan({
+          'gen_ai.operation.name': 'chat',
+          'gen_ai.usage.input_tokens': 1500,
+          'gen_ai.usage.output_tokens': 2000,
+        })}
+      />
+    );
+    expect(screen.getByText('↑1.5k ↓2k')).toBeInTheDocument();
+  });
+
+  it('works for text_completion spans', () => {
+    render(
+      <GenAITokenBadge
+        span={makeSpan({
+          'gen_ai.operation.name': 'text_completion',
+          'gen_ai.usage.input_tokens': 100,
+          'gen_ai.usage.output_tokens': 50,
+        })}
+      />
+    );
+    expect(screen.getByText('↑100 ↓50')).toBeInTheDocument();
+  });
+
+  it('sets an accessible aria-label', () => {
+    render(
+      <GenAITokenBadge
+        span={makeSpan({
+          'gen_ai.operation.name': 'chat',
+          'gen_ai.usage.input_tokens': 512,
+          'gen_ai.usage.output_tokens': 128,
+        })}
+      />
+    );
+    expect(screen.getByLabelText('tokens: ↑512 ↓128')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAITokenBadge.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAITokenBadge.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import { classifySpan } from '../../../utils/genai/detect';
+import { IOtelSpan } from '../../../types/otel';
+
+function formatCount(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `${Number.isInteger(k) ? k : k.toFixed(1)}k`;
+  }
+  return String(n);
+}
+
+function getNumericAttr(span: IOtelSpan, key: string): number | null {
+  const attr = span.attributes.find(a => a.key === key);
+  if (!attr) return null;
+  const n = Number(attr.value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+type Props = { span: IOtelSpan };
+
+export function GenAITokenBadge({ span }: Props): React.ReactElement | null {
+  if (classifySpan(span) !== 'LLM_CALL') return null;
+
+  const input = getNumericAttr(span, 'gen_ai.usage.input_tokens');
+  const output = getNumericAttr(span, 'gen_ai.usage.output_tokens');
+
+  if (input === null && output === null) return null;
+
+  const parts: string[] = [];
+  if (input !== null) parts.push(`↑${formatCount(input)}`);
+  if (output !== null) parts.push(`↓${formatCount(output)}`);
+
+  const label = parts.join(' ');
+  return (
+    <span className="SpanBarRow--tokenBadge" aria-label={`tokens: ${label}`}>
+      {label}
+    </span>
+  );
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -208,3 +208,10 @@ SPDX-License-Identifier: Apache-2.0
 .SpanBarRow--arrowForwardIcon {
   vertical-align: middle;
 }
+
+.SpanBarRow--tokenBadge {
+  color: var(--text-secondary);
+  font-size: 0.75em;
+  margin-left: 0.35rem;
+  white-space: nowrap;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -14,6 +14,7 @@ import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
 import { GenAISpanIcon } from './GenAISpanIcon';
+import { GenAITokenBadge } from './GenAITokenBadge';
 
 import './SpanBarRow.css';
 
@@ -176,6 +177,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               )}
             </span>
             <small className="endpoint-name">{rpc ? rpc.operationName : operationName}</small>
+            <GenAITokenBadge span={span} />
           </a>
           {hasLinks && (
             <ReferencesButton

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -13,6 +13,7 @@ import Ticks from './Ticks';
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
+import { GenAISpanIcon } from './GenAISpanIcon';
 
 import './SpanBarRow.css';
 
@@ -154,6 +155,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               {!hasOwnError && hasChildError && (
                 <IoAlert className="SpanBarRow--errorIcon SpanBarRow--errorIcon--hollow" />
               )}
+              <GenAISpanIcon span={span} size={14} />
               {serviceName}{' '}
               {rpc && (
                 <span>

--- a/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
@@ -72,6 +72,26 @@ describe('OtelTraceFacade', () => {
     expect(facade.services).toEqual([{ name: 'test-service', numberOfSpans: 1 }]);
   });
 
+  it('isGenAITrace is false when spans have no gen_ai.* attributes', () => {
+    expect(facade.isGenAITrace).toBe(false);
+  });
+
+  it('isGenAITrace is true when at least one span has gen_ai.* attributes', () => {
+    const genAISpan: Span = {
+      ...mockSpan,
+      spanID: 'genai-span',
+      tags: [{ key: 'gen_ai.operation.name', value: 'chat' }],
+    };
+    const genAITrace: Trace = {
+      ...mockLegacyTrace,
+      spans: [genAISpan],
+      spanMap: new Map([['genai-span', genAISpan]]),
+      rootSpans: [genAISpan],
+    };
+    const genAIFacade = new OtelTraceFacade(genAITrace);
+    expect(genAIFacade.isGenAITrace).toBe(true);
+  });
+
   describe('span wiring', () => {
     const parentSpan: Span = { ...mockSpan, spanID: 'parent', hasChildren: true };
     const childSpan: Span = {

--- a/packages/jaeger-ui/src/model/OtelTraceFacade.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.ts
@@ -4,6 +4,7 @@
 import { Trace } from '../types/trace';
 import { IOtelTrace, IOtelSpan } from '../types/otel';
 import OtelSpanFacade from './OtelSpanFacade';
+import { isGenAITrace } from '../utils/genai/detect';
 
 export default class OtelTraceFacade implements IOtelTrace {
   private legacyTrace: Trace;
@@ -11,6 +12,7 @@ export default class OtelTraceFacade implements IOtelTrace {
   private _spanMap: Map<string, IOtelSpan>;
   private _rootSpans: IOtelSpan[];
   private _orphanSpanCount: number;
+  readonly isGenAITrace: boolean;
 
   constructor(legacyTrace: Trace) {
     this.legacyTrace = legacyTrace;
@@ -36,6 +38,8 @@ export default class OtelTraceFacade implements IOtelTrace {
     this._orphanSpanCount = this._spans.filter(
       s => s.parentSpanID && !this._spanMap.has(s.parentSpanID)
     ).length;
+
+    this.isGenAITrace = isGenAITrace(this);
 
     // Wire up parentSpan, childSpans, and link span references
     this._spans.forEach(span => {

--- a/packages/jaeger-ui/src/types/otel.ts
+++ b/packages/jaeger-ui/src/types/otel.ts
@@ -117,6 +117,9 @@ export interface IOtelTrace {
   // Number of orphan spans (spans with parent references to spans not in the trace)
   orphanSpanCount: number;
 
+  // True when at least one span carries gen_ai.* attributes (OpenTelemetry GenAI semconv).
+  readonly isGenAITrace: boolean;
+
   // Helper methods
   hasErrors(): boolean;
 }

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { classifySpan, isGenAITrace, GenAISpanKind } from './detect';
+import { IOtelSpan, IOtelTrace, SpanKind, StatusCode } from '../../types/otel';
+
+function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
+  return {
+    traceID: 'trace-1',
+    spanID: 'span-1',
+    name: 'test',
+    kind: SpanKind.INTERNAL,
+    startTime: 0 as IOtelSpan['startTime'],
+    endTime: 1 as IOtelSpan['endTime'],
+    duration: 1 as IOtelSpan['duration'],
+    attributes: Object.entries(attrs).map(([key, value]) => ({ key, value })),
+    events: [],
+    links: [],
+    inboundLinks: [],
+    status: { code: StatusCode.OK },
+    resource: { attributes: [], serviceName: 'svc' },
+    instrumentationScope: { name: 'test' },
+    depth: 0,
+    hasChildren: false,
+    childSpans: [],
+    relativeStartTime: 0 as IOtelSpan['relativeStartTime'],
+    warnings: null,
+  };
+}
+
+function makeTrace(spans: IOtelSpan[]): IOtelTrace {
+  return {
+    traceID: 'trace-1',
+    spans,
+    duration: 1 as IOtelTrace['duration'],
+    startTime: 0 as IOtelTrace['startTime'],
+    endTime: 1 as IOtelTrace['endTime'],
+    traceName: 'test',
+    tracePageTitle: 'test',
+    traceEmoji: '',
+    services: [],
+    spanMap: new Map(spans.map(s => [s.spanID, s])),
+    rootSpans: spans.slice(0, 1),
+    orphanSpanCount: 0,
+    hasErrors: () => false,
+  };
+}
+
+describe('classifySpan', () => {
+  it.each<[string, GenAISpanKind]>([
+    ['chat', 'LLM_CALL'],
+    ['text_completion', 'LLM_CALL'],
+    ['execute_tool', 'TOOL_CALL'],
+    ['invoke_agent', 'AGENT'],
+    ['retrieval', 'RETRIEVAL'],
+  ])('classifies gen_ai.operation.name=%s as %s', (opName, expected) => {
+    expect(classifySpan(makeSpan({ 'gen_ai.operation.name': opName }))).toBe(expected);
+  });
+
+  it('returns UNKNOWN_GENAI for unrecognized gen_ai.operation.name with other gen_ai.* attrs', () => {
+    expect(
+      classifySpan(makeSpan({ 'gen_ai.operation.name': 'future_op', 'gen_ai.provider.name': 'acme' }))
+    ).toBe('UNKNOWN_GENAI');
+  });
+
+  it('returns UNKNOWN_GENAI when gen_ai.* attrs exist but no operation.name', () => {
+    expect(classifySpan(makeSpan({ 'gen_ai.provider.name': 'acme' }))).toBe('UNKNOWN_GENAI');
+  });
+
+  it('returns STANDARD when no gen_ai.* attrs exist', () => {
+    expect(classifySpan(makeSpan({ 'http.method': 'GET' }))).toBe('STANDARD');
+  });
+
+  it('returns STANDARD for span with no attributes', () => {
+    expect(classifySpan(makeSpan())).toBe('STANDARD');
+  });
+});
+
+describe('isGenAITrace', () => {
+  it('returns true when at least one span has gen_ai.* attributes', () => {
+    const spans = [makeSpan({ 'http.method': 'GET' }), makeSpan({ 'gen_ai.operation.name': 'chat' })];
+    expect(isGenAITrace(makeTrace(spans))).toBe(true);
+  });
+
+  it('returns false when all spans are STANDARD', () => {
+    const spans = [makeSpan({ 'http.method': 'GET' }), makeSpan({ 'db.system': 'postgresql' })];
+    expect(isGenAITrace(makeTrace(spans))).toBe(false);
+  });
+
+  it('returns false for an empty trace', () => {
+    expect(isGenAITrace(makeTrace([]))).toBe(false);
+  });
+});

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -29,7 +29,7 @@ function makeSpan(attrs: Record<string, string> = {}): IOtelSpan {
 }
 
 function makeTrace(spans: IOtelSpan[]): IOtelTrace {
-  return {
+  const trace: Omit<IOtelTrace, 'isGenAITrace'> & { isGenAITrace: boolean } = {
     traceID: 'trace-1',
     spans,
     duration: 1 as IOtelTrace['duration'],
@@ -42,8 +42,10 @@ function makeTrace(spans: IOtelSpan[]): IOtelTrace {
     spanMap: new Map(spans.map(s => [s.spanID, s])),
     rootSpans: spans.slice(0, 1),
     orphanSpanCount: 0,
+    isGenAITrace: false,
     hasErrors: () => false,
   };
+  return trace;
 }
 
 describe('classifySpan', () => {

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IOtelSpan, IOtelTrace } from '../../types/otel';
+
+export type GenAISpanKind = 'LLM_CALL' | 'TOOL_CALL' | 'AGENT' | 'RETRIEVAL' | 'UNKNOWN_GENAI' | 'STANDARD';
+
+const OPERATION_NAME_MAP: Record<string, GenAISpanKind> = {
+  chat: 'LLM_CALL',
+  text_completion: 'LLM_CALL',
+  execute_tool: 'TOOL_CALL',
+  invoke_agent: 'AGENT',
+  retrieval: 'RETRIEVAL',
+};
+
+export function classifySpan(span: IOtelSpan): GenAISpanKind {
+  const opAttr = span.attributes.find(a => a.key === 'gen_ai.operation.name');
+  if (opAttr) {
+    return OPERATION_NAME_MAP[String(opAttr.value)] ?? 'UNKNOWN_GENAI';
+  }
+  return span.attributes.some(a => a.key.startsWith('gen_ai.')) ? 'UNKNOWN_GENAI' : 'STANDARD';
+}
+
+export function isGenAITrace(trace: IOtelTrace): boolean {
+  return trace.spans.some(s => classifySpan(s) !== 'STANDARD');
+}

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -24,3 +24,14 @@ export function classifySpan(span: IOtelSpan): GenAISpanKind {
 export function isGenAITrace(trace: IOtelTrace): boolean {
   return trace.spans.some(s => classifySpan(s) !== 'STANDARD');
 }
+
+// Attribute keys that carry structured GenAI content and deserve richer rendering.
+export const RICH_MEDIA_ATTRIBUTE_KEYS: Readonly<Record<string, 'markdown' | 'json'>> = {
+  'gen_ai.input.messages': 'markdown',
+  'gen_ai.output.messages': 'markdown',
+  'gen_ai.system_instructions': 'markdown',
+  'gen_ai.tool.call.arguments': 'json',
+  'gen_ai.tool.call.result': 'json',
+  'gen_ai.tool.definitions': 'json',
+  'gen_ai.retrieval.documents': 'json',
+};


### PR DESCRIPTION
Adds a compact token usage badge to LLM call spans in the trace timeline. For any span classified as `LLM_CALL` (i.e. `gen_ai.operation.name` is `chat` or `text_completion`), the badge renders `↑{input} ↓{output}` inline after the operation name — making token consumption visible at a glance without having to open each span's detail panel.

The badge only appears when `gen_ai.usage.input_tokens` or `gen_ai.usage.output_tokens` are present. If only one is set it renders just that value. Counts above 1000 are formatted as `1.5k` to stay compact. Non-LLM spans (AGENT, TOOL_CALL, RETRIEVAL, STANDARD) get nothing.

Implementation is a new `GenAITokenBadge` component that returns `null` for all non-LLM spans, so there is no overhead on the common case. It slots into `SpanBarRow` alongside the existing `GenAISpanIcon`, no new dependencies needed.

Closes #3863. Depends on #3826 (GenAI span iconography, which provides `classifySpan`).

Tested with 9 unit tests covering: both tokens present, input only, output only, k-formatting, `text_completion` op name, non-LLM spans, standard spans, and the aria-label.