### PR TITLE
fix(api): accept otlp proto3 default omissions

### DIFF
--- a/packages/jaeger-ui/src/api/v3/generated-client.ts
+++ b/packages/jaeger-ui/src/api/v3/generated-client.ts
@@ -31,83 +31,93 @@ const Operation = z.object({ name: z.string(), spanKind: z.string() }).passthrou
 const GetOperationsResponse = z.object({ operations: z.array(Operation) }).passthrough();
 const GoogleProtobufAny = z.object({ '@type': z.string() }).passthrough();
 const Status = z
-  .object({ code: z.number().int(), message: z.string(), details: z.array(GoogleProtobufAny) })
+  .object({
+    code: z.number().int().optional(),
+    message: z.string().optional(),
+    details: z.array(GoogleProtobufAny).optional(),
+  })
   .passthrough();
 const GetServicesResponse = z.object({ services: z.array(z.string()) }).passthrough();
-const ArrayValue: z.ZodType<ArrayValue> = z.lazy(() => z.object({ values: z.array(AnyValue) }).passthrough());
+const ArrayValue: z.ZodType<ArrayValue> = z.lazy(() =>
+  z.object({ values: z.array(AnyValue).optional() }).passthrough()
+);
 const KeyValueList: z.ZodType<KeyValueList> = z.lazy(() =>
-  z.object({ values: z.array(KeyValue) }).passthrough()
+  z.object({ values: z.array(KeyValue).optional() }).passthrough()
 );
 const AnyValue: z.ZodType<AnyValue> = z.lazy(() =>
   z
     .object({
-      stringValue: z.string(),
-      boolValue: z.boolean(),
-      intValue: z.string(),
-      doubleValue: z.number(),
-      arrayValue: ArrayValue,
-      kvlistValue: KeyValueList,
-      bytesValue: z.string(),
+      stringValue: z.string().optional(),
+      boolValue: z.boolean().optional(),
+      intValue: z.string().optional(),
+      doubleValue: z.number().optional(),
+      arrayValue: ArrayValue.optional(),
+      kvlistValue: KeyValueList.optional(),
+      bytesValue: z.string().optional(),
     })
     .passthrough()
 );
 const KeyValue: z.ZodType<KeyValue> = z.lazy(() =>
-  z.object({ key: z.string(), value: AnyValue }).passthrough()
+  z.object({ key: z.string().optional(), value: AnyValue.optional() }).passthrough()
 );
 const Resource = z
-  .object({ attributes: z.array(KeyValue), droppedAttributesCount: z.number().int() })
+  .object({ attributes: z.array(KeyValue).optional(), droppedAttributesCount: z.number().int().optional() })
   .passthrough();
 const InstrumentationScope = z
   .object({
-    name: z.string(),
-    version: z.string(),
-    attributes: z.array(KeyValue),
-    droppedAttributesCount: z.number().int(),
+    name: z.string().optional(),
+    version: z.string().optional(),
+    attributes: z.array(KeyValue).optional(),
+    droppedAttributesCount: z.number().int().optional(),
   })
   .passthrough();
 const Span_Event = z
   .object({
-    timeUnixNano: z.string(),
-    name: z.string(),
-    attributes: z.array(KeyValue),
-    droppedAttributesCount: z.number().int(),
+    timeUnixNano: z.string().optional(),
+    name: z.string().optional(),
+    attributes: z.array(KeyValue).optional(),
+    droppedAttributesCount: z.number().int().optional(),
   })
   .passthrough();
 const Span_Link = z
   .object({
-    traceId: z.string(),
-    spanId: z.string(),
-    traceState: z.string(),
-    attributes: z.array(KeyValue),
-    droppedAttributesCount: z.number().int(),
-    flags: z.number().int(),
+    traceId: z.string().optional(),
+    spanId: z.string().optional(),
+    traceState: z.string().optional(),
+    attributes: z.array(KeyValue).optional(),
+    droppedAttributesCount: z.number().int().optional(),
+    flags: z.number().int().optional(),
   })
   .passthrough();
 const Span = z
   .object({
     traceId: z.string(),
     spanId: z.string(),
-    traceState: z.string(),
-    parentSpanId: z.string(),
-    flags: z.number().int(),
+    traceState: z.string().optional(),
+    parentSpanId: z.string().optional(),
+    flags: z.number().int().optional(),
     name: z.string(),
     kind: z.number().int(),
     startTimeUnixNano: z.string(),
     endTimeUnixNano: z.string(),
-    attributes: z.array(KeyValue),
-    droppedAttributesCount: z.number().int(),
-    events: z.array(Span_Event),
-    droppedEventsCount: z.number().int(),
-    links: z.array(Span_Link),
-    droppedLinksCount: z.number().int(),
+    attributes: z.array(KeyValue).optional(),
+    droppedAttributesCount: z.number().int().optional(),
+    events: z.array(Span_Event).optional(),
+    droppedEventsCount: z.number().int().optional(),
+    links: z.array(Span_Link).optional(),
+    droppedLinksCount: z.number().int().optional(),
     status: Status,
   })
   .passthrough();
 const ScopeSpans = z
