### PR TITLE
fix(plexus): Reset Digraph layout on prop changes and remove key hacks

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.tsx
@@ -256,11 +256,9 @@ export class DeepDependencyGraphPageImpl extends React.PureComponent<TProps, TSt
       );
       if (vertices.length > 1) {
         wrapperClassName = 'is-horizontal';
-        // TODO: using `key` here is a hack, debug digraph to fix the underlying issue
         content = (
           <>
             <Graph
-              key={JSON.stringify({ density, showOp, service, operation, visEncoding })}
               baseUrl={baseUrl}
               density={density}
               edges={edges}

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.tsx
@@ -114,9 +114,6 @@ export const UnconnectedTraceDiffGraph: React.FC<Props> = React.memo(props => {
   return (
     <div className="TraceDiffGraph--graphWrapper">
       <Digraph
-        // `key` is necessary to see updates to the graph when a or b changes
-        // TODO(joe): debug this issue in Digraph
-        key={`${a.id} vs ${b.id}`}
         minimap
         zoom
         className={dagClassName}

--- a/packages/plexus/src/Digraph/index.test.tsx
+++ b/packages/plexus/src/Digraph/index.test.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ELayoutPhase } from './types';
+import Digraph from './index';
+
+describe('Digraph.getDerivedStateFromProps', () => {
+  const vertices = [{ key: 'a' }, { key: 'b' }];
+  const edges = [{ from: 'a', to: 'b' }];
+  const prevState = {
+    edges,
+    vertices,
+    layoutPhase: ELayoutPhase.Done,
+  };
+
+  it('returns null if edges and vertices are unchanged', () => {
+    const nextProps = { edges, vertices };
+    expect(Digraph.getDerivedStateFromProps(nextProps as any, prevState as any)).toBeNull();
+  });
+
+  it('returns reset state with NoData phase if edges are cleared', () => {
+    const nextProps = { edges: [], vertices };
+    const result = Digraph.getDerivedStateFromProps(nextProps as any, prevState as any);
+    expect(result).toMatchObject({
+      edges: [],
+      layoutPhase: ELayoutPhase.NoData,
+      layoutEdges: null,
+      layoutVertices: null,
+    });
+  });
+
+  it('returns reset state with CalcSizes phase if edges change', () => {
+    const newEdges = [{ from: 'b', to: 'a' }];
+    const nextProps = { edges: newEdges, vertices };
+    const result = Digraph.getDerivedStateFromProps(nextProps as any, prevState as any);
+    expect(result).toMatchObject({
+      edges: newEdges,
+      layoutPhase: ELayoutPhase.CalcSizes,
+      layoutEdges: null,
+      layoutVertices: null,
+    });
+  });
+
+  it('returns reset state with CalcSizes phase if vertices change', () => {
+    const newVertices = [{ key: 'a' }, { key: 'b' }, { key: 'c' }];
+    const nextProps = { edges, vertices: newVertices };
+    const result = Digraph.getDerivedStateFromProps(nextProps as any, prevState as any);
+    expect(result).toMatchObject({
+      vertices: newVertices,
+      layoutPhase: ELayoutPhase.CalcSizes,
+      layoutEdges: null,
+      layoutVertices: null,
+    });
+  });
+});

--- a/packages/plexus/src/Digraph/index.test.tsx
+++ b/packages/plexus/src/Digraph/index.test.tsx
@@ -57,3 +57,46 @@ describe('Digraph.getDerivedStateFromProps', () => {
     });
   });
 });
+
+describe('Digraph.onLayoutDone', () => {
+  it('ignores stale layout results', () => {
+    const instance = new Digraph({} as any);
+    instance.state = { layoutVersion: 2, layoutPhase: ELayoutPhase.CalcPositions } as any;
+
+    // Simulate a layout result for an older version
+    const staleResult = { isCancelled: false, edges: [], vertices: [], graph: {} };
+    (instance as any).onLayoutDone(staleResult, 1);
+
+    // State should not change
+    expect(instance.state.layoutPhase).toBe(ELayoutPhase.CalcPositions);
+  });
+
+  it('processes current layout results', () => {
+    const instance = new Digraph({} as any);
+    instance.state = { layoutVersion: 2, layoutPhase: ELayoutPhase.CalcPositions } as any;
+
+    let contentSizeCalled = false;
+    (instance as any).zoomManager = {
+      setContentSize: () => {
+        contentSizeCalled = true;
+      },
+    };
+
+    // We mock setState because it's a React component
+    let setStateCalledWith = null;
+    instance.setState = newState => {
+      setStateCalledWith = newState;
+    };
+
+    const currentResult = { isCancelled: false, edges: [], vertices: [], graph: {} };
+    (instance as any).onLayoutDone(currentResult, 2);
+
+    expect(setStateCalledWith).toMatchObject({
+      layoutPhase: ELayoutPhase.Done,
+      layoutEdges: [],
+      layoutVertices: [],
+      layoutGraph: {},
+    });
+    expect(contentSizeCalled).toBe(true);
+  });
+});

