### PR TITLE
fix(jaeger-ui): correct typos in SpanDetail CSS class names

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -68,7 +68,7 @@ function AccordionLinks({
   useOtelTerms,
 }: AccordionLinksProps) {
   const isEmpty = !Array.isArray(data) || !data.length;
-  const iconCls = cx('u-align-icon', { 'AccordianKReferences--emptyIcon': isEmpty });
+  const iconCls = cx('u-align-icon', { 'AccordionLinks--emptyIcon': isEmpty });
 
   let arrow: React.ReactNode | null = null;
   let headerProps: object | null = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -92,7 +92,7 @@ function formatValue(key: string, value: any) {
           nullValue: 'json-markup-null',
           undefinedValue: 'json-markup-undefined',
           basicChildStyle: 'json-markup-child',
-          punctuation: 'json-markup-puncuation',
+          punctuation: 'json-markup-punctuation',
           otherValue: 'json-markup-other',
         }}
       />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -103,6 +103,6 @@ SPDX-License-Identifier: Apache-2.0
   padding: 0;
 }
 
-.json-markup-puncuation {
+.json-markup-punctuation {
   font-weight: bold;
 }


### PR DESCRIPTION
## Summary
Corrects two CSS class name typos in the SpanDetail components:
- `json-markup-puncuation` → `json-markup-punctuation` (AttributesTable.tsx and index.css)
- `AccordianKReferences--emptyIcon` → `AccordionLinks--emptyIcon` (AccordionLinks.tsx)

## Root Cause
These CSS class names contained spelling errors (`puncuation` instead of `punctuation`, and `AccordianKReferences` instead of `AccordionLinks`), making them inconsistent with the component naming.

## Solution
Fixed the class name strings in both TypeScript and CSS files:
1. `AttributesTable.tsx` – corrected `json-markup-puncuation` to `json-markup-punctuation`
2. `AccordionLinks.tsx` – corrected `AccordianKReferences--emptyIcon` to `AccordionLinks--emptyIcon`
3. `index.css` – updated the CSS selector to match the corrected class name

## Testing
- Verified no remaining occurrences of the misspelled strings
- Diff is minimal: 3 files changed, 3 insertions, 3 deletions

Closes jaegertracing/jaeger#8452