### PR TITLE
refactor(ui): Encapsulate TraceDiff URL logic and fix RelativeDate typing

### DIFF
--- a/packages/jaeger-ui/src/components/App/TraceRouter.tsx
+++ b/packages/jaeger-ui/src/components/App/TraceRouter.tsx
@@ -4,6 +4,7 @@
 import { useParams } from 'react-router-dom';
 import TraceDiff from '../TraceDiff';
 import TracePage from '../TracePage';
+import { isDiffUrl } from '../TraceDiff/url';
 
 /*
 React Router v6 cannot correctly match the old TraceDiff path (/trace/:a?\.\.\.":b?), so we don’t use that route anymore.
@@ -12,7 +13,7 @@ When the user is comparing, the id looks like abc...def.
 */
 export default function TraceRouter() {
   const { id = '' } = useParams<{ id: string }>();
-  if (id.includes('...')) {
+  if (isDiffUrl(id)) {
     return <TraceDiff />;
   }
 

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
@@ -139,8 +139,8 @@ export function TraceDiffImpl({ a, b, cohort }: TStateProps & TOwnProps) {
   );
 }
 
-// TODO(joe): simplify but do not invalidate the URL
-export function mapStateToProps(state: ReduxState, ownProps: TOwnProps) {
+// export for tests
+export function mapStateToProps(_state: ReduxState, ownProps: TOwnProps): TStateProps {
   let { a, b } = ownProps.params;
   const { id } = ownProps.params;
   if (!a && id) {

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { useShallow } from 'zustand/react/shallow';
 
-import { getUrl, TDiffRouteParams } from './url';
+import { getUrl, TDiffRouteParams, getDiffIds } from './url';
 import TraceDiffGraph from './TraceDiffGraph';
 import TraceDiffHeader from './TraceDiffHeader';
 import { TOP_NAV_HEIGHT } from '../../constants';
@@ -139,21 +139,12 @@ export function TraceDiffImpl({ a, b, cohort }: TStateProps & TOwnProps) {
   );
 }
 
-// export for tests
-export function mapStateToProps(_state: ReduxState, ownProps: TOwnProps): TStateProps {
-  let { a, b, id } = ownProps.params;
-  /*
-  In v5, the route pattern /trace/:a?\.\.\.":b? 
-  tells the router to split the path segment at ... automatically, 
-  giving the component two separate params.
-  But in v6, that regex-style pattern is not supported, so the route never matched. 
-  We replaced it with /trace/:id, which gives a single param: params.id = '73b4e476...9c18cb9d'.
-  This code then manually splits that string on ... to get a and b
-  */
-  if (!a && id && id.includes('...')) {
-    const parts = id.split('...');
-    a = parts[0] || undefined;
-    b = parts[1] || undefined;
+// TODO(joe): simplify but do not invalidate the URL
+export function mapStateToProps(state: ReduxState, ownProps: TOwnProps) {
+  let { a, b } = ownProps.params;
+  const { id } = ownProps.params;
+  if (!a && id) {
+    ({ a, b } = getDiffIds(id));
   }
   const { cohort: origCohort = [] } = parseQuery(ownProps.search || '');
   const fullCohortSet: Set<string> = new Set(pluckTruthy([a, b].concat(origCohort)));

--- a/packages/jaeger-ui/src/components/TraceDiff/url.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/url.test.js
@@ -3,7 +3,7 @@
 
 import * as ReactRouterDom from 'react-router-dom';
 
-import { ROUTE_PATH, matches, getUrl, getDiffIds } from './url';
+import { ROUTE_PATH, matches, getUrl, getDiffIds, isDiffUrl } from './url';
 
 vi.mock('react-router-dom', () => ({
   matchPath: vi.fn(),
@@ -58,6 +58,19 @@ describe('TraceDiff/url', () => {
     });
   });
 
+  describe('isDiffUrl', () => {
+    it('returns false for undefined', () => {
+      expect(isDiffUrl(undefined)).toBe(false);
+    });
+
+    it('returns false for a plain trace ID (no ...)', () => {
+      expect(isDiffUrl('abc123')).toBe(false);
+    });
+
+    it('returns true for a diff URL segment (contains ...)', () => {
+      expect(isDiffUrl('a...b')).toBe(true);
+    });
+  });
   describe('getDiffIds', () => {
     it('returns empty object when id is undefined', () => {
       expect(getDiffIds(undefined)).toEqual({});

--- a/packages/jaeger-ui/src/components/TraceDiff/url.test.js
+++ b/packages/jaeger-ui/src/components/TraceDiff/url.test.js
@@ -3,7 +3,7 @@
 
 import * as ReactRouterDom from 'react-router-dom';
 
-import { ROUTE_PATH, matches, getUrl } from './url';
+import { ROUTE_PATH, matches, getUrl, getDiffIds } from './url';
 
 vi.mock('react-router-dom', () => ({
   matchPath: vi.fn(),
@@ -55,6 +55,28 @@ describe('TraceDiff/url', () => {
       cohort.forEach(cohortEntry => {
         expect(result).toMatch(`cohort=${cohortEntry}`);
       });
+    });
+  });
+
+  describe('getDiffIds', () => {
+    it('returns empty object when id is undefined', () => {
+      expect(getDiffIds(undefined)).toEqual({});
+    });
+
+    it('returns empty object when id does not contain "..."', () => {
+      expect(getDiffIds('abc')).toEqual({});
+    });
+
+    it('splits a...b into a and b', () => {
+      expect(getDiffIds('a...b')).toEqual({ a: 'a', b: 'b' });
+    });
+
+    it('splits a... into a and undefined', () => {
+      expect(getDiffIds('a...')).toEqual({ a: 'a', b: undefined });
+    });
+
+    it('splits ...b into undefined and b', () => {
+      expect(getDiffIds('...b')).toEqual({ a: undefined, b: 'b' });
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TraceDiff/url.ts
+++ b/packages/jaeger-ui/src/components/TraceDiff/url.ts
@@ -29,3 +29,13 @@ export function getUrl(state: TTraceDiffState) {
   const search = queryString.stringify({ cohort });
   return prefixUrl(`/trace/${a || ''}...${b || ''}${search ? '?' : ''}${search}`);
 }
+export function getDiffIds(id: string | undefined): TDiffRouteParams {
+  if (id && id.includes('...')) {
+    const parts = id.split('...');
+    return {
+      a: parts[0] || undefined,
+      b: parts[1] || undefined,
+    };
+  }
+  return {};
+}

--- a/packages/jaeger-ui/src/components/TraceDiff/url.ts
+++ b/packages/jaeger-ui/src/components/TraceDiff/url.ts
@@ -15,13 +15,18 @@ export type TDiffRouteParams = {
 
 export const ROUTE_PATH = prefixUrl('/trace/:id');
 
+/** Returns true when `id` is a diff URL segment (contains "..."). */
+export function isDiffUrl(id: string | undefined): boolean {
+  return Boolean(id?.includes('...'));
+}
+
 export function matches(path: string) {
   const match = matchPath(ROUTE_PATH, path);
   if (!match) {
     return false;
   }
   // Single-trace and compare both use `/trace/:id`; only compare URLs contain "..." in the segment.
-  return match.params?.id?.includes('...') ?? false;
+  return isDiffUrl(match.params?.id);
 }
 
 export function getUrl(state: TTraceDiffState) {
@@ -29,9 +34,14 @@ export function getUrl(state: TTraceDiffState) {
   const search = queryString.stringify({ cohort });
   return prefixUrl(`/trace/${a || ''}...${b || ''}${search ? '?' : ''}${search}`);
 }
+/**
+ * Splits a diff URL id segment (e.g. "abc...def") into its two trace IDs.
+ * Returns an empty object when `id` is undefined or does not contain "...".
+ */
 export function getDiffIds(id: string | undefined): TDiffRouteParams {
-  if (id && id.includes('...')) {
-    const parts = id.split('...');
+  if (isDiffUrl(id)) {
+    // isDiffUrl guarantees id is a non-empty string containing '...'
+    const parts = (id as string).split('...');
     return {
       a: parts[0] || undefined,
       b: parts[1] || undefined,


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3935 

## Description of the changes
- Created a `getDiffIds` helper function in `url.ts` to encapsulate the `...` string splitting logic for Trace ID comparisons.
- Updated `TraceDiff.tsx` to utilize the new `getDiffIds` helper within `mapStateToProps`, reducing code duplication.
- Updated the return type of `RelativeDate` from `React.JSX.Element` to `React.ReactNode` to correctly support rendering plain text.

## How was this change tested?
- Ran `npm test -w packages/jaeger-ui -- src/components/TraceDiff/TraceDiff.test.jsx` to verify that URL routing and ID splitting still functions as expected.
- Verified TypeScript checks pass locally with `npm run tsc-lint`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided some help in code generation/debugging (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
