### PR TITLE
fix(ui): correct typos in AccordionLinks class name and CSS punctuation key

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.css
@@ -45,6 +45,10 @@ SPDX-License-Identifier: Apache-2.0
   content: attr(data-label);
 }
 
+.AccordionLinks--emptyIcon {
+  color: var(--text-muted);
+}
+
 .SpanReference--debugLabel {
   margin: 0 5px 0 5px;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionLinks.tsx
@@ -68,7 +68,7 @@ function AccordionLinks({
   useOtelTerms,
 }: AccordionLinksProps) {
   const isEmpty = !Array.isArray(data) || !data.length;
-  const iconCls = cx('u-align-icon', { 'AccordianKReferences--emptyIcon': isEmpty });
+  const iconCls = cx('u-align-icon', { 'AccordionLinks--emptyIcon': isEmpty });
 
   let arrow: React.ReactNode | null = null;
   let headerProps: object | null = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -92,7 +92,7 @@ function formatValue(key: string, value: any) {
           nullValue: 'json-markup-null',
           undefinedValue: 'json-markup-undefined',
           basicChildStyle: 'json-markup-child',
-          punctuation: 'json-markup-puncuation',
+          punctuation: 'json-markup-punctuation',
           otherValue: 'json-markup-other',
         }}
       />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -103,6 +103,6 @@ SPDX-License-Identifier: Apache-2.0
   padding: 0;
 }
 
-.json-markup-puncuation {
+.json-markup-punctuation {
   font-weight: bold;
 }


### PR DESCRIPTION
## Summary

- Renames the mistyped CSS class `AccordianKReferences--emptyIcon` to `AccordionLinks--emptyIcon` in `AccordionLinks.tsx` and adds the corresponding CSS rule in `AccordionLinks.css` (following the same pattern as `AccordionAttributes--emptyIcon`)
- Renames the misspelled CSS key `json-markup-puncuation` to `json-markup-punctuation` in both `AttributesTable.tsx` (the class name reference) and `index.css` (the rule definition)

Fixes #8452

## Test plan

- [ ] Verify the empty-state icon in the Links accordion still renders with correct muted color styling
- [ ] Verify JSON attribute values still display bold punctuation characters in span details

🤖 Generated with [Claude Code](https://claude.com/claude-code)