--- a/packages/plexus/src/Digraph/index.test.tsx
+++ b/packages/plexus/src/Digraph/index.test.tsx
@@ -11,6 +11,7 @@ describe('Digraph.getDerivedStateFromProps', () => {
     edges,
     vertices,
     layoutPhase: ELayoutPhase.Done,
+    layoutVersion: 1,
   };
 
   it('returns null if edges and vertices are unchanged', () => {
@@ -26,6 +27,7 @@ describe('Digraph.getDerivedStateFromProps', () => {
       layoutPhase: ELayoutPhase.NoData,
       layoutEdges: null,
       layoutVertices: null,
+      layoutVersion: 2,
     });
   });
 
@@ -38,6 +40,7 @@ describe('Digraph.getDerivedStateFromProps', () => {
       layoutPhase: ELayoutPhase.CalcSizes,
       layoutEdges: null,
       layoutVertices: null,
+      layoutVersion: 2,
     });
   });
 
@@ -50,6 +53,7 @@ describe('Digraph.getDerivedStateFromProps', () => {
       layoutPhase: ELayoutPhase.CalcSizes,
       layoutEdges: null,
       layoutVertices: null,
+      layoutVersion: 2,
     });
   });
 });

--- a/packages/plexus/src/Digraph/index.tsx
+++ b/packages/plexus/src/Digraph/index.tsx
@@ -122,6 +122,11 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
     };
   }
 
+  /**
+   * Note: Digraph relies on referential equality to detect data changes.
+   * Callers MUST NOT mutate `edges` or `vertices` in place. They must pass
+   * new array references when the graph data changes to trigger a layout reset.
+   */
   static getDerivedStateFromProps(nextProps: TDigraphProps<any, any>, prevState: TDigraphState<any, any>) {
     const { edges, vertices } = nextProps;
     if (edges !== prevState.edges || vertices !== prevState.vertices) {
@@ -176,7 +181,6 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
       const values = `expected ${JSON.stringify(expectedKey)}, received ${JSON.stringify(senderKey)}`;
       throw new Error(`Key mismatch for measuring nodes; ${values}`);
     }
-    this.setState({ sizeVertices });
     const version = this.state.layoutVersion;
     const { layout } = layoutManager.getLayout(edges, sizeVertices);
     layout.then(result => this.onLayoutDone(result, version));

--- a/packages/plexus/src/Digraph/index.tsx
+++ b/packages/plexus/src/Digraph/index.tsx
@@ -28,6 +28,7 @@ import ZoomManager, { zoomIdentity, ZoomTransform } from '../zoom/ZoomManager';
 
 type TDigraphState<T = {}, U = {}> = Omit<TExposedGraphState<T, U>, 'renderUtils'> & {
   sizeVertices: TSizeVertex<T>[] | null;
+  layoutVersion: number;
 };
 
 type TDigraphProps<T = unknown, U = unknown> = {
@@ -91,6 +92,7 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
     sizeVertices: null,
     vertices: [],
     zoomTransform: zoomIdentity,
+    layoutVersion: 0,
   };
 
   baseId = `plexus--Digraph--${idCounter++}`;
@@ -132,6 +134,7 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
           layoutPhase: ELayoutPhase.CalcSizes,
           layoutVertices: null,
           sizeVertices: null,
+          layoutVersion: prevState.layoutVersion + 1,
         };
       }
       return {
@@ -142,6 +145,7 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
         layoutPhase: ELayoutPhase.NoData,
         layoutVertices: null,
         sizeVertices: null,
+        layoutVersion: prevState.layoutVersion + 1,
       };
     }
     return null;
@@ -165,8 +169,9 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
       throw new Error(`Key mismatch for measuring nodes; ${values}`);
     }
     this.setState({ sizeVertices });
