### PR TITLE
perf(spanview): Use Set lookups in TraceSpanView filter

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
@@ -119,4 +119,20 @@ describe('<TraceSpanView>', () => {
       expect.arrayContaining(['op1', 'op2', 'op3', 'op4', 'op6', 'op7'])
     );
   });
+
+  it('renders only rows matching the selected service filter', () => {
+    // testTrace has 3 spans on service2; selecting service2 should leave
+    // exactly those 3 rows. Pins the Set-based lookup behaves the same as
+    // the previous Array.includes path.
+    const { container } = render(<TraceSpanView {...defaultProps} />);
+
+    fireEvent.change(screen.getByTestId('select-service'), { target: { value: 'service2' } });
+
+    const filteredRows = container.querySelectorAll('.ant-table-row');
+    expect(filteredRows.length).toBe(3);
+    filteredRows.forEach(row => {
+      expect(row.textContent).toContain('service2');
+      expect(row.textContent).not.toContain('service1');
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
@@ -128,7 +128,7 @@ describe('<TraceSpanView>', () => {
 
     fireEvent.change(screen.getByTestId('select-service'), { target: { value: 'service2' } });
 
-    const filteredRows = container.querySelectorAll('.ant-table-row');
+    const filteredRows = container.querySelectorAll('.ant-table-tbody .ant-table-row');
     expect(filteredRows.length).toBe(3);
     filteredRows.forEach(row => {
       expect(row.textContent).toContain('service2');

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -76,14 +76,17 @@ export default function TraceSpanView(props: Props) {
       return props.trace.spans;
     }
 
-    // Filter spans: a span passes if it matches all active filters
+    // Build lookup Sets once per filter change so per-span checks are O(1)
+    // instead of Array.includes which is O(M) and pushes the whole filter to
+    // O(N × M) on traces with many spans.
+    const serviceSet = new Set(filters.serviceName);
+    const operationSet = new Set(filters.operationName);
+
     return props.trace.spans.filter(span => {
-      if (filters.serviceName.length > 0 && !filters.serviceName.includes(span.resource.serviceName)) {
+      if (serviceSet.size > 0 && !serviceSet.has(span.resource.serviceName)) {
         return false;
       }
-
-      // Check operationName filter (if active)
-      if (filters.operationName.length > 0 && !filters.operationName.includes(span.name)) {
+      if (operationSet.size > 0 && !operationSet.has(span.name)) {
         return false;
       }
       return true;

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -78,7 +78,7 @@ export default function TraceSpanView(props: Props) {
 
     // Build lookup Sets once per filter change so per-span checks are O(1)
     // instead of Array.includes which is O(M) and pushes the whole filter to
-    // O(N × M) on traces with many spans.
+    // O(N × (M_service + M_operation)) on traces with many spans.
     const serviceSet = new Set(filters.serviceName);
     const operationSet = new Set(filters.operationName);
 


### PR DESCRIPTION
## Problem

`TraceSpanView` (the Span Table view inside `TracePage`) filters spans by selected service names and operation names. The filter calls `Array.includes` against the selected-services array and the selected-operations array for each span in the trace. `Array.includes` is O(M) per call, so the per-filter-change cost was O(N × (M_svc + M_op)).

For a 50k-span trace with 20 services and 50 operations selected, that's ~3.5M array-element comparisons each time the user adjusts a filter. Jaeger UI is tested with traces up to 80k spans, so this scales to a real concern.

## Fix

Build `Set<string>` lookups for each filter array once inside the `useMemo`, then use `Set.has` in the per-span check. Same behaviour, complexity drops to O(N + M_svc + M_op).

## Testing

Added a test that selects a service from the filter dropdown and asserts the rendered table contains only rows for that service. Pins the filter behaviour the perf fix preserves.

`npm run lint`, `npm run tsc-lint`, `npm test -w packages/jaeger-ui -- src/components/TracePage/TraceSpanView/`, and `npm run build` green locally on Node 24.

Fixes #3869

## AI Usage in this PR

- [x] **Specific parts**: AI assisted with code generation on parts of the change, reviewed and verified before submission.