### PR TITLE
Revert "Add environment checks to prepare-release target (#3512)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,8 @@ draft-release:
 	chmod 755 ./scripts/draft-release.py
 	./scripts/draft-release.py --title "Jaeger UI" --repo jaeger-ui
 
-.PHONY: check-env
-check-env:
-	nvm use
-
 .PHONY: prepare-release
-prepare-release: check-env
+prepare-release:
 	@test $(VERSION) || (echo "VERSION is not set. Use 'make prepare-release VERSION=vX.Y.Z'"; exit 1)
 	python3 scripts/prepare-release.py --version $(VERSION)
 


### PR DESCRIPTION
This reverts commit bdcf63ba3c0858e69fe19d2920560136534a26fe.

```
  $ nvm use
  Found '/Users/yuri_shkuro/dev/jaegertracing/jaeger-ui/jaeger-ui1/.nvmrc' with version <24>
  Now using node v24.13.0 (npm v11.6.0)

  $ make prepare-release VERSION=v2.18.0
  nvm use
  make: nvm: No such file or directory
  make: *** [check-env] Error 1
```

nvm is not available in sub-shell
