### PR TITLE
chore: Bump tsconfig target from es2016 to es2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2020",
     "lib": ["es2022", "dom", "dom.iterable", "webworker"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Bumps `tsconfig.json` `target` from `es2016` to `es2020` to align with Vite's build target (es2020-era browsers)
- Removes the mismatch that caused tsc to reject valid modern syntax (e.g. BigInt literals) even though esbuild handles them correctly for targeted browsers
- No impact on browser compatibility — esbuild (via Vite) controls the final output target, not tsc

Fixes #3944

## Test plan

- [ ] `npm run lint` passes (tsc-lint included)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)