+    const version = this.state.layoutVersion;
     const { layout } = layoutManager.getLayout(edges, sizeVertices);
-    layout.then(this.onLayoutDone);
+    layout.then(result => this.onLayoutDone(result, version));
     this.setState({ sizeVertices, layoutPhase: ELayoutPhase.CalcPositions });
     // We can add support for drawing nodes in the correct position before we have edges
     // via the following (instead of the above)
@@ -272,8 +277,8 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
     this.setState({ zoomTransform });
   };
 
-  private onLayoutDone = (result: TCancelled | TLayoutDone<T, U>) => {
-    if (result.isCancelled) {
+  private onLayoutDone = (result: TCancelled | TLayoutDone<T, U>, version: number) => {
+    if (result.isCancelled || version !== this.state.layoutVersion) {
       return;
     }
     const { edges: layoutEdges, graph: layoutGraph, vertices: layoutVertices } = result;

--- a/packages/plexus/src/Digraph/index.tsx
+++ b/packages/plexus/src/Digraph/index.tsx
@@ -158,6 +158,14 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
     }
   }
 
+  componentDidUpdate(_prevProps: TDigraphProps<T, U>, prevState: TDigraphState<T, U>) {
+    if (this.state.layoutPhase === ELayoutPhase.NoData && prevState.layoutPhase !== ELayoutPhase.NoData) {
+      if (this.zoomManager) {
+        this.zoomManager.resetZoom();
+      }
+    }
+  }
+
   getGlobalId = (name: string) => `${this.baseId}--${name}`;
 
   getZoomTransform = () => this.state.zoomTransform;
@@ -165,7 +173,7 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
   private setSizeVertices = (senderKey: string, sizeVertices: TSizeVertex<T>[]) => {
     const { edges, layoutManager, measurableNodesKey: expectedKey } = this.props;
     if (senderKey !== expectedKey) {
-      const values = `expected ${JSON.stringify(expectedKey)}, recieved ${JSON.stringify(senderKey)}`;
+      const values = `expected ${JSON.stringify(expectedKey)}, received ${JSON.stringify(senderKey)}`;
       throw new Error(`Key mismatch for measuring nodes; ${values}`);
     }
     this.setState({ sizeVertices });

--- a/packages/plexus/src/Digraph/index.tsx
+++ b/packages/plexus/src/Digraph/index.tsx
@@ -120,6 +120,33 @@ export default class Digraph<T = unknown, U = unknown> extends React.PureCompone
     };
   }
 
+  static getDerivedStateFromProps(nextProps: TDigraphProps<any, any>, prevState: TDigraphState<any, any>) {
+    const { edges, vertices } = nextProps;
+    if (edges !== prevState.edges || vertices !== prevState.vertices) {
+      if (Array.isArray(edges) && edges.length && Array.isArray(vertices) && vertices.length) {
+        return {
+          edges,
+          vertices,
+          layoutEdges: null,
+          layoutGraph: null,
+          layoutPhase: ELayoutPhase.CalcSizes,
+          layoutVertices: null,
+          sizeVertices: null,
+        };
+      }
+      return {
+        edges,
+        vertices,
+        layoutEdges: null,
+        layoutGraph: null,
+        layoutPhase: ELayoutPhase.NoData,
+        layoutVertices: null,
+        sizeVertices: null,
+      };
+    }
+    return null;
+  }
+
   componentDidMount() {
     const { current } = this.rootRef;
     if (current && this.zoomManager) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3866

## Description of the changes
- Implemented `static getDerivedStateFromProps` in the `Digraph` component within the `@jaegertracing/plexus` package. This ensures that the internal layout state (edges, vertices, and layout phase) is correctly reset when the corresponding props are updated after the initial mount.
- Removed legacy `key` prop workarounds in `packages/jaeger-ui/src/components/DeepDependencies/index.tsx` and `packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/TraceDiffGraph.tsx` that were previously used to force graph re-renders by unmounting/remounting the component.

## How was this change tested?
- **Unit Tests**: Created a new test file `packages/plexus/src/Digraph/index.test.tsx` to verify that `getDerivedStateFromProps` correctly resets the layout phase to `CalcSizes` when data changes, and returns `null` when it stays the same.
- **Integration**: Verified that the graph now updates correctly in the UI without needing manual `key` changes.
- **Verification**: Ran the complete test suite (`npm test`) and linting (`npm run lint`).

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `npm run lint` and `npm test`

## AI Usage in this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)