### PR TITLE
feat: highlight spans by tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,9 +1293,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,9 +1310,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1333,9 +1327,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1353,9 +1344,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1373,9 +1361,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1393,9 +1378,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1413,9 +1395,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1433,9 +1412,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { Button, Input, InputRef, Tooltip } from 'antd';
+import { Button, InputRef, Space, Tooltip } from 'antd';
 import cx from 'classnames';
 import { IoLocate, IoHelp, IoChevronDown, IoChevronUp } from 'react-icons/io5';
 
@@ -75,13 +75,13 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
   return (
     <div className="TracePageSearchBar">
       {/* style inline because compact overwrites the display */}
-      <Input.Group className="ub-justify-end" compact style={{ display: 'flex' }}>
+      <Space.Compact className="ub-justify-end" style={{ display: 'flex' }}>
         <UiFindInput inputProps={uiFindInputInputProps} ref={forwardedRef} trackFindFunction={trackFilter} />
         <Tooltip
           arrow={{ pointAtCenter: true }}
           placement="bottomLeft"
           trigger="hover"
-          overlayStyle={{ maxWidth: '600px' }} // This is a large tooltip and the default is too narrow.
+          styles={{ root: { maxWidth: '600px' } }} // This is a large tooltip and the default is too narrow.
           title={renderTooltip()}
         >
           <div className="help-btn-container">
@@ -118,7 +118,7 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
             </Button>
           </>
         )}
-      </Input.Group>
+      </Space.Compact>
     </div>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -7,6 +7,15 @@ SPDX-License-Identifier: Apache-2.0
   background-color: var(--trace-emphasis-highlight);
 }
 
