### PR TITLE
feat(SpanDetail): surface span.kind in the overview header

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.css
@@ -7,6 +7,15 @@ SPDX-License-Identifier: Apache-2.0
   background: var(--border-default);
 }
 
+.SpanDetail--kindBadge {
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  font-size: 0.8em;
+  font-weight: 500;
+  padding: 0.1em 0.4em;
+}
+
 .SpanDetail--debugInfo {
   display: block;
   letter-spacing: 0.25px;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -198,19 +198,29 @@ describe('<SpanDetail>', () => {
     expect(heading).toHaveTextContent(span.name);
   });
 
-  it('renders overview items with service name, duration and start time labels', () => {
+  it('renders overview items with service name, kind, duration and start time labels', () => {
     render(<SpanDetail {...props} />);
 
     const labeledList = screen.getByTestId('labeled-list');
     expect(labeledList).toBeInTheDocument();
 
     expect(screen.getByTestId('item-svc')).toBeInTheDocument();
+    expect(screen.getByTestId('item-kind')).toBeInTheDocument();
     expect(screen.getByTestId('item-duration')).toBeInTheDocument();
     expect(screen.getByTestId('item-start')).toBeInTheDocument();
 
     expect(screen.getByTestId('item-svc')).toHaveTextContent('Service:');
+    expect(screen.getByTestId('item-kind')).toHaveTextContent('Kind:');
     expect(screen.getByTestId('item-duration')).toHaveTextContent('Duration:');
     expect(screen.getByTestId('item-start')).toHaveTextContent('Start Time:');
+  });
+
+  it('displays span kind as a lowercase badge in the overview', () => {
+    render(<SpanDetail {...props} />);
+    const kindItem = screen.getByTestId('item-kind');
+    const badge = kindItem.querySelector('.SpanDetail--kindBadge');
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toBe(span.kind.toLowerCase());
   });
 
   it('renders span tags accordian and triggers toggle callback with span ID', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -74,6 +74,11 @@ export default function SpanDetail(props: SpanDetailProps) {
       value: span.resource.serviceName,
     },
     {
+      key: 'kind',
+      label: 'Kind:',
+      value: <span className="SpanDetail--kindBadge">{span.kind.toLowerCase()}</span>,
+    },
+    {
       key: 'duration',
       label: 'Duration:',
       value: formatDurationCompact(span.duration),


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3870

## Description of the changes
- `span.kind` is a top-level OTel field but had no presence in the span detail header. The only way to find it was scrolling through the attributes table looking for the synthetic `span.kind` tag
- Added it as a small inline badge in the overview row alongside Service, Duration, and Start Time
- Badge styling uses existing design tokens, no hardcoded colors
- Updated the overview items test and added a test for the badge render

## How was this change tested?
- Loaded a trace via the Upload feature locally and confirmed the Kind badge renders correctly in the span detail header
- Pre-existing test failures on this file (`formatDuration.mockReset is not a function`) are present on main before this change

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes