### PR TITLE
feat(monitor): Add operator-configured dimension filters to Monitor page

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.test.js
+++ b/packages/jaeger-ui/src/api/jaeger.test.js
@@ -219,6 +219,29 @@ describe('fetchMetrics', () => {
     );
   });
 
+  it('GETs metrics query with repeated filter params', () => {
+    fetchMock.mockReset();
+    const metricsType = 'calls';
+    const serviceName = ['serviceName'];
+    const query = {
+      quantile: 95,
+      filter: ['deployment.environment:prod', 'k8s.cluster:us-west-1'],
+    };
+    fetchMock.mockReturnValue(
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({ someObj: {} }),
+      })
+    );
+
+    JaegerAPI.fetchMetrics(metricsType, serviceName, query);
+    const url = fetchMock.mock.calls[fetchMock.mock.calls.length - 1][0];
+    // Each filter must be its own query-string entry so the Go backend's
+    // r.URL.Query()[filterParam] returns both values.
+    expect(url).toContain('filter=deployment.environment%3Aprod');
+    expect(url).toContain('filter=k8s.cluster%3Aus-west-1');
+  });
+
   it('fetchMetrics() should add quantile to response', async () => {
     const metricsType = 'latencies';
     const serviceName = ['serviceName'];
@@ -235,5 +258,20 @@ describe('fetchMetrics', () => {
 
     const resp = await JaegerAPI.fetchMetrics(metricsType, serviceName, query);
     expect(resp.quantile).toBe(query.quantile);
+  });
+});
+
+describe('fetchMetricDimensions', () => {
+  it('GETs /api/metrics/dimensions', () => {
+    fetchMock.mockReset();
+    fetchMock.mockReturnValue(
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve([]),
+      })
+    );
+
+    JaegerAPI.fetchMetricDimensions();
+    expect(fetchMock).toHaveBeenLastCalledWith(`${DEFAULT_API_ROOT}metrics/dimensions`, defaultOptions);
   });
 });

--- a/packages/jaeger-ui/src/api/jaeger.ts
+++ b/packages/jaeger-ui/src/api/jaeger.ts
@@ -136,6 +136,9 @@ const JaegerAPI = {
       query: `${servicesName}&${queryString.stringify(query)}`,
     }).then((d: any) => ({ ...d, quantile: query.quantile }));
   },
+  fetchMetricDimensions(): Promise<any> {
+    return getJSON(`${this.apiRoot}metrics/dimensions`);
+  },
 };
 
 export default JaegerAPI;

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
@@ -22,6 +22,16 @@ SPDX-License-Identifier: Apache-2.0
   padding-left: 10px;
 }
 
+.dimension-selector-header {
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.dimension-selector {
+  padding-left: 10px;
+  width: 50%;
+}
+
 .operations-metrics-text {
   margin-top: 17px;
   margin-bottom: 14px;

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -13,6 +13,8 @@ import {
   getLoopbackInterval,
   yAxisTickFormat,
 } from '.';
+import JaegerAPI from '../../../api/jaeger';
+import store from '../../../utils/storage';
 import { useServices } from '../../../hooks/useTraceDiscovery';
 import {
   originInitialState,
@@ -121,6 +123,12 @@ vi.mock('../../common/SearchableSelect', async () => {
     );
   });
 });