+.span-row.is-tag-highlighted .span-name-wrapper {
+  background-color: rgba(255, 140, 0, 0.25) !important;
+  border-left: 4px solid #ff8c00 !important;
+}
+
+.span-row.is-tag-highlighted .span-view {
+  background-color: rgba(255, 140, 0, 0.15) !important;
+}
+
 .span-row.is-selected .span-name-wrapper {
   background-color: var(--interactive-primary-light);
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -25,6 +25,7 @@ type SpanBarRowProps = {
   isDetailExpanded: boolean;
   isMatchingFilter: boolean;
   isSelected?: boolean;
+  isTagHighlighted?: boolean;
   timelineBarsVisible: boolean;
   onDetailToggled: (spanID: string) => void;
   onChildrenToggled: (spanID: string) => void;
@@ -71,6 +72,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   isDetailExpanded,
   isMatchingFilter,
   isSelected,
+  isTagHighlighted = false,
   timelineBarsVisible,
   numTicks,
   rpc = null,
@@ -137,6 +139,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
           ${className || ''}
           ${isDetailExpanded ? 'is-expanded' : ''}
           ${isMatchingFilter ? 'is-matching-filter' : ''}
+          ${isTagHighlighted ? 'is-tag-highlighted' : ''}
           ${isSelected ? 'is-selected' : ''}
         `}
     >

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TagHighlightInput.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TagHighlightInput.css
@@ -1,0 +1,9 @@
+/*
+Copyright (c) 2026 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+.TagHighlightInput {
+  min-width: 150px;
+  max-width: 250px;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TagHighlightInput.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TagHighlightInput.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState, useCallback } from 'react';
+import { Input, InputRef, Tooltip } from 'antd';
+import { useTraceTimelineStore } from './store';
+import './TagHighlightInput.css';
+
+type TagHighlightInputProps = {
+  inputRef?: React.Ref<InputRef>;
+};
+
+export default React.forwardRef<InputRef, TagHighlightInputProps>(function TagHighlightInput(_props, ref) {
+  const tagHighlight = useTraceTimelineStore(s => s.tagHighlight);
+  const setTagHighlight = useTraceTimelineStore(s => s.setTagHighlight);
+  const [inputValue, setInputValue] = useState(tagHighlight || '');
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setInputValue(value);
+      setTagHighlight(value || null);
+    },
+    [setTagHighlight]
+  );
+
+  return (
+    <Tooltip title="Highlight spans by tag (e.g., component=jdbc)" styles={{ root: { maxWidth: 300 } }}>
+      <Input
+        ref={ref}
+        placeholder="Highlight by tag..."
+        value={inputValue}
+        onChange={handleChange}
+        allowClear
+        className="TagHighlightInput"
+        data-testid="tag-highlight-input"
+      />
+    </Tooltip>
+  );
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -8,6 +8,7 @@ import TimelineCollapser from './TimelineCollapser';
 import TimelineViewingLayer from './TimelineViewingLayer';
 import Ticks from '../Ticks';
 import TimelineRow from '../TimelineRow';
+import TagHighlightInput from '../TagHighlightInput';
 import { TUpdateViewRangeTimeFunction, IViewRangeTime, ViewRangeTimeUpdate } from '../../types';
 import { IOtelSpan } from '../../../../types/otel';
 
@@ -75,6 +76,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
           onCollapseOne={onCollapseOne}
           onExpandOne={onExpandOne}
         />
+        <TagHighlightInput />
       </TimelineRow.Cell>
       {timelineBarsVisible && (
         <>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import cx from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import _isEqual from 'lodash/isEqual';
@@ -30,6 +30,7 @@ import { Accessors } from '../ScrollManager';
 import { extractUiFindFromState, TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
 import getLinks from '../../../model/link-patterns';
 import colorGenerator from '../../../utils/color-generator';
+import filterSpans from '../../../utils/filter-spans';
 import { TNil, ReduxState } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan, IOtelTrace, IAttribute, IEvent } from '../../../types/otel';
@@ -44,6 +45,7 @@ import withRouteProps from '../../../utils/withRouteProps';
 type TVirtualizedTraceViewOwnProps = {
   currentViewRangeTime: [number, number];
   findMatchesIDs: Set<string> | TNil;
+  tagHighlightedSpanIds: Set<string> | TNil;
   nameColumnWidth: number;
   scrollToFirstVisibleSpan: () => void;
   registerAccessors: (accesors: Accessors) => void;
@@ -515,6 +517,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
       detailStates,
       detailToggle,
       findMatchesIDs,
+      tagHighlightedSpanIds,
       nameColumnWidth,
       prunedServices,
       selectedSpanID,
@@ -534,6 +537,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
     const isCollapsed = childrenHiddenIDs.has(spanID);
     const isDetailExpanded = detailStates.has(spanID);
     const isMatchingFilter = findMatchesIDs ? findMatchesIDs.has(spanID) : false;
+    const isTagHighlighted = tagHighlightedSpanIds ? tagHighlightedSpanIds.has(spanID) : false;
     const isSelected = selectedSpanID === spanID;
     const hasOwnError = isErrorSpan(span);
     const hasChildError = isCollapsed && spanContainsErredSpan(spans, spanIndex);
@@ -583,6 +587,7 @@ export class VirtualizedTraceViewImpl extends React.Component<VirtualizedTraceVi
           isChildrenExpanded={!isCollapsed}
           isDetailExpanded={isDetailExpanded}
           isMatchingFilter={isMatchingFilter}
+          isTagHighlighted={isTagHighlighted}
           isSelected={isSelected}
           timelineBarsVisible={timelineBarsVisible}
           numTicks={NUM_TICKS}
@@ -696,7 +701,14 @@ function VirtualizedTraceViewWrapper(
   const detailStates = useTraceTimelineStore(s => s.detailStates);
   const shouldScrollToFirstUiFindMatch = useTraceTimelineStore(s => s.shouldScrollToFirstUiFindMatch);
   const prunedServices = useTraceTimelineStore(s => s.prunedServices);
+  const tagHighlight = useTraceTimelineStore(s => s.tagHighlight);
   const selectedSpanID = detailPanelMode === 'sidepanel' ? getSelectedSpanID(detailStates) : null;
+
+  const tagHighlightedSpanIds = useMemo(() => {
+    if (!tagHighlight || !ownProps.trace) return null;
+    const matchedIds = filterSpans(tagHighlight, ownProps.trace.spans);
+    return matchedIds;
+  }, [tagHighlight, ownProps.trace]);
 
   const zustandSetTrace = useTraceTimelineStore(s => s.setTrace);
   const zustandChildrenToggle = useTraceTimelineStore(s => s.childrenToggle);
@@ -818,6 +830,7 @@ function VirtualizedTraceViewWrapper(
     shouldScrollToFirstUiFindMatch,
     prunedServices,
     selectedSpanID,
+    tagHighlightedSpanIds,
     setTrace,
     childrenToggle,
     detailToggle,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.timeline.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.timeline.ts
@@ -19,6 +19,7 @@ type TraceTimelineInteractionStore = {
   detailStates: Map<string, DetailState>;
   shouldScrollToFirstUiFindMatch: boolean;
   prunedServices: Set<string>;
+  tagHighlight: string | TNil;
   setPrunedServices: (pruned: Set<string>) => void;
   clearServiceFilter: () => void;
   // Resets ephemeral fields for a new trace and optionally pre-apply a uiFind filter
@@ -37,6 +38,7 @@ type TraceTimelineInteractionStore = {
   detailReferencesToggle: (spanID: string) => void;
   clearShouldScrollToFirstUiFindMatch: () => void;
   focusUiFindMatches: (trace: IOtelTrace, uiFind?: string | TNil, allowHide?: boolean) => void;
+  setTagHighlight: (query: string | TNil, spans?: ReadonlyArray<IOtelSpan>) => void;
 };
 
 export const useTraceTimelineStore = create<TraceTimelineInteractionStore>()((set, get) => ({
@@ -45,6 +47,7 @@ export const useTraceTimelineStore = create<TraceTimelineInteractionStore>()((se
   detailStates: new Map<string, DetailState>(),
   shouldScrollToFirstUiFindMatch: false,
   prunedServices: new Set<string>(),
+  tagHighlight: null,
 
   setPrunedServices: (pruned: Set<string>) => set({ prunedServices: new Set(pruned) }),
 
@@ -213,5 +216,9 @@ export const useTraceTimelineStore = create<TraceTimelineInteractionStore>()((se
     let focused = calculateFocusedFindRowStates(uiFind, trace.spans, allowHide);
     focused = trimFocusedDetailStatesForSidePanel(focused, detailPanelMode);
     set(focused);
+  },
+
+  setTagHighlight: (query: string | TNil) => {
+    set({ tagHighlight: query });
   },
 }));


### PR DESCRIPTION
fixes Allow highlight spans base on tag in trace detail view #651 


This PR :
-Add TagHighlightInput component with antd Input in timeline header
- Add tagHighlight state and setTagHighlight action in store.timeline.ts
- Calculate tagHighlightedSpanIds using filterSpans in VirtualizedTraceView
- Pass isTagHighlighted prop to SpanBarRow
- Add CSS highlight styling for matched spans
- Fix deprecated antd Input.Group -> Space.Compact in TracePageSearchBar