-  .object({ scope: InstrumentationScope, spans: z.array(Span), schemaUrl: z.string() })
+  .object({ scope: InstrumentationScope.optional(), spans: z.array(Span), schemaUrl: z.string().optional() })
   .passthrough();
 const ResourceSpans = z
-  .object({ resource: Resource, scopeSpans: z.array(ScopeSpans), schemaUrl: z.string() })
+  .object({
+    resource: Resource.optional(),
+    scopeSpans: z.array(ScopeSpans),
+    schemaUrl: z.string().optional(),
+  })
   .passthrough();
 const TracesData = z.object({ resourceSpans: z.array(ResourceSpans) }).passthrough();
 

--- a/packages/jaeger-ui/src/api/v3/schemas.test.ts
+++ b/packages/jaeger-ui/src/api/v3/schemas.test.ts
@@ -9,6 +9,8 @@ import {
   traceIdHex,
   spanIdHex,
 } from './schemas';
+import { schemas } from './generated-client';
+import otlpFixture from '../../utils/fixtures/otlp2jaeger-in.json';
 
 describe('ServicesResponseSchema', () => {
   it('validates correct structure', () => {
@@ -163,5 +165,36 @@ describe('ID Validators', () => {
     it('rejects empty string', () => {
       expect(() => spanIdHex.parse('')).toThrow('must be 16-char hex string');
     });
+  });
+});
+
+describe('OTLP wire-format schemas', () => {
+  it('accepts a real trace fixture with omitted proto3 default fields', () => {
+    expect('droppedAttributesCount' in otlpFixture.resourceSpans[0].resource).toBe(false);
+    expect('version' in otlpFixture.resourceSpans[0].scopeSpans[0].scope).toBe(false);
+    expect('traceState' in otlpFixture.resourceSpans[0].scopeSpans[0].spans[0]).toBe(false);
+    expect('code' in otlpFixture.resourceSpans[0].scopeSpans[0].spans[0].status).toBe(false);
+
+    const result = schemas.TracesData.safeParse(otlpFixture);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects spans missing required identity fields', () => {
+    const trace = JSON.parse(JSON.stringify(otlpFixture));
+    delete trace.resourceSpans[0].scopeSpans[0].spans[0].traceId;
+
+    const result = schemas.TracesData.safeParse(trace);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects spans missing required status', () => {
+    const trace = JSON.parse(JSON.stringify(otlpFixture));
+    delete trace.resourceSpans[0].scopeSpans[0].spans[0].status;
+
+    const result = schemas.TracesData.safeParse(trace);
+
+    expect(result.success).toBe(false);
   });
 });

--- a/scripts/postprocess-schemas.cjs
+++ b/scripts/postprocess-schemas.cjs
@@ -6,9 +6,10 @@
 /**
  * Post-process generated OpenAPI client to:
  * 1. Prepend copyright header
- * 2. Remove .partial() calls for strict validation (Proto3/OpenAPI optionality mismatch)
- * 3. Comment out Zodios imports/usage (avoid runtime dependency until needed)
- * 4. Add convenience exports for schemas
+ * 2. Remove broad .partial() calls for strict validation
+ * 3. Restore optionality for proto3 fields that may be omitted from JSON wire format
+ * 4. Comment out Zodios imports/usage (avoid runtime dependency until needed)
+ * 5. Add convenience exports for schemas
  */
 
 const fs = require('fs');
@@ -25,6 +26,56 @@ if (!fs.existsSync(filePath)) {
 }
 
 let content = fs.readFileSync(filePath, 'utf8');
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function optionalizeSchemaFields(schemaName, fields) {
+  const schemaStart = content.indexOf(`const ${schemaName}`);
+  if (schemaStart === -1) {
+    console.warn(`⚠️  Schema ${schemaName} not found; skipping optional field post-process`);
+    return;
+  }
+
+  const objectStart = content.indexOf('.object({', schemaStart);
+  if (objectStart === -1) {
+    console.warn(`⚠️  Schema ${schemaName} object not found; skipping optional field post-process`);
+    return;
+  }
+
+  const bodyStart = objectStart + '.object({'.length;
+  let depth = 1;
+  let bodyEnd = bodyStart;
+
+  while (bodyEnd < content.length && depth > 0) {
+    const char = content[bodyEnd];
+    if (char === '{') depth += 1;
+    if (char === '}') depth -= 1;
+    bodyEnd += 1;
+  }
+
+  if (depth !== 0) {
+    console.warn(`⚠️  Schema ${schemaName} object body was not closed; skipping optional field post-process`);
+    return;
+  }
+
+  bodyEnd -= 1;
+
+  let body = content.slice(bodyStart, bodyEnd);
+  for (const field of fields) {
+    const fieldRegex = new RegExp(`(\\b${escapeRegExp(field)}\\s*:\\s*)([^,\\n]+?)(\\s*)(?=(,|\\n|$))`, 'g');
+    body = body.replace(fieldRegex, (match, prefix, expression, trailingWhitespace) => {
+      const trimmedExpression = expression.trimEnd();
+      if (trimmedExpression.endsWith('.optional()')) {
+        return match;
+      }
+      return `${prefix}${trimmedExpression}.optional()${trailingWhitespace}`;
+    });
+  }
+
+  content = content.slice(0, bodyStart) + body + content.slice(bodyEnd);
+}
 
 // 1. Prepend Copyright Header
 const copyrightHeader = `// Copyright (c) 2026 The Jaeger Authors.
@@ -44,8 +95,47 @@ const beforeCountPartial = (content.match(/\.partial\(\)/g) || []).length;
 content = content.replace(/\.partial\(\)\s*/g, '');
 const afterCountPartial = (content.match(/\.partial\(\)/g) || []).length;
 
-// 3. Comment out Zodios imports
-const zodiosImportRegex = /import\s+\{\s*makeApi,\s*Zodios.*?\} from '@zodios\/core';/g;
+// 3. Restore optionality for proto3 JSON fields that may be absent when they hold default values.
+optionalizeSchemaFields('Status', ['code', 'message', 'details']);
+optionalizeSchemaFields('ArrayValue', ['values']);
+optionalizeSchemaFields('KeyValueList', ['values']);
+optionalizeSchemaFields('AnyValue', [
+  'stringValue',
+  'boolValue',
+  'intValue',
+  'doubleValue',
+  'arrayValue',
+  'kvlistValue',
+  'bytesValue',
+]);
+optionalizeSchemaFields('KeyValue', ['key', 'value']);
+optionalizeSchemaFields('Resource', ['attributes', 'droppedAttributesCount']);
+optionalizeSchemaFields('InstrumentationScope', ['name', 'version', 'attributes', 'droppedAttributesCount']);
+optionalizeSchemaFields('Span_Event', ['timeUnixNano', 'name', 'attributes', 'droppedAttributesCount']);
+optionalizeSchemaFields('Span_Link', [
+  'traceId',
+  'spanId',
+  'traceState',
+  'attributes',
+  'droppedAttributesCount',
+  'flags',
+]);
+optionalizeSchemaFields('Span', [
+  'traceState',
+  'parentSpanId',
+  'flags',
+  'attributes',
+  'droppedAttributesCount',
+  'events',
+  'droppedEventsCount',
+  'links',
+  'droppedLinksCount',
+]);
+optionalizeSchemaFields('ScopeSpans', ['scope', 'schemaUrl']);
+optionalizeSchemaFields('ResourceSpans', ['resource', 'schemaUrl']);
+
+// 4. Comment out Zodios imports
+const zodiosImportRegex = /^import\s+\{\s*makeApi,\s*Zodios.*?\} from '@zodios\/core';/gm;
 if (zodiosImportRegex.test(content)) {
   content = content.replace(
     zodiosImportRegex,
@@ -54,16 +144,23 @@ if (zodiosImportRegex.test(content)) {
   console.log('✅ Commented out Zodios imports');
 }
 
-// 4. Comment out Zodios usage
-content = content.replace(/(const endpoints = makeApi\(\[[\s\S]*?\]\);)/, '/*\n$1\n*/');
+// 5. Comment out Zodios usage
+if (!/\/\*\r?\nconst endpoints = makeApi\(\[/.test(content)) {
+  content = content.replace(/(const endpoints = makeApi\(\[[\s\S]*?\]\);)/, '/*\n$1\n*/');
+}
 
-content = content.replace(/(export const api = new Zodios\(endpoints\);)/, '// $1');
-content = content.replace(
-  /(export function createApiClient\(baseUrl: string, options\?: ZodiosOptions\) \{[\s\S]*?\})/,
-  '/*\n$1\n*/'
-);
+if (!/^\/\/ export const api = new Zodios\(endpoints\);/m.test(content)) {
+  content = content.replace(/(export const api = new Zodios\(endpoints\);)/, '// $1');
+}
 
-// 5. Append convenience exports
+if (!/\/\*\r?\nexport function createApiClient/.test(content)) {
+  content = content.replace(
+    /(export function createApiClient\(baseUrl: string, options\?: ZodiosOptions\) \{[\s\S]*?\})/,
+    '/*\n$1\n*/'
+  );
+}
+
+// 6. Append convenience exports
 const extraExports = `
 // Export commonly used schemas individually for convenience
 export { GetServicesResponse as ServicesResponseSchema };


### PR DESCRIPTION
## Which problem is this PR solving?
  - Resolves #3891

  ## Description of the changes
  - Restore proto3 JSON optionality for OTLP schemas generated in `generated-client.ts`.
  - Keep semantically required span fields enforced while allowing default-valued scalar/repeated/message fields to be omitted from wire-format responses.
  - Update `scripts/postprocess-schemas.cjs` so regenerated API schemas preserve this per-field optionality.
  - Add schema tests covering the existing OTLP fixture and preserving rejection for spans missing required identity fields.

  ## How was this change tested?
  - `make lint`
  - `NODE_OPTIONS=--localstorage-file=/private/tmp/jaeger-ui-node-localstorage-full-3891 make test`
  - `NODE_OPTIONS=--localstorage-file=/private/tmp/jaeger-ui-node-localstorage npm test -w packages/jaeger-ui -- src/api/v3/schemas.test.ts`

  ## Checklist
  - [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
  - [x] I have signed all commits
  - [x] I have added unit tests for the new functionality
  - [x] I have run lint and test steps successfully: `make lint test`

  ## AI Usage in this PR (choose one)
  - [x] **Moderate**: AI helped with code generation or debugging specific parts
