### PR TITLE
fix(test): unmount between renders in TraceId length-class test

### DIFF
--- a/packages/jaeger-ui/src/components/common/TraceId.test.jsx
+++ b/packages/jaeger-ui/src/components/common/TraceId.test.jsx
@@ -82,15 +82,14 @@ describe('TraceIdDisplayLength', () => {
 
     it('adds a length-based class depending on the configuration', () => {
       getConfig.mockReturnValue({ traceIdDisplayLength: DEFAULT_LENGTH });
-      renderComponent();
+      const { unmount } = render(<TraceId traceId={MOCK_TRACE_ID} />);
       expect(screen.getByText(MOCK_TRACE_ID.slice(0, DEFAULT_LENGTH))).toHaveClass('TraceIDLength--short');
+      unmount();
 
       const longLength = MOCK_TRACE_ID.length;
       getConfig.mockReturnValue({ traceIdDisplayLength: longLength });
-      renderComponent();
-
-      const all = screen.getAllByText(MOCK_TRACE_ID.slice(0, 7));
-      expect(all[all.length - 1]).toHaveClass('TraceIDLength--short');
+      render(<TraceId traceId={MOCK_TRACE_ID} />);
+      expect(screen.getByText(MOCK_TRACE_ID)).toHaveClass('TraceIDLength--full');
     });
   });
 });

--- a/packages/jaeger-ui/src/components/common/TraceId.test.jsx
+++ b/packages/jaeger-ui/src/components/common/TraceId.test.jsx
@@ -88,8 +88,9 @@ describe('TraceIdDisplayLength', () => {
 
       const longLength = MOCK_TRACE_ID.length;
       getConfig.mockReturnValue({ traceIdDisplayLength: longLength });
-      renderComponent();
+      const { unmount: unmountFull } = renderComponent();
       expect(screen.getByText(MOCK_TRACE_ID)).toHaveClass('TraceIDLength--full');
+      unmountFull();
     });
   });
 });

--- a/packages/jaeger-ui/src/components/common/TraceId.test.jsx
+++ b/packages/jaeger-ui/src/components/common/TraceId.test.jsx
@@ -82,15 +82,14 @@ describe('TraceIdDisplayLength', () => {
 
     it('adds a length-based class depending on the configuration', () => {
       getConfig.mockReturnValue({ traceIdDisplayLength: DEFAULT_LENGTH });
-      const { unmount } = renderComponent();
+      const { rerender } = renderComponent();
       expect(screen.getByText(MOCK_TRACE_ID.slice(0, DEFAULT_LENGTH))).toHaveClass('TraceIDLength--short');
-      unmount();
 
       const longLength = MOCK_TRACE_ID.length;
       getConfig.mockReturnValue({ traceIdDisplayLength: longLength });
-      const { unmount: unmountFull } = renderComponent();
+      rerender(<TraceId {...defaultProps} />);
+      expect(screen.queryByText(MOCK_TRACE_ID.slice(0, DEFAULT_LENGTH))).not.toBeInTheDocument();
       expect(screen.getByText(MOCK_TRACE_ID)).toHaveClass('TraceIDLength--full');
-      unmountFull();
     });
   });
 });

--- a/packages/jaeger-ui/src/components/common/TraceId.test.jsx
+++ b/packages/jaeger-ui/src/components/common/TraceId.test.jsx
@@ -23,7 +23,7 @@ describe('TraceIdDisplayLength', () => {
   });
 
   const renderComponent = (props = {}) => {
-    render(<TraceId {...defaultProps} {...props} />);
+    return render(<TraceId {...defaultProps} {...props} />);
   };
 
   describe('TraceIdDisplayLength Component', () => {
@@ -82,13 +82,13 @@ describe('TraceIdDisplayLength', () => {
 
     it('adds a length-based class depending on the configuration', () => {
       getConfig.mockReturnValue({ traceIdDisplayLength: DEFAULT_LENGTH });
-      const { unmount } = render(<TraceId traceId={MOCK_TRACE_ID} />);
+      const { unmount } = renderComponent();
       expect(screen.getByText(MOCK_TRACE_ID.slice(0, DEFAULT_LENGTH))).toHaveClass('TraceIDLength--short');
       unmount();
 
       const longLength = MOCK_TRACE_ID.length;
       getConfig.mockReturnValue({ traceIdDisplayLength: longLength });
-      render(<TraceId traceId={MOCK_TRACE_ID} />);
+      renderComponent();
       expect(screen.getByText(MOCK_TRACE_ID)).toHaveClass('TraceIDLength--full');
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3799

The test `adds a length-based class depending on the configuration` in `TraceId.test.jsx` was passing for the wrong reason. The second `renderComponent()` call doesn't unmount the first render, so both versions of the component are in the DOM at once. `getAllByText(MOCK_TRACE_ID.slice(0, 7))` grabs the element from the first render, and the last assertion ends up checking `TraceIDLength--short` twice. The `TraceIDLength--full` check never actually ran against the right element.

## Description of the changes

Unmount after the first assertion, then render fresh for the second case. The second assertion now queries the full trace ID text and correctly checks for `TraceIDLength--full`.

## How was this change tested?

Ran the `TraceId` test file — both assertions now verify the right thing.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes