### PR TITLE
refactor(trace): Convert TimelineViewingLayer to hooks

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
@@ -5,29 +5,60 @@ import React from 'react';
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+const { draggerInstances } = vi.hoisted(() => {
+  const draggerInstances = [];
+  return { draggerInstances };
+});
+
+vi.mock('../../../../utils/DraggableManager', async () => {
+  const actual = await vi.importActual('../../../../utils/DraggableManager');
+
+  class MockDraggableManager {
+    constructor(opts) {
+      this._opts = opts;
+      this.getBounds = opts.getBounds;
+      this.handleMouseDown = vi.fn();
+      this.handleMouseLeave = vi.fn();
+      this.handleMouseMove = vi.fn();
+      this.resetBounds = vi.fn();
+      this.dispose = vi.fn();
+      draggerInstances.push(this);
+    }
+  }
+
+  return {
+    ...actual,
+    default: MockDraggableManager,
+  };
+});
+
 import TimelineViewingLayer from './TimelineViewingLayer';
 
 function mapFromSubRange(viewStart, viewEnd, value) {
   return viewStart + value * (viewEnd - viewStart);
 }
 
+function getDragger() {
+  return draggerInstances[0];
+}
+
 describe('<TimelineViewingLayer>', () => {
   const viewStart = 0.25;
   const viewEnd = 0.9;
-  const props = {
-    boundsInvalidator: Math.random(),
-    updateNextViewRangeTime: jest.fn(),
-    updateViewRangeTime: jest.fn(),
-    viewRangeTime: {
-      current: [viewStart, viewEnd],
-    },
-  };
+  let props;
 
   beforeEach(() => {
-    props.updateNextViewRangeTime.mockReset();
-    props.updateViewRangeTime.mockReset();
+    draggerInstances.length = 0;
+    props = {
+      boundsInvalidator: Math.random(),
+      updateNextViewRangeTime: vi.fn(),
+      updateViewRangeTime: vi.fn(),
+      viewRangeTime: {
+        current: [viewStart, viewEnd],
+      },
+    };
 
-    Element.prototype.getBoundingClientRect = jest.fn(() => ({
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
       left: 10,
       width: 100,
       top: 0,
@@ -39,7 +70,7 @@ describe('<TimelineViewingLayer>', () => {
 
   afterEach(() => {
     cleanup();
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('renders without exploding', () => {
@@ -47,84 +78,106 @@ describe('<TimelineViewingLayer>', () => {
     expect(container.querySelector('.TimelineViewingLayer')).toBeInTheDocument();
   });
 
-  it('sets _root to the root DOM node', () => {
+  it('wires DOM mouse events to the DraggableManager handlers', () => {
     const { container } = render(<TimelineViewingLayer {...props} />);
     const timelineLayer = container.querySelector('.TimelineViewingLayer');
-    expect(timelineLayer).toBeDefined();
+    const dragger = getDragger();
+
+    fireEvent.mouseDown(timelineLayer);
+    fireEvent.mouseLeave(timelineLayer);
+    fireEvent.mouseMove(timelineLayer);
+
+    expect(dragger.handleMouseDown).toHaveBeenCalled();
+    expect(dragger.handleMouseLeave).toHaveBeenCalled();
+    expect(dragger.handleMouseMove).toHaveBeenCalled();
   });
 
-  describe('uses DraggableManager', () => {
-    it('initializes the DraggableManager', () => {
-      const comp = new TimelineViewingLayer(props);
-      expect(comp._draggerReframe).toBeDefined();
+  describe('DraggableManager callbacks', () => {
+    it('returns the dragging bounds from the root DOM node', () => {
+      render(<TimelineViewingLayer {...props} />);
+      expect(getDragger().getBounds()).toEqual({ clientXLeft: 10, width: 100 });
     });
 
-    it('returns the dragging bounds from _getDraggingBounds()', () => {
-      const comp = new TimelineViewingLayer(props);
-      comp._root.current = document.createElement('div');
-      comp._root.current.getBoundingClientRect = () => ({ left: 10, width: 100 });
-      expect(comp._getDraggingBounds()).toEqual({ clientXLeft: 10, width: 100 });
-    });
+    it('throws error when dragging bounds are requested after unmount', () => {
+      const { unmount } = render(<TimelineViewingLayer {...props} />);
+      const dragger = getDragger();
 
-    it('throws error on call to _getDraggingBounds() on unmounted component', () => {
-      const comp = new TimelineViewingLayer(props);
-      comp._root.current = null;
-      expect(() => comp._getDraggingBounds()).toThrow(
+      unmount();
+
+      expect(() => dragger.getBounds()).toThrow(
         'Component must be mounted in order to determine DraggableBounds'
       );
     });
 
-    it('updates viewRange.time.cursor via _draggerReframe._onMouseMove', () => {
-      const { container } = render(<TimelineViewingLayer {...props} />);
-      fireEvent.mouseMove(container.querySelector('.TimelineViewingLayer'), { clientX: 60 });
-      expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({ cursor: expect.any(Number) });
+    it('updates viewRangeTime.cursor on mouse move', () => {
+      render(<TimelineViewingLayer {...props} />);
+      getDragger()._opts.onMouseMove({ value: 0.5 });
+      expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({
+        cursor: mapFromSubRange(viewStart, viewEnd, 0.5),
+      });
     });
 
-    it('resets viewRange.time.cursor via _draggerReframe._onMouseLeave', () => {
-      const { container } = render(<TimelineViewingLayer {...props} />);
-      fireEvent.mouseLeave(container.querySelector('.TimelineViewingLayer'));
+    it('clears viewRangeTime.cursor on mouse leave', () => {
+      render(<TimelineViewingLayer {...props} />);
+      getDragger()._opts.onMouseLeave();
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({ cursor: undefined });
     });
 
-    it('handles drag start via _draggerReframe._onDragStart', () => {
-      const { container } = render(<TimelineViewingLayer {...props} />);
-      fireEvent.mouseDown(container.querySelector('.TimelineViewingLayer'), { clientX: 60 });
+    it('handles drag start without an existing anchor', () => {
+      render(<TimelineViewingLayer {...props} />);
+      getDragger()._opts.onDragStart({ value: 0.5 });
+      const shift = mapFromSubRange(viewStart, viewEnd, 0.5);
+
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({
-        reframe: {
-          anchor: expect.any(Number),
-          shift: expect.any(Number),
-        },
+        reframe: { anchor: shift, shift },
       });
     });
 
-    it('handles drag move via _draggerReframe._onDragMove', () => {
-      const anchor = 0.25;
-      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
-      const { container } = render(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);
-      fireEvent.mouseDown(container.querySelector('.TimelineViewingLayer'), { clientX: 60 });
-      expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({
-        reframe: {
-          anchor: expect.any(Number),
-          shift: expect.any(Number),
-        },
-      });
-    });
-
-    it('handles drag end via _draggerReframe._onDragEnd', () => {
+    it('uses the latest reframe anchor after props update', () => {
+      const { rerender } = render(<TimelineViewingLayer {...props} />);
       const anchor = 0.75;
       const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
-      const { container } = render(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);
-      fireEvent.mouseDown(container.querySelector('.TimelineViewingLayer'), { clientX: 60 });
-      fireEvent.mouseUp(container.querySelector('.TimelineViewingLayer'), { clientX: 40 });
-      const [start, end, source] = props.updateViewRangeTime.mock.calls.at(-1);
-      expect(start).toBeLessThanOrEqual(end);
-      expect(source).toBe('timeline-header');
+
+      rerender(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);
+      getDragger()._opts.onDragMove({ value: 0.5 });
+
+      expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({
+        reframe: { anchor, shift: mapFromSubRange(viewStart, viewEnd, 0.5) },
+      });
     });
 
-    it('resets draggable bounds on boundsInvalidator update', () => {
-      const { rerender, container } = render(<TimelineViewingLayer {...props} />);
+    it('handles drag end and orders the resulting range', () => {
+      const anchor = 0.75;
+      const manager = { resetBounds: vi.fn() };
+      const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
+
+      render(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);
+      getDragger()._opts.onDragEnd({ manager, value: 0.25 });
+
+      expect(manager.resetBounds).toHaveBeenCalled();
+      expect(props.updateViewRangeTime).toHaveBeenCalledWith(
+        mapFromSubRange(viewStart, viewEnd, 0.25),
+        anchor,
+        'timeline-header'
+      );
+    });
+
+    it('resets draggable bounds when boundsInvalidator changes', () => {
+      const { rerender } = render(<TimelineViewingLayer {...props} />);
+      const dragger = getDragger();
+
       rerender(<TimelineViewingLayer {...props} boundsInvalidator={Math.random()} />);
-      expect(container.firstChild).toBeInTheDocument();
+
+      expect(dragger.resetBounds).toHaveBeenCalled();
+    });
+
+    it('disposes the DraggableManager on unmount', () => {
+      const { unmount } = render(<TimelineViewingLayer {...props} />);
+      const dragger = getDragger();
+
+      unmount();
+
+      expect(dragger.dispose).toHaveBeenCalled();
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
@@ -58,7 +58,7 @@ describe('<TimelineViewingLayer>', () => {
       },
     };
 
-    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
       left: 10,
       width: 100,
       top: 0,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { render, fireEvent, cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 
 const { draggerInstances } = vi.hoisted(() => {
   const draggerInstances = [];
@@ -17,12 +17,23 @@ vi.mock('../../../../utils/DraggableManager', async () => {
     constructor(opts) {
       this._opts = opts;
       this.getBounds = opts.getBounds;
-      this.handleMouseDown = vi.fn();
-      this.handleMouseLeave = vi.fn();
-      this.handleMouseMove = vi.fn();
+      this.handleMouseDown = vi.fn(event => {
+        opts.onDragStart?.({ manager: this, value: this._getValue(event) });
+      });
+      this.handleMouseLeave = vi.fn(() => {
+        opts.onMouseLeave?.({ manager: this });
+      });
+      this.handleMouseMove = vi.fn(event => {
+        opts.onMouseMove?.({ manager: this, value: this._getValue(event) });
+      });
       this.resetBounds = vi.fn();
       this.dispose = vi.fn();
       draggerInstances.push(this);
+    }
+
+    _getValue(event) {
+      const { clientXLeft, width } = this.getBounds();
+      return (event.clientX - clientXLeft) / width;
     }
   }
 
@@ -39,7 +50,18 @@ function mapFromSubRange(viewStart, viewEnd, value) {
 }
 
 function getDragger() {
+  if (draggerInstances.length !== 1) {
+    throw new Error(
+      `Expected exactly one MockDraggableManager instance, but found ${draggerInstances.length}.`
+    );
+  }
   return draggerInstances[0];
+}
+
+function getTimelineLayer(container) {
+  const timelineLayer = container.querySelector('.TimelineViewingLayer');
+  expect(timelineLayer).toBeInTheDocument();
+  return timelineLayer;
 }
 
 describe('<TimelineViewingLayer>', () => {
@@ -80,12 +102,12 @@ describe('<TimelineViewingLayer>', () => {
 
   it('wires DOM mouse events to the DraggableManager handlers', () => {
     const { container } = render(<TimelineViewingLayer {...props} />);
-    const timelineLayer = container.querySelector('.TimelineViewingLayer');
+    const timelineLayer = getTimelineLayer(container);
     const dragger = getDragger();
 
-    fireEvent.mouseDown(timelineLayer);
+    fireEvent.mouseDown(timelineLayer, { clientX: 60 });
     fireEvent.mouseLeave(timelineLayer);
-    fireEvent.mouseMove(timelineLayer);
+    fireEvent.mouseMove(timelineLayer, { clientX: 60 });
 
     expect(dragger.handleMouseDown).toHaveBeenCalled();
     expect(dragger.handleMouseLeave).toHaveBeenCalled();
@@ -110,22 +132,22 @@ describe('<TimelineViewingLayer>', () => {
     });
 
     it('updates viewRangeTime.cursor on mouse move', () => {
-      render(<TimelineViewingLayer {...props} />);
-      getDragger()._opts.onMouseMove({ value: 0.5 });
+      const { container } = render(<TimelineViewingLayer {...props} />);
+      fireEvent.mouseMove(getTimelineLayer(container), { clientX: 60 });
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({
         cursor: mapFromSubRange(viewStart, viewEnd, 0.5),
       });
     });
 
     it('clears viewRangeTime.cursor on mouse leave', () => {
-      render(<TimelineViewingLayer {...props} />);
-      getDragger()._opts.onMouseLeave();
+      const { container } = render(<TimelineViewingLayer {...props} />);
+      fireEvent.mouseLeave(getTimelineLayer(container));
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({ cursor: undefined });
     });
 
     it('handles drag start without an existing anchor', () => {
-      render(<TimelineViewingLayer {...props} />);
-      getDragger()._opts.onDragStart({ value: 0.5 });
+      const { container } = render(<TimelineViewingLayer {...props} />);
+      fireEvent.mouseDown(getTimelineLayer(container), { clientX: 60 });
       const shift = mapFromSubRange(viewStart, viewEnd, 0.5);
 
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx
@@ -35,6 +35,14 @@ vi.mock('../../../../utils/DraggableManager', async () => {
       const { clientXLeft, width } = this.getBounds();
       return (event.clientX - clientXLeft) / width;
     }
+
+    triggerDragMove(value) {
+      this._opts.onDragMove?.({ manager: this, value });
+    }
+
+    triggerDragEnd(value, manager = this) {
+      this._opts.onDragEnd?.({ manager, value });
+    }
   }
 
   return {
@@ -161,7 +169,7 @@ describe('<TimelineViewingLayer>', () => {
       const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
 
       rerender(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);
-      getDragger()._opts.onDragMove({ value: 0.5 });
+      getDragger().triggerDragMove(0.5);
 
       expect(props.updateNextViewRangeTime).toHaveBeenCalledWith({
         reframe: { anchor, shift: mapFromSubRange(viewStart, viewEnd, 0.5) },
@@ -174,7 +182,7 @@ describe('<TimelineViewingLayer>', () => {
       const viewRangeTime = { ...props.viewRangeTime, reframe: { anchor, shift: 0.5 } };
 
       render(<TimelineViewingLayer {...props} viewRangeTime={viewRangeTime} />);
-      getDragger()._opts.onDragEnd({ manager, value: 0.25 });
+      getDragger().triggerDragEnd(0.25, manager);
 
       expect(manager.resetBounds).toHaveBeenCalled();
       expect(props.updateViewRangeTime).toHaveBeenCalledWith(

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -16,7 +16,7 @@ type TimelineViewingLayerProps = {
    * bounds for dragging need to be recalculated. In practice, the name column
    * width serves fine for this.
    */
-  boundsInvalidator: any | null | undefined;
+  boundsInvalidator: unknown;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRangeTime: IViewRangeTime;
@@ -109,98 +109,109 @@ function getMarkers(
  * labels; it handles showing the current view range and handles mouse UX for
  * modifying it.
  */
-export default class TimelineViewingLayer extends React.PureComponent<TimelineViewingLayerProps> {
-  _draggerReframe: DraggableManager;
-  _root = React.createRef<HTMLDivElement>();
+function TimelineViewingLayer(props: TimelineViewingLayerProps) {
+  const { boundsInvalidator, viewRangeTime } = props;
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const propsRef = React.useRef(props);
+  propsRef.current = props;
 
-  constructor(props: TimelineViewingLayerProps) {
-    super(props);
-    this._draggerReframe = new DraggableManager({
-      getBounds: this._getDraggingBounds,
-      onDragEnd: this._handleReframeDragEnd,
-      onDragMove: this._handleReframeDragUpdate,
-      onDragStart: this._handleReframeDragUpdate,
-      onMouseLeave: this._handleReframeMouseLeave,
-      onMouseMove: this._handleReframeMouseMove,
-    });
-  }
-
-  componentDidUpdate(prevProps: Readonly<TimelineViewingLayerProps>) {
-    const { boundsInvalidator } = this.props;
-    if (prevProps.boundsInvalidator !== boundsInvalidator) {
-      this._draggerReframe.resetBounds();
-    }
-  }
-
-  componentWillUnmount() {
-    this._draggerReframe.dispose();
-  }
-
-  _getDraggingBounds = (): DraggableBounds => {
-    const current = this._root.current;
+  const getDraggingBounds = React.useCallback((): DraggableBounds => {
+    const current = rootRef.current;
     if (!current) {
       throw new Error('Component must be mounted in order to determine DraggableBounds');
     }
     const { left: clientXLeft, width } = current.getBoundingClientRect();
     return { clientXLeft, width };
-  };
+  }, []);
 
-  _handleReframeMouseMove = ({ value }: DraggingUpdate) => {
-    const [viewStart, viewEnd] = this.props.viewRangeTime.current;
-    const cursor = mapFromViewSubRange(viewStart, viewEnd, value);
-    this.props.updateNextViewRangeTime({ cursor });
-  };
-
-  _handleReframeMouseLeave = () => {
-    this.props.updateNextViewRangeTime({ cursor: undefined });
-  };
-
-  _getAnchorAndShift = (value: number) => {
-    const { current, reframe } = this.props.viewRangeTime;
+  const getAnchorAndShift = React.useCallback((value: number) => {
+    const { current, reframe } = propsRef.current.viewRangeTime;
     const [viewStart, viewEnd] = current;
     const shift = mapFromViewSubRange(viewStart, viewEnd, value);
     const anchor = reframe ? reframe.anchor : shift;
     return { anchor, shift };
-  };
+  }, []);
 
-  _handleReframeDragUpdate = ({ value }: DraggingUpdate) => {
-    const { anchor, shift } = this._getAnchorAndShift(value);
-    const update = { reframe: { anchor, shift } };
-    this.props.updateNextViewRangeTime(update);
-  };
+  const handleReframeMouseMove = React.useCallback(({ value }: DraggingUpdate) => {
+    const [viewStart, viewEnd] = propsRef.current.viewRangeTime.current;
+    const cursor = mapFromViewSubRange(viewStart, viewEnd, value);
+    propsRef.current.updateNextViewRangeTime({ cursor });
+  }, []);
 
-  _handleReframeDragEnd = ({ manager, value }: DraggingUpdate) => {
-    const { anchor, shift } = this._getAnchorAndShift(value);
-    const [start, end] = shift < anchor ? [shift, anchor] : [anchor, shift];
-    manager.resetBounds();
-    this.props.updateViewRangeTime(start, end, 'timeline-header');
-  };
+  const handleReframeMouseLeave = React.useCallback(() => {
+    propsRef.current.updateNextViewRangeTime({ cursor: undefined });
+  }, []);
 
-  render() {
-    const { viewRangeTime } = this.props;
-    const { current, cursor, reframe, shiftEnd, shiftStart } = viewRangeTime;
-    const [viewStart, viewEnd] = current;
-    const haveNextTimeRange = reframe != null || shiftEnd != null || shiftStart != null;
-    let cusrorPosition: string | TNil;
-    if (!haveNextTimeRange && cursor != null && cursor >= viewStart && cursor <= viewEnd) {
-      cusrorPosition = `${mapToViewSubRange(viewStart, viewEnd, cursor) * 100}%`;
-    }
-    return (
-      <div
-        aria-hidden
-        className="TimelineViewingLayer"
-        ref={this._root}
-        onMouseDown={this._draggerReframe.handleMouseDown}
-        onMouseLeave={this._draggerReframe.handleMouseLeave}
-        onMouseMove={this._draggerReframe.handleMouseMove}
-      >
-        {cusrorPosition != null && (
-          <div className="TimelineViewingLayer--cursorGuide" style={{ left: cusrorPosition }} />
-        )}
-        {reframe != null && getMarkers(viewStart, viewEnd, reframe.anchor, reframe.shift, false)}
-        {shiftEnd != null && getMarkers(viewStart, viewEnd, viewEnd, shiftEnd, true)}
-        {shiftStart != null && getMarkers(viewStart, viewEnd, viewStart, shiftStart, true)}
-      </div>
-    );
+  const handleReframeDragUpdate = React.useCallback(
+    ({ value }: DraggingUpdate) => {
+      const { anchor, shift } = getAnchorAndShift(value);
+      const update = { reframe: { anchor, shift } };
+      propsRef.current.updateNextViewRangeTime(update);
+    },
+    [getAnchorAndShift]
+  );
+
+  const handleReframeDragEnd = React.useCallback(
+    ({ manager, value }: DraggingUpdate) => {
+      const { anchor, shift } = getAnchorAndShift(value);
+      const [start, end] = shift < anchor ? [shift, anchor] : [anchor, shift];
+      manager.resetBounds();
+      propsRef.current.updateViewRangeTime(start, end, 'timeline-header');
+    },
+    [getAnchorAndShift]
+  );
+
+  const draggerReframeRef = React.useRef<DraggableManager | null>(null);
+  if (!draggerReframeRef.current) {
+    draggerReframeRef.current = new DraggableManager({
+      getBounds: getDraggingBounds,
+      onDragEnd: handleReframeDragEnd,
+      onDragMove: handleReframeDragUpdate,
+      onDragStart: handleReframeDragUpdate,
+      onMouseLeave: handleReframeMouseLeave,
+      onMouseMove: handleReframeMouseMove,
+    });
   }
+
+  const previousBoundsInvalidatorRef = React.useRef(boundsInvalidator);
+  React.useEffect(() => {
+    if (previousBoundsInvalidatorRef.current !== boundsInvalidator) {
+      draggerReframeRef.current?.resetBounds();
+      previousBoundsInvalidatorRef.current = boundsInvalidator;
+    }
+  }, [boundsInvalidator]);
+
+  React.useEffect(() => {
+    return () => {
+      draggerReframeRef.current?.dispose();
+    };
+  }, []);
+
+  const { current, cursor, reframe, shiftEnd, shiftStart } = viewRangeTime;
+  const [viewStart, viewEnd] = current;
+  const haveNextTimeRange = reframe != null || shiftEnd != null || shiftStart != null;
+  let cursorPosition: string | TNil;
+  if (!haveNextTimeRange && cursor != null && cursor >= viewStart && cursor <= viewEnd) {
+    cursorPosition = `${mapToViewSubRange(viewStart, viewEnd, cursor) * 100}%`;
+  }
+
+  return (
+    <div
+      aria-hidden
+      className="TimelineViewingLayer"
+      ref={rootRef}
+      onMouseDown={draggerReframeRef.current.handleMouseDown}
+      onMouseLeave={draggerReframeRef.current.handleMouseLeave}
+      onMouseMove={draggerReframeRef.current.handleMouseMove}
+    >
+      {cursorPosition != null && (
+        <div className="TimelineViewingLayer--cursorGuide" style={{ left: cursorPosition }} />
+      )}
+      {reframe != null && getMarkers(viewStart, viewEnd, reframe.anchor, reframe.shift, false)}
+      {shiftEnd != null && getMarkers(viewStart, viewEnd, viewEnd, shiftEnd, true)}
+      {shiftStart != null && getMarkers(viewStart, viewEnd, viewStart, shiftStart, true)}
+    </div>
+  );
 }
+
+export default React.memo(TimelineViewingLayer);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -12,11 +12,11 @@ import './TimelineViewingLayer.css';
 
 type TimelineViewingLayerProps = {
   /**
-   * `boundsInvalidator` is an arbitrary prop that lets the component know the
+   * `boundsInvalidator` is an arbitrary value that lets the component know the
    * bounds for dragging need to be recalculated. In practice, the name column
    * width serves fine for this.
    */
-  boundsInvalidator?: unknown;
+  boundsInvalidator: unknown;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRangeTime: IViewRangeTime;
@@ -162,10 +162,8 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
   );
 
   const draggerReframeRef = React.useRef<DraggableManager | null>(null);
-  // DraggableManager is intentionally created once; its callbacks read from
-  // propsRef so drag events use the latest props after rerenders.
-  if (!draggerReframeRef.current) {
-    draggerReframeRef.current = new DraggableManager({
+  React.useEffect(() => {
+    const manager = new DraggableManager({
       getBounds: getDraggingBounds,
       onDragEnd: handleReframeDragEnd,
       onDragMove: handleReframeDragUpdate,
@@ -173,23 +171,45 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
       onMouseLeave: handleReframeMouseLeave,
       onMouseMove: handleReframeMouseMove,
     });
-  }
-  const draggerReframe = draggerReframeRef.current;
+    draggerReframeRef.current = manager;
+    return () => {
+      if (draggerReframeRef.current === manager) {
+        draggerReframeRef.current = null;
+      }
+      manager.dispose();
+    };
+  }, [
+    getDraggingBounds,
+    handleReframeDragEnd,
+    handleReframeDragUpdate,
+    handleReframeMouseLeave,
+    handleReframeMouseMove,
+  ]);
+
+  const handleMouseDown = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    draggerReframeRef.current?.handleMouseDown(event);
+  }, []);
+
+  const handleMouseLeave = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    draggerReframeRef.current?.handleMouseLeave(event);
+  }, []);
+
+  const handleMouseMove = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    draggerReframeRef.current?.handleMouseMove(event);
+  }, []);
 
   const hasMountedRef = React.useRef(false);
   React.useEffect(() => {
+    const manager = draggerReframeRef.current;
+    if (!manager) {
+      return;
+    }
     if (hasMountedRef.current) {
-      draggerReframe.resetBounds();
+      manager.resetBounds();
     } else {
       hasMountedRef.current = true;
     }
-  }, [boundsInvalidator, draggerReframe]);
-
-  React.useEffect(() => {
-    return () => {
-      draggerReframeRef.current?.dispose();
-    };
-  }, []);
+  }, [boundsInvalidator]);
 
   const { current, cursor, reframe, shiftEnd, shiftStart } = viewRangeTime;
   const [viewStart, viewEnd] = current;
@@ -204,9 +224,9 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
       aria-hidden
       className="TimelineViewingLayer"
       ref={rootRef}
-      onMouseDown={draggerReframe.handleMouseDown}
-      onMouseLeave={draggerReframe.handleMouseLeave}
-      onMouseMove={draggerReframe.handleMouseMove}
+      onMouseDown={handleMouseDown}
+      onMouseLeave={handleMouseLeave}
+      onMouseMove={handleMouseMove}
     >
       {cursorPosition != null && (
         <div className="TimelineViewingLayer--cursorGuide" style={{ left: cursorPosition }} />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -16,7 +16,7 @@ type TimelineViewingLayerProps = {
    * bounds for dragging need to be recalculated. In practice, the name column
    * width serves fine for this.
    */
-  boundsInvalidator: unknown;
+  boundsInvalidator?: unknown;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
   viewRangeTime: IViewRangeTime;
@@ -162,6 +162,8 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
   );
 
   const draggerReframeRef = React.useRef<DraggableManager | null>(null);
+  // DraggableManager is intentionally created once; its callbacks read from
+  // propsRef so drag events use the latest props after rerenders.
   if (!draggerReframeRef.current) {
     draggerReframeRef.current = new DraggableManager({
       getBounds: getDraggingBounds,
@@ -172,14 +174,16 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
       onMouseMove: handleReframeMouseMove,
     });
   }
+  const draggerReframe = draggerReframeRef.current;
 
-  const previousBoundsInvalidatorRef = React.useRef(boundsInvalidator);
+  const hasMountedRef = React.useRef(false);
   React.useEffect(() => {
-    if (previousBoundsInvalidatorRef.current !== boundsInvalidator) {
-      draggerReframeRef.current?.resetBounds();
-      previousBoundsInvalidatorRef.current = boundsInvalidator;
+    if (hasMountedRef.current) {
+      draggerReframe.resetBounds();
+    } else {
+      hasMountedRef.current = true;
     }
-  }, [boundsInvalidator]);
+  }, [boundsInvalidator, draggerReframe]);
 
   React.useEffect(() => {
     return () => {
@@ -200,9 +204,9 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
       aria-hidden
       className="TimelineViewingLayer"
       ref={rootRef}
-      onMouseDown={draggerReframeRef.current.handleMouseDown}
-      onMouseLeave={draggerReframeRef.current.handleMouseLeave}
-      onMouseMove={draggerReframeRef.current.handleMouseMove}
+      onMouseDown={draggerReframe.handleMouseDown}
+      onMouseLeave={draggerReframe.handleMouseLeave}
+      onMouseMove={draggerReframe.handleMouseMove}
     >
       {cursorPosition != null && (
         <div className="TimelineViewingLayer--cursorGuide" style={{ left: cursorPosition }} />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.tsx
@@ -113,7 +113,9 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
   const { boundsInvalidator, viewRangeTime } = props;
   const rootRef = React.useRef<HTMLDivElement>(null);
   const propsRef = React.useRef(props);
-  propsRef.current = props;
+  React.useLayoutEffect(() => {
+    propsRef.current = props;
+  });
 
   const getDraggingBounds = React.useCallback((): DraggableBounds => {
     const current = rootRef.current;
@@ -162,7 +164,7 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
   );
 
   const draggerReframeRef = React.useRef<DraggableManager | null>(null);
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const manager = new DraggableManager({
       getBounds: getDraggingBounds,
       onDragEnd: handleReframeDragEnd,
@@ -198,16 +200,16 @@ function TimelineViewingLayer(props: TimelineViewingLayerProps) {
     draggerReframeRef.current?.handleMouseMove(event);
   }, []);
 
-  const hasMountedRef = React.useRef(false);
-  React.useEffect(() => {
+  const previousBoundsInvalidatorRef = React.useRef(boundsInvalidator);
+  React.useLayoutEffect(() => {
     const manager = draggerReframeRef.current;
     if (!manager) {
+      previousBoundsInvalidatorRef.current = boundsInvalidator;
       return;
     }
-    if (hasMountedRef.current) {
+    if (previousBoundsInvalidatorRef.current !== boundsInvalidator) {
       manager.resetBounds();
-    } else {
-      hasMountedRef.current = true;
+      previousBoundsInvalidatorRef.current = boundsInvalidator;
     }
   }, [boundsInvalidator]);
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3368

## Description of the changes
- Refactors `TimelineViewingLayer` from a React `PureComponent` class to a memoized functional component using hooks.
- Replaces lifecycle behavior with `useEffect` cleanup/update handling.
- Uses refs to keep `DraggableManager` callbacks in sync with the latest props and avoid stale closures.
- Updates unit tests to verify rendered behavior and `DraggableManager` callbacks without relying on class instances.

## How was this change tested?
- `npm test -w packages/jaeger-ui -- src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.test.jsx`
- `npm run tsc-lint`
- `npm run build`
- no visual regression observed.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
