### PR TITLE
fix(ui): Delay empty-root error check to avoid flash with React 18

### DIFF
--- a/packages/jaeger-ui/index.html
+++ b/packages/jaeger-ui/index.html
@@ -39,11 +39,16 @@
           'afterend',
           '<base href="' + safe + '" data-inject-target="BASE_URL" />'
         );
+        // Delay the check: React 18 createRoot().render() is async (concurrent mode),
+        // so the root is empty at DOMContentLoaded even when the app loaded successfully.
+        // Only show the error if the root is still empty after a generous timeout.
         document.addEventListener('DOMContentLoaded', function () {
-          var root = document.getElementById('jaeger-ui-root');
-          if (root && !root.hasChildNodes()) {
-            root.textContent = 'Jaeger UI did not load. Unknown or invalid path: ' + path;
-          }
+          setTimeout(function () {
+            var root = document.getElementById('jaeger-ui-root');
+            if (root && !root.hasChildNodes()) {
+              root.textContent = 'Jaeger UI did not load. Unknown or invalid path: ' + path;
+            }
+          }, 3000);
         });
       })();
     </script>


### PR DESCRIPTION
React's createRoot().render() is asynchronous (concurrent mode) so the root div is still empty when DOMContentLoaded fires, even when the app loaded successfully. The premature check (introduced #3874) was writing the error text and then React would overwrite it — visible as a brief flash on page load.

Wrap the check in a 3s setTimeout so it only triggers when the app genuinely failed to mount (e.g. assets unreachable, invalid base path).
