### PR TITLE
fix(ui): Correct typos in AttributesTable and AccordionLinks

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -68,7 +68,7 @@ function AccordionLinks({
   useOtelTerms,
 }: AccordionLinksProps) {
   const isEmpty = !Array.isArray(data) || !data.length;
-  const iconCls = cx('u-align-icon', { 'AccordianKReferences--emptyIcon': isEmpty });
+  const iconCls = cx('u-align-icon', { 'AccordionReferences--emptyIcon': isEmpty });
 
   let arrow: React.ReactNode | null = null;
   let headerProps: object | null = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -92,7 +92,7 @@ function formatValue(key: string, value: any) {
           nullValue: 'json-markup-null',
           undefinedValue: 'json-markup-undefined',
           basicChildStyle: 'json-markup-child',
-          punctuation: 'json-markup-puncuation',
+          punctuation: 'json-markup-punctuation',
           otherValue: 'json-markup-other',
         }}
       />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -103,6 +103,6 @@ SPDX-License-Identifier: Apache-2.0
   padding: 0;
 }
 
-.json-markup-puncuation {
+.json-markup-punctuation {
   font-weight: bold;
 }


### PR DESCRIPTION
## Summary
Fixes jaegertracing/jaeger#8452 - Corrects two typos in the SpanDetail UI components:

1. **AttributesTable.tsx** + **index.css**: `puncuation` → `punctuation` (CSS class name for JSON markup)
2. **AccordionLinks.tsx**: `AccordianKReferences--emptyIcon` → `AccordionReferences--emptyIcon` (class name typo)

## Changes
- `packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx`
- `packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx`
- `packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css`