### PR TITLE
refactor(search): Introduce TraceSummary type for search results

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
@@ -33,7 +33,7 @@ beforeEach(() => {
 it('<ResultItem /> should render base case correctly', () => {
   renderWithRouter(
     <ResultItem
-      trace={traceSummary}
+      traceSummary={traceSummary}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}
@@ -50,7 +50,7 @@ it('<ResultItem /> should render base case correctly', () => {
 it('<ResultItem /> should not render any ServiceTags when there are no services', () => {
   renderWithRouter(
     <ResultItem
-      trace={{ ...traceSummary, services: [] }}
+      traceSummary={{ ...traceSummary, services: [] }}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}
@@ -77,7 +77,7 @@ it('<ResultItem /> should render error icon on ServiceTags that have an error sp
 
   renderWithRouter(
     <ResultItem
-      trace={summaryWithError}
+      traceSummary={summaryWithError}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}
@@ -107,7 +107,7 @@ it('passes router state to destination route when linkTo is a TracePageLink', as
         path: '/',
         element: (
           <ResultItem
-            trace={traceSummary}
+            traceSummary={traceSummary}
             durationPercent={50}
             linkTo={{ pathname: '/trace/abc', state: { fromSearch: '/search?service=foo' } }}
             toggleComparison={() => {}}
@@ -136,7 +136,7 @@ it('calls trackConversions on click', () => {
   const spy = jest.spyOn(tracking, 'trackConversions');
   renderWithRouter(
     <ResultItem
-      trace={traceSummary}
+      traceSummary={traceSummary}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
@@ -11,6 +11,7 @@ import ResultItem from './ResultItem';
 import * as markers from './ResultItem.markers';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
+import { traceToTraceSummary } from '../../../model/trace-summary';
 import * as tracking from './index.track';
 
 // Helper function to wrap component with Router
@@ -18,7 +19,7 @@ const renderWithRouter = ui => {
   return render(ui, { wrapper: MemoryRouter });
 };
 
-let otelTrace; // OTEL facade of trace
+let traceSummary;
 
 beforeEach(() => {
   // Reset trace data before each test.
@@ -26,13 +27,13 @@ beforeEach(() => {
   // Resetting ensures that each test starts with a clean, unmodified trace,
   // preventing side effects between tests and maintaining test isolation.
   const trace = transformTraceData(traceGenerator.trace({}));
-  otelTrace = trace.asOtelTrace();
+  traceSummary = traceToTraceSummary(trace.asOtelTrace());
 });
 
 it('<ResultItem /> should render base case correctly', () => {
   renderWithRouter(
     <ResultItem
-      trace={otelTrace}
+      trace={traceSummary}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}
@@ -40,22 +41,16 @@ it('<ResultItem /> should render base case correctly', () => {
       disableComparision={false}
     />
   );
-  expect(screen.getByTestId(markers.NUM_SPANS)).toHaveTextContent(`${otelTrace.spans.length} Spans`);
+  expect(screen.getByTestId(markers.NUM_SPANS)).toHaveTextContent(`${traceSummary.spanCount} Spans`);
   const serviceTagsContainer = screen.getByTestId(markers.SERVICE_TAGS);
   const serviceTags = serviceTagsContainer.querySelectorAll('li > .ResultItem--serviceTag');
-  expect(serviceTags).toHaveLength(otelTrace.services.length);
+  expect(serviceTags).toHaveLength(traceSummary.services.length);
 });
 
 it('<ResultItem /> should not render any ServiceTags when there are no services', () => {
-  // Create a proper OTEL trace with empty services but valid spans
-  const otelTraceWithoutServices = {
-    ...otelTrace,
-    services: [],
-    spans: otelTrace.spans, // Keep spans array
-  };
   renderWithRouter(
     <ResultItem
-      trace={otelTraceWithoutServices}
+      trace={{ ...traceSummary, services: [] }}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}
@@ -68,34 +63,21 @@ it('<ResultItem /> should not render any ServiceTags when there are no services'
   expect(serviceTags).toHaveLength(0);
 });
 
-it('<ResultItem /> should render error icon on ServiceTags that have an error tag', () => {
-  // Create a new trace for this test that we can modify
-  const trace = transformTraceData(traceGenerator.trace({}));
+it('<ResultItem /> should render error icon on ServiceTags that have an error span', () => {
+  // Assume the summary has at least one service.
+  expect(traceSummary.services.length).toBeGreaterThan(0);
+  const targetService = traceSummary.services[0];
 
-  // Assume trace has services and spans from the generator. Assert this assumption.
-  expect(trace.services).toBeDefined();
-  expect(trace.services.length).toBeGreaterThan(0);
-  expect(trace.spans).toBeDefined();
-  expect(trace.spans.length).toBeGreaterThan(0);
-
-  // Find the first span belonging to the first service.
-  const firstService = trace.services[0];
-  const spanWithError = trace.spans.find(span => span.process.serviceName === firstService.name);
-
-  // Assert that a span for the first service was found. If not, the fixture is wrong.
-  expect(spanWithError).toBeDefined();
-
-  // Add the error tag directly, initializing tags array if necessary.
-  spanWithError.tags = spanWithError.tags || [];
-  spanWithError.tags.push({ key: 'error', value: true });
-
-  // Clear cached OTEL facade and regenerate with the updated error tag
-  trace._otelFacade = undefined;
-  const updatedOtelTrace = trace.asOtelTrace();
+  // Mark the first service as having errors.
+  const summaryWithError = {
+    ...traceSummary,
+    errorSpanCount: 1,
+    services: traceSummary.services.map((s, i) => (i === 0 ? { ...s, errorSpanCount: 1 } : s)),
+  };
 
   renderWithRouter(
     <ResultItem
-      trace={updatedOtelTrace}
+      trace={summaryWithError}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}
@@ -105,12 +87,10 @@ it('<ResultItem /> should render error icon on ServiceTags that have an error ta
   );
 
   const serviceTagsContainer = screen.getByTestId(markers.SERVICE_TAGS);
-  // Find the tag associated with the service that should have the error
   const errorTag = Array.from(serviceTagsContainer.querySelectorAll('li > .ResultItem--serviceTag')).find(
-    tag => tag.textContent.includes(firstService.name)
+    tag => tag.textContent.includes(targetService.name)
   );
 
-  // Assert that the specific service tag is found and has the error icon
   expect(errorTag).toBeDefined();
   expect(errorTag.querySelector('.ResultItem--errorIcon')).toBeInTheDocument();
 });
@@ -127,7 +107,7 @@ it('passes router state to destination route when linkTo is a TracePageLink', as
         path: '/',
         element: (
           <ResultItem
-            trace={otelTrace}
+            trace={traceSummary}
             durationPercent={50}
             linkTo={{ pathname: '/trace/abc', state: { fromSearch: '/search?service=foo' } }}
             toggleComparison={() => {}}
@@ -156,7 +136,7 @@ it('calls trackConversions on click', () => {
   const spy = jest.spyOn(tracking, 'trackConversions');
   renderWithRouter(
     <ResultItem
-      trace={otelTrace}
+      trace={traceSummary}
       durationPercent={50}
       linkTo={{ pathname: '/' }}
       toggleComparison={() => {}}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -18,7 +18,7 @@ import colorGenerator from '../../../utils/color-generator';
 import { formatRelativeDate } from '../../../utils/date';
 import { getIncompleteTraceTooltip } from '../../../model/trace-viewer';
 
-import { TraceSummary } from '../../../types/trace-summary';
+import type { TraceSummary } from '../../../types/trace-summary';
 import type { TracePageLink } from '../../TracePage/url';
 
 import './ResultItem.css';
@@ -30,7 +30,7 @@ type Props = {
   isInDiffCohort: boolean;
   linkTo: TracePageLink;
   toggleComparison: (traceID: string) => void;
-  trace: TraceSummary;
+  traceSummary: TraceSummary;
   disableComparision: boolean;
 };
 
@@ -41,7 +41,7 @@ export default function ResultItem({
   isInDiffCohort,
   linkTo,
   toggleComparison,
-  trace,
+  traceSummary,
   disableComparision,
 }: Props) {
   const {
@@ -53,7 +53,7 @@ export default function ResultItem({
     spanCount,
     errorSpanCount,
     orphanSpanCount,
-  } = trace;
+  } = traceSummary;
 
   const startTimeDayjs = dayjs(startTime / 1000);
   const timeStr = startTimeDayjs.format('h:mm:ss a');
@@ -93,21 +93,18 @@ export default function ResultItem({
           </Col>
           <Col xs={24} sm={16} className="ub-p2">
             <ul className="ub-list-reset" data-testid={markers.SERVICE_TAGS}>
-              {_sortBy(services, s => s.name).map(service => {
-                const { name, spanCount: count, errorSpanCount: errorCount } = service;
-                return (
-                  <li key={name} className="ub-inline-block ub-m1">
-                    <Tag
-                      className="ResultItem--serviceTag"
-                      style={{ borderLeftColor: colorGenerator.getColorByKey(name) }}
-                      variant="outlined"
-                    >
-                      {errorCount > 0 && <IoAlert className="ResultItem--errorIcon" />}
-                      {name} ({count})
-                    </Tag>
-                  </li>
-                );
-              })}
+              {_sortBy(services, s => s.name).map(service => (
+                <li key={service.name} className="ub-inline-block ub-m1">
+                  <Tag
+                    className="ResultItem--serviceTag"
+                    style={{ borderLeftColor: colorGenerator.getColorByKey(service.name) }}
+                    variant="outlined"
+                  >
+                    {service.errorSpanCount > 0 && <IoAlert className="ResultItem--errorIcon" />}
+                    {service.name} ({service.spanCount})
+                  </Tag>
+                </li>
+              ))}
             </ul>
           </Col>
           <Col xs={24} sm={4} className="ub-p3 ub-tx-right-align">

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -18,7 +18,7 @@ import colorGenerator from '../../../utils/color-generator';
 import { formatRelativeDate } from '../../../utils/date';
 import { getIncompleteTraceTooltip } from '../../../model/trace-viewer';
 
-import { IOtelTrace, StatusCode } from '../../../types/otel';
+import { TraceSummary } from '../../../types/trace-summary';
 import type { TracePageLink } from '../../TracePage/url';
 
 import './ResultItem.css';
@@ -30,7 +30,7 @@ type Props = {
   isInDiffCohort: boolean;
   linkTo: TracePageLink;
   toggleComparison: (traceID: string) => void;
-  trace: IOtelTrace;
+  trace: TraceSummary;
   disableComparision: boolean;
 };
 
@@ -44,30 +44,20 @@ export default function ResultItem({
   trace,
   disableComparision,
 }: Props) {
-  const { duration, services = [], startTime, traceName, traceID, spans, orphanSpanCount } = trace;
+  const {
+    duration,
+    services = [],
+    startTime,
+    traceName,
+    traceID,
+    spanCount,
+    errorSpanCount,
+    orphanSpanCount,
+  } = trace;
 
-  // Initialize state values
-  const [erroredServices, setErroredServices] = React.useState<Set<string>>(new Set());
-  const [numSpans] = React.useState(spans.length);
-  const [numErredSpans, setNumErredSpans] = React.useState(0);
-  const [timeStr, setTimeStr] = React.useState('');
-  const [fromNow, setFromNow] = React.useState<string | boolean>('');
-
-  React.useEffect(() => {
-    const startTimeDayjs = dayjs(startTime / 1000);
-    setTimeStr(startTimeDayjs.format('h:mm:ss a'));
-    setFromNow(startTimeDayjs.fromNow());
-
-    const errored = new Set<string>();
-    const erredCount = spans.filter(sp => {
-      const hasError = sp.status.code === StatusCode.ERROR;
-      if (hasError) errored.add(sp.resource.serviceName);
-      return hasError;
-    }).length;
-
-    setErroredServices(errored);
-    setNumErredSpans(erredCount);
-  }, [startTime, spans]);
+  const startTimeDayjs = dayjs(startTime / 1000);
+  const timeStr = startTimeDayjs.format('h:mm:ss a');
+  const fromNow = startTimeDayjs.fromNow();
 
   return (
     <div className="ResultItem" onClick={trackTraceConversions} role="button">
@@ -85,11 +75,11 @@ export default function ResultItem({
         <Row>
           <Col xs={24} sm={4} className="ub-p2">
             <Tag className="ub-m1" data-testid={markers.NUM_SPANS} variant="outlined">
-              {numSpans} Span{numSpans > 1 && 's'}
+              {spanCount} Span{spanCount > 1 && 's'}
             </Tag>
-            {Boolean(numErredSpans) && (
+            {Boolean(errorSpanCount) && (
               <Tag className="ub-m1" color="red" variant="outlined">
-                {numErredSpans} Error{numErredSpans > 1 && 's'}
+                {errorSpanCount} Error{errorSpanCount > 1 && 's'}
               </Tag>
             )}
             {orphanSpanCount > 0 && (
@@ -104,7 +94,7 @@ export default function ResultItem({
           <Col xs={24} sm={16} className="ub-p2">
             <ul className="ub-list-reset" data-testid={markers.SERVICE_TAGS}>
               {_sortBy(services, s => s.name).map(service => {
-                const { name, numberOfSpans: count } = service;
+                const { name, spanCount: count, errorSpanCount: errorCount } = service;
                 return (
                   <li key={name} className="ub-inline-block ub-m1">
                     <Tag
@@ -112,7 +102,7 @@ export default function ResultItem({
                       style={{ borderLeftColor: colorGenerator.getColorByKey(name) }}
                       variant="outlined"
                     >
-                      {erroredServices.has(name) && <IoAlert className="ResultItem--errorIcon" />}
+                      {errorCount > 0 && <IoAlert className="ResultItem--errorIcon" />}
                       {name} ({count})
                     </Tag>
                   </li>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
@@ -11,15 +11,15 @@ import { fetchedState } from '../../../constants';
 import { formatDurationCompact } from '../../../utils/date';
 
 import { FetchedState, TNil } from '../../../types';
-import { IOtelTrace } from '../../../types/otel';
 import { ApiError } from '../../../types/api-error';
+import { Microseconds } from '../../../types/units';
 import type { TracePageLink } from '../../TracePage/url';
 
 import './ResultItemTitle.css';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 
 type Props = {
-  duration?: IOtelTrace['duration'];
+  duration?: Microseconds;
   durationPercent?: number;
   error?: ApiError;
   isInDiffCohort: boolean;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItemTitle.tsx
@@ -12,14 +12,14 @@ import { formatDurationCompact } from '../../../utils/date';
 
 import { FetchedState, TNil } from '../../../types';
 import { ApiError } from '../../../types/api-error';
-import { Microseconds } from '../../../types/units';
+import type { TraceSummary } from '../../../types/trace-summary';
 import type { TracePageLink } from '../../TracePage/url';
 
 import './ResultItemTitle.css';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 
 type Props = {
-  duration?: Microseconds;
+  duration?: TraceSummary['duration'];
   durationPercent?: number;
   error?: ApiError;
   isInDiffCohort: boolean;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.test.jsx
@@ -71,25 +71,29 @@ const sampleData = [
     x: generateTimestamp(22, 10, 17),
     y: 1,
     traceID: '576b0c2330db100b',
-    size: 1,
+    spanCount: 1,
+    serviceCount: 1,
   },
   {
     x: generateTimestamp(22, 10, 22),
     y: 2,
     traceID: '6fb42ddd88f4b4f2',
-    size: 1,
+    spanCount: 1,
+    serviceCount: 1,
   },
   {
     x: generateTimestamp(22, 10, 46),
     y: 77707,
     traceID: '1f7185d56ef5dc07',
-    size: 3,
+    spanCount: 3,
+    serviceCount: 2,
   },
   {
     x: generateTimestamp(22, 11, 6),
     y: 80509,
     traceID: '21ba1f993ceddd8f',
-    size: 3,
+    spanCount: 3,
+    serviceCount: 2,
   },
 ];
 
@@ -275,8 +279,8 @@ describe('CustomTooltip', () => {
   it('renders stats information when active and payload is provided', () => {
     const payload = {
       name: 'Test Trace',
-      size: 42,
-      services: [{ name: 'service1' }, { name: 'service2' }],
+      spanCount: 42,
+      serviceCount: 2,
     };
     const { container } = render(<CustomTooltip active payload={[{ payload }]} />);
 
@@ -289,27 +293,26 @@ describe('CustomTooltip', () => {
     expect(statsElement.textContent).toContain('Services: 2');
   });
 
-  it('handles missing services data', () => {
-    const payload = {
-      name: 'Test Trace',
-      size: 10,
-    };
+  it('handles missing counts', () => {
+    const payload = { name: 'Test Trace' };
     const { container } = render(<CustomTooltip active payload={[{ payload }]} />);
 
     const statsElement = container.querySelector('.scatter-plot-hint-stats');
-    expect(statsElement.textContent).toContain('Services: 0');
+    expect(statsElement.textContent).toContain('Spans:');
+    expect(statsElement.textContent).toContain('Services:');
   });
 
-  it('handles services data', () => {
+  it('renders correct spanCount and serviceCount', () => {
     const payload = {
       name: 'Test Trace',
-      size: 15,
-      services: [{ name: 'service1' }, { name: 'service2' }],
+      spanCount: 15,
+      serviceCount: 3,
     };
     const { container } = render(<CustomTooltip active payload={[{ payload }]} />);
 
     const statsElement = container.querySelector('.scatter-plot-hint-stats');
-    expect(statsElement.textContent).toContain('Services: 2');
+    expect(statsElement.textContent).toContain('Spans: 15');
+    expect(statsElement.textContent).toContain('Services: 3');
   });
 
   it('returns null when not active', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ScatterPlot.tsx
@@ -24,12 +24,9 @@ type TScatterPlotPoint = {
   x: number;
   y: number;
   traceID: string;
-  size: number;
+  spanCount: number;
+  serviceCount: number;
   name?: string;
-  services?: ReadonlyArray<{
-    name: string;
-    numberOfSpans: number;
-  }>;
   color?: string;
 };
 
@@ -50,17 +47,15 @@ export const CustomTooltip = ({
 }) => {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
-    const numServices = data.services ? data.services.length : 0;
-
     return (
       <div className="scatter-plot-hint">
         <h4>{data.name || FALLBACK_TRACE_NAME}</h4>
         <div className="scatter-plot-hint-stats">
           <div>
-            <strong>Spans:</strong> {data.size}
+            <strong>Spans:</strong> {data.spanCount}
           </div>
           <div>
-            <strong>Services:</strong> {numServices}
+            <strong>Services:</strong> {data.serviceCount}
           </div>
         </div>
       </div>
@@ -181,7 +176,7 @@ export default function ScatterPlot({
                 angle={-90}
               />
             </YAxis>
-            <ZAxis dataKey="size" type="number" range={[1, 300]} />
+            <ZAxis dataKey="spanCount" type="number" range={[1, 300]} />
             <Tooltip content={<CustomTooltip />} cursor={false} isAnimationActive={false} />
             <Scatter
               data={data.map(point => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -14,7 +14,6 @@ import { getUrl } from '../url';
 import ResultItem from './ResultItem';
 import ScatterPlot from './ScatterPlot';
 import DiffSelection from './DiffSelection';
-import { StatusCode } from '../../../types/otel';
 
 const mockNavigate = jest.fn();
 vi.mock('react-router-dom', async () => {
@@ -96,31 +95,35 @@ afterEach(() => {
 const baseTraces = [
   {
     traceID: 'a',
-    spans: [],
-    durationMicros: 1000,
-    startTimeUnixMicros: 0,
-    endTimeUnixMicros: 1000,
     traceName: 'trace-a',
-    services: [],
-    spanMap: new Map(),
-    rootSpans: [],
+    rootServiceName: 'svc-a',
+    rootOperationName: 'op-a',
+    startTime: 0,
+    duration: 1000,
+    spanCount: 0,
+    errorSpanCount: 0,
     orphanSpanCount: 0,
-    hasErrors: () => false,
+    services: [],
   },
   {
     traceID: 'b',
-    spans: [],
-    durationMicros: 1000,
-    startTimeUnixMicros: 0,
-    endTimeUnixMicros: 1000,
     traceName: 'trace-b',
-    services: [],
-    spanMap: new Map(),
-    rootSpans: [],
+    rootServiceName: 'svc-b',
+    rootOperationName: 'op-b',
+    startTime: 0,
+    duration: 1000,
+    spanCount: 0,
+    errorSpanCount: 0,
     orphanSpanCount: 0,
-    hasErrors: () => false,
+    services: [],
   },
 ];
+
+const baseRawTraces = [
+  { traceID: 'a', spans: [], durationMicros: 1000, startTimeUnixMicros: 0, endTimeUnixMicros: 1000 },
+  { traceID: 'b', spans: [], durationMicros: 1000, startTimeUnixMicros: 0, endTimeUnixMicros: 1000 },
+];
+
 const baseProps = {
   cohortAddTrace: jest.fn(),
   cohortRemoveTrace: jest.fn(),
@@ -135,7 +138,7 @@ const baseProps = {
   skipMessage: false,
   spanLinks: undefined,
   traces: baseTraces,
-  rawTraces: baseTraces,
+  rawTraces: baseRawTraces,
   sortBy: orderBy.MOST_RECENT,
   handleSortChange: jest.fn(),
 };
@@ -202,29 +205,19 @@ describe('<SearchResults>', () => {
     expect(remove).toHaveBeenCalledWith('id-2');
   });
 
-  it('sets trace color to red if error tag is present', () => {
+  it('sets trace color to red if errorSpanCount > 0', () => {
     const errorTrace = [
       {
         traceID: 'err',
         traceName: 'T',
-        startTimeUnixMicros: 0,
-        endTimeUnixMicros: 1000,
-        durationMicros: 1,
-        services: [],
-        spanMap: new Map(),
-        rootSpans: [],
+        rootServiceName: 'svc-A',
+        rootOperationName: 'op-A',
+        startTime: 0,
+        duration: 1,
+        spanCount: 1,
+        errorSpanCount: 1,
         orphanSpanCount: 0,
-        hasErrors: () => true,
-        spans: [
-          {
-            status: { code: StatusCode.ERROR },
-            resource: { serviceName: 'svc-A', attributes: [] },
-            name: 'op-A',
-            spanID: 's1',
-            traceID: 'err',
-            attributes: [],
-          },
-        ],
+        services: [{ name: 'svc-A', spanCount: 1, errorSpanCount: 1 }],
       },
     ];
     renderWithRouter(<SearchResults {...baseProps} traces={errorTrace} />);
@@ -246,7 +239,7 @@ describe('<SearchResults>', () => {
     expect(navigateCall[0]).toContain('/trace/a');
   });
 
-  it('handles trace with no spans', () => {
+  it('handles trace with zero spans', () => {
     renderWithRouter(
       <SearchResults
         {...baseProps}
@@ -254,15 +247,14 @@ describe('<SearchResults>', () => {
           {
             traceID: 'no-spans',
             traceName: 'Empty Trace',
-            startTimeUnixMicros: 0,
-            endTimeUnixMicros: 1000,
-            durationMicros: 1,
-            services: [],
-            spanMap: new Map(),
-            rootSpans: [],
-            spans: [],
+            rootServiceName: '',
+            rootOperationName: '',
+            startTime: 0,
+            duration: 1,
+            spanCount: 0,
+            errorSpanCount: 0,
             orphanSpanCount: 0,
-            hasErrors: () => false,
+            services: [],
           },
         ]}
       />
@@ -271,7 +263,7 @@ describe('<SearchResults>', () => {
     expect(data.services).toEqual([]);
   });
 
-  it('handles trace with no services property', () => {
+  it('handles trace with empty services list', () => {
     renderWithRouter(
       <SearchResults
         {...baseProps}
@@ -279,24 +271,14 @@ describe('<SearchResults>', () => {
           {
             traceID: 'no-services',
             traceName: 'No Services',
-            startTimeUnixMicros: 0,
-            endTimeUnixMicros: 1000,
-            durationMicros: 1,
-            services: [],
-            spanMap: new Map(),
-            rootSpans: [],
+            rootServiceName: 'test-service',
+            rootOperationName: 'test-operation',
+            startTime: 0,
+            duration: 1,
+            spanCount: 1,
+            errorSpanCount: 0,
             orphanSpanCount: 0,
-            hasErrors: () => false,
-            spans: [
-              {
-                resource: { serviceName: 'test-service', attributes: [] },
-                name: 'test-operation',
-                spanID: 's1',
-                traceID: 'no-services',
-                attributes: [],
-                status: { code: 'OK' },
-              },
-            ],
+            services: [],
           },
         ]}
       />
@@ -336,29 +318,27 @@ describe('<SearchResults>', () => {
       const zeroIDTraces = [
         {
           traceID: traceID0,
-          spans: [],
-          durationMicros: 1000,
-          startTimeUnixMicros: 0,
-          endTimeUnixMicros: 1000,
           traceName: traceID0,
-          services: [],
-          spanMap: new Map(),
-          rootSpans: [],
+          rootServiceName: '',
+          rootOperationName: '',
+          startTime: 0,
+          duration: 1000,
+          spanCount: 0,
+          errorSpanCount: 0,
           orphanSpanCount: 0,
-          hasErrors: () => false,
+          services: [],
         },
         {
           traceID: `000${traceID1}`,
-          spans: [],
-          durationMicros: 1000,
-          startTimeUnixMicros: 0,
-          endTimeUnixMicros: 1000,
           traceName: `000${traceID1}`,
-          services: [],
-          spanMap: new Map(),
-          rootSpans: [],
+          rootServiceName: '',
+          rootOperationName: '',
+          startTime: 0,
+          duration: 1000,
+          spanCount: 0,
+          errorSpanCount: 0,
           orphanSpanCount: 0,
-          hasErrors: () => false,
+          services: [],
         },
       ];
       renderWithRouter(<SearchResults {...baseProps} traces={zeroIDTraces} spanLinks={spanLinks} />);
@@ -460,39 +440,17 @@ describe('<SearchResults>', () => {
         expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
         const blobArg = URL.createObjectURL.mock.calls[0][0];
 
-        // Construct expected output by keeping only non-derived fields
-        const expectedTraces = baseProps.rawTraces.map(
-          ({ traceID, spans, durationMicros, startTimeUnixMicros, endTimeUnixMicros }) => ({
-            traceID,
-            spans,
-            durationMicros,
-            startTimeUnixMicros,
-            endTimeUnixMicros,
-          })
-        );
-
-        expect(blobArg.text).toEqual([`{"data":${JSON.stringify(expectedTraces)}}`]);
+        expect(blobArg.text).toEqual([`{"data":${JSON.stringify(baseRawTraces)}}`]);
         expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
 
         global.Blob = orig;
       });
 
       it('when create a download file then it can be read back', async () => {
-        // Construct expected output by keeping only non-derived fields
-        const expectedTraces = baseProps.rawTraces.map(
-          ({ traceID, spans, durationMicros, startTimeUnixMicros, endTimeUnixMicros }) => ({
-            traceID,
-            spans,
-            durationMicros,
-            startTimeUnixMicros,
-            endTimeUnixMicros,
-          })
-        );
-
-        const content = `{"data":${JSON.stringify(expectedTraces)}}`;
+        const content = `{"data":${JSON.stringify(baseRawTraces)}}`;
         // Pass the blob content (string) directly to File to avoid JSDOM Blob-in-File issues if any
         // createBlob returns a Blob. getting text from it.
-        const blob = createBlob(baseProps.rawTraces);
+        const blob = createBlob(baseRawTraces);
         // In JSDOM/Node, blob parts are stored. We can extract string.
         // But here we rely on standard APIs.
         // If createBlob returns a real JSDOM Blob, new File([blob]) should work.

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -44,7 +44,7 @@ vi.mock('./DiffSelection', () =>
 );
 
 vi.mock('./ResultItem', () =>
-  mockDefault(jest.fn(({ trace }) => <div data-testid={`result-${trace.traceID}`} />))
+  mockDefault(jest.fn(({ traceSummary }) => <div data-testid={`result-${traceSummary.traceID}`} />))
 );
 
 vi.mock('./ScatterPlot', () => mockDefault(jest.fn(props => <div data-testid="scatterplot" {...props} />)));
@@ -137,7 +137,7 @@ const baseProps = {
   showStandaloneLink: false,
   skipMessage: false,
   spanLinks: undefined,
-  traces: baseTraces,
+  traceSummaries: baseTraces,
   rawTraces: baseRawTraces,
   sortBy: orderBy.MOST_RECENT,
   handleSortChange: jest.fn(),
@@ -153,13 +153,13 @@ const renderWithRouter = (ui, options = {}) => {
 
 describe('<SearchResults>', () => {
   it('shows the "no results" message when the search result is empty', () => {
-    renderWithRouter(<SearchResults {...baseProps} traces={[]} />);
+    renderWithRouter(<SearchResults {...baseProps} traceSummaries={[]} />);
     expect(screen.getByText(/No trace results\. Try another query\./i)).toBeInTheDocument();
   });
 
   it('uses default skipMessage value when not provided', () => {
     const { skipMessage, ...propsWithoutSkipMessage } = baseProps;
-    renderWithRouter(<SearchResults {...propsWithoutSkipMessage} traces={[]} />);
+    renderWithRouter(<SearchResults {...propsWithoutSkipMessage} traceSummaries={[]} />);
     expect(screen.getByText(/No trace results\. Try another query\./i)).toBeInTheDocument();
   });
 
@@ -220,7 +220,7 @@ describe('<SearchResults>', () => {
         services: [{ name: 'svc-A', spanCount: 1, errorSpanCount: 1 }],
       },
     ];
-    renderWithRouter(<SearchResults {...baseProps} traces={errorTrace} />);
+    renderWithRouter(<SearchResults {...baseProps} traceSummaries={errorTrace} />);
     const scatterProps = ScatterPlot.mock.calls[0][0];
     expect(scatterProps.data[0].color).toBe('red');
   });
@@ -243,7 +243,7 @@ describe('<SearchResults>', () => {
     renderWithRouter(
       <SearchResults
         {...baseProps}
-        traces={[
+        traceSummaries={[
           {
             traceID: 'no-spans',
             traceName: 'Empty Trace',
@@ -267,7 +267,7 @@ describe('<SearchResults>', () => {
     renderWithRouter(
       <SearchResults
         {...baseProps}
-        traces={[
+        traceSummaries={[
           {
             traceID: 'no-services',
             traceName: 'No Services',
@@ -341,7 +341,7 @@ describe('<SearchResults>', () => {
           services: [],
         },
       ];
-      renderWithRouter(<SearchResults {...baseProps} traces={zeroIDTraces} spanLinks={spanLinks} />);
+      renderWithRouter(<SearchResults {...baseProps} traceSummaries={zeroIDTraces} spanLinks={spanLinks} />);
       const calls = ResultItem.mock.calls;
       expect(calls[0][0].linkTo.search).toBe(`uiFind=${uiFind0}`);
       expect(calls[1][0].linkTo.search).toBe(`uiFind=${uiFind1}`);

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -260,7 +260,7 @@ describe('<SearchResults>', () => {
       />
     );
     const data = ScatterPlot.mock.calls[0][0].data[0];
-    expect(data.services).toEqual([]);
+    expect(data.serviceCount).toBe(0);
   });
 
   it('handles trace with empty services list', () => {
@@ -284,7 +284,7 @@ describe('<SearchResults>', () => {
       />
     );
     const data = ScatterPlot.mock.calls[0][0].data[0];
-    expect(data.services).toEqual([]);
+    expect(data.serviceCount).toBe(0);
   });
 
   describe('search finished with results', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -46,7 +46,7 @@ type SearchResultsProps = {
   showStandaloneLink: boolean;
   skipMessage?: boolean;
   spanLinks?: Record<string, string> | undefined;
-  traces: TraceSummary[];
+  traceSummaries: TraceSummary[];
   rawTraces: any[];
   sortBy: string;
   handleSortChange: (sortBy: string) => void;
@@ -134,7 +134,7 @@ export function UnconnectedSearchResults({
   showStandaloneLink,
   skipMessage = false,
   spanLinks,
-  traces,
+  traceSummaries,
   rawTraces,
   sortBy,
   handleSortChange,
@@ -196,7 +196,7 @@ export function UnconnectedSearchResults({
       </React.Fragment>
     );
   }
-  if (!Array.isArray(traces) || !traces.length) {
+  if (!Array.isArray(traceSummaries) || !traceSummaries.length) {
     return (
       <React.Fragment key="no-results">
         {diffCohort.length > 0 && diffSelection}
@@ -216,7 +216,7 @@ export function UnconnectedSearchResults({
         {!hideGraph && traceResultsView && (
           <div className="ub-p3 SearchResults--headerScatterPlot">
             <ScatterPlot
-              data={traces.map(t => {
+              data={traceSummaries.map(t => {
                 return {
                   x: t.startTime,
                   y: t.duration,
@@ -227,7 +227,7 @@ export function UnconnectedSearchResults({
                   color: t.errorSpanCount > 0 ? 'red' : '#12939A',
                 };
               })}
-              onValueClick={(t: TraceSummary) => {
+              onValueClick={(t: { traceID: string }) => {
                 goToTrace(t.traceID);
               }}
             />
@@ -235,7 +235,7 @@ export function UnconnectedSearchResults({
         )}
         <div className="SearchResults--headerOverview">
           <h2 className="ub-m0 u-flex-1">
-            {traces.length} Trace{traces.length > 1 && 's'}
+            {traceSummaries.length} Trace{traceSummaries.length > 1 && 's'}
           </h2>
           {traceResultsView && <SelectSort sortBy={sortBy} handleSortChange={handleSortChange} />}
           {traceResultsView && <DownloadResults onDownloadResultsClicked={onDownloadResultsClicked} />}
@@ -260,18 +260,19 @@ export function UnconnectedSearchResults({
       {traceResultsView && diffSelection}
       {traceResultsView && (
         <ul className="ub-list-reset">
-          {traces.map(trace => (
-            <li className="ub-my3" key={trace.traceID}>
+          {traceSummaries.map(traceSummary => (
+            <li className="ub-my3" key={traceSummary.traceID}>
               <ResultItem
-                durationPercent={getPercentageOfDuration(trace.duration, maxTraceDuration)}
-                isInDiffCohort={cohortIds.has(trace.traceID)}
+                durationPercent={getPercentageOfDuration(traceSummary.duration, maxTraceDuration)}
+                isInDiffCohort={cohortIds.has(traceSummary.traceID)}
                 linkTo={getTracePageLink(
-                  trace.traceID,
+                  traceSummary.traceID,
                   { fromSearch: searchUrl },
-                  spanLinks && (spanLinks[trace.traceID] || spanLinks[trace.traceID.replace(/^0*/, '')])
+                  spanLinks &&
+                    (spanLinks[traceSummary.traceID] || spanLinks[traceSummary.traceID.replace(/^0*/, '')])
                 )}
                 toggleComparison={toggleComparison}
-                trace={trace}
+                traceSummary={traceSummary}
                 disableComparision={disableComparisons}
               />
             </li>

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -221,10 +221,10 @@ export function UnconnectedSearchResults({
                   x: t.startTime,
                   y: t.duration,
                   traceID: t.traceID,
-                  size: t.spanCount,
+                  spanCount: t.spanCount,
+                  serviceCount: t.services.length,
                   name: t.traceName,
                   color: t.errorSpanCount > 0 ? 'red' : '#12939A',
-                  services: t.services.map(s => ({ name: s.name, numberOfSpans: s.spanCount })),
                 };
               })}
               onValueClick={(t: TraceSummary) => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -26,7 +26,7 @@ import { stripEmbeddedState } from '../../../utils/embedded-url';
 
 import { FetchedTrace } from '../../../types';
 import { SearchQuery } from '../../../types/search';
-import { IOtelTrace } from '../../../types/otel';
+import { TraceSummary } from '../../../types/trace-summary';
 
 import './index.css';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
@@ -46,7 +46,7 @@ type SearchResultsProps = {
   showStandaloneLink: boolean;
   skipMessage?: boolean;
   spanLinks?: Record<string, string> | undefined;
-  traces: IOtelTrace[];
+  traces: TraceSummary[];
   rawTraces: any[];
   sortBy: string;
   handleSortChange: (sortBy: string) => void;
@@ -221,13 +221,13 @@ export function UnconnectedSearchResults({
                   x: t.startTime,
                   y: t.duration,
                   traceID: t.traceID,
-                  size: t.spans.length,
+                  size: t.spanCount,
                   name: t.traceName,
-                  color: t.hasErrors() ? 'red' : '#12939A',
-                  services: t.services || [],
+                  color: t.errorSpanCount > 0 ? 'red' : '#12939A',
+                  services: t.services.map(s => ({ name: s.name, numberOfSpans: s.spanCount })),
                 };
               })}
-              onValueClick={(t: IOtelTrace) => {
+              onValueClick={(t: TraceSummary) => {
                 goToTrace(t.traceID);
               }}
             />

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
@@ -189,7 +189,7 @@ export function SearchTracePageImpl(props: SearchTracePageImplProps) {
               showStandaloneLink: Boolean(embedded),
               skipMessage: isHomepage,
               spanLinks: urlQueryParams && urlQueryParams.spanLinks,
-              traces: traceResults,
+              traceSummaries: traceResults,
               rawTraces: traceResultsToDownload,
               sortBy,
               handleSortChange,

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
@@ -31,7 +31,8 @@ import { useShallow } from 'zustand/react/shallow';
 import { ReduxState } from '../../types';
 import { SearchQuery } from '../../types/search';
 import { Trace } from '../../types/trace';
-import { IOtelTrace } from '../../types/otel';
+import { TraceSummary } from '../../types/trace-summary';
+import { traceToTraceSummary } from '../../model/trace-summary';
 import type { TUrlState } from './url';
 
 interface IQueryOfResults extends Partial<SearchQuery> {
@@ -53,7 +54,7 @@ interface IStateProps {
   traceResultsToDownload: unknown[];
   errors: Array<{ message: string }> | null;
   maxTraceDuration: number;
-  sortedTracesXformer: (traces: Trace[], sortBy: string) => IOtelTrace[];
+  sortedTracesXformer: (traces: Trace[], sortBy: string) => TraceSummary[];
   urlQueryParams: TUrlState | null;
 }
 
@@ -235,8 +236,7 @@ export const stateTraceDiffXformer = memoizeOne(
 const sortedTracesXformer = memoizeOne((traces: Trace[], sortBy: string) => {
   const traceResults = traces.slice();
   sortTraces(traceResults, sortBy);
-  // Convert to OTEL traces
-  return traceResults.map(t => t.asOtelTrace());
+  return traceResults.map(t => traceToTraceSummary(t.asOtelTrace()));
 });
 
 export function mapStateToProps(

--- a/packages/jaeger-ui/src/model/trace-summary.test.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { traceToTraceSummary } from './trace-summary';
+import transformTraceData from './transform-trace-data';
+import traceGenerator from '../demo/trace-generators';
+import { StatusCode, IOtelTrace, IOtelSpan, IResource, SpanKind } from '../types/otel';
+import { Microseconds } from '../types/units';
+
+const us = (n: number) => n as Microseconds;
+
+function makeMinimalTrace(overrides: Partial<IOtelTrace> = {}): IOtelTrace {
+  return {
+    traceID: 'abc123',
+    spans: [],
+    duration: us(500),
+    startTime: us(1000),
+    endTime: us(1500),
+    traceName: 'svc / op',
+    tracePageTitle: 'svc: op',
+    traceEmoji: '',
+    services: [],
+    spanMap: new Map(),
+    rootSpans: [],
+    orphanSpanCount: 0,
+    hasErrors: () => false,
+    ...overrides,
+  };
+}
+
+function makeSpan(
+  serviceName: string,
+  statusCode: StatusCode = StatusCode.OK,
+  spanID = Math.random().toString(16).slice(2)
+): IOtelSpan {
+  const resource: IResource = { serviceName, attributes: [] };
+  return {
+    traceID: 'abc123',
+    spanID,
+    name: 'op',
+    kind: SpanKind.INTERNAL,
+    startTime: us(1000),
+    endTime: us(1500),
+    duration: us(500),
+    attributes: [],
+    events: [],
+    links: [],
+    status: { code: statusCode },
+    resource,
+    instrumentationScope: { name: 'unknown' },
+    depth: 0,
+    hasChildren: false,
+    childSpans: [],
+    relativeStartTime: us(0),
+    inboundLinks: [],
+    warnings: null,
+  };
+}
+
+describe('traceToTraceSummary', () => {
+  it('produces correct summary for an empty trace', () => {
+    const trace = makeMinimalTrace();
+    const summary = traceToTraceSummary(trace);
+
+    expect(summary.traceID).toBe('abc123');
+    expect(summary.traceName).toBe('svc / op');
+    expect(summary.rootServiceName).toBe('');
+    expect(summary.rootOperationName).toBe('');
+    expect(summary.startTime).toBe(1000);
+    expect(summary.duration).toBe(500);
+    expect(summary.spanCount).toBe(0);
+    expect(summary.errorSpanCount).toBe(0);
+    expect(summary.orphanSpanCount).toBe(0);
+    expect(summary.services).toEqual([]);
+  });
+
+  it('extracts root service and operation from the first root span', () => {
+    const rootSpan = makeSpan('frontend', StatusCode.OK, 'root1');
+    rootSpan.name = 'GET /home';
+    const trace = makeMinimalTrace({ rootSpans: [rootSpan] });
+    const summary = traceToTraceSummary(trace);
+
+    expect(summary.rootServiceName).toBe('frontend');
+    expect(summary.rootOperationName).toBe('GET /home');
+  });
+
+  it('counts total and per-service error spans', () => {
+    const s1 = makeSpan('svc-a', StatusCode.ERROR, 's1');
+    const s2 = makeSpan('svc-a', StatusCode.OK, 's2');
+    const s3 = makeSpan('svc-b', StatusCode.ERROR, 's3');
+    const trace = makeMinimalTrace({
+      spans: [s1, s2, s3],
+      services: [
+        { name: 'svc-a', numberOfSpans: 2 },
+        { name: 'svc-b', numberOfSpans: 1 },
+      ],
+    });
+    const summary = traceToTraceSummary(trace);
+
+    expect(summary.spanCount).toBe(3);
+    expect(summary.errorSpanCount).toBe(2);
+
+    const svcA = summary.services.find(s => s.name === 'svc-a')!;
+    expect(svcA.spanCount).toBe(2);
+    expect(svcA.errorSpanCount).toBe(1);
+
+    const svcB = summary.services.find(s => s.name === 'svc-b')!;
+    expect(svcB.spanCount).toBe(1);
+    expect(svcB.errorSpanCount).toBe(1);
+  });
+
+  it('reports zero errors when no spans have error status', () => {
+    const s1 = makeSpan('svc-a', StatusCode.OK, 's1');
+    const s2 = makeSpan('svc-a', StatusCode.UNSET, 's2');
+    const trace = makeMinimalTrace({
+      spans: [s1, s2],
+      services: [{ name: 'svc-a', numberOfSpans: 2 }],
+    });
+    const summary = traceToTraceSummary(trace);
+
+    expect(summary.errorSpanCount).toBe(0);
+    expect(summary.services[0].errorSpanCount).toBe(0);
+  });
+
+  it('propagates orphanSpanCount from the OTEL trace', () => {
+    const trace = makeMinimalTrace({ orphanSpanCount: 3 });
+    const summary = traceToTraceSummary(trace);
+    expect(summary.orphanSpanCount).toBe(3);
+  });
+
+  it('round-trips correctly through transformTraceData and traceGenerator', () => {
+    const raw = traceGenerator.trace({});
+    const legacyTrace = transformTraceData(raw)!;
+    expect(legacyTrace).not.toBeNull();
+
+    const otelTrace = legacyTrace.asOtelTrace();
+    const summary = traceToTraceSummary(otelTrace);
+
+    expect(summary.traceID).toBe(legacyTrace.traceID);
+    expect(summary.spanCount).toBe(otelTrace.spans.length);
+    expect(summary.duration).toBe(otelTrace.duration);
+    expect(summary.startTime).toBe(otelTrace.startTime);
+    expect(summary.services).toHaveLength(otelTrace.services.length);
+    summary.services.forEach((s, i) => {
+      expect(s.name).toBe(otelTrace.services[i].name);
+      expect(s.spanCount).toBe(otelTrace.services[i].numberOfSpans);
+    });
+  });
+});

--- a/packages/jaeger-ui/src/model/trace-summary.test.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.test.ts
@@ -4,8 +4,9 @@
 import { traceToTraceSummary } from './trace-summary';
 import transformTraceData from './transform-trace-data';
 import traceGenerator from '../demo/trace-generators';
-import { StatusCode, IOtelTrace, IOtelSpan, IResource, SpanKind } from '../types/otel';
-import { Microseconds } from '../types/units';
+import { StatusCode, SpanKind } from '../types/otel';
+import type { IOtelTrace, IOtelSpan, IResource } from '../types/otel';
+import type { Microseconds } from '../types/units';
 
 const us = (n: number) => n as Microseconds;
 
@@ -28,11 +29,7 @@ function makeMinimalTrace(overrides: Partial<IOtelTrace> = {}): IOtelTrace {
   };
 }
 
-function makeSpan(
-  serviceName: string,
-  statusCode: StatusCode = StatusCode.OK,
-  spanID = Math.random().toString(16).slice(2)
-): IOtelSpan {
+function makeSpan(serviceName: string, spanID: string, statusCode: StatusCode = StatusCode.OK): IOtelSpan {
   const resource: IResource = { serviceName, attributes: [] };
   return {
     traceID: 'abc123',
@@ -75,7 +72,7 @@ describe('traceToTraceSummary', () => {
   });
 
   it('extracts root service and operation from the first root span', () => {
-    const rootSpan = makeSpan('frontend', StatusCode.OK, 'root1');
+    const rootSpan = makeSpan('frontend', 'root1');
     rootSpan.name = 'GET /home';
     const trace = makeMinimalTrace({ rootSpans: [rootSpan] });
     const summary = traceToTraceSummary(trace);
@@ -85,9 +82,9 @@ describe('traceToTraceSummary', () => {
   });
 
   it('counts total and per-service error spans', () => {
-    const s1 = makeSpan('svc-a', StatusCode.ERROR, 's1');
-    const s2 = makeSpan('svc-a', StatusCode.OK, 's2');
-    const s3 = makeSpan('svc-b', StatusCode.ERROR, 's3');
+    const s1 = makeSpan('svc-a', 's1', StatusCode.ERROR);
+    const s2 = makeSpan('svc-a', 's2');
+    const s3 = makeSpan('svc-b', 's3', StatusCode.ERROR);
     const trace = makeMinimalTrace({
       spans: [s1, s2, s3],
       services: [
@@ -110,8 +107,8 @@ describe('traceToTraceSummary', () => {
   });
 
   it('reports zero errors when no spans have error status', () => {
-    const s1 = makeSpan('svc-a', StatusCode.OK, 's1');
-    const s2 = makeSpan('svc-a', StatusCode.UNSET, 's2');
+    const s1 = makeSpan('svc-a', 's1');
+    const s2 = makeSpan('svc-a', 's2', StatusCode.UNSET);
     const trace = makeMinimalTrace({
       spans: [s1, s2],
       services: [{ name: 'svc-a', numberOfSpans: 2 }],

--- a/packages/jaeger-ui/src/model/trace-summary.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { StatusCode, IOtelTrace } from '../types/otel';
-import { ServiceSummary, TraceSummary } from '../types/trace-summary';
+import { StatusCode } from '../types/otel';
+import type { IOtelTrace } from '../types/otel';
+import type { ServiceSummary, TraceSummary } from '../types/trace-summary';
 
 export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
   const rootSpan = trace.rootSpans[0];

--- a/packages/jaeger-ui/src/model/trace-summary.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatusCode, IOtelTrace } from '../types/otel';
+import { ServiceSummary, TraceSummary } from '../types/trace-summary';
+
+export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
+  const rootSpan = trace.rootSpans[0];
+  const rootServiceName = rootSpan?.resource.serviceName ?? '';
+  const rootOperationName = rootSpan?.name ?? '';
+
+  const errorsByService = new Map<string, number>();
+  let errorSpanCount = 0;
+  for (const span of trace.spans) {
+    if (span.status.code === StatusCode.ERROR) {
+      errorSpanCount++;
+      const svc = span.resource.serviceName;
+      errorsByService.set(svc, (errorsByService.get(svc) ?? 0) + 1);
+    }
+  }
+
+  const services: ServiceSummary[] = trace.services.map(s => ({
+    name: s.name,
+    spanCount: s.numberOfSpans,
+    errorSpanCount: errorsByService.get(s.name) ?? 0,
+  }));
+
+  return {
+    traceID: trace.traceID,
+    traceName: trace.traceName,
+    rootServiceName,
+    rootOperationName,
+    startTime: trace.startTime,
+    duration: trace.duration,
+    spanCount: trace.spans.length,
+    errorSpanCount,
+    orphanSpanCount: trace.orphanSpanCount,
+    services,
+  };
+}

--- a/packages/jaeger-ui/src/types/trace-summary.ts
+++ b/packages/jaeger-ui/src/types/trace-summary.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Microseconds } from './units';
+
+export type ServiceSummary = {
+  name: string;
+  spanCount: number;
+  errorSpanCount: number;
+};
+
+export type TraceSummary = {
+  traceID: string;
+  traceName: string;
+  rootServiceName: string;
+  rootOperationName: string;
+  startTime: Microseconds;
+  duration: Microseconds;
+  spanCount: number;
+  errorSpanCount: number;
+  orphanSpanCount: number;
+  services: ServiceSummary[];
+};


### PR DESCRIPTION
## Summary

- Introduces `TraceSummary` and `ServiceSummary` types in `src/types/trace-summary.ts` as a lightweight alternative to `IOtelTrace` for the search results view
- Replaces `IOtelTrace` with `TraceSummary` in `ResultItem`, `SearchResults`, and `SearchTracePage` — error counts and per-service error flags are now read from pre-computed fields instead of iterating spans on every render
- Adds `traceToTraceSummary(trace: IOtelTrace): TraceSummary` adapter in `src/model/trace-summary.ts` so the existing `sortedTracesXformer` path continues to work unchanged
- `ResultItemTitle.duration` prop type simplified from `IOtelTrace['duration']` to `Microseconds` directly, removing the dependency on `IOtelTrace`
- Prepares for ADR-010 Milestone 2: once the UI calls `GET /api/v3/trace-summaries`, the reducer can populate `TraceSummary` directly from the API response without the `transformTraceData` aggregation step

## Test plan

- [ ] New unit tests in `src/model/trace-summary.test.ts` cover: empty trace, root service/operation extraction, error span counting (total and per-service), zero-error case, orphan count propagation, and a round-trip through `traceGenerator` + `transformTraceData`
- [ ] Existing `ResultItem.test.jsx` and `SearchResults/index.test.jsx` updated to use `TraceSummary`-shaped fixtures
- [ ] `npm test`, `npm run lint`, `npm run build` all pass

## Related

- Part of jaegertracing/jaeger#8606
- ADR-010: jaegertracing/jaeger#8602
- Backend PR: jaegertracing/jaeger#8604

🤖 Generated with [Claude Code](https://claude.com/claude-code)