### PR TITLE
feat(v3): add OTLP trace parser, getTrace client method, and useTrace hook

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -3,6 +3,11 @@
 
 import { JaegerClient, jaegerClient } from './client';
 import { ZodError } from 'zod';
+import { parseOtlpTrace } from './parser';
+
+vi.mock('./parser', () => ({
+  parseOtlpTrace: vi.fn(),
+}));
 
 describe('JaegerClient', () => {
   let client: JaegerClient;
@@ -256,6 +261,61 @@ describe('JaegerClient', () => {
     });
   });
 
+  describe('getTrace', () => {
+    const mockTrace = { traceID: 'trace-abc', spans: [] } as any;
+
+    it('successfully fetches and parses a trace', async () => {
+      const mockData = { resourceSpans: [] };
+      mockFetch.mockResolvedValue({ ok: true, json: async () => mockData });
+      (parseOtlpTrace as ReturnType<typeof vi.fn>).mockReturnValue(mockTrace);
+
+      const promise = client.getTrace('trace-abc');
+      vi.runAllTimers();
+      const result = await promise;
+
+      expect(result).toBe(mockTrace);
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v3/traces/trace-abc',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      expect(parseOtlpTrace).toHaveBeenCalledWith(mockData);
+    });
+
+    it('URL-encodes the traceId', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+      (parseOtlpTrace as ReturnType<typeof vi.fn>).mockReturnValue(mockTrace);
+
+      const promise = client.getTrace('id with spaces');
+      vi.runAllTimers();
+      await promise;
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v3/traces/id%20with%20spaces',
+        expect.anything()
+      );
+    });
+
+    it('throws with traceId in message when response is not OK', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+      const promise = client.getTrace('missing-trace');
+      vi.runAllTimers();
+
+      await expect(promise).rejects.toThrow('Failed to fetch trace "missing-trace": 404 Not Found');
+    });
+
+    it('throws on 500 errors', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' });
+
+      const promise = client.getTrace('some-trace');
+      vi.runAllTimers();
+
+      await expect(promise).rejects.toThrow(
+        'Failed to fetch trace "some-trace": 500 Internal Server Error'
+      );
+    });
+  });
+
   describe('singleton instance', () => {
     it('exports a singleton jaegerClient instance', () => {
       expect(jaegerClient).toBeInstanceOf(JaegerClient);
@@ -264,6 +324,7 @@ describe('JaegerClient', () => {
     it('singleton instance has all expected methods', () => {
       expect(jaegerClient.fetchServices).toBeInstanceOf(Function);
       expect(jaegerClient.fetchSpanNames).toBeInstanceOf(Function);
+      expect(jaegerClient.getTrace).toBeInstanceOf(Function);
     });
   });
 });

--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -309,6 +309,27 @@ describe('JaegerClient', () => {
 
       await expect(promise).rejects.toThrow('Failed to fetch trace "some-trace": 500 Internal Server Error');
     });
+
+    it('wraps parser errors with traceId context', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ resourceSpans: [] }) });
+      (parseOtlpTrace as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('No spans found in trace data');
+      });
+
+      const promise = client.getTrace('broken-trace');
+      vi.runAllTimers();
+
+      await expect(promise).rejects.toThrow('Failed to parse trace "broken-trace"');
+    });
+
+    it('throws ZodError when response lacks expected envelope shape', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => 'not-an-object' });
+
+      const promise = client.getTrace('bad-trace');
+      vi.runAllTimers();
+
+      await expect(promise).rejects.toBeInstanceOf(ZodError);
+    });
   });
 
   describe('singleton instance', () => {

--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -289,10 +289,7 @@ describe('JaegerClient', () => {
       vi.runAllTimers();
       await promise;
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/v3/traces/id%20with%20spaces',
-        expect.anything()
-      );
+      expect(mockFetch).toHaveBeenCalledWith('/api/v3/traces/id%20with%20spaces', expect.anything());
     });
 
     it('throws with traceId in message when response is not OK', async () => {
@@ -310,9 +307,7 @@ describe('JaegerClient', () => {
       const promise = client.getTrace('some-trace');
       vi.runAllTimers();
 
-      await expect(promise).rejects.toThrow(
-        'Failed to fetch trace "some-trace": 500 Internal Server Error'
-      );
+      await expect(promise).rejects.toThrow('Failed to fetch trace "some-trace": 500 Internal Server Error');
     });
   });
 

--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -278,7 +278,7 @@ describe('JaegerClient', () => {
         '/api/v3/traces/trace-abc',
         expect.objectContaining({ signal: expect.any(AbortSignal) })
       );
-      expect(parseOtlpTrace).toHaveBeenCalledWith(mockData);
+      expect(parseOtlpTrace).toHaveBeenCalledWith(expect.objectContaining({ resourceSpans: [] }));
     });
 
     it('URL-encodes the traceId', async () => {

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -64,7 +64,8 @@ export class JaegerClient {
       return parseOtlpTrace(raw);
     } catch (err) {
       throw new Error(
-        `Failed to parse trace "${traceId}": ${err instanceof Error ? err.message : String(err)}`
+        `Failed to parse trace "${traceId}": ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err }
       );
     }
   }

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -9,7 +9,7 @@
  */
 
 import prefixUrl from '../../utils/prefix-url';
-import { ServicesResponseSchema, OperationsResponseSchema } from './schemas';
+import { ServicesResponseSchema, OperationsResponseSchema, OtlpEnvelopeSchema } from './schemas';
 import { parseOtlpTrace } from './parser';
 import { IOtelTrace } from '../../types/otel';
 
@@ -58,8 +58,15 @@ export class JaegerClient {
     if (!response.ok) {
       throw new Error(`Failed to fetch trace "${traceId}": ${response.status} ${response.statusText}`);
     }
-    const data = await response.json();
-    return parseOtlpTrace(data);
+    const raw = await response.json();
+    OtlpEnvelopeSchema.parse(raw);
+    try {
+      return parseOtlpTrace(raw);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse trace "${traceId}": ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
   }
 
   /**

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -54,13 +54,9 @@ export class JaegerClient {
   }
 
   async getTrace(traceId: string): Promise<IOtelTrace> {
-    const response = await this.fetchWithTimeout(
-      `${this.apiRoot}/traces/${encodeURIComponent(traceId)}`
-    );
+    const response = await this.fetchWithTimeout(`${this.apiRoot}/traces/${encodeURIComponent(traceId)}`);
     if (!response.ok) {
-      throw new Error(
-        `Failed to fetch trace "${traceId}": ${response.status} ${response.statusText}`
-      );
+      throw new Error(`Failed to fetch trace "${traceId}": ${response.status} ${response.statusText}`);
     }
     const data = await response.json();
     return parseOtlpTrace(data);

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -10,7 +10,7 @@
 
 import prefixUrl from '../../utils/prefix-url';
 import { ServicesResponseSchema, OperationsResponseSchema, OtlpEnvelopeSchema } from './schemas';
-import { parseOtlpTrace } from './parser';
+import { parseOtlpTrace, OtlpTracesData } from './parser';
 import { IOtelTrace } from '../../types/otel';
 
 export class JaegerClient {
@@ -59,9 +59,9 @@ export class JaegerClient {
       throw new Error(`Failed to fetch trace "${traceId}": ${response.status} ${response.statusText}`);
     }
     const raw = await response.json();
-    OtlpEnvelopeSchema.parse(raw);
+    const validated = OtlpEnvelopeSchema.parse(raw);
     try {
-      return parseOtlpTrace(raw);
+      return parseOtlpTrace(validated as unknown as OtlpTracesData);
     } catch (err) {
       throw new Error(
         `Failed to parse trace "${traceId}": ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -10,7 +10,7 @@
 
 import prefixUrl from '../../utils/prefix-url';
 import { ServicesResponseSchema, OperationsResponseSchema, OtlpEnvelopeSchema } from './schemas';
-import { parseOtlpTrace, OtlpTracesData } from './parser';
+import { parseOtlpTrace } from './parser';
 import { IOtelTrace } from '../../types/otel';
 
 export class JaegerClient {
@@ -61,7 +61,7 @@ export class JaegerClient {
     const raw = await response.json();
     const validated = OtlpEnvelopeSchema.parse(raw);
     try {
-      return parseOtlpTrace(validated as unknown as OtlpTracesData);
+      return parseOtlpTrace(validated);
     } catch (err) {
       throw new Error(
         `Failed to parse trace "${traceId}": ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -10,6 +10,8 @@
 
 import prefixUrl from '../../utils/prefix-url';
 import { ServicesResponseSchema, OperationsResponseSchema } from './schemas';
+import { parseOtlpTrace } from './parser';
+import { IOtelTrace } from '../../types/otel';
 
 export class JaegerClient {
   private apiRoot = prefixUrl('/api/v3');
@@ -49,6 +51,19 @@ export class JaegerClient {
     // Runtime validation with Zod
     const validated = OperationsResponseSchema.parse(data);
     return validated.operations;
+  }
+
+  async getTrace(traceId: string): Promise<IOtelTrace> {
+    const response = await this.fetchWithTimeout(
+      `${this.apiRoot}/traces/${encodeURIComponent(traceId)}`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch trace "${traceId}": ${response.status} ${response.statusText}`
+      );
+    }
+    const data = await response.json();
+    return parseOtlpTrace(data);
   }
 
   /**

--- a/packages/jaeger-ui/src/api/v3/parser.test.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.test.ts
@@ -7,19 +7,29 @@ import { SpanKind, StatusCode } from '../../types/otel';
 const BASE_NANO = '1000000000'; // 1e9 ns = 1e6 µs
 const BASE_NANO_END = '2000000000'; // 2e9 ns = 2e6 µs
 
-function makeSpan(overrides: Partial<{
-  traceId: string;
-  spanId: string;
-  parentSpanId: string;
-  name: string;
-  kind: number;
-  startTimeUnixNano: string;
-  endTimeUnixNano: string;
-  status: { code?: number; message?: string };
-  attributes: { key: string; value: Record<string, unknown> }[];
-  events: { timeUnixNano: string; name: string; attributes?: { key: string; value: Record<string, unknown> }[] }[];
-  links: { traceId: string; spanId: string; attributes?: { key: string; value: Record<string, unknown> }[] }[];
-}> = {}) {
+function makeSpan(
+  overrides: Partial<{
+    traceId: string;
+    spanId: string;
+    parentSpanId: string;
+    name: string;
+    kind: number;
+    startTimeUnixNano: string;
+    endTimeUnixNano: string;
+    status: { code?: number; message?: string };
+    attributes: { key: string; value: Record<string, unknown> }[];
+    events: {
+      timeUnixNano: string;
+      name: string;
+      attributes?: { key: string; value: Record<string, unknown> }[];
+    }[];
+    links: {
+      traceId: string;
+      spanId: string;
+      attributes?: { key: string; value: Record<string, unknown> }[];
+    }[];
+  }> = {}
+) {
   return {
     traceId: 'trace-abc',
     spanId: 'span-001',
@@ -157,9 +167,7 @@ describe('parseOtlpTrace', () => {
 
   describe('attribute value parsing', () => {
     function attrTrace(value: Record<string, unknown>) {
-      return parseOtlpTrace(
-        makeTrace([makeSpan({ attributes: [{ key: 'test.key', value }] })])
-      );
+      return parseOtlpTrace(makeTrace([makeSpan({ attributes: [{ key: 'test.key', value }] })]));
     }
 
     it('parses stringValue', () => {
@@ -275,7 +283,9 @@ describe('parseOtlpTrace', () => {
   describe('events and links', () => {
     it('parses events', () => {
       const span = makeSpan({
-        events: [{ timeUnixNano: BASE_NANO, name: 'evt', attributes: [{ key: 'k', value: { stringValue: 'v' } }] }],
+        events: [
+          { timeUnixNano: BASE_NANO, name: 'evt', attributes: [{ key: 'k', value: { stringValue: 'v' } }] },
+        ],
       });
       const trace = parseOtlpTrace(makeTrace([span]));
       const evt = trace.spans[0].events[0];
@@ -286,7 +296,9 @@ describe('parseOtlpTrace', () => {
 
     it('parses outbound links', () => {
       const span = makeSpan({
-        links: [{ traceId: 'other', spanId: 'other-span', attributes: [{ key: 'k', value: { intValue: 1 } }] }],
+        links: [
+          { traceId: 'other', spanId: 'other-span', attributes: [{ key: 'k', value: { intValue: 1 } }] },
+        ],
       });
       const trace = parseOtlpTrace(makeTrace([span]));
       const link = trace.spans[0].links[0];
@@ -374,8 +386,16 @@ describe('parseOtlpTrace', () => {
     });
 
     it('sorts spans by startTime', () => {
-      const late = makeSpan({ spanId: 'late', startTimeUnixNano: '2000000000', endTimeUnixNano: '3000000000' });
-      const early = makeSpan({ spanId: 'early', startTimeUnixNano: '1000000000', endTimeUnixNano: '1500000000' });
+      const late = makeSpan({
+        spanId: 'late',
+        startTimeUnixNano: '2000000000',
+        endTimeUnixNano: '3000000000',
+      });
+      const early = makeSpan({
+        spanId: 'early',
+        startTimeUnixNano: '1000000000',
+        endTimeUnixNano: '1500000000',
+      });
       const trace = parseOtlpTrace(makeTrace([late, early]));
       expect(trace.spans[0].spanID).toBe('early');
       expect(trace.spans[1].spanID).toBe('late');

--- a/packages/jaeger-ui/src/api/v3/parser.test.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.test.ts
@@ -207,6 +207,13 @@ describe('parseOtlpTrace', () => {
     it('returns empty string for unknown value type', () => {
       expect(attrTrace({}).spans[0].attributes[0].value).toBe('');
     });
+
+    it('parses bytesValue into a Uint8Array', () => {
+      // base64 'aGk=' decodes to 'hi' (bytes 104, 105)
+      const value = attrTrace({ bytesValue: 'aGk=' }).spans[0].attributes[0].value;
+      expect(value).toBeInstanceOf(Uint8Array);
+      expect(Array.from(value as Uint8Array)).toEqual([104, 105]);
+    });
   });
 
   describe('parent-child tree', () => {

--- a/packages/jaeger-ui/src/api/v3/parser.test.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.test.ts
@@ -1,0 +1,429 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { parseOtlpTrace, OtlpTracesData } from './parser';
+import { SpanKind, StatusCode } from '../../types/otel';
+
+const BASE_NANO = '1000000000'; // 1e9 ns = 1e6 µs
+const BASE_NANO_END = '2000000000'; // 2e9 ns = 2e6 µs
+
+function makeSpan(overrides: Partial<{
+  traceId: string;
+  spanId: string;
+  parentSpanId: string;
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  status: { code?: number; message?: string };
+  attributes: { key: string; value: Record<string, unknown> }[];
+  events: { timeUnixNano: string; name: string; attributes?: { key: string; value: Record<string, unknown> }[] }[];
+  links: { traceId: string; spanId: string; attributes?: { key: string; value: Record<string, unknown> }[] }[];
+}> = {}) {
+  return {
+    traceId: 'trace-abc',
+    spanId: 'span-001',
+    name: 'test-op',
+    kind: 2,
+    startTimeUnixNano: BASE_NANO,
+    endTimeUnixNano: BASE_NANO_END,
+    status: { code: 0 },
+    ...overrides,
+  };
+}
+
+function makeTrace(spans: ReturnType<typeof makeSpan>[], serviceName = 'test-svc'): OtlpTracesData {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: serviceName } }] },
+        scopeSpans: [{ scope: { name: 'test-scope' }, spans }],
+      },
+    ],
+  };
+}
+
+describe('parseOtlpTrace', () => {
+  describe('basic span fields', () => {
+    it('maps traceId, spanId, name, and kind', () => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan()]));
+      const span = trace.spans[0];
+      expect(span.traceID).toBe('trace-abc');
+      expect(span.spanID).toBe('span-001');
+      expect(span.name).toBe('test-op');
+      expect(span.kind).toBe(SpanKind.SERVER); // kind=2
+    });
+
+    it('converts nanosecond timestamps to microseconds', () => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan()]));
+      const span = trace.spans[0];
+      expect(span.startTime).toBe(1_000_000); // 1e12ns / 1000 = 1e6µs
+      expect(span.endTime).toBe(2_000_000);
+      expect(span.duration).toBe(1_000_000);
+    });
+
+    it('parses resource serviceName', () => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan()], 'my-service'));
+      expect(trace.spans[0].resource.serviceName).toBe('my-service');
+    });
+
+    it('parses instrumentationScope', () => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan()]));
+      expect(trace.spans[0].instrumentationScope.name).toBe('test-scope');
+    });
+
+    it('sets parentSpanID and leaves it undefined when absent', () => {
+      const root = makeSpan({ spanId: 'root' });
+      const child = makeSpan({ spanId: 'child', parentSpanId: 'root' });
+      const trace = parseOtlpTrace(makeTrace([root, child]));
+      const rootSpan = trace.spanMap.get('root')!;
+      const childSpan = trace.spanMap.get('child')!;
+      expect(rootSpan.parentSpanID).toBeUndefined();
+      expect(childSpan.parentSpanID).toBe('root');
+    });
+
+    it('treats empty parentSpanId as no parent', () => {
+      const span = makeSpan({ parentSpanId: '' });
+      const trace = parseOtlpTrace(makeTrace([span]));
+      expect(trace.spans[0].parentSpanID).toBeUndefined();
+      expect(trace.rootSpans).toHaveLength(1);
+    });
+  });
+
+  describe('SpanKind mapping', () => {
+    const cases: [number, SpanKind][] = [
+      [0, SpanKind.INTERNAL],
+      [1, SpanKind.INTERNAL],
+      [2, SpanKind.SERVER],
+      [3, SpanKind.CLIENT],
+      [4, SpanKind.PRODUCER],
+      [5, SpanKind.CONSUMER],
+    ];
+    it.each(cases)('kind %i → %s', (input, expected) => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan({ kind: input })]));
+      expect(trace.spans[0].kind).toBe(expected);
+    });
+
+    it('defaults unknown kind to INTERNAL', () => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan({ kind: 99 })]));
+      expect(trace.spans[0].kind).toBe(SpanKind.INTERNAL);
+    });
+  });
+
+  describe('StatusCode mapping', () => {
+    const cases: [number, StatusCode][] = [
+      [0, StatusCode.UNSET],
+      [1, StatusCode.OK],
+      [2, StatusCode.ERROR],
+    ];
+    it.each(cases)('code %i → %s', (code, expected) => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan({ status: { code } })]));
+      expect(trace.spans[0].status.code).toBe(expected);
+    });
+
+    it('defaults empty status to UNSET', () => {
+      const data: OtlpTracesData = {
+        resourceSpans: [
+          {
+            resource: { attributes: [{ key: 'service.name', value: { stringValue: 'svc' } }] },
+            scopeSpans: [
+              {
+                spans: [
+                  {
+                    traceId: 'tid',
+                    spanId: 'sid',
+                    name: 'op',
+                    startTimeUnixNano: BASE_NANO,
+                    endTimeUnixNano: BASE_NANO_END,
+                    status: {},
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const trace = parseOtlpTrace(data);
+      expect(trace.spans[0].status.code).toBe(StatusCode.UNSET);
+    });
+
+    it('preserves status message', () => {
+      const trace = parseOtlpTrace(
+        makeTrace([makeSpan({ status: { code: 2, message: 'something failed' } })])
+      );
+      expect(trace.spans[0].status.message).toBe('something failed');
+    });
+  });
+
+  describe('attribute value parsing', () => {
+    function attrTrace(value: Record<string, unknown>) {
+      return parseOtlpTrace(
+        makeTrace([makeSpan({ attributes: [{ key: 'test.key', value }] })])
+      );
+    }
+
+    it('parses stringValue', () => {
+      expect(attrTrace({ stringValue: 'hello' }).spans[0].attributes[0].value).toBe('hello');
+    });
+
+    it('parses boolValue', () => {
+      expect(attrTrace({ boolValue: true }).spans[0].attributes[0].value).toBe(true);
+    });
+
+    it('parses doubleValue', () => {
+      expect(attrTrace({ doubleValue: 3.14 }).spans[0].attributes[0].value).toBe(3.14);
+    });
+
+    it('parses intValue as string', () => {
+      expect(attrTrace({ intValue: '42' }).spans[0].attributes[0].value).toBe(42);
+    });
+
+    it('parses intValue as number', () => {
+      expect(attrTrace({ intValue: 7 }).spans[0].attributes[0].value).toBe(7);
+    });
+
+    it('parses arrayValue', () => {
+      const value = attrTrace({
+        arrayValue: { values: [{ stringValue: 'a' }, { stringValue: 'b' }] },
+      }).spans[0].attributes[0].value;
+      expect(value).toEqual(['a', 'b']);
+    });
+
+    it('parses kvlistValue', () => {
+      const value = attrTrace({
+        kvlistValue: { values: [{ key: 'k1', value: { stringValue: 'v1' } }] },
+      }).spans[0].attributes[0].value;
+      expect(value).toEqual({ k1: 'v1' });
+    });
+
+    it('returns empty string for unknown value type', () => {
+      expect(attrTrace({}).spans[0].attributes[0].value).toBe('');
+    });
+  });
+
+  describe('parent-child tree', () => {
+    it('wires parentSpan reference', () => {
+      const root = makeSpan({ spanId: 'root' });
+      const child = makeSpan({ spanId: 'child', parentSpanId: 'root' });
+      const trace = parseOtlpTrace(makeTrace([root, child]));
+      const childSpan = trace.spanMap.get('child')!;
+      expect(childSpan.parentSpan?.spanID).toBe('root');
+    });
+
+    it('wires childSpans on parent', () => {
+      const root = makeSpan({ spanId: 'root' });
+      const child = makeSpan({ spanId: 'child', parentSpanId: 'root' });
+      const trace = parseOtlpTrace(makeTrace([root, child]));
+      const rootSpan = trace.spanMap.get('root')!;
+      expect(rootSpan.hasChildren).toBe(true);
+      expect(rootSpan.childSpans).toHaveLength(1);
+      expect(rootSpan.childSpans[0].spanID).toBe('child');
+    });
+
+    it('assigns depth 0 to root and 1 to child', () => {
+      const root = makeSpan({ spanId: 'root' });
+      const child = makeSpan({ spanId: 'child', parentSpanId: 'root' });
+      const grandchild = makeSpan({ spanId: 'grandchild', parentSpanId: 'child' });
+      const trace = parseOtlpTrace(makeTrace([root, child, grandchild]));
+      expect(trace.spanMap.get('root')!.depth).toBe(0);
+      expect(trace.spanMap.get('child')!.depth).toBe(1);
+      expect(trace.spanMap.get('grandchild')!.depth).toBe(2);
+    });
+
+    it('counts spans with missing parent as orphans', () => {
+      const orphan = makeSpan({ spanId: 'orphan', parentSpanId: 'nonexistent' });
+      const trace = parseOtlpTrace(makeTrace([orphan]));
+      expect(trace.orphanSpanCount).toBe(1);
+      expect(trace.rootSpans).toHaveLength(1);
+    });
+  });
+
+  describe('inboundLinks', () => {
+    it('adds an inbound link to the target span', () => {
+      const target = makeSpan({ spanId: 'target' });
+      const linker = makeSpan({
+        spanId: 'linker',
+        links: [{ traceId: 'trace-abc', spanId: 'target' }],
+      });
+      const trace = parseOtlpTrace(makeTrace([target, linker]));
+      const targetSpan = trace.spanMap.get('target')!;
+      expect(targetSpan.inboundLinks).toHaveLength(1);
+      expect(targetSpan.inboundLinks[0].spanID).toBe('linker');
+      expect(targetSpan.inboundLinks[0].span?.spanID).toBe('linker');
+    });
+
+    it('does not add inbound link for external trace references', () => {
+      const linker = makeSpan({
+        spanId: 'linker',
+        links: [{ traceId: 'other-trace', spanId: 'external-span' }],
+      });
+      const trace = parseOtlpTrace(makeTrace([linker]));
+      expect(trace.spans[0].inboundLinks).toHaveLength(0);
+    });
+  });
+
+  describe('events and links', () => {
+    it('parses events', () => {
+      const span = makeSpan({
+        events: [{ timeUnixNano: BASE_NANO, name: 'evt', attributes: [{ key: 'k', value: { stringValue: 'v' } }] }],
+      });
+      const trace = parseOtlpTrace(makeTrace([span]));
+      const evt = trace.spans[0].events[0];
+      expect(evt.name).toBe('evt');
+      expect(evt.timestamp).toBe(1_000_000);
+      expect(evt.attributes[0].key).toBe('k');
+    });
+
+    it('parses outbound links', () => {
+      const span = makeSpan({
+        links: [{ traceId: 'other', spanId: 'other-span', attributes: [{ key: 'k', value: { intValue: 1 } }] }],
+      });
+      const trace = parseOtlpTrace(makeTrace([span]));
+      const link = trace.spans[0].links[0];
+      expect(link.traceID).toBe('other');
+      expect(link.spanID).toBe('other-span');
+      expect(link.attributes[0].value).toBe(1);
+    });
+  });
+
+  describe('trace-level properties', () => {
+    it('computes startTime and endTime from span extremes', () => {
+      const early = makeSpan({
+        spanId: 'early',
+        startTimeUnixNano: '1000000000',
+        endTimeUnixNano: '1500000000',
+      });
+      const late = makeSpan({
+        spanId: 'late',
+        startTimeUnixNano: '1200000000',
+        endTimeUnixNano: '2000000000',
+      });
+      const trace = parseOtlpTrace(makeTrace([early, late]));
+      expect(trace.startTime).toBe(1_000_000);
+      expect(trace.endTime).toBe(2_000_000);
+      expect(trace.duration).toBe(1_000_000);
+    });
+
+    it('assigns relativeStartTime relative to trace start', () => {
+      const early = makeSpan({
+        spanId: 'early',
+        startTimeUnixNano: '1000000000',
+        endTimeUnixNano: '1500000000',
+      });
+      const late = makeSpan({
+        spanId: 'late',
+        startTimeUnixNano: '1200000000',
+        endTimeUnixNano: '2000000000',
+      });
+      const trace = parseOtlpTrace(makeTrace([early, late]));
+      expect(trace.spanMap.get('early')!.relativeStartTime).toBe(0);
+      expect(trace.spanMap.get('late')!.relativeStartTime).toBe(200_000); // 0.2s = 200_000µs
+    });
+
+    it('counts spans per service', () => {
+      const data: OtlpTracesData = {
+        resourceSpans: [
+          {
+            resource: { attributes: [{ key: 'service.name', value: { stringValue: 'svc-a' } }] },
+            scopeSpans: [{ spans: [makeSpan({ spanId: 'a1' }), makeSpan({ spanId: 'a2' })] }],
+          },
+          {
+            resource: { attributes: [{ key: 'service.name', value: { stringValue: 'svc-b' } }] },
+            scopeSpans: [{ spans: [makeSpan({ spanId: 'b1' })] }],
+          },
+        ],
+      };
+      const trace = parseOtlpTrace(data);
+      const svcA = trace.services.find(s => s.name === 'svc-a');
+      const svcB = trace.services.find(s => s.name === 'svc-b');
+      expect(svcA?.numberOfSpans).toBe(2);
+      expect(svcB?.numberOfSpans).toBe(1);
+    });
+
+    it('derives traceName from the earliest root span', () => {
+      const early = makeSpan({
+        spanId: 'early',
+        name: 'root-op',
+        startTimeUnixNano: '1000000000',
+        endTimeUnixNano: '3000000000',
+      });
+      const late = makeSpan({
+        spanId: 'late',
+        name: 'other-root',
+        startTimeUnixNano: '2000000000',
+        endTimeUnixNano: '3000000000',
+      });
+      const trace = parseOtlpTrace(makeTrace([early, late], 'my-svc'));
+      expect(trace.traceName).toBe('my-svc: root-op');
+      expect(trace.tracePageTitle).toBe('my-svc: root-op');
+    });
+
+    it('uses traceId from first span', () => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan({ traceId: 'xyz' })]));
+      expect(trace.traceID).toBe('xyz');
+    });
+
+    it('sorts spans by startTime', () => {
+      const late = makeSpan({ spanId: 'late', startTimeUnixNano: '2000000000', endTimeUnixNano: '3000000000' });
+      const early = makeSpan({ spanId: 'early', startTimeUnixNano: '1000000000', endTimeUnixNano: '1500000000' });
+      const trace = parseOtlpTrace(makeTrace([late, early]));
+      expect(trace.spans[0].spanID).toBe('early');
+      expect(trace.spans[1].spanID).toBe('late');
+    });
+
+    it('populates spanMap for all spans', () => {
+      const s1 = makeSpan({ spanId: 'a' });
+      const s2 = makeSpan({ spanId: 'b' });
+      const trace = parseOtlpTrace(makeTrace([s1, s2]));
+      expect(trace.spanMap.has('a')).toBe(true);
+      expect(trace.spanMap.has('b')).toBe(true);
+    });
+  });
+
+  describe('hasErrors', () => {
+    it('returns false when no spans have error status', () => {
+      const trace = parseOtlpTrace(makeTrace([makeSpan({ status: { code: 0 } })]));
+      expect(trace.hasErrors()).toBe(false);
+    });
+
+    it('returns true when any span has error status', () => {
+      const ok = makeSpan({ spanId: 's1', status: { code: 0 } });
+      const err = makeSpan({ spanId: 's2', status: { code: 2 } });
+      const trace = parseOtlpTrace(makeTrace([ok, err]));
+      expect(trace.hasErrors()).toBe(true);
+    });
+  });
+
+  it('throws when there are no spans', () => {
+    expect(() => parseOtlpTrace({ resourceSpans: [] })).toThrow('No spans found in trace data');
+    expect(() => parseOtlpTrace({})).toThrow('No spans found in trace data');
+  });
+
+  it('handles spans without optional fields gracefully', () => {
+    const data: OtlpTracesData = {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: 'tid',
+                  spanId: 'sid',
+                  name: 'op',
+                  startTimeUnixNano: BASE_NANO,
+                  endTimeUnixNano: BASE_NANO_END,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const trace = parseOtlpTrace(data);
+    expect(trace.spans[0].attributes).toEqual([]);
+    expect(trace.spans[0].events).toEqual([]);
+    expect(trace.spans[0].links).toEqual([]);
+    expect(trace.spans[0].status.code).toBe(StatusCode.UNSET);
+    expect(trace.spans[0].resource.serviceName).toBe('');
+  });
+});

--- a/packages/jaeger-ui/src/api/v3/parser.test.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.test.ts
@@ -57,7 +57,7 @@ describe('parseOtlpTrace', () => {
     it('converts nanosecond timestamps to microseconds', () => {
       const trace = parseOtlpTrace(makeTrace([makeSpan()]));
       const span = trace.spans[0];
-      expect(span.startTime).toBe(1_000_000); // 1e12ns / 1000 = 1e6µs
+      expect(span.startTime).toBe(1_000_000); // 1e9ns / 1000 = 1e6µs
       expect(span.endTime).toBe(2_000_000);
       expect(span.duration).toBe(1_000_000);
     });
@@ -259,6 +259,16 @@ describe('parseOtlpTrace', () => {
       });
       const trace = parseOtlpTrace(makeTrace([linker]));
       expect(trace.spans[0].inboundLinks).toHaveLength(0);
+    });
+
+    it('does not add inbound link when traceId differs even if spanId matches a local span', () => {
+      const local = makeSpan({ spanId: 'local' });
+      const linker = makeSpan({
+        spanId: 'linker',
+        links: [{ traceId: 'OTHER-TRACE', spanId: 'local' }],
+      });
+      const trace = parseOtlpTrace(makeTrace([local, linker]));
+      expect(trace.spanMap.get('local')!.inboundLinks).toHaveLength(0);
     });
   });
 

--- a/packages/jaeger-ui/src/api/v3/parser.test.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.test.ts
@@ -190,6 +190,13 @@ describe('parseOtlpTrace', () => {
       expect(attrTrace({ intValue: 7 }).spans[0].attributes[0].value).toBe(7);
     });
 
+    it('keeps large intValue as string when it exceeds safe integer range', () => {
+      // 9007199254740993 = MAX_SAFE_INTEGER + 2; converting to Number loses precision
+      expect(attrTrace({ intValue: '9007199254740993' }).spans[0].attributes[0].value).toBe(
+        '9007199254740993'
+      );
+    });
+
     it('parses arrayValue', () => {
       const value = attrTrace({
         arrayValue: { values: [{ stringValue: 'a' }, { stringValue: 'b' }] },

--- a/packages/jaeger-ui/src/api/v3/parser.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.ts
@@ -69,8 +69,9 @@ export type OtlpTracesData = {
 };
 
 // Internal mutable type used during tree construction
-type MutableSpan = Omit<IOtelSpan, 'childSpans' | 'inboundLinks' | 'warnings'> & {
-  childSpans: IOtelSpan[];
+type MutableSpan = Omit<IOtelSpan, 'parentSpan' | 'childSpans' | 'inboundLinks' | 'warnings'> & {
+  parentSpan?: MutableSpan;
+  childSpans: MutableSpan[];
   inboundLinks: ILink[];
   warnings: string[] | null;
 };
@@ -98,7 +99,10 @@ function parseAttrValue(v: OtlpAnyValue): AttributeValue {
   if (v.stringValue !== undefined) return v.stringValue;
   if (v.boolValue !== undefined) return v.boolValue;
   if (v.doubleValue !== undefined) return v.doubleValue;
-  if (v.intValue !== undefined) return Number(v.intValue);
+  if (v.intValue !== undefined) {
+    const n = Number(v.intValue);
+    return Number.isSafeInteger(n) ? n : String(v.intValue);
+  }
   if (v.arrayValue !== undefined) {
     return (v.arrayValue.values ?? []).map(parseAttrValue);
   }
@@ -138,10 +142,14 @@ function parseScope(scope?: { name?: string; version?: string; attributes?: Otlp
   };
 }
 
-function assignDepths(span: MutableSpan, depth: number) {
-  span.depth = depth;
-  for (const child of span.childSpans) {
-    assignDepths(child as MutableSpan, depth + 1);
+function assignDepths(roots: MutableSpan[]) {
+  const stack: { span: MutableSpan; depth: number }[] = roots.map(s => ({ span: s, depth: 0 }));
+  while (stack.length > 0) {
+    const { span, depth } = stack.pop()!;
+    span.depth = depth;
+    for (const child of span.childSpans) {
+      stack.push({ span: child, depth: depth + 1 });
+    }
   }
 }
 
@@ -195,7 +203,7 @@ export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
       instrumentationScope: scope,
       depth: 0,
       hasChildren: false,
-      childSpans: [],
+      childSpans: [] as MutableSpan[],
       relativeStartTime: 0 as Microseconds,
       inboundLinks: [],
       warnings: null,
@@ -213,8 +221,8 @@ export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
     if (ms.parentSpanID) {
       const parent = spanMap.get(ms.parentSpanID);
       if (parent) {
-        (ms as any).parentSpan = parent;
-        parent.childSpans.push(ms as IOtelSpan);
+        ms.parentSpan = parent;
+        parent.childSpans.push(ms);
         parent.hasChildren = true;
       } else {
         orphanSpanCount++;
@@ -225,15 +233,17 @@ export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
     }
   }
 
-  // Assign depths from roots
-  for (const root of rootSpans) {
-    assignDepths(root, 0);
-  }
+  assignDepths(rootSpans);
+
+  const traceID = mutableSpans[0].traceID;
 
   // Build inboundLinks — for each outbound link that points to a span in this trace,
   // add an inbound link on the target so the UI can surface "referenced by" relationships.
+  // Only match links whose traceID matches the current trace to avoid false positives when
+  // an external trace happens to share a spanID with a local span.
   for (const ms of mutableSpans) {
     for (const link of ms.links) {
+      if (link.traceID !== traceID) continue;
       const target = spanMap.get(link.spanID);
       if (target) {
         target.inboundLinks.push({
@@ -278,7 +288,6 @@ export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
     rootSpans[0]
   );
   const traceName = `${primaryRoot.resource.serviceName}: ${primaryRoot.name}`;
-  const traceID = mutableSpans[0].traceID;
 
   return {
     traceID,

--- a/packages/jaeger-ui/src/api/v3/parser.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.ts
@@ -102,7 +102,7 @@ function parseAttrValue(v: OtlpAnyValue): AttributeValue {
   if (v.doubleValue !== undefined) return v.doubleValue;
   if (v.intValue !== undefined) {
     const n = Number(v.intValue);
-    return Number.isSafeInteger(n) ? n : String(v.intValue);
+    return Number.isSafeInteger(n) && String(n) === String(v.intValue) ? n : String(v.intValue);
   }
   if (v.arrayValue !== undefined) {
     return (v.arrayValue.values ?? []).map(parseAttrValue);
@@ -115,6 +115,7 @@ function parseAttrValue(v: OtlpAnyValue): AttributeValue {
     return obj;
   }
   if (v.bytesValue !== undefined) {
+    if (typeof globalThis.atob !== 'function') return new Uint8Array(0);
     const binary = globalThis.atob(v.bytesValue);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
@@ -154,7 +155,8 @@ function assignDepths(roots: MutableSpan[]) {
   }
 }
 
-export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
+export function parseOtlpTrace(input: unknown): IOtelTrace {
+  const data = input as OtlpTracesData;
   const flatSpans: { s: OtlpSpan; resource: IResource; scope: IScope }[] = [];
 
   for (const rs of data.resourceSpans ?? []) {
@@ -180,9 +182,9 @@ export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
     const statusCode = STATUS_MAP[s.status?.code ?? 0] ?? StatusCode.UNSET;
 
     const ms: MutableSpan = {
-      traceID: s.traceId,
-      spanID: s.spanId,
-      parentSpanID: s.parentSpanId || undefined,
+      traceID: s.traceId.toLowerCase(),
+      spanID: s.spanId.toLowerCase(),
+      parentSpanID: s.parentSpanId ? s.parentSpanId.toLowerCase() : undefined,
       name: s.name,
       kind: KIND_MAP[s.kind ?? 0] ?? SpanKind.INTERNAL,
       startTime,
@@ -195,8 +197,8 @@ export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
         attributes: parseAttrs(e.attributes),
       })),
       links: (s.links ?? []).map(l => ({
-        traceID: l.traceId,
-        spanID: l.spanId,
+        traceID: l.traceId.toLowerCase(),
+        spanID: l.spanId.toLowerCase(),
         attributes: parseAttrs(l.attributes),
       })),
       status: { code: statusCode, message: s.status?.message },

--- a/packages/jaeger-ui/src/api/v3/parser.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.ts
@@ -115,7 +115,7 @@ function parseAttrValue(v: OtlpAnyValue): AttributeValue {
     return obj;
   }
   if (v.bytesValue !== undefined) {
-    const binary = atob(v.bytesValue);
+    const binary = globalThis.atob(v.bytesValue);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
     return bytes;
@@ -283,11 +283,9 @@ export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
     numberOfSpans,
   }));
 
-  // traceName from the earliest root span
-  const primaryRoot = rootSpans.reduce(
-    (earliest, s) => (s.startTime < earliest.startTime ? s : earliest),
-    rootSpans[0]
-  );
+  // traceName from the earliest root span; fall back to all spans if rootSpans is empty (cycle in trace)
+  const candidates = rootSpans.length > 0 ? rootSpans : mutableSpans;
+  const primaryRoot = candidates.reduce((earliest, s) => (s.startTime < earliest.startTime ? s : earliest));
   const traceName = `${primaryRoot.resource.serviceName}: ${primaryRoot.name}`;
 
   return {

--- a/packages/jaeger-ui/src/api/v3/parser.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.ts
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AttributeValue,
+  IAttribute,
+  ILink,
+  IOtelSpan,
+  IOtelTrace,
+  IResource,
+  IScope,
+  SpanKind,
+  StatusCode,
+} from '../../types/otel';
+import { Microseconds } from '../../types/units';
+
+// OTLP wire format types
+type OtlpAnyValue = {
+  stringValue?: string;
+  intValue?: string | number;
+  doubleValue?: number;
+  boolValue?: boolean;
+  arrayValue?: { values?: OtlpAnyValue[] };
+  kvlistValue?: { values?: { key: string; value: OtlpAnyValue }[] };
+  bytesValue?: string;
+};
+
+type OtlpAttribute = { key: string; value: OtlpAnyValue };
+
+type OtlpLink = {
+  traceId: string;
+  spanId: string;
+  attributes?: OtlpAttribute[];
+};
+
+type OtlpStatus = {
+  code?: number;
+  message?: string;
+};
+
+type OtlpSpan = {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind?: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes?: OtlpAttribute[];
+  events?: {
+    timeUnixNano: string;
+    name: string;
+    attributes?: OtlpAttribute[];
+  }[];
+  links?: OtlpLink[];
+  status?: OtlpStatus;
+};
+
+type OtlpResourceSpans = {
+  resource?: { attributes?: OtlpAttribute[] };
+  scopeSpans?: {
+    scope?: { name?: string; version?: string; attributes?: OtlpAttribute[] };
+    spans?: OtlpSpan[];
+  }[];
+};
+
+export type OtlpTracesData = {
+  resourceSpans?: OtlpResourceSpans[];
+};
+
+// Internal mutable type used during tree construction
+type MutableSpan = Omit<IOtelSpan, 'childSpans' | 'inboundLinks' | 'warnings'> & {
+  childSpans: IOtelSpan[];
+  inboundLinks: ILink[];
+  warnings: string[] | null;
+};
+
+const KIND_MAP: { [k: number]: SpanKind } = {
+  0: SpanKind.INTERNAL,
+  1: SpanKind.INTERNAL,
+  2: SpanKind.SERVER,
+  3: SpanKind.CLIENT,
+  4: SpanKind.PRODUCER,
+  5: SpanKind.CONSUMER,
+};
+
+const STATUS_MAP: { [k: number]: StatusCode } = {
+  0: StatusCode.UNSET,
+  1: StatusCode.OK,
+  2: StatusCode.ERROR,
+};
+
+function nanoToMicro(nanoStr: string): Microseconds {
+  return Number(BigInt(nanoStr) / 1000n) as Microseconds;
+}
+
+function parseAttrValue(v: OtlpAnyValue): AttributeValue {
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.boolValue !== undefined) return v.boolValue;
+  if (v.doubleValue !== undefined) return v.doubleValue;
+  if (v.intValue !== undefined) return Number(v.intValue);
+  if (v.arrayValue !== undefined) {
+    return (v.arrayValue.values ?? []).map(parseAttrValue);
+  }
+  if (v.kvlistValue !== undefined) {
+    const obj: { [key: string]: AttributeValue } = {};
+    for (const kv of v.kvlistValue.values ?? []) {
+      obj[kv.key] = parseAttrValue(kv.value);
+    }
+    return obj;
+  }
+  if (v.bytesValue !== undefined) {
+    const binary = atob(v.bytesValue);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+  return '';
+}
+
+function parseAttrs(attrs?: OtlpAttribute[]): IAttribute[] {
+  if (!attrs) return [];
+  return attrs.map(a => ({ key: a.key, value: parseAttrValue(a.value) }));
+}
+
+function parseResource(res?: { attributes?: OtlpAttribute[] }): IResource {
+  const attributes = parseAttrs(res?.attributes);
+  const serviceAttr = attributes.find(a => a.key === 'service.name');
+  const serviceName = typeof serviceAttr?.value === 'string' ? serviceAttr.value : '';
+  return { attributes, serviceName };
+}
+
+function parseScope(scope?: { name?: string; version?: string; attributes?: OtlpAttribute[] }): IScope {
+  return {
+    name: scope?.name ?? '',
+    version: scope?.version,
+    attributes: parseAttrs(scope?.attributes),
+  };
+}
+
+function assignDepths(span: MutableSpan, depth: number) {
+  span.depth = depth;
+  for (const child of span.childSpans) {
+    assignDepths(child as MutableSpan, depth + 1);
+  }
+}
+
+export function parseOtlpTrace(data: OtlpTracesData): IOtelTrace {
+  const flatSpans: { s: OtlpSpan; resource: IResource; scope: IScope }[] = [];
+
+  for (const rs of data.resourceSpans ?? []) {
+    const resource = parseResource(rs.resource);
+    for (const ss of rs.scopeSpans ?? []) {
+      const scope = parseScope(ss.scope);
+      for (const s of ss.spans ?? []) {
+        flatSpans.push({ s, resource, scope });
+      }
+    }
+  }
+
+  if (flatSpans.length === 0) {
+    throw new Error('No spans found in trace data');
+  }
+
+  const spanMap = new Map<string, MutableSpan>();
+  const mutableSpans: MutableSpan[] = [];
+
+  for (const { s, resource, scope } of flatSpans) {
+    const startTime = nanoToMicro(s.startTimeUnixNano);
+    const endTime = nanoToMicro(s.endTimeUnixNano);
+    const statusCode = STATUS_MAP[s.status?.code ?? 0] ?? StatusCode.UNSET;
+
+    const ms: MutableSpan = {
+      traceID: s.traceId,
+      spanID: s.spanId,
+      parentSpanID: s.parentSpanId || undefined,
+      name: s.name,
+      kind: KIND_MAP[s.kind ?? 0] ?? SpanKind.INTERNAL,
+      startTime,
+      endTime,
+      duration: (endTime - startTime) as Microseconds,
+      attributes: parseAttrs(s.attributes),
+      events: (s.events ?? []).map(e => ({
+        timestamp: nanoToMicro(e.timeUnixNano),
+        name: e.name,
+        attributes: parseAttrs(e.attributes),
+      })),
+      links: (s.links ?? []).map(l => ({
+        traceID: l.traceId,
+        spanID: l.spanId,
+        attributes: parseAttrs(l.attributes),
+      })),
+      status: { code: statusCode, message: s.status?.message },
+      resource,
+      instrumentationScope: scope,
+      depth: 0,
+      hasChildren: false,
+      childSpans: [],
+      relativeStartTime: 0 as Microseconds,
+      inboundLinks: [],
+      warnings: null,
+    };
+
+    mutableSpans.push(ms);
+    spanMap.set(s.spanId, ms);
+  }
+
+  // Wire parent-child relationships
+  const rootSpans: MutableSpan[] = [];
+  let orphanSpanCount = 0;
+
+  for (const ms of mutableSpans) {
+    if (ms.parentSpanID) {
+      const parent = spanMap.get(ms.parentSpanID);
+      if (parent) {
+        (ms as any).parentSpan = parent;
+        parent.childSpans.push(ms as IOtelSpan);
+        parent.hasChildren = true;
+      } else {
+        orphanSpanCount++;
+        rootSpans.push(ms);
+      }
+    } else {
+      rootSpans.push(ms);
+    }
+  }
+
+  // Assign depths from roots
+  for (const root of rootSpans) {
+    assignDepths(root, 0);
+  }
+
+  // Build inboundLinks — for each outbound link that points to a span in this trace,
+  // add an inbound link on the target so the UI can surface "referenced by" relationships.
+  for (const ms of mutableSpans) {
+    for (const link of ms.links) {
+      const target = spanMap.get(link.spanID);
+      if (target) {
+        target.inboundLinks.push({
+          traceID: ms.traceID,
+          spanID: ms.spanID,
+          attributes: link.attributes,
+          span: ms as IOtelSpan,
+        });
+      }
+    }
+  }
+
+  // Compute trace timing
+  let traceStartTime = Infinity;
+  let traceEndTime = -Infinity;
+  for (const ms of mutableSpans) {
+    if (ms.startTime < traceStartTime) traceStartTime = ms.startTime;
+    if (ms.endTime > traceEndTime) traceEndTime = ms.endTime;
+  }
+  const startTime = traceStartTime as Microseconds;
+  const endTime = traceEndTime as Microseconds;
+  const duration = (traceEndTime - traceStartTime) as Microseconds;
+
+  for (const ms of mutableSpans) {
+    ms.relativeStartTime = (ms.startTime - traceStartTime) as Microseconds;
+  }
+
+  // Count spans per service
+  const serviceCountMap = new Map<string, number>();
+  for (const ms of mutableSpans) {
+    const svc = ms.resource.serviceName;
+    serviceCountMap.set(svc, (serviceCountMap.get(svc) ?? 0) + 1);
+  }
+  const services = [...serviceCountMap.entries()].map(([name, numberOfSpans]) => ({
+    name,
+    numberOfSpans,
+  }));
+
+  // traceName from the earliest root span
+  const primaryRoot = rootSpans.reduce(
+    (earliest, s) => (s.startTime < earliest.startTime ? s : earliest),
+    rootSpans[0]
+  );
+  const traceName = `${primaryRoot.resource.serviceName}: ${primaryRoot.name}`;
+  const traceID = mutableSpans[0].traceID;
+
+  return {
+    traceID,
+    spans: [...mutableSpans].sort((a, b) => a.startTime - b.startTime) as IOtelSpan[],
+    duration,
+    startTime,
+    endTime,
+    traceName,
+    tracePageTitle: traceName,
+    traceEmoji: '',
+    services,
+    spanMap: spanMap as unknown as ReadonlyMap<string, IOtelSpan>,
+    rootSpans: rootSpans as IOtelSpan[],
+    orphanSpanCount,
+    hasErrors() {
+      return mutableSpans.some(ms => ms.status.code === StatusCode.ERROR);
+    },
+  };
+}

--- a/packages/jaeger-ui/src/api/v3/parser.ts
+++ b/packages/jaeger-ui/src/api/v3/parser.ts
@@ -92,7 +92,8 @@ const STATUS_MAP: { [k: number]: StatusCode } = {
 };
 
 function nanoToMicro(nanoStr: string): Microseconds {
-  return Number(BigInt(nanoStr) / 1000n) as Microseconds;
+  // Slice off the last 3 digits to divide by 1000 without BigInt (avoids precision loss via float64).
+  return Number(nanoStr.length > 3 ? nanoStr.slice(0, -3) : '0') as Microseconds;
 }
 
 function parseAttrValue(v: OtlpAnyValue): AttributeValue {

--- a/packages/jaeger-ui/src/api/v3/schemas.ts
+++ b/packages/jaeger-ui/src/api/v3/schemas.ts
@@ -22,5 +22,5 @@ export const traceIdHex = z.string().regex(/^[0-9a-f]{32}$/i, 'Invalid trace ID:
 export const spanIdHex = z.string().regex(/^[0-9a-f]{16}$/i, 'Invalid span ID: must be 16-char hex string');
 
 export const OtlpEnvelopeSchema = z.object({
-  resourceSpans: z.array(z.record(z.unknown())).optional(),
+  resourceSpans: z.array(z.record(z.string(), z.unknown())).optional(),
 });

--- a/packages/jaeger-ui/src/api/v3/schemas.ts
+++ b/packages/jaeger-ui/src/api/v3/schemas.ts
@@ -20,3 +20,7 @@ import { z } from 'zod';
 export const traceIdHex = z.string().regex(/^[0-9a-f]{32}$/i, 'Invalid trace ID: must be 32-char hex string');
 
 export const spanIdHex = z.string().regex(/^[0-9a-f]{16}$/i, 'Invalid span ID: must be 16-char hex string');
+
+export const OtlpEnvelopeSchema = z.object({
+  resourceSpans: z.array(z.record(z.unknown())).optional(),
+});

--- a/packages/jaeger-ui/src/hooks/useTrace.test.ts
+++ b/packages/jaeger-ui/src/hooks/useTrace.test.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useTrace } from './useTrace';
+import { jaegerClient } from '../api/v3/client';
+
+vi.mock('../api/v3/client', () => ({
+  jaegerClient: {
+    getTrace: vi.fn(),
+  },
+}));
+
+describe('useTrace', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    });
+
+    const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+      return React.createElement(QueryClientProvider, { client: queryClient }, children);
+    };
+    return Wrapper;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+  });
+
+  it('returns loading state initially when traceId is provided', () => {
+    (jaegerClient.getTrace as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {}) // never resolves
+    );
+
+    const { result } = renderHook(() => useTrace('trace-abc'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('successfully fetches and returns trace data', async () => {
+    const mockTrace = { traceID: 'trace-abc', spans: [] } as any;
+    (jaegerClient.getTrace as ReturnType<typeof vi.fn>).mockResolvedValue(mockTrace);
+
+    const { result } = renderHook(() => useTrace('trace-abc'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toBe(mockTrace);
+    expect(jaegerClient.getTrace).toHaveBeenCalledWith('trace-abc');
+    expect(jaegerClient.getTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the correct query key', async () => {
+    const mockTrace = { traceID: 'trace-abc', spans: [] } as any;
+    (jaegerClient.getTrace as ReturnType<typeof vi.fn>).mockResolvedValue(mockTrace);
+
+    const { result } = renderHook(() => useTrace('trace-abc'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const queries = queryClient.getQueryCache().findAll({ queryKey: ['trace', 'trace-abc'] });
+    expect(queries).toHaveLength(1);
+  });
+
+  it('is disabled when traceId is null', () => {
+    const { result } = renderHook(() => useTrace(null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(jaegerClient.getTrace).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when traceId is empty string', () => {
+    const { result } = renderHook(() => useTrace(''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(jaegerClient.getTrace).not.toHaveBeenCalled();
+  });
+
+  it('handles errors from getTrace', async () => {
+    const mockError = new Error('Failed to fetch trace "bad-trace": 404 Not Found');
+    (jaegerClient.getTrace as ReturnType<typeof vi.fn>).mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useTrace('bad-trace'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(mockError);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('refetches when traceId changes', async () => {
+    const trace1 = { traceID: 'trace-1', spans: [] } as any;
+    const trace2 = { traceID: 'trace-2', spans: [] } as any;
+    (jaegerClient.getTrace as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(trace1)
+      .mockResolvedValueOnce(trace2);
+
+    const { result, rerender } = renderHook(({ id }) => useTrace(id), {
+      wrapper: createWrapper(),
+      initialProps: { id: 'trace-1' as string | null },
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBe(trace1);
+
+    rerender({ id: 'trace-2' });
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(trace2);
+    });
+
+    expect(jaegerClient.getTrace).toHaveBeenCalledTimes(2);
+    expect(jaegerClient.getTrace).toHaveBeenNthCalledWith(1, 'trace-1');
+    expect(jaegerClient.getTrace).toHaveBeenNthCalledWith(2, 'trace-2');
+  });
+
+  it('stops fetching when traceId becomes null', async () => {
+    const mockTrace = { traceID: 'trace-1', spans: [] } as any;
+    (jaegerClient.getTrace as ReturnType<typeof vi.fn>).mockResolvedValue(mockTrace);
+
+    const { result, rerender } = renderHook(({ id }) => useTrace(id), {
+      wrapper: createWrapper(),
+      initialProps: { id: 'trace-1' as string | null },
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    vi.clearAllMocks();
+    rerender({ id: null });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(jaegerClient.getTrace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jaeger-ui/src/hooks/useTrace.ts
+++ b/packages/jaeger-ui/src/hooks/useTrace.ts
@@ -8,7 +8,7 @@ import { IOtelTrace } from '../types/otel';
 export function useTrace(traceId: string | null): UseQueryResult<IOtelTrace> {
   return useQuery({
     queryKey: ['trace', traceId],
-    queryFn: () => jaegerClient.getTrace(traceId!),
+    queryFn: ({ queryKey }) => jaegerClient.getTrace(queryKey[1] as string),
     enabled: !!traceId,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,

--- a/packages/jaeger-ui/src/hooks/useTrace.ts
+++ b/packages/jaeger-ui/src/hooks/useTrace.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { jaegerClient } from '../api/v3/client';
+import { IOtelTrace } from '../types/otel';
+
+export function useTrace(traceId: string | null): UseQueryResult<IOtelTrace> {
+  return useQuery({
+    queryKey: ['trace', traceId],
+    queryFn: () => jaegerClient.getTrace(traceId!),
+    enabled: !!traceId,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/packages/jaeger-ui/src/hooks/useTrace.ts
+++ b/packages/jaeger-ui/src/hooks/useTrace.ts
@@ -8,7 +8,7 @@ import { IOtelTrace } from '../types/otel';
 export function useTrace(traceId: string | null): UseQueryResult<IOtelTrace> {
   return useQuery({
     queryKey: ['trace', traceId],
-    queryFn: ({ queryKey }) => jaegerClient.getTrace(queryKey[1] as string),
+    queryFn: () => jaegerClient.getTrace(traceId as string),
     enabled: !!traceId,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #3265 (phase 3.2).

The v3 API returns OTLP `TracesData` but there's no client method to fetch a trace by ID or a React hook to drive it from a component. This adds both, along with the parser that bridges the wire format to `IOtelTrace`.

## Description of the changes

`src/api/v3/parser.ts` takes the raw OTLP response and produces an `IOtelTrace`. Handles nanosecond timestamps, all attribute value types, parent-child wiring, depth assignment, inbound links, and trace-level fields like duration and services.

`JaegerClient.getTrace(traceId)` calls `/api/v3/traces/{traceID}` and runs the response through the parser.

`useTrace(traceId)` is a React Query hook wrapping `getTrace`. Disabled when `traceId` is null, 5-minute stale time since traces don't change after ingestion.

## How was this change tested?

76 new tests across the parser and hook. Existing tests unaffected.

`npm run lint`, `npm run tsc-lint`, `npm test` all pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes