### PR TITLE
fix(SearchTracePage): Improve duration unit regex validation

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -764,6 +764,12 @@ describe('validation', () => {
 
   it('should return `undefined` if the value is a populated string that adheres to expected format', () => {
     expect(validateDurationFields('100ms')).toBeUndefined();
+    expect(validateDurationFields('100 ms')).toBeUndefined();
+    expect(validateDurationFields('500us')).toBeUndefined();
+    expect(validateDurationFields('500 us')).toBeUndefined();
+    expect(validateDurationFields('1.2s')).toBeUndefined();
+    expect(validateDurationFields('1.2 s')).toBeUndefined();
+    expect(validateDurationFields('1h')).toBeUndefined();
   });
 });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -195,7 +195,7 @@ interface ValidationError {
 
 export function validateDurationFields(value: string | null | undefined): ValidationError | undefined {
   if (!value) return undefined;
-  return /\d[\d.]*( us|ms|s|m|h)$/.test(value)
+  return /\d[\d.]*\s*(us|ms|s|m|h)$/.test(value)
     ? undefined
     : {
         content: `Please enter a number followed by a duration unit, ${placeholderDurationFields}`,


### PR DESCRIPTION
Improves the duration unit regex in SearchForm.tsx by:
- Allowing optional whitespace between the numeric value and the unit.
- Supporting us, ms, s, m, h units.

Closes #3939