+
+vi.mock('../../../api/jaeger', async () => ({
+  default: {
+    fetchMetricDimensions: jest.fn(() => Promise.resolve([])),
+  },
+}));
 
 vi.mock('antd', async () => {
   const actualAntd = await vi.importActual('antd');
@@ -777,6 +785,138 @@ describe('<MonitorATMServicesView> on page switch', () => {
   it('metrics fetch invocation check on page load', () => {
     expect(mockFetchAllServiceMetrics).toHaveBeenCalled();
     expect(mockFetchAggregatedServiceMetrics).toHaveBeenCalled();
+  });
+});
+
+describe('Dimension filters', () => {
+  const mockFetchAllServiceMetrics = jest.fn();
+  const mockFetchAggregatedServiceMetrics = jest.fn();
+
+  const renderWithDimensions = (dimensions, extraProps = {}) => {
+    JaegerAPI.fetchMetricDimensions.mockResolvedValueOnce(dimensions);
+    const defaultProps = {
+      ...props,
+      fetchAllServiceMetrics: mockFetchAllServiceMetrics,
+      fetchAggregatedServiceMetrics: mockFetchAggregatedServiceMetrics,
+      ...extraProps,
+    };
+    return renderWithRouter(<MonitorATMServicesView {...defaultProps} />);
+  };
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('renders no dropdown when the backend reports an empty dimensions list', async () => {
+    renderWithDimensions([]);
+    // Wait for the fetchMetricDimensions promise to resolve and React to flush.
+    await waitFor(() => expect(JaegerAPI.fetchMetricDimensions).toHaveBeenCalled());
+    expect(screen.queryByTestId('dimension-selector')).not.toBeInTheDocument();
+  });
+
+  it('renders a dropdown for each dimension that has a non-empty values list', async () => {
+    renderWithDimensions([
+      { name: 'deployment.environment', displayName: 'Environment', values: ['prod', 'staging'] },
+      { name: 'k8s.cluster', values: ['us-west-1'] },
+    ]);
+    await waitFor(() => expect(screen.getByText('Environment')).toBeInTheDocument());
+    expect(screen.getByText('Environment')).toBeInTheDocument();
+    // Falls back to name when displayName is absent.
+    expect(screen.getByText('k8s.cluster')).toBeInTheDocument();
+  });
+
+  it('skips free-text dimensions (empty values list) in this v1 UI', async () => {
+    renderWithDimensions([
+      { name: 'free.text.dim' }, // no values: hidden by the dropdown UI for now
+      { name: 'deployment.environment', displayName: 'Environment', values: ['prod'] },
+    ]);
+    await waitFor(() => expect(screen.getByText('Environment')).toBeInTheDocument());
+    expect(screen.queryByText('free.text.dim')).not.toBeInTheDocument();
+  });
+
+  it('selecting a value triggers a refetch with the filter param included', async () => {
+    renderWithDimensions([
+      { name: 'deployment.environment', displayName: 'Environment', values: ['prod', 'staging'] },
+    ]);
+    await waitFor(() => expect(screen.getByText('Environment')).toBeInTheDocument());
+
+    mockFetchAllServiceMetrics.mockClear();
+    const select = screen.getByTestId('dimension-selector');
+    await userEvent.selectOptions(select, 'prod');
+
+    await waitFor(() => {
+      expect(mockFetchAllServiceMetrics).toHaveBeenCalled();
+    });
+    const lastCall = mockFetchAllServiceMetrics.mock.calls[mockFetchAllServiceMetrics.mock.calls.length - 1];
+    const queryPayload = lastCall[1];
+    expect(queryPayload.filter).toEqual(['deployment.environment:prod']);
+  });
+
+  it('selecting "All" removes the filter for that dimension', async () => {
+    renderWithDimensions([
+      { name: 'deployment.environment', displayName: 'Environment', values: ['prod', 'staging'] },
+    ]);
+    await waitFor(() => expect(screen.getByText('Environment')).toBeInTheDocument());
+
+    const select = screen.getByTestId('dimension-selector');
+    await userEvent.selectOptions(select, 'prod');
+    await waitFor(() => {
+      const calls = mockFetchAllServiceMetrics.mock.calls;
+      expect(calls[calls.length - 1][1].filter).toEqual(['deployment.environment:prod']);
+    });
+
+    await userEvent.selectOptions(select, ''); // "All"
+    await waitFor(() => {
+      const calls = mockFetchAllServiceMetrics.mock.calls;
+      // filter is omitted entirely when no dimensions are selected.
+      expect(calls[calls.length - 1][1]).not.toHaveProperty('filter');
+    });
+  });
+
+  it('persists selected filters via storage.set', async () => {
+    renderWithDimensions([{ name: 'deployment.environment', values: ['prod'] }]);
+    await waitFor(() => expect(screen.getByText('deployment.environment')).toBeInTheDocument());
+
+    store.set.mockClear();
+    const select = screen.getByTestId('dimension-selector');
+    await userEvent.selectOptions(select, 'prod');
+
+    await waitFor(() => {
+      expect(store.set).toHaveBeenCalledWith('lastAtmSearchFilters', {
+        'deployment.environment': 'prod',
+      });
+    });
+  });
+
+  it('restores selected filters from storage on mount and ignores keys for unadvertised dimensions', async () => {
+    // localStorage carries a stale "removed.dimension" entry; the UI must drop it
+    // so unfiltered requests don't accidentally inherit a stale selection.
+    store.getJSON.mockReturnValueOnce({
+      'deployment.environment': 'prod',
+      'removed.dimension': 'old-value',
+    });
+    renderWithDimensions([{ name: 'deployment.environment', values: ['prod', 'staging'] }]);
+
+    // The initial fetch fires before dimensions resolve (filter is empty
+    // because `advertised` is still empty). After fetchMetricDimensions
+    // resolves, fetchMetrics re-runs with the now-known dimension list.
+    await waitFor(() => {
+      const calls = mockFetchAllServiceMetrics.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[calls.length - 1][1].filter).toEqual(['deployment.environment:prod']);
+    });
+  });
+
+  it('does not crash when fetchMetricDimensions rejects', async () => {
+    JaegerAPI.fetchMetricDimensions.mockReset();
+    JaegerAPI.fetchMetricDimensions.mockRejectedValueOnce(new Error('501 Not Implemented'));
+    renderWithDimensions([]); // queues a second resolved value, but the rejected one fires first
+    await waitFor(() => expect(JaegerAPI.fetchMetricDimensions).toHaveBeenCalled());
+    expect(screen.queryByTestId('dimension-selector')).not.toBeInTheDocument();
+    // Page still renders the rest of the Monitor UI.
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Span Kind')).toBeInTheDocument();
   });
 });
 

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -24,7 +24,9 @@ import {
   ServiceOpsMetrics,
   spanKinds,
   FetchAggregatedServiceMetricsResponse,
+  MetricDimension,
 } from '../../../types/metrics';
+import JaegerAPI from '../../../api/jaeger';
 import prefixUrl from '../../../utils/prefix-url';
 import { convertToTimeUnit, convertTimeUnitToShortTerm, getSuitableTimeUnit } from '../../../utils/date';
 
@@ -143,6 +145,13 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   const [selectedTimeFrame, setSelectedTimeFrame] = useState<number>(
     store.getNumber('lastAtmSearchTimeframe', oneHourInMilliSeconds)
   );
+  const [dimensions, setDimensions] = useState<MetricDimension[]>([]);
+  const [selectedFilters, setSelectedFilters] = useState<Record<string, string>>(() => {
+    const stored = store.getJSON('lastAtmSearchFilters');
+    return stored && typeof stored === 'object' && !Array.isArray(stored)
+      ? (stored as Record<string, string>)
+      : {};
+  });
 
   const calcGraphXDomain = useCallback(() => {
     const currentTime = Date.now();
@@ -176,6 +185,19 @@ export function MonitorATMServicesViewImpl(props: TProps) {
     trackSelectTimeframe(label);
   }, []);
 
+  const handleFilterChange = useCallback((dimensionName: string, value: string) => {
+    setSelectedFilters(prev => {
+      const next = { ...prev };
+      // Empty value = "All" = no filter on this dimension.
+      if (value === '') {
+        delete next[dimensionName];
+      } else {
+        next[dimensionName] = value;
+      }
+      return next;
+    });
+  }, []);
+
   const fetchMetrics = useCallback(() => {
     const currentService = selectedService || services[0];
 
@@ -185,14 +207,24 @@ export function MonitorATMServicesViewImpl(props: TProps) {
       store.set('lastAtmSearchSpanKind', selectedSpanKind);
       store.set('lastAtmSearchTimeframe', selectedTimeFrame);
       store.set('lastAtmSearchService', currentService);
+      store.set('lastAtmSearchFilters', selectedFilters);
 
-      const metricQueryPayload = {
+      // Build the repeated `filter=key:value` list. We only send filters for
+      // dimensions still advertised by the backend, so stale localStorage
+      // entries from removed dimensions are silently ignored.
+      const advertised = new Set(dimensions.map(d => d.name));
+      const filter = Object.entries(selectedFilters)
+        .filter(([k, v]) => v && advertised.has(k))
+        .map(([k, v]) => `${k}:${v}`);
+
+      const metricQueryPayload: MetricsAPIQueryParams = {
         quantile: 0.95,
         endTs: newEndTime,
         lookback: selectedTimeFrame,
         step: 60 * 1000,
         ratePer: 10 * 60 * 1000,
         spanKind: selectedSpanKind,
+        ...(filter.length > 0 ? { filter } : {}),
       };
 
       fetchAllServiceMetrics(currentService, metricQueryPayload);
@@ -208,6 +240,8 @@ export function MonitorATMServicesViewImpl(props: TProps) {
     selectedService,
     selectedSpanKind,
     selectedTimeFrame,
+    selectedFilters,
+    dimensions,
   ]);
 
   // componentDidMount equivalent
@@ -219,6 +253,28 @@ export function MonitorATMServicesViewImpl(props: TProps) {
       window.removeEventListener('resize', updateDimensions);
     };
   }, [updateDimensions, calcGraphXDomain]);
+
+  // Fetch the operator-configured filterable dimensions on mount. A backend
+  // without dimension support (or older Jaeger) returns [] or 5xx; in both
+  // cases we just render no dropdowns and the rest of the page is unaffected.
+  useEffect(() => {
+    let cancelled = false;
+    JaegerAPI.fetchMetricDimensions()
+      .then((response: unknown) => {
+        if (cancelled) return;
+        if (Array.isArray(response)) {
+          setDimensions(response as MetricDimension[]);
+        } else {
+          setDimensions([]);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setDimensions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Measure the graph container width after every servicesLoading → false
   // transition. useLayoutEffect ensures the measurement happens before paint,
@@ -287,7 +343,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
               ))}
             </SearchableSelect>
           </Col>
-          <Col span={6}>
+          <Col span={4}>
             <h2 className="span-kind-selector-header">Span Kind</h2>
             <SearchableSelect
               value={selectedSpanKind}
@@ -304,6 +360,29 @@ export function MonitorATMServicesViewImpl(props: TProps) {
               ))}
             </SearchableSelect>
           </Col>
+          {dimensions
+            .filter(dim => dim.values && dim.values.length > 0)
+            .map(dim => (
+              <Col span={4} key={dim.name}>
+                <h2 className="dimension-selector-header">{dim.displayName || dim.name}</h2>
+                <SearchableSelect
+                  value={selectedFilters[dim.name] || ''}
+                  onChange={(value: string) => handleFilterChange(dim.name, value)}
+                  placeholder="All"
+                  className="dimension-selector"
+                  data-testid={`dimension-selector-${dim.name}`}
+                  disabled={metrics.operationMetricsLoading}
+                  loading={metrics.operationMetricsLoading}
+                >
+                  <Option value="">All</Option>
+                  {dim.values!.map(value => (
+                    <Option key={value} value={value}>
+                      {value}
+                    </Option>
+                  ))}
+                </SearchableSelect>
+              </Col>
+            ))}
         </Row>
         <Row align="middle">
           <Col span={16}>

--- a/packages/jaeger-ui/src/types/metrics.ts
+++ b/packages/jaeger-ui/src/types/metrics.ts
@@ -19,6 +19,20 @@ export type MetricsAPIQueryParams = {
   step: number;
   ratePer: number;
   spanKind: spanKinds;
+  // filter is a list of pre-configured `dimension:value` strings, one per
+  // user-selected dropdown on the Monitor page (e.g. `deployment.environment:prod`).
+  // The available dimensions are advertised by the backend via
+  // GET /api/metrics/dimensions and configured per-deployment by the operator.
+  filter?: string[];
+};
+
+// MetricDimension describes one pre-configured filterable dimension advertised
+// by the backend (see jaegertracing/jaeger#5438). Backends that do not support
+// dimension filtering return an empty list.
+export type MetricDimension = {
+  name: string;
+  displayName?: string;
+  values?: string[];
 };
 
 type LableObject = {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves Frontend Part of jaegertracing/jaeger#7433
- Follow-up to backend PR jaegertracing/jaeger#8579

Wires the UI side of operator-declared dimension filtering on the Monitor (SPM) page. When the backend advertises filterable dimensions via **GET** `/api/metrics/dimensions`, the Monitor page renders a dropdown per dimension; selecting a value scopes all metrics queries to that environment/cluster/etc. without requiring a separate Jaeger deployment.

## Description of the changes
- Adds `GET /api/metrics/dimensions` support: the backend can advertise a list of filterable dimensions (e.g. `deployment.environment`) with pre-configured values.
- Renders a dropdown per advertised dimension on the Monitor page; selecting a value appends repeated `filter=dim:value` params to every metrics query.
- Selected filters are persisted to localStorage (`lastAtmSearchFilters`) and restored on reload; stale entries for dimensions no longer advertised are silently dropped.
- **backwards-compatible**: backends that return `[]` or error show no dropdowns and the rest of the Monitor page is unaffected.

## How was this change tested?
#### Unit tests:
All existing tests pass and New tests added in index.test.jsx and jaeger.test.js

#### Manual (against SPM docker-compose stack from jaeger#8579):
Config used (`jaeger/cmd/jaeger/config-spm.yaml`):
```yaml
extra_dimensions:
  - name: deployment.environment
    display_name: Environment
    values: [prod, staging, dev]
```

  Verified:
  - "Environment" dropdown appears in Monitor page header alongside Service and Span Kind
<img width="1470" height="678" alt="image" src="https://github.com/user-attachments/assets/53953fe5-b039-4062-9bff-85ecdc66d4c2" />
<br><br>
<img width="796" height="230" alt="image" src="https://github.com/user-attachments/assets/9db56b0f-3686-486c-9952-cdde7284dcd9" />

<br><br>

- Selecting "prod" appends `filter=deployment.environment%3Aprod` to metrics API calls
 
<img width="798" height="293" alt="image" src="https://github.com/user-attachments/assets/40499fd4-796e-41a3-b26e-78c8e78068f9" />
 <br><br>

  - Selecting "All" removes the filter param
  - Refreshing the page restores the last selected filter
  - With an older backend (no /api/metrics/dimensions), no dropdown appears and the page loads normally

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
