### PR TITLE
Fix timeline side panel header resizer

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -6,6 +6,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import TimelineHeaderRow from './TimelineHeaderRow';
+import { SIDE_PANEL_WIDTH_MAX, SIDE_PANEL_WIDTH_MIN } from '../store.constants';
+
+const { RESIZER_DRAG_DELTA } = vi.hoisted(() => ({
+  RESIZER_DRAG_DELTA: 0.05,
+}));
 
 vi.mock('../TimelineRow', () => {
   const TimelineRowMock = ({ children, className }) => (
@@ -23,7 +28,7 @@ vi.mock('../TimelineRow', () => {
 
 vi.mock('../../../common/VerticalResizer', () => ({
   default: ({ position, min, max, onChange }) => {
-    const nextPosition = position - 0.05;
+    const nextPosition = position - RESIZER_DRAG_DELTA;
     return (
       <button
         type="button"
@@ -142,15 +147,17 @@ describe('<TimelineHeaderRow>', () => {
   });
 
   describe('side panel visible', () => {
-    const sidePanelWidth = 0.3;
+    const sidePanelWidth = 1 - SIDE_PANEL_WIDTH_MAX;
+    const sidePanelResizerMin = 1 - SIDE_PANEL_WIDTH_MAX;
+    const sidePanelResizerMax = 1 - SIDE_PANEL_WIDTH_MIN;
     const sidePanelProps = {
       ...props,
       sidePanelVisible: true,
       sidePanelWidth,
       sidePanelLabel: 'Span Details',
       resizerMax: 1 - sidePanelWidth,
-      sidePanelResizerMin: 0.35,
-      sidePanelResizerMax: 0.8,
+      sidePanelResizerMin,
+      sidePanelResizerMax,
     };
 
     it('renders the side panel header cell', () => {
@@ -175,9 +182,12 @@ describe('<TimelineHeaderRow>', () => {
       const [, sidePanelResizer] = screen.getAllByTestId('vertical-resizer');
 
       expect(sidePanelResizer).toHaveAttribute('data-position', String(1 - sidePanelWidth));
-      expect(sidePanelResizer).toHaveAttribute('data-next-position', String(1 - sidePanelWidth - 0.05));
-      expect(sidePanelResizer).toHaveAttribute('data-min', '0.35');
-      expect(sidePanelResizer).toHaveAttribute('data-max', '0.8');
+      expect(sidePanelResizer).toHaveAttribute(
+        'data-next-position',
+        String(1 - sidePanelWidth - RESIZER_DRAG_DELTA)
+      );
+      expect(sidePanelResizer).toHaveAttribute('data-min', String(sidePanelResizerMin));
+      expect(sidePanelResizer).toHaveAttribute('data-max', String(sidePanelResizerMax));
     });
 
     it('does not render the side panel resizer when its config is omitted', () => {
@@ -196,7 +206,7 @@ describe('<TimelineHeaderRow>', () => {
       fireEvent.click(sidePanelResizer);
 
       expect(onSidePanelWidthChange).toHaveBeenCalledTimes(1);
-      expect(onSidePanelWidthChange.mock.calls[0][0]).toBeCloseTo(sidePanelWidth + 0.05);
+      expect(onSidePanelWidthChange.mock.calls[0][0]).toBeCloseTo(sidePanelWidth + RESIZER_DRAG_DELTA);
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -183,7 +183,7 @@ describe('<TimelineHeaderRow>', () => {
       fireEvent.click(sidePanelResizer);
 
       expect(onSidePanelWidthChange).toHaveBeenCalledTimes(1);
-      expect(onSidePanelWidthChange).toHaveBeenCalledWith(1 - sidePanelWidth);
+      expect(onSidePanelWidthChange.mock.calls[0][0]).toBeCloseTo(sidePanelWidth);
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import TimelineHeaderRow from './TimelineHeaderRow';
@@ -22,8 +22,15 @@ vi.mock('../TimelineRow', () => {
 });
 
 vi.mock('../../../common/VerticalResizer', () => ({
-  default: ({ position, min, max }) => (
-    <div data-testid="vertical-resizer" data-position={position} data-min={min} data-max={max} />
+  default: ({ position, min, max, onChange }) => (
+    <button
+      type="button"
+      data-testid="vertical-resizer"
+      data-position={position}
+      data-min={min}
+      data-max={max}
+      onClick={() => onChange(position)}
+    />
   ),
 }));
 
@@ -62,9 +69,12 @@ describe('<TimelineHeaderRow>', () => {
     onCollapseAll: jest.fn(),
     onCollapseOne: jest.fn(),
     onColummWidthChange: jest.fn(),
+    onSidePanelWidthChange: jest.fn(),
     onExpandAll: jest.fn(),
     onExpandOne: jest.fn(),
     resizerMax: 0.85,
+    sidePanelResizerMin: 0.3,
+    sidePanelResizerMax: 0.8,
     timelineBarsVisible: true,
     updateNextViewRangeTime: jest.fn(),
     updateViewRangeTime: jest.fn(),
@@ -135,6 +145,8 @@ describe('<TimelineHeaderRow>', () => {
       sidePanelWidth,
       sidePanelLabel: 'Span Details',
       resizerMax: 1 - sidePanelWidth,
+      sidePanelResizerMin: 0.35,
+      sidePanelResizerMax: 0.8,
     };
 
     it('renders the side panel header cell', () => {
@@ -149,8 +161,29 @@ describe('<TimelineHeaderRow>', () => {
 
     it('sets resizer max to 1 - sidePanelWidth', () => {
       render(<TimelineHeaderRow {...sidePanelProps} />);
-      const resizer = screen.getByTestId('vertical-resizer');
-      expect(resizer).toHaveAttribute('data-max', String(1 - sidePanelWidth));
+      const [nameColumnResizer] = screen.getAllByTestId('vertical-resizer');
+
+      expect(nameColumnResizer).toHaveAttribute('data-max', String(1 - sidePanelWidth));
+    });
+
+    it('renders a side panel resizer aligned with the side panel boundary', () => {
+      render(<TimelineHeaderRow {...sidePanelProps} />);
+      const [, sidePanelResizer] = screen.getAllByTestId('vertical-resizer');
+
+      expect(sidePanelResizer).toHaveAttribute('data-position', String(1 - sidePanelWidth));
+      expect(sidePanelResizer).toHaveAttribute('data-min', '0.35');
+      expect(sidePanelResizer).toHaveAttribute('data-max', '0.8');
+    });
+
+    it('calls the side panel width handler from the side panel resizer', () => {
+      const onSidePanelWidthChange = jest.fn();
+      render(<TimelineHeaderRow {...sidePanelProps} onSidePanelWidthChange={onSidePanelWidthChange} />);
+      const [, sidePanelResizer] = screen.getAllByTestId('vertical-resizer');
+
+      fireEvent.click(sidePanelResizer);
+
+      expect(onSidePanelWidthChange).toHaveBeenCalledTimes(1);
+      expect(onSidePanelWidthChange).toHaveBeenCalledWith(1 - sidePanelWidth);
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -190,14 +190,6 @@ describe('<TimelineHeaderRow>', () => {
       expect(sidePanelResizer).toHaveAttribute('data-max', String(sidePanelResizerMax));
     });
 
-    it('does not render the side panel resizer when its config is omitted', () => {
-      const { onSidePanelWidthChange, sidePanelResizerMin, sidePanelResizerMax, ...propsWithoutResizer } =
-        sidePanelProps;
-      render(<TimelineHeaderRow {...propsWithoutResizer} />);
-
-      expect(screen.getAllByTestId('vertical-resizer')).toHaveLength(1);
-    });
-
     it('calls the side panel width handler from the side panel resizer', () => {
       const onSidePanelWidthChange = jest.fn();
       render(<TimelineHeaderRow {...sidePanelProps} onSidePanelWidthChange={onSidePanelWidthChange} />);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -77,7 +77,7 @@ describe('<TimelineHeaderRow>', () => {
     numTicks: 5,
     onCollapseAll: jest.fn(),
     onCollapseOne: jest.fn(),
-    onColummWidthChange: jest.fn(),
+    onColumnWidthChange: jest.fn(),
     onSidePanelWidthChange: jest.fn(),
     onExpandAll: jest.fn(),
     onExpandOne: jest.fn(),
@@ -170,11 +170,12 @@ describe('<TimelineHeaderRow>', () => {
       expect(screen.getByText('Trace Root')).toBeInTheDocument();
     });
 
-    it('sets resizer max to 1 - sidePanelWidth', () => {
-      render(<TimelineHeaderRow {...sidePanelProps} />);
+    it('passes resizerMax through to the name-column resizer', () => {
+      const resizerMax = 0.42;
+      render(<TimelineHeaderRow {...sidePanelProps} resizerMax={resizerMax} />);
       const [nameColumnResizer] = screen.getAllByTestId('vertical-resizer');
 
-      expect(nameColumnResizer).toHaveAttribute('data-max', String(1 - sidePanelWidth));
+      expect(nameColumnResizer).toHaveAttribute('data-max', String(resizerMax));
     });
 
     it('renders a side panel resizer aligned with the side panel boundary', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -22,16 +22,20 @@ vi.mock('../TimelineRow', () => {
 });
 
 vi.mock('../../../common/VerticalResizer', () => ({
-  default: ({ position, min, max, onChange }) => (
-    <button
-      type="button"
-      data-testid="vertical-resizer"
-      data-position={position}
-      data-min={min}
-      data-max={max}
-      onClick={() => onChange(position)}
-    />
-  ),
+  default: ({ position, min, max, onChange }) => {
+    const nextPosition = position - 0.05;
+    return (
+      <button
+        type="button"
+        data-testid="vertical-resizer"
+        data-position={position}
+        data-next-position={nextPosition}
+        data-min={min}
+        data-max={max}
+        onClick={() => onChange(nextPosition)}
+      />
+    );
+  },
 }));
 
 vi.mock('./TimelineViewingLayer', () => ({
@@ -171,8 +175,17 @@ describe('<TimelineHeaderRow>', () => {
       const [, sidePanelResizer] = screen.getAllByTestId('vertical-resizer');
 
       expect(sidePanelResizer).toHaveAttribute('data-position', String(1 - sidePanelWidth));
+      expect(sidePanelResizer).toHaveAttribute('data-next-position', String(1 - sidePanelWidth - 0.05));
       expect(sidePanelResizer).toHaveAttribute('data-min', '0.35');
       expect(sidePanelResizer).toHaveAttribute('data-max', '0.8');
+    });
+
+    it('does not render the side panel resizer when its config is omitted', () => {
+      const { onSidePanelWidthChange, sidePanelResizerMin, sidePanelResizerMax, ...propsWithoutResizer } =
+        sidePanelProps;
+      render(<TimelineHeaderRow {...propsWithoutResizer} />);
+
+      expect(screen.getAllByTestId('vertical-resizer')).toHaveLength(1);
     });
 
     it('calls the side panel width handler from the side panel resizer', () => {
@@ -183,7 +196,7 @@ describe('<TimelineHeaderRow>', () => {
       fireEvent.click(sidePanelResizer);
 
       expect(onSidePanelWidthChange).toHaveBeenCalledTimes(1);
-      expect(onSidePanelWidthChange.mock.calls[0][0]).toBeCloseTo(sidePanelWidth);
+      expect(onSidePanelWidthChange.mock.calls[0][0]).toBeCloseTo(sidePanelWidth + 0.05);
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -23,7 +23,7 @@ type TimelineHeaderRowProps = {
   numTicks: number;
   onCollapseAll: () => void;
   onCollapseOne: () => void;
-  onColummWidthChange: (width: number) => void;
+  onColumnWidthChange: (width: number) => void;
   onSidePanelWidthChange: (width: number) => void;
   onExpandAll: () => void;
   onExpandOne: () => void;
@@ -48,7 +48,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
     numTicks,
     onCollapseAll,
     onCollapseOne,
-    onColummWidthChange,
+    onColumnWidthChange,
     onSidePanelWidthChange,
     onExpandAll,
     onExpandOne,
@@ -95,7 +95,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
           </TimelineRow.Cell>
           <VerticalResizer
             position={nameColumnWidth}
-            onChange={onColummWidthChange}
+            onChange={onColumnWidthChange}
             min={0.15}
             max={resizerMax}
           />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -24,7 +24,7 @@ type TimelineHeaderRowProps = {
   onCollapseAll: () => void;
   onCollapseOne: () => void;
   onColummWidthChange: (width: number) => void;
-  onSidePanelWidthChange: (position: number) => void;
+  onSidePanelWidthChange: (width: number) => void;
   onExpandAll: () => void;
   onExpandOne: () => void;
   resizerMax: number;
@@ -109,7 +109,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
       {sidePanelVisible && timelineBarsVisible && (
         <VerticalResizer
           position={1 - sidePanelWidth}
-          onChange={onSidePanelWidthChange}
+          onChange={position => onSidePanelWidthChange(1 - position)}
           min={sidePanelResizerMin}
           max={sidePanelResizerMax}
         />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -24,7 +24,7 @@ type TimelineHeaderRowProps = {
   onCollapseAll: () => void;
   onCollapseOne: () => void;
   onColummWidthChange: (width: number) => void;
-  onSidePanelWidthChange?: (width: number) => void;
+  onSidePanelWidthChange: (width: number) => void;
   onExpandAll: () => void;
   onExpandOne: () => void;
   resizerMax: number;
@@ -32,8 +32,8 @@ type TimelineHeaderRowProps = {
   sidePanelVisible: boolean;
   sidePanelWidth: number;
   sidePanelLabel: string;
-  sidePanelResizerMin?: number;
-  sidePanelResizerMax?: number;
+  sidePanelResizerMin: number;
+  sidePanelResizerMax: number;
   timelineBarsVisible: boolean;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
@@ -68,12 +68,6 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
   const startTime = (viewStart * duration) as IOtelSpan['startTime'];
   const endTime = (viewEnd * duration) as IOtelSpan['endTime'];
   const timelineColumnWidth = 1 - nameColumnWidth - (sidePanelVisible ? sidePanelWidth : 0);
-  const showSidePanelResizer =
-    sidePanelVisible &&
-    timelineBarsVisible &&
-    onSidePanelWidthChange &&
-    typeof sidePanelResizerMin === 'number' &&
-    typeof sidePanelResizerMax === 'number';
   return (
     <TimelineRow className="TimelineHeaderRow">
       <TimelineRow.Cell className="ub-flex ub-px2" width={nameColumnWidth}>
@@ -112,7 +106,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
           <h3 className="TimelineHeaderRow--title">{sidePanelLabel}</h3>
         </TimelineRow.Cell>
       )}
-      {showSidePanelResizer && (
+      {sidePanelVisible && timelineBarsVisible && (
         <VerticalResizer
           position={1 - sidePanelWidth}
           onChange={position => onSidePanelWidthChange(1 - position)}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -24,6 +24,7 @@ type TimelineHeaderRowProps = {
   onCollapseAll: () => void;
   onCollapseOne: () => void;
   onColummWidthChange: (width: number) => void;
+  onSidePanelWidthChange: (position: number) => void;
   onExpandAll: () => void;
   onExpandOne: () => void;
   resizerMax: number;
@@ -31,6 +32,8 @@ type TimelineHeaderRowProps = {
   sidePanelVisible: boolean;
   sidePanelWidth: number;
   sidePanelLabel: string;
+  sidePanelResizerMin: number;
+  sidePanelResizerMax: number;
   timelineBarsVisible: boolean;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
@@ -46,6 +49,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
     onCollapseAll,
     onCollapseOne,
     onColummWidthChange,
+    onSidePanelWidthChange,
     onExpandAll,
     onExpandOne,
     resizerMax,
@@ -53,6 +57,8 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
     sidePanelVisible,
     sidePanelWidth,
     sidePanelLabel,
+    sidePanelResizerMin,
+    sidePanelResizerMax,
     timelineBarsVisible,
     updateViewRangeTime,
     updateNextViewRangeTime,
@@ -99,6 +105,14 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
         <TimelineRow.Cell className="ub-flex ub-px2 TimelineHeaderRow--sidePanelCell" width={sidePanelWidth}>
           <h3 className="TimelineHeaderRow--title">{sidePanelLabel}</h3>
         </TimelineRow.Cell>
+      )}
+      {sidePanelVisible && timelineBarsVisible && (
+        <VerticalResizer
+          position={1 - sidePanelWidth}
+          onChange={onSidePanelWidthChange}
+          min={sidePanelResizerMin}
+          max={sidePanelResizerMax}
+        />
       )}
     </TimelineRow>
   );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -24,7 +24,7 @@ type TimelineHeaderRowProps = {
   onCollapseAll: () => void;
   onCollapseOne: () => void;
   onColummWidthChange: (width: number) => void;
-  onSidePanelWidthChange: (width: number) => void;
+  onSidePanelWidthChange?: (width: number) => void;
   onExpandAll: () => void;
   onExpandOne: () => void;
   resizerMax: number;
@@ -32,8 +32,8 @@ type TimelineHeaderRowProps = {
   sidePanelVisible: boolean;
   sidePanelWidth: number;
   sidePanelLabel: string;
-  sidePanelResizerMin: number;
-  sidePanelResizerMax: number;
+  sidePanelResizerMin?: number;
+  sidePanelResizerMax?: number;
   timelineBarsVisible: boolean;
   updateNextViewRangeTime: (update: ViewRangeTimeUpdate) => void;
   updateViewRangeTime: TUpdateViewRangeTimeFunction;
@@ -68,6 +68,12 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
   const startTime = (viewStart * duration) as IOtelSpan['startTime'];
   const endTime = (viewEnd * duration) as IOtelSpan['endTime'];
   const timelineColumnWidth = 1 - nameColumnWidth - (sidePanelVisible ? sidePanelWidth : 0);
+  const showSidePanelResizer =
+    sidePanelVisible &&
+    timelineBarsVisible &&
+    onSidePanelWidthChange &&
+    typeof sidePanelResizerMin === 'number' &&
+    typeof sidePanelResizerMax === 'number';
   return (
     <TimelineRow className="TimelineHeaderRow">
       <TimelineRow.Cell className="ub-flex ub-px2" width={nameColumnWidth}>
@@ -106,7 +112,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
           <h3 className="TimelineHeaderRow--title">{sidePanelLabel}</h3>
         </TimelineRow.Cell>
       )}
-      {sidePanelVisible && timelineBarsVisible && (
+      {showSidePanelResizer && (
         <VerticalResizer
           position={1 - sidePanelWidth}
           onChange={position => onSidePanelWidthChange(1 - position)}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -73,7 +73,12 @@ vi.mock('../../common/VerticalResizer', () => ({
 }));
 vi.mock('./TimelineHeaderRow', () =>
   mockDefault(props => (
-    <div data-testid="timeline-header-row-mock" data-side-panel-label={props.sidePanelLabel}>
+    <div
+      data-testid="timeline-header-row-mock"
+      data-side-panel-label={props.sidePanelLabel}
+      data-side-panel-resizer-min={props.sidePanelResizerMin}
+      data-side-panel-resizer-max={props.sidePanelResizerMax}
+    >
       {props.serviceFilterNode}
       <button data-testid="collapse-all-button" type="button" onClick={props.onCollapseAll}>
         Collapse All
@@ -87,6 +92,11 @@ vi.mock('./TimelineHeaderRow', () =>
       <button data-testid="expand-one-button" type="button" onClick={props.onExpandOne}>
         Expand One
       </button>
+      <button
+        data-testid="side-panel-resizer-change"
+        type="button"
+        onClick={() => props.onSidePanelWidthChange && props.onSidePanelWidthChange(0.7)}
+      />
     </div>
   ))
 );
@@ -233,19 +243,13 @@ describe('<TraceTimelineViewer>', () => {
         render(<TraceTimelineViewerImpl {...props} />);
 
         const sidePanelActive = detailPanelMode === 'sidepanel';
-        const resizerExpected = sidePanelActive && timelineBarsVisible;
-
         if (sidePanelActive) {
           expect(screen.getByTestId('span-detail-side-panel-mock')).toBeInTheDocument();
         } else {
           expect(screen.queryByTestId('span-detail-side-panel-mock')).not.toBeInTheDocument();
         }
 
-        if (resizerExpected) {
-          expect(screen.getByTestId('vertical-resizer-mock')).toBeInTheDocument();
-        } else {
-          expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
-        }
+        expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
 
         // VirtualizedTraceView is always rendered.
         expect(screen.getByTestId('virtualized-trace-view-mock')).toBeInTheDocument();
@@ -265,9 +269,17 @@ describe('<TraceTimelineViewer>', () => {
       expect(screen.getByTestId('virtualized-trace-view-mock')).toBeInTheDocument();
     });
 
-    it('renders a VerticalResizer between main and side panel when timeline bars are visible', () => {
+    it('does not render a body VerticalResizer between main and side panel when timeline bars are visible', () => {
       render(<TraceTimelineViewerImpl {...props} />);
-      expect(screen.getByTestId('vertical-resizer-mock')).toBeInTheDocument();
+      expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
+    });
+
+    it('passes side panel resizer bounds to the header row', () => {
+      render(<TraceTimelineViewerImpl {...props} />);
+      const header = screen.getByTestId('timeline-header-row-mock');
+
+      expect(Number(header.dataset.sidePanelResizerMin)).toBeCloseTo(0.3);
+      expect(Number(header.dataset.sidePanelResizerMax)).toBeCloseTo(0.8);
     });
 
     it('does not render a VerticalResizer when timeline bars are hidden', () => {
@@ -276,9 +288,9 @@ describe('<TraceTimelineViewer>', () => {
       expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
     });
 
-    it('calls setSidePanelWidth (Zustand + Redux) when the VerticalResizer onChange fires', () => {
+    it('calls setSidePanelWidth (Zustand + Redux) when the header side panel resizer onChange fires', () => {
       render(<TraceTimelineViewerImpl {...props} />);
-      fireEvent.click(screen.getByTestId('vertical-resizer-change'));
+      fireEvent.click(screen.getByTestId('side-panel-resizer-change'));
       // onChange receives newPosition=0.7 → setSidePanelWidth(1 - 0.7 ≈ 0.3)
       expect(mockLayoutPrefsStore.setSidePanelWidth).toHaveBeenCalledTimes(1);
       expect(mockLayoutPrefsStore.setSidePanelWidth.mock.calls[0][0]).toBeCloseTo(0.3);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -148,6 +148,16 @@ describe('<TraceTimelineViewer>', () => {
     };
   }
 
+  function withLayoutPrefs(updates, callback) {
+    const previous = Object.fromEntries(Object.keys(updates).map(key => [key, mockLayoutPrefsStore[key]]));
+    Object.assign(mockLayoutPrefsStore, updates);
+    try {
+      return callback();
+    } finally {
+      Object.assign(mockLayoutPrefsStore, previous);
+    }
+  }
+
   beforeEach(() => {
     props.expandAll.mockClear();
     props.collapseAll.mockClear();
@@ -310,23 +320,23 @@ describe('<TraceTimelineViewer>', () => {
     });
 
     it('computes side panel resizer bounds from the effective header name width', () => {
-      mockLayoutPrefsStore.spanNameColumnWidth = 0.7;
-      mockLayoutPrefsStore.sidePanelWidth = 0.4;
-      render(<TraceTimelineViewerImpl {...props} />);
-      const header = screen.getByTestId('timeline-header-row-mock');
-      const mainFraction = 1 - mockLayoutPrefsStore.sidePanelWidth;
-      const effectiveHeaderNameWidth =
-        Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction;
-      const expectedMin = Math.min(
-        1 -
-          Math.min(
-            layoutConstants.SIDE_PANEL_WIDTH_MAX,
-            1 - effectiveHeaderNameWidth - layoutConstants.MIN_TIMELINE_COLUMN_WIDTH
-          ),
-        1 - layoutConstants.SIDE_PANEL_WIDTH_MIN
-      );
+      withLayoutPrefs({ spanNameColumnWidth: 0.7, sidePanelWidth: 0.4 }, () => {
+        render(<TraceTimelineViewerImpl {...props} />);
+        const header = screen.getByTestId('timeline-header-row-mock');
+        const mainFraction = 1 - mockLayoutPrefsStore.sidePanelWidth;
+        const effectiveHeaderNameWidth =
+          Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction;
+        const expectedMin = Math.min(
+          1 -
+            Math.min(
+              layoutConstants.SIDE_PANEL_WIDTH_MAX,
+              1 - effectiveHeaderNameWidth - layoutConstants.MIN_TIMELINE_COLUMN_WIDTH
+            ),
+          1 - layoutConstants.SIDE_PANEL_WIDTH_MIN
+        );
 
-      expect(Number(header.dataset.sidePanelResizerMin)).toBeCloseTo(expectedMin);
+        expect(Number(header.dataset.sidePanelResizerMin)).toBeCloseTo(expectedMin);
+      });
     });
 
     it('does not render a VerticalResizer when timeline bars are hidden', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -11,48 +11,63 @@ import * as KeyboardShortcuts from '../keyboard-shortcuts';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
 
-const { mockLayoutPrefsStore, mockTraceTimelineStore, mockUseTraceTimelineStore } = vi.hoisted(() => {
-  const mockTraceTimelineStore = {
-    detailStates: new Map(),
-    prunedServices: new Set(),
-    setPrunedServices: vi.fn(),
-    collapseAll: vi.fn(),
-    collapseOne: vi.fn(),
-    expandAll: vi.fn(),
-    expandOne: vi.fn(),
-  };
-  const mockUseTraceTimelineStore = Object.assign(
-    vi.fn(selector => selector(mockTraceTimelineStore)),
-    {
-      getState: () => mockTraceTimelineStore,
-      setState: vi.fn(partial => Object.assign(mockTraceTimelineStore, partial)),
-    }
-  );
-  return {
-    mockLayoutPrefsStore: {
-      spanNameColumnWidth: 0.25,
-      sidePanelWidth: 0.375,
-      detailPanelMode: 'inline',
-      timelineBarsVisible: true,
-      setSpanNameColumnWidth: vi.fn(),
-      setSidePanelWidth: vi.fn(),
-      setTimelineBarsVisible: vi.fn(),
-    },
-    mockTraceTimelineStore,
-    mockUseTraceTimelineStore,
-  };
-});
+const { layoutConstants, mockLayoutPrefsStore, mockTraceTimelineStore, mockUseTraceTimelineStore } =
+  vi.hoisted(() => {
+    const layoutConstants = {
+      SPAN_NAME_COLUMN_WIDTH_MIN: 0.15,
+      SPAN_NAME_COLUMN_WIDTH_MAX: 0.85,
+      SIDE_PANEL_WIDTH_MIN: 0.2,
+      SIDE_PANEL_WIDTH_MAX: 0.7,
+      MIN_TIMELINE_COLUMN_WIDTH: 0.05,
+    };
+    const mockTraceTimelineStore = {
+      detailStates: new Map(),
+      prunedServices: new Set(),
+      setPrunedServices: vi.fn(),
+      collapseAll: vi.fn(),
+      collapseOne: vi.fn(),
+      expandAll: vi.fn(),
+      expandOne: vi.fn(),
+    };
+    const mockUseTraceTimelineStore = Object.assign(
+      vi.fn(selector => selector(mockTraceTimelineStore)),
+      {
+        getState: () => mockTraceTimelineStore,
+        setState: vi.fn(partial => Object.assign(mockTraceTimelineStore, partial)),
+      }
+    );
+    return {
+      layoutConstants,
+      mockLayoutPrefsStore: {
+        spanNameColumnWidth: 0.25,
+        sidePanelWidth: 0.375,
+        detailPanelMode: 'inline',
+        timelineBarsVisible: true,
+        setSpanNameColumnWidth: vi.fn(),
+        setSidePanelWidth: vi.fn(),
+        setTimelineBarsVisible: vi.fn(),
+      },
+      mockTraceTimelineStore,
+      mockUseTraceTimelineStore,
+    };
+  });
 
 vi.mock('./store', () => ({
   useLayoutPrefsStore: vi.fn(selector => selector(mockLayoutPrefsStore)),
   useTraceTimelineStore: mockUseTraceTimelineStore,
   getSelectedSpanID: detailStatesArg =>
     detailStatesArg.size > 0 ? detailStatesArg.keys().next().value : null,
-  SPAN_NAME_COLUMN_WIDTH_MIN: 0.15,
-  SPAN_NAME_COLUMN_WIDTH_MAX: 0.85,
-  SIDE_PANEL_WIDTH_MIN: 0.2,
-  SIDE_PANEL_WIDTH_MAX: 0.7,
-  MIN_TIMELINE_COLUMN_WIDTH: 0.05,
+  ...layoutConstants,
+}));
+vi.mock('./duck', () => ({
+  actions: {
+    setSpanNameColumnWidth: width => ({ type: 'setSpanNameColumnWidth', width }),
+    setSidePanelWidth: width => ({ type: 'setSidePanelWidth', width }),
+    expandAll: () => ({ type: 'expandAll' }),
+    expandOne: spans => ({ type: 'expandOne', spans }),
+    collapseAll: spans => ({ type: 'collapseAll', spans }),
+    collapseOne: spans => ({ type: 'collapseOne', spans }),
+  },
 }));
 
 const mockUseServiceFilter = vi.hoisted(() => ({
@@ -95,7 +110,7 @@ vi.mock('./TimelineHeaderRow', () =>
       <button
         data-testid="side-panel-resizer-change"
         type="button"
-        onClick={() => props.onSidePanelWidthChange && props.onSidePanelWidthChange(0.7)}
+        onClick={() => props.onSidePanelWidthChange && props.onSidePanelWidthChange(0.3)}
       />
     </div>
   ))
@@ -277,9 +292,41 @@ describe('<TraceTimelineViewer>', () => {
     it('passes side panel resizer bounds to the header row', () => {
       render(<TraceTimelineViewerImpl {...props} />);
       const header = screen.getByTestId('timeline-header-row-mock');
+      const resizerMin = Number(header.dataset.sidePanelResizerMin);
+      const resizerMax = Number(header.dataset.sidePanelResizerMax);
+      const expectedMax = 1 - layoutConstants.SIDE_PANEL_WIDTH_MIN;
+      const expectedMin = Math.min(
+        1 -
+          Math.min(
+            layoutConstants.SIDE_PANEL_WIDTH_MAX,
+            1 - mockLayoutPrefsStore.spanNameColumnWidth - layoutConstants.MIN_TIMELINE_COLUMN_WIDTH
+          ),
+        expectedMax
+      );
 
-      expect(Number(header.dataset.sidePanelResizerMin)).toBeCloseTo(0.3);
-      expect(Number(header.dataset.sidePanelResizerMax)).toBeCloseTo(0.8);
+      expect(resizerMin).toBeCloseTo(expectedMin);
+      expect(resizerMax).toBeCloseTo(expectedMax);
+      expect(resizerMin).toBeLessThanOrEqual(resizerMax);
+    });
+
+    it('computes side panel resizer bounds from the effective header name width', () => {
+      mockLayoutPrefsStore.spanNameColumnWidth = 0.7;
+      mockLayoutPrefsStore.sidePanelWidth = 0.4;
+      render(<TraceTimelineViewerImpl {...props} />);
+      const header = screen.getByTestId('timeline-header-row-mock');
+      const mainFraction = 1 - mockLayoutPrefsStore.sidePanelWidth;
+      const effectiveHeaderNameWidth =
+        Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction;
+      const expectedMin = Math.min(
+        1 -
+          Math.min(
+            layoutConstants.SIDE_PANEL_WIDTH_MAX,
+            1 - effectiveHeaderNameWidth - layoutConstants.MIN_TIMELINE_COLUMN_WIDTH
+          ),
+        1 - layoutConstants.SIDE_PANEL_WIDTH_MIN
+      );
+
+      expect(Number(header.dataset.sidePanelResizerMin)).toBeCloseTo(expectedMin);
     });
 
     it('does not render a VerticalResizer when timeline bars are hidden', () => {
@@ -291,7 +338,7 @@ describe('<TraceTimelineViewer>', () => {
     it('calls setSidePanelWidth (Zustand + Redux) when the header side panel resizer onChange fires', () => {
       render(<TraceTimelineViewerImpl {...props} />);
       fireEvent.click(screen.getByTestId('side-panel-resizer-change'));
-      // onChange receives newPosition=0.7 → setSidePanelWidth(1 - 0.7 ≈ 0.3)
+      // TimelineHeaderRow converts the resizer position to a side-panel width before calling back.
       expect(mockLayoutPrefsStore.setSidePanelWidth).toHaveBeenCalledTimes(1);
       expect(mockLayoutPrefsStore.setSidePanelWidth.mock.calls[0][0]).toBeCloseTo(0.3);
       expect(props.setSidePanelWidth).toHaveBeenCalledTimes(1);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -85,6 +85,8 @@ vi.mock('./TimelineHeaderRow', () =>
   mockDefault(props => (
     <div
       data-testid="timeline-header-row-mock"
+      data-name-column-width={props.nameColumnWidth}
+      data-resizer-max={props.resizerMax}
       data-side-panel-label={props.sidePanelLabel}
       data-side-panel-resizer-min={props.sidePanelResizerMin}
       data-side-panel-resizer-max={props.sidePanelResizerMax}
@@ -319,14 +321,34 @@ describe('<TraceTimelineViewer>', () => {
         render(<TraceTimelineViewerImpl {...props} />);
         const header = screen.getByTestId('timeline-header-row-mock');
         const mainFraction = 1 - mockLayoutPrefsStore.sidePanelWidth;
-        const effectiveHeaderNameWidth =
-          Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction;
+        const resizerMax = mainFraction - MIN_TIMELINE_COLUMN_WIDTH;
+        const effectiveHeaderNameWidth = Math.min(
+          Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction,
+          resizerMax
+        );
         const expectedMin = Math.min(
           1 - Math.min(SIDE_PANEL_WIDTH_MAX, 1 - effectiveHeaderNameWidth - MIN_TIMELINE_COLUMN_WIDTH),
           1 - SIDE_PANEL_WIDTH_MIN
         );
 
+        expect(Number(header.dataset.nameColumnWidth)).toBeCloseTo(effectiveHeaderNameWidth);
+        expect(Number(header.dataset.nameColumnWidth)).toBeLessThanOrEqual(Number(header.dataset.resizerMax));
         expect(Number(header.dataset.sidePanelResizerMin)).toBeCloseTo(expectedMin);
+      });
+    });
+
+    it('keeps header resizer positions ordered when the stored name column would consume the main area', () => {
+      withLayoutPrefs({ spanNameColumnWidth: 0.95, sidePanelWidth: 0.7 }, () => {
+        render(<TraceTimelineViewerImpl {...props} />);
+        const header = screen.getByTestId('timeline-header-row-mock');
+        const nameColumnWidth = Number(header.dataset.nameColumnWidth);
+        const resizerMax = Number(header.dataset.resizerMax);
+        const sidePanelResizerMin = Number(header.dataset.sidePanelResizerMin);
+        const sidePanelResizerMax = Number(header.dataset.sidePanelResizerMax);
+
+        expect(nameColumnWidth).toBeCloseTo(resizerMax);
+        expect(nameColumnWidth).toBeLessThanOrEqual(resizerMax);
+        expect(sidePanelResizerMin).toBeLessThanOrEqual(sidePanelResizerMax);
       });
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -7,58 +7,53 @@ import { legacy_createStore as createStore } from 'redux';
 import { Provider } from 'react-redux';
 
 import TraceTimelineViewer, { TraceTimelineViewerImpl } from './index';
+import { MIN_TIMELINE_COLUMN_WIDTH, SIDE_PANEL_WIDTH_MAX, SIDE_PANEL_WIDTH_MIN } from './store.constants';
 import * as KeyboardShortcuts from '../keyboard-shortcuts';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
 
-const { layoutConstants, mockLayoutPrefsStore, mockTraceTimelineStore, mockUseTraceTimelineStore } =
-  vi.hoisted(() => {
-    const layoutConstants = {
-      SPAN_NAME_COLUMN_WIDTH_MIN: 0.15,
-      SPAN_NAME_COLUMN_WIDTH_MAX: 0.85,
-      SIDE_PANEL_WIDTH_MIN: 0.2,
-      SIDE_PANEL_WIDTH_MAX: 0.7,
-      MIN_TIMELINE_COLUMN_WIDTH: 0.05,
-    };
-    const mockTraceTimelineStore = {
-      detailStates: new Map(),
-      prunedServices: new Set(),
-      setPrunedServices: vi.fn(),
-      collapseAll: vi.fn(),
-      collapseOne: vi.fn(),
-      expandAll: vi.fn(),
-      expandOne: vi.fn(),
-    };
-    const mockUseTraceTimelineStore = Object.assign(
-      vi.fn(selector => selector(mockTraceTimelineStore)),
-      {
-        getState: () => mockTraceTimelineStore,
-        setState: vi.fn(partial => Object.assign(mockTraceTimelineStore, partial)),
-      }
-    );
-    return {
-      layoutConstants,
-      mockLayoutPrefsStore: {
-        spanNameColumnWidth: 0.25,
-        sidePanelWidth: 0.375,
-        detailPanelMode: 'inline',
-        timelineBarsVisible: true,
-        setSpanNameColumnWidth: vi.fn(),
-        setSidePanelWidth: vi.fn(),
-        setTimelineBarsVisible: vi.fn(),
-      },
-      mockTraceTimelineStore,
-      mockUseTraceTimelineStore,
-    };
-  });
+const { mockLayoutPrefsStore, mockTraceTimelineStore, mockUseTraceTimelineStore } = vi.hoisted(() => {
+  const mockTraceTimelineStore = {
+    detailStates: new Map(),
+    prunedServices: new Set(),
+    setPrunedServices: vi.fn(),
+    collapseAll: vi.fn(),
+    collapseOne: vi.fn(),
+    expandAll: vi.fn(),
+    expandOne: vi.fn(),
+  };
+  const mockUseTraceTimelineStore = Object.assign(
+    vi.fn(selector => selector(mockTraceTimelineStore)),
+    {
+      getState: () => mockTraceTimelineStore,
+      setState: vi.fn(partial => Object.assign(mockTraceTimelineStore, partial)),
+    }
+  );
+  return {
+    mockLayoutPrefsStore: {
+      spanNameColumnWidth: 0.25,
+      sidePanelWidth: 0.375,
+      detailPanelMode: 'inline',
+      timelineBarsVisible: true,
+      setSpanNameColumnWidth: vi.fn(),
+      setSidePanelWidth: vi.fn(),
+      setTimelineBarsVisible: vi.fn(),
+    },
+    mockTraceTimelineStore,
+    mockUseTraceTimelineStore,
+  };
+});
 
-vi.mock('./store', () => ({
-  useLayoutPrefsStore: vi.fn(selector => selector(mockLayoutPrefsStore)),
-  useTraceTimelineStore: mockUseTraceTimelineStore,
-  getSelectedSpanID: detailStatesArg =>
-    detailStatesArg.size > 0 ? detailStatesArg.keys().next().value : null,
-  ...layoutConstants,
-}));
+vi.mock('./store', async () => {
+  const constants = await vi.importActual('./store.constants');
+  return {
+    useLayoutPrefsStore: vi.fn(selector => selector(mockLayoutPrefsStore)),
+    useTraceTimelineStore: mockUseTraceTimelineStore,
+    getSelectedSpanID: detailStatesArg =>
+      detailStatesArg.size > 0 ? detailStatesArg.keys().next().value : null,
+    ...constants,
+  };
+});
 vi.mock('./duck', () => ({
   actions: {
     setSpanNameColumnWidth: width => ({ type: 'setSpanNameColumnWidth', width }),
@@ -294,7 +289,7 @@ describe('<TraceTimelineViewer>', () => {
       expect(screen.getByTestId('virtualized-trace-view-mock')).toBeInTheDocument();
     });
 
-    it('does not render a body VerticalResizer between main and side panel when timeline bars are visible', () => {
+    it('keeps the side panel VerticalResizer in TimelineHeaderRow instead of the body layout', () => {
       render(<TraceTimelineViewerImpl {...props} />);
       expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
     });
@@ -304,12 +299,12 @@ describe('<TraceTimelineViewer>', () => {
       const header = screen.getByTestId('timeline-header-row-mock');
       const resizerMin = Number(header.dataset.sidePanelResizerMin);
       const resizerMax = Number(header.dataset.sidePanelResizerMax);
-      const expectedMax = 1 - layoutConstants.SIDE_PANEL_WIDTH_MIN;
+      const expectedMax = 1 - SIDE_PANEL_WIDTH_MIN;
       const expectedMin = Math.min(
         1 -
           Math.min(
-            layoutConstants.SIDE_PANEL_WIDTH_MAX,
-            1 - mockLayoutPrefsStore.spanNameColumnWidth - layoutConstants.MIN_TIMELINE_COLUMN_WIDTH
+            SIDE_PANEL_WIDTH_MAX,
+            1 - mockLayoutPrefsStore.spanNameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH
           ),
         expectedMax
       );
@@ -327,12 +322,8 @@ describe('<TraceTimelineViewer>', () => {
         const effectiveHeaderNameWidth =
           Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction;
         const expectedMin = Math.min(
-          1 -
-            Math.min(
-              layoutConstants.SIDE_PANEL_WIDTH_MAX,
-              1 - effectiveHeaderNameWidth - layoutConstants.MIN_TIMELINE_COLUMN_WIDTH
-            ),
-          1 - layoutConstants.SIDE_PANEL_WIDTH_MIN
+          1 - Math.min(SIDE_PANEL_WIDTH_MAX, 1 - effectiveHeaderNameWidth - MIN_TIMELINE_COLUMN_WIDTH),
+          1 - SIDE_PANEL_WIDTH_MIN
         );
 
         expect(Number(header.dataset.sidePanelResizerMin)).toBeCloseTo(expectedMin);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -7,7 +7,12 @@ import { legacy_createStore as createStore } from 'redux';
 import { Provider } from 'react-redux';
 
 import TraceTimelineViewer, { TraceTimelineViewerImpl } from './index';
-import { MIN_TIMELINE_COLUMN_WIDTH, SIDE_PANEL_WIDTH_MAX, SIDE_PANEL_WIDTH_MIN } from './store.constants';
+import {
+  MIN_TIMELINE_COLUMN_WIDTH,
+  SIDE_PANEL_WIDTH_MAX,
+  SIDE_PANEL_WIDTH_MIN,
+  SPAN_NAME_COLUMN_WIDTH_MIN,
+} from './store.constants';
 import * as KeyboardShortcuts from '../keyboard-shortcuts';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
@@ -320,10 +325,17 @@ describe('<TraceTimelineViewer>', () => {
       withLayoutPrefs({ spanNameColumnWidth: 0.7, sidePanelWidth: 0.4 }, () => {
         render(<TraceTimelineViewerImpl {...props} />);
         const header = screen.getByTestId('timeline-header-row-mock');
-        const mainFraction = 1 - mockLayoutPrefsStore.sidePanelWidth;
+        const effectiveSidePanelWidth = Math.min(
+          mockLayoutPrefsStore.sidePanelWidth,
+          1 - SPAN_NAME_COLUMN_WIDTH_MIN - MIN_TIMELINE_COLUMN_WIDTH
+        );
+        const mainFraction = 1 - effectiveSidePanelWidth;
         const resizerMax = mainFraction - MIN_TIMELINE_COLUMN_WIDTH;
         const effectiveHeaderNameWidth = Math.min(
-          Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction,
+          Math.max(
+            Math.min(mockLayoutPrefsStore.spanNameColumnWidth / mainFraction, 1) * mainFraction,
+            SPAN_NAME_COLUMN_WIDTH_MIN
+          ),
           resizerMax
         );
         const expectedMin = Math.min(
@@ -338,7 +350,7 @@ describe('<TraceTimelineViewer>', () => {
     });
 
     it('keeps header resizer positions ordered when the stored name column would consume the main area', () => {
-      withLayoutPrefs({ spanNameColumnWidth: 0.95, sidePanelWidth: 0.7 }, () => {
+      withLayoutPrefs({ spanNameColumnWidth: 0.95, sidePanelWidth: 0.95 }, () => {
         render(<TraceTimelineViewerImpl {...props} />);
         const header = screen.getByTestId('timeline-header-row-mock');
         const nameColumnWidth = Number(header.dataset.nameColumnWidth);
@@ -347,6 +359,7 @@ describe('<TraceTimelineViewer>', () => {
         const sidePanelResizerMax = Number(header.dataset.sidePanelResizerMax);
 
         expect(nameColumnWidth).toBeCloseTo(resizerMax);
+        expect(nameColumnWidth).toBeGreaterThanOrEqual(SPAN_NAME_COLUMN_WIDTH_MIN);
         expect(nameColumnWidth).toBeLessThanOrEqual(resizerMax);
         expect(sidePanelResizerMin).toBeLessThanOrEqual(sidePanelResizerMax);
       });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -158,7 +158,7 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   const headerNameWidth = nameColumnWidth * mainFraction;
   const resizerMax = sidePanelActive ? mainFraction - MIN_TIMELINE_COLUMN_WIDTH : SPAN_NAME_COLUMN_WIDTH_MAX;
   const sidePanelResizerMax = clamp01(1 - SIDE_PANEL_WIDTH_MIN);
-  const sidePanelAvailableSpace = clamp01(1 - spanNameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH);
+  const sidePanelAvailableSpace = clamp01(1 - headerNameWidth - MIN_TIMELINE_COLUMN_WIDTH);
   const sidePanelResizerMin = Math.min(
     clamp01(1 - Math.min(SIDE_PANEL_WIDTH_MAX, sidePanelAvailableSpace)),
     sidePanelResizerMax
@@ -223,7 +223,7 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
       sidePanelLabel={sidePanelLabel}
       sidePanelResizerMin={sidePanelResizerMin}
       sidePanelResizerMax={sidePanelResizerMax}
-      onSidePanelWidthChange={newPosition => setSidePanelWidth(1 - newPosition)}
+      onSidePanelWidthChange={setSidePanelWidth}
       timelineBarsVisible={timelineBarsVisible}
       viewRangeTime={viewRange.time}
       updateNextViewRangeTime={updateNextViewRangeTime}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -19,7 +19,6 @@ import SpanDetailSidePanel from './SpanDetailSidePanel';
 import TimelineHeaderRow from './TimelineHeaderRow';
 import { useServiceFilter } from './useServiceFilter';
 import VirtualizedTraceView from './VirtualizedTraceView';
-import VerticalResizer from '../../common/VerticalResizer';
 import { merge as mergeShortcuts } from '../keyboard-shortcuts';
 import { Accessors } from '../ScrollManager';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../types';
@@ -52,6 +51,7 @@ type TProps = TDispatchProps & {
 };
 
 const NUM_TICKS = 5;
+const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
 
 /**
  * `TraceTimelineViewer` now renders the header row because it is sensitive to
@@ -157,6 +157,12 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   // When bars are hidden with no side panel, the name column spans the full page.
   const headerNameWidth = nameColumnWidth * mainFraction;
   const resizerMax = sidePanelActive ? mainFraction - MIN_TIMELINE_COLUMN_WIDTH : SPAN_NAME_COLUMN_WIDTH_MAX;
+  const sidePanelResizerMax = clamp01(1 - SIDE_PANEL_WIDTH_MIN);
+  const sidePanelAvailableSpace = clamp01(1 - spanNameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH);
+  const sidePanelResizerMin = Math.min(
+    clamp01(1 - Math.min(SIDE_PANEL_WIDTH_MAX, sidePanelAvailableSpace)),
+    sidePanelResizerMax
+  );
 
   // Column header label: "Trace Root" when showing the root span (explicit or fallback),
   // "Span Details" for any other selected span.
@@ -215,6 +221,9 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
       sidePanelVisible={sidePanelActive}
       sidePanelWidth={effectiveSidePanelWidth}
       sidePanelLabel={sidePanelLabel}
+      sidePanelResizerMin={sidePanelResizerMin}
+      sidePanelResizerMax={sidePanelResizerMax}
+      onSidePanelWidthChange={newPosition => setSidePanelWidth(1 - newPosition)}
       timelineBarsVisible={timelineBarsVisible}
       viewRangeTime={viewRange.time}
       updateNextViewRangeTime={updateNextViewRangeTime}
@@ -249,14 +258,6 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
           <div className="TraceTimelineViewer--main" style={{ width: `${mainWidth}%` }}>
             {virtualizedView}
           </div>
-          {timelineBarsVisible && (
-            <VerticalResizer
-              position={1 - sidePanelWidth}
-              min={1 - Math.min(SIDE_PANEL_WIDTH_MAX, 1 - spanNameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH)}
-              max={1 - SIDE_PANEL_WIDTH_MIN}
-              onChange={newPosition => setSidePanelWidth(1 - newPosition)}
-            />
-          )}
           <div className="TraceTimelineViewer--sidePanel" style={sidePanelStyle}>
             <SpanDetailSidePanel
               trace={trace}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -151,12 +151,16 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   // stored pixel width. When timeline bars are hidden the name column fills everything (= 1).
   const panelFraction = sidePanelActive ? effectiveSidePanelWidth : 0;
   const mainFraction = 1 - panelFraction;
-  const nameColumnWidth = timelineBarsVisible ? Math.min(spanNameColumnWidth / mainFraction, 1) : 1;
+  const rawNameColumnWidth = timelineBarsVisible ? Math.min(spanNameColumnWidth / mainFraction, 1) : 1;
+  const resizerMax = sidePanelActive
+    ? clamp01(mainFraction - MIN_TIMELINE_COLUMN_WIDTH)
+    : SPAN_NAME_COLUMN_WIDTH_MAX;
   // Page-fraction width of the name column header cell and resizer position.
   // Equals spanNameColumnWidth when bars are visible (the round-trip through mainFraction cancels).
   // When bars are hidden with no side panel, the name column spans the full page.
-  const headerNameWidth = nameColumnWidth * mainFraction;
-  const resizerMax = sidePanelActive ? mainFraction - MIN_TIMELINE_COLUMN_WIDTH : SPAN_NAME_COLUMN_WIDTH_MAX;
+  const rawHeaderNameWidth = rawNameColumnWidth * mainFraction;
+  const headerNameWidth = timelineBarsVisible ? Math.min(rawHeaderNameWidth, resizerMax) : rawHeaderNameWidth;
+  const nameColumnWidth = timelineBarsVisible && mainFraction > 0 ? headerNameWidth / mainFraction : 1;
   const sidePanelResizerMax = clamp01(1 - SIDE_PANEL_WIDTH_MIN);
   const sidePanelAvailableSpace = clamp01(1 - headerNameWidth - MIN_TIMELINE_COLUMN_WIDTH);
   const sidePanelResizerMin = Math.min(

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -12,6 +12,7 @@ import {
   SIDE_PANEL_WIDTH_MAX,
   SIDE_PANEL_WIDTH_MIN,
   SPAN_NAME_COLUMN_WIDTH_MAX,
+  SPAN_NAME_COLUMN_WIDTH_MIN,
   useLayoutPrefsStore,
   useTraceTimelineStore,
 } from './store';
@@ -143,8 +144,11 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
 
   // When timeline bars are hidden with the side panel active, the side panel expands to absorb
   // the timeline column so the Service/Operation column keeps its pixel width unchanged.
-  const effectiveSidePanelWidth =
-    sidePanelActive && !timelineBarsVisible ? 1 - spanNameColumnWidth : sidePanelWidth;
+  const effectiveSidePanelWidth = sidePanelActive
+    ? timelineBarsVisible
+      ? Math.min(sidePanelWidth, 1 - SPAN_NAME_COLUMN_WIDTH_MIN - MIN_TIMELINE_COLUMN_WIDTH)
+      : 1 - spanNameColumnWidth
+    : sidePanelWidth;
 
   // Fraction of the main (non-panel) content area occupied by the name column.
   // In side panel mode the --main container is narrowed; rescaling keeps the name column at its
@@ -159,7 +163,9 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   // Equals spanNameColumnWidth when bars are visible (the round-trip through mainFraction cancels).
   // When bars are hidden with no side panel, the name column spans the full page.
   const rawHeaderNameWidth = rawNameColumnWidth * mainFraction;
-  const headerNameWidth = timelineBarsVisible ? Math.min(rawHeaderNameWidth, resizerMax) : rawHeaderNameWidth;
+  const headerNameWidth = timelineBarsVisible
+    ? Math.min(Math.max(rawHeaderNameWidth, SPAN_NAME_COLUMN_WIDTH_MIN), resizerMax)
+    : rawHeaderNameWidth;
   const nameColumnWidth = timelineBarsVisible && mainFraction > 0 ? headerNameWidth / mainFraction : 1;
   const sidePanelResizerMax = clamp01(1 - SIDE_PANEL_WIDTH_MIN);
   const sidePanelAvailableSpace = clamp01(1 - headerNameWidth - MIN_TIMELINE_COLUMN_WIDTH);
@@ -217,7 +223,7 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
       numTicks={NUM_TICKS}
       onCollapseAll={collapseAll}
       onCollapseOne={collapseOne}
-      onColummWidthChange={setSpanNameColumnWidth}
+      onColumnWidthChange={setSpanNameColumnWidth}
       onExpandAll={expandAll}
       onExpandOne={expandOne}
       resizerMax={resizerMax}


### PR DESCRIPTION
## Which problem is this PR solving?
  - Resolves #3925

  ## Description of the changes
  - Move the timeline side panel resize handle into the fixed header row so the divider can be dragged from the header as well as the body area.
  - Share the side panel resize bounds from the timeline viewer with the header row.
  - Update timeline/header tests to cover the side panel header resizer and callback wiring.

  ## How was this change tested?
  - `npm test -w packages/jaeger-ui -- src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx src/components/TracePage/
  TraceTimelineViewer/index.test.jsx`
  - `npm test`
  - `npm run fmt`
  - `npm run lint`
  - `npm run build`
  - Browser verification with mocked trace data: confirmed the side panel drag handle starts at the fixed header top and aligns with the side panel
  boundary.

  ## Checklist
  - [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
  - [ ] I have signed all commits
  - [x] I have added unit tests for the new functionality
  - [x] I have run lint and test steps successfully: `make lint test`

  ## AI Usage in this PR (choose one)
  See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
  - [ ] **None**: No AI tools were used in creating this PR
  - [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
  - [x] **Moderate**: AI helped with code generation or debugging specific parts
  - [ ] **Heavy**: AI generated most or all of the code changes
