### PR TITLE
refactor(ddg): Convert node content to hooks

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
@@ -9,18 +9,23 @@ vi.mock('./calc-positioning', async () =>
     svcMarginTop: 10,
   }))
 );
-vi.mock('antd', async () => {
-  const actual = await vi.importActual('antd');
-  return {
-    ...actual,
-    Popover: ({ children, content }) => (
-      <>
-        {children}
-        {content}
-      </>
-    ),
-  };
-});
+vi.mock('antd', () => ({
+  Checkbox: ({ checked, className, indeterminate }) => (
+    <input
+      checked={checked}
+      className={className}
+      data-indeterminate={indeterminate}
+      readOnly
+      type="checkbox"
+    />
+  ),
+  Popover: ({ children, content }) => (
+    <>
+      {children}
+      {content}
+    </>
+  ),
+}));
 
 // Mutable object so individual tests can control the location without re-creating the mock.
 const mockLocation = { search: '' };

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
@@ -9,6 +9,18 @@ vi.mock('./calc-positioning', async () =>
     svcMarginTop: 10,
   }))
 );
+vi.mock('antd', async () => {
+  const actual = await vi.importActual('antd');
+  return {
+    ...actual,
+    Popover: ({ children, content }) => (
+      <>
+        {children}
+        {content}
+      </>
+    ),
+  };
+});
 
 // Mutable object so individual tests can control the location without re-creating the mock.
 const mockLocation = { search: '' };
@@ -17,6 +29,17 @@ vi.mock('../../../../model/path-agnostic-decorations', () => mockDefault(jest.fn
 vi.mock('react-router-dom', () => ({
   useLocation: () => mockLocation,
 }));
+vi.mock('../../../common/FilteredList', () =>
+  mockDefault(({ options, setValue }) => (
+    <div>
+      {options.map(option => (
+        <button key={option} type="button" onClick={() => setValue(option)}>
+          {option}
+        </button>
+      ))}
+    </div>
+  ))
+);
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -364,46 +387,24 @@ describe('<DdgNodeContent>', () => {
       expect(tooltip).not.toBeInTheDocument();
     });
 
-    it('handles case when node ref is not available', () => {
-      const instance = new DdgNodeContent(props);
-      instance.nodeRef = { current: null };
+    it('does not check position before the node is hovered', () => {
       mockQuerySelector.mockClear();
 
-      expect(() => {
-        instance.checkTooltipPosition();
-      }).not.toThrow();
+      render(<DdgNodeContent {...props} />);
 
       expect(mockQuerySelector).not.toHaveBeenCalled();
     });
 
-    it('does not update state when tooltip position has not changed', () => {
-      const instance = new DdgNodeContent(props);
-      instance.nodeRef = {
-        current: {
-          getBoundingClientRect: () => ({
-            top: 100,
-            bottom: 200,
-            left: 50,
-            right: 150,
-            width: 100,
-            height: 100,
-          }),
-        },
-      };
+    it('does not recheck position when tooltip position has not changed', () => {
+      const { container } = render(<DdgNodeContent {...props} />);
+      const nodeContent = container.querySelector('.DdgNodeContent');
+      expect(nodeContent).toBeInTheDocument();
 
-      // set initial state directly (not using setState on unmounted component)
-      instance.state = { shouldPositionTooltipBelow: true };
+      fireEvent.mouseOver(nodeContent, { type: 'mouseover' });
+      mockQuerySelector.mockClear();
+      fireEvent.mouseOver(nodeContent, { type: 'mouseover' });
 
-      // Spy on setState
-      const setStateSpy = jest.spyOn(instance, 'setState');
-
-      // call checkTooltipPosition with same conditions that would result in true
-      instance.checkTooltipPosition();
-
-      // setState should not be called since position hasn't changed (still true)
-      expect(setStateSpy).not.toHaveBeenCalled();
-
-      setStateSpy.mockRestore();
+      expect(mockQuerySelector).not.toHaveBeenCalled();
     });
 
     it('does not check position when already determined on subsequent hovers', () => {
@@ -534,9 +535,10 @@ describe('<DdgNodeContent>', () => {
 
     describe('setOperation', () => {
       it('calls setOperation with the provided operation and tracks the event', () => {
-        const instance = new DdgNodeContent(props);
         const newOperation = 'op1';
-        instance.setOperation(newOperation);
+        render(<DdgNodeContent {...props} operation={operationArray} />);
+
+        fireEvent.click(screen.getByText(newOperation));
 
         expect(props.setOperation).toHaveBeenCalledWith(newOperation);
         expect(track.trackVertexSetOperation).toHaveBeenCalled();
@@ -545,8 +547,14 @@ describe('<DdgNodeContent>', () => {
 
     describe('updateChildren', () => {
       it('calls updateGenerationVisibility with vertexKey and Downstream direction', () => {
-        const instance = new DdgNodeContent(props);
-        instance.updateChildren();
+        props.getGenerationVisibility.mockImplementation((_key, direction) =>
+          direction === EDirection.Downstream ? ECheckedStatus.Full : null
+        );
+        const { container } = render(<DdgNodeContent {...props} />);
+        const nodeContent = container.querySelector('.DdgNodeContent');
+
+        fireEvent.mouseOver(nodeContent, { type: 'mouseover' });
+        fireEvent.click(screen.getByText('View Children'));
 
         expect(props.updateGenerationVisibility).toHaveBeenCalledWith(vertexKey, EDirection.Downstream);
       });
@@ -554,8 +562,14 @@ describe('<DdgNodeContent>', () => {
 
     describe('updateParents', () => {
       it('calls updateGenerationVisibility with vertexKey and Upstream direction', () => {
-        const instance = new DdgNodeContent(props);
-        instance.updateParents();
+        props.getGenerationVisibility.mockImplementation((_key, direction) =>
+          direction === EDirection.Upstream ? ECheckedStatus.Full : null
+        );
+        const { container } = render(<DdgNodeContent {...props} />);
+        const nodeContent = container.querySelector('.DdgNodeContent');
+
+        fireEvent.mouseOver(nodeContent, { type: 'mouseover' });
+        fireEvent.click(screen.getByText('View Parents'));
 
         expect(props.updateGenerationVisibility).toHaveBeenCalledWith(vertexKey, EDirection.Upstream);
       });

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx
@@ -395,18 +395,6 @@ describe('<DdgNodeContent>', () => {
       expect(mockQuerySelector).not.toHaveBeenCalled();
     });
 
-    it('does not recheck position when tooltip position has not changed', () => {
-      const { container } = render(<DdgNodeContent {...props} />);
-      const nodeContent = container.querySelector('.DdgNodeContent');
-      expect(nodeContent).toBeInTheDocument();
-
-      fireEvent.mouseOver(nodeContent, { type: 'mouseover' });
-      mockQuerySelector.mockClear();
-      fireEvent.mouseOver(nodeContent, { type: 'mouseover' });
-
-      expect(mockQuerySelector).not.toHaveBeenCalled();
-    });
-
     it('does not check position when already determined on subsequent hovers', () => {
       const { container } = render(<DdgNodeContent {...props} />);
       const nodeContent = container.querySelector('.DdgNodeContent');

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
@@ -351,14 +351,7 @@ export const UnconnectedDdgNodeContent = React.memo(function UnconnectedDdgNodeC
   ];
 
   return (
-    <div
-      ref={nodeRef}
-      className="DdgNodeContent"
-      role="button"
-      tabIndex={0}
-      onMouseOver={onMouseUx}
-      onMouseOut={onMouseUx}
-    >
+    <div ref={nodeRef} className="DdgNodeContent" onMouseOver={onMouseUx} onMouseOut={onMouseUx}>
       {decorationProgressbar}
       <div
         className={cx('DdgNodeContent--core', {
@@ -408,7 +401,7 @@ export const UnconnectedDdgNodeContent = React.memo(function UnconnectedDdgNodeC
   );
 });
 
-export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
+export function mapDispatchToProps(dispatch: Dispatch): TDispatchProps {
   const { getDecoration } = bindActionCreators(padActions, dispatch);
 
   return {
@@ -420,8 +413,8 @@ type DdgNodeContentProps = Omit<TProps, keyof TDispatchProps | keyof TDecoration
 
 function DdgNodeContent(props: DdgNodeContentProps) {
   const { search } = useLocation();
-  const dispatch = useDispatch();
-  const dispatchProps = React.useMemo(() => mapDispatchToProps(dispatch as Dispatch<ReduxState>), [dispatch]);
+  const dispatch = useDispatch<Dispatch>();
+  const dispatchProps = React.useMemo(() => mapDispatchToProps(dispatch), [dispatch]);
   const decorationProps = useSelector(
     (state: ReduxState) =>
       extractDecorationFromState(state, {

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
@@ -138,6 +138,7 @@ export const UnconnectedDdgNodeContent = React.memo(function UnconnectedDdgNodeC
   const hoveredIndices = React.useRef<Set<number>>(new Set());
   const nodeRef = React.useRef<HTMLDivElement | null>(null);
   const prevDecorationID = React.useRef<string | undefined>(undefined);
+  const setViewModifierRef = React.useRef<TProps['setViewModifier']>(() => {});
 
   const {
     decorationID,
@@ -162,6 +163,11 @@ export const UnconnectedDdgNodeContent = React.memo(function UnconnectedDdgNodeC
   } = props;
 
   React.useEffect(() => {
+    setViewModifierRef.current = setViewModifier;
+  }, [setViewModifier]);
+
+  React.useEffect(() => {
+    // Match the former componentDidUpdate behavior: refresh only when decorationID changes.
     if (decorationID && prevDecorationID.current !== decorationID) {
       getDecoration(decorationID, service, typeof operation === 'string' ? operation : undefined);
     }
@@ -171,11 +177,11 @@ export const UnconnectedDdgNodeContent = React.memo(function UnconnectedDdgNodeC
   React.useEffect(
     () => () => {
       if (hoveredIndices.current.size) {
-        setViewModifier(Array.from(hoveredIndices.current), EViewModifier.Hovered, false);
+        setViewModifierRef.current(Array.from(hoveredIndices.current), EViewModifier.Hovered, false);
         hoveredIndices.current.clear();
       }
     },
-    [setViewModifier]
+    []
   );
 
   const checkTooltipPosition = React.useCallback(() => {

--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/index.tsx
@@ -7,7 +7,7 @@ import cx from 'classnames';
 import { useLocation } from 'react-router-dom';
 import { TLayoutVertex } from '@jaegertracing/plexus/lib/types';
 import { IoLocate, IoEyeOff } from 'react-icons/io5';
-import { connect } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
 import calcPositioning from './calc-positioning';
@@ -133,80 +133,94 @@ export function measureNode() {
   };
 }
 
-export class UnconnectedDdgNodeContent extends React.PureComponent<TProps, TState> {
-  state: TState = {};
-  hoveredIndices: Set<number> = new Set();
-  private nodeRef = React.createRef<HTMLDivElement>();
+export const UnconnectedDdgNodeContent = React.memo(function UnconnectedDdgNodeContent(props: TProps) {
+  const [state, setState] = React.useState<TState>({});
+  const hoveredIndices = React.useRef<Set<number>>(new Set());
+  const nodeRef = React.useRef<HTMLDivElement | null>(null);
+  const prevDecorationID = React.useRef<string | undefined>(undefined);
 
-  constructor(props: TProps) {
-    super(props);
+  const {
+    decorationID,
+    decorationProgressbar,
+    decorationValue,
+    focalNodeUrl,
+    focusPathsThroughVertex,
+    getDecoration,
+    getGenerationVisibility,
+    getVisiblePathElems,
+    hideVertex: hideVertexProp,
+    isFocalNode,
+    isPositioned,
+    operation,
+    selectVertex,
+    service,
+    setOperation: setOperationProp,
+    setViewModifier,
+    updateGenerationVisibility,
+    vertex,
+    vertexKey,
+  } = props;
 
-    this.getDecoration();
-  }
-
-  componentDidUpdate(prevProps: TProps) {
-    if (prevProps.decorationID !== this.props.decorationID) this.getDecoration();
-  }
-
-  componentWillUnmount() {
-    if (this.hoveredIndices.size) {
-      this.props.setViewModifier(Array.from(this.hoveredIndices), EViewModifier.Hovered, false);
-      this.hoveredIndices.clear();
-    }
-  }
-
-  private getDecoration() {
-    const { decorationID, getDecoration, operation, service } = this.props;
-
-    if (decorationID) {
+  React.useEffect(() => {
+    if (decorationID && prevDecorationID.current !== decorationID) {
       getDecoration(decorationID, service, typeof operation === 'string' ? operation : undefined);
     }
-  }
+    prevDecorationID.current = decorationID;
+  }, [decorationID, getDecoration, operation, service]);
 
-  private checkTooltipPosition = () => {
-    if (!this.nodeRef.current) return;
+  React.useEffect(
+    () => () => {
+      if (hoveredIndices.current.size) {
+        setViewModifier(Array.from(hoveredIndices.current), EViewModifier.Hovered, false);
+        hoveredIndices.current.clear();
+      }
+    },
+    [setViewModifier]
+  );
+
+  const checkTooltipPosition = React.useCallback(() => {
+    if (!nodeRef.current) return;
     const header = document.querySelector('.DdgHeader--controlHeader');
     if (!header) return;
     const shouldPositionBelow =
-      this.nodeRef.current.getBoundingClientRect().top - 200 < header.getBoundingClientRect().bottom + 20;
-    if (this.state.shouldPositionTooltipBelow !== shouldPositionBelow) {
-      this.setState({ shouldPositionTooltipBelow: shouldPositionBelow });
-    }
-  };
+      nodeRef.current.getBoundingClientRect().top - 200 < header.getBoundingClientRect().bottom + 20;
+    setState(prevState =>
+      prevState.shouldPositionTooltipBelow === shouldPositionBelow
+        ? prevState
+        : { ...prevState, shouldPositionTooltipBelow: shouldPositionBelow }
+    );
+  }, []);
 
-  private focusPaths = () => {
-    const { focusPathsThroughVertex, vertexKey } = this.props;
+  const focusPaths = React.useCallback(() => {
     focusPathsThroughVertex(vertexKey);
-  };
+  }, [focusPathsThroughVertex, vertexKey]);
 
-  private handleClick = () => {
-    const { decorationValue, selectVertex, vertex } = this.props;
+  const handleClick = React.useCallback(() => {
     if (decorationValue) selectVertex(vertex);
-  };
+  }, [decorationValue, selectVertex, vertex]);
 
-  private hideVertex = () => {
-    const { hideVertex, vertexKey } = this.props;
-    hideVertex(vertexKey);
-  };
+  const hideVertex = React.useCallback(() => {
+    hideVertexProp(vertexKey);
+  }, [hideVertexProp, vertexKey]);
 
-  private setOperation = (operation: string) => {
-    trackVertexSetOperation();
-    this.props.setOperation(operation);
-  };
+  const setOperation = React.useCallback(
+    (newOperation: string) => {
+      trackVertexSetOperation();
+      setOperationProp(newOperation);
+    },
+    [setOperationProp]
+  );
 
-  private updateChildren = () => {
-    const { updateGenerationVisibility, vertexKey } = this.props;
+  const updateChildren = React.useCallback(() => {
     updateGenerationVisibility(vertexKey, EDirection.Downstream);
-  };
+  }, [updateGenerationVisibility, vertexKey]);
 
-  private updateParents = () => {
-    const { updateGenerationVisibility, vertexKey } = this.props;
+  const updateParents = React.useCallback(() => {
     updateGenerationVisibility(vertexKey, EDirection.Upstream);
-  };
+  }, [updateGenerationVisibility, vertexKey]);
 
-  private viewTraces = () => {
+  const viewTraces = React.useCallback(() => {
     trackViewTraces();
-    const { vertexKey, getVisiblePathElems } = this.props;
     const elems = getVisiblePathElems(vertexKey);
     if (elems) {
       const urlIds: Set<string> = new Set();
@@ -234,160 +248,159 @@ export class UnconnectedDdgNodeContent extends React.PureComponent<TProps, TStat
       }
       window.open(getSearchUrl({ traceID: Array.from(urlIds) }), '_blank');
     }
-  };
+  }, [getVisiblePathElems, vertexKey]);
 
-  private onMouseUx = (event: React.MouseEvent<HTMLElement>) => {
-    const { getGenerationVisibility, getVisiblePathElems, setViewModifier, vertexKey } = this.props;
-    const hovered = event.type === 'mouseover';
-    const visIndices = hovered
-      ? (getVisiblePathElems(vertexKey) || []).map(({ visibilityIdx }) => {
-          this.hoveredIndices.add(visibilityIdx);
-          return visibilityIdx;
-        })
-      : Array.from(this.hoveredIndices);
-    setViewModifier(visIndices, EViewModifier.Hovered, hovered);
+  const onMouseUx = React.useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      const hovered = event.type === 'mouseover';
+      const visIndices = hovered
+        ? (getVisiblePathElems(vertexKey) || []).map(({ visibilityIdx }) => {
+            hoveredIndices.current.add(visibilityIdx);
+            return visibilityIdx;
+          })
+        : Array.from(hoveredIndices.current);
+      setViewModifier(visIndices, EViewModifier.Hovered, hovered);
 
-    if (hovered) {
-      if (this.state.shouldPositionTooltipBelow === undefined) this.checkTooltipPosition();
-      this.setState({
-        childrenVisibility: getGenerationVisibility(vertexKey, EDirection.Downstream),
-        parentVisibility: getGenerationVisibility(vertexKey, EDirection.Upstream),
-      });
-    } else this.hoveredIndices.clear();
-  };
+      if (hovered) {
+        if (state.shouldPositionTooltipBelow === undefined) checkTooltipPosition();
+        setState(prevState => ({
+          ...prevState,
+          childrenVisibility: getGenerationVisibility(vertexKey, EDirection.Downstream),
+          parentVisibility: getGenerationVisibility(vertexKey, EDirection.Upstream),
+        }));
+      } else hoveredIndices.current.clear();
+    },
+    [
+      checkTooltipPosition,
+      getGenerationVisibility,
+      getVisiblePathElems,
+      setViewModifier,
+      state.shouldPositionTooltipBelow,
+      vertexKey,
+    ]
+  );
 
-  render() {
-    const { childrenVisibility, parentVisibility } = this.state;
-    const {
-      decorationProgressbar,
-      decorationValue,
-      focalNodeUrl,
-      isFocalNode,
-      isPositioned,
-      operation,
-      service,
-    } = this.props;
+  const { childrenVisibility, parentVisibility } = state;
 
-    const { radius, svcWidth, opWidth, svcMarginTop } = calcPositioning(service, operation);
-    const trueRadius = decorationProgressbar ? RADIUS - PROGRESS_BAR_STROKE_WIDTH : RADIUS;
-    const scaleFactor = trueRadius / radius;
-    const transform = `translate(${RADIUS - radius}px, ${RADIUS - radius}px) scale(${scaleFactor})`;
+  const { radius, svcWidth, opWidth, svcMarginTop } = calcPositioning(service, operation);
+  const trueRadius = decorationProgressbar ? RADIUS - PROGRESS_BAR_STROKE_WIDTH : RADIUS;
+  const scaleFactor = trueRadius / radius;
+  const transform = `translate(${RADIUS - radius}px, ${RADIUS - radius}px) scale(${scaleFactor})`;
 
-    const menuItems: IActionMenuItem[] = [
-      {
-        id: 'set-focus',
-        label: 'Set focus',
-        icon: setFocusIcon,
-        href: focalNodeUrl || undefined,
-        onClick: trackSetFocus,
-        isVisible: Boolean(focalNodeUrl),
-      },
-      {
-        id: 'view-traces',
-        label: 'View traces',
-        icon: <NewWindowIcon />,
-        onClick: this.viewTraces,
-      },
-      {
-        id: 'focus-paths',
-        label: 'Focus paths through this node',
-        icon: <IoLocate />,
-        onClick: this.focusPaths,
-        isVisible: !isFocalNode,
-      },
-      {
-        id: 'hide-node',
-        label: 'Hide node',
-        icon: <IoEyeOff />,
-        onClick: this.hideVertex,
-        isVisible: !isFocalNode,
-      },
-      {
-        id: 'view-parents',
-        label: 'View Parents',
-        icon: null,
-        onClick: this.updateParents,
-        isVisible: Boolean(parentVisibility),
-        checkboxProps: parentVisibility
-          ? {
-              checked: parentVisibility === ECheckedStatus.Full,
-              indeterminate: parentVisibility === ECheckedStatus.Partial,
-            }
-          : undefined,
-      },
-      {
-        id: 'view-children',
-        label: 'View Children',
-        icon: null,
-        onClick: this.updateChildren,
-        isVisible: Boolean(childrenVisibility),
-        checkboxProps: childrenVisibility
-          ? {
-              checked: childrenVisibility === ECheckedStatus.Full,
-              indeterminate: childrenVisibility === ECheckedStatus.Partial,
-            }
-          : undefined,
-      },
-    ];
+  const menuItems: IActionMenuItem[] = [
+    {
+      id: 'set-focus',
+      label: 'Set focus',
+      icon: setFocusIcon,
+      href: focalNodeUrl || undefined,
+      onClick: trackSetFocus,
+      isVisible: Boolean(focalNodeUrl),
+    },
+    {
+      id: 'view-traces',
+      label: 'View traces',
+      icon: <NewWindowIcon />,
+      onClick: viewTraces,
+    },
+    {
+      id: 'focus-paths',
+      label: 'Focus paths through this node',
+      icon: <IoLocate />,
+      onClick: focusPaths,
+      isVisible: !isFocalNode,
+    },
+    {
+      id: 'hide-node',
+      label: 'Hide node',
+      icon: <IoEyeOff />,
+      onClick: hideVertex,
+      isVisible: !isFocalNode,
+    },
+    {
+      id: 'view-parents',
+      label: 'View Parents',
+      icon: null,
+      onClick: updateParents,
+      isVisible: Boolean(parentVisibility),
+      checkboxProps: parentVisibility
+        ? {
+            checked: parentVisibility === ECheckedStatus.Full,
+            indeterminate: parentVisibility === ECheckedStatus.Partial,
+          }
+        : undefined,
+    },
+    {
+      id: 'view-children',
+      label: 'View Children',
+      icon: null,
+      onClick: updateChildren,
+      isVisible: Boolean(childrenVisibility),
+      checkboxProps: childrenVisibility
+        ? {
+            checked: childrenVisibility === ECheckedStatus.Full,
+            indeterminate: childrenVisibility === ECheckedStatus.Partial,
+          }
+        : undefined,
+    },
+  ];
 
-    return (
+  return (
+    <div
+      ref={nodeRef}
+      className="DdgNodeContent"
+      role="button"
+      tabIndex={0}
+      onMouseOver={onMouseUx}
+      onMouseOut={onMouseUx}
+    >
+      {decorationProgressbar}
       <div
-        ref={this.nodeRef}
-        className="DdgNodeContent"
+        className={cx('DdgNodeContent--core', {
+          'is-decorated': decorationValue,
+          'is-focalNode': isFocalNode,
+          'is-missingDecoration': typeof decorationValue === 'string',
+          'is-positioned': isPositioned,
+        })}
+        onClick={handleClick}
         role="button"
-        tabIndex={0}
-        onMouseOver={this.onMouseUx}
-        onMouseOut={this.onMouseUx}
+        style={{ width: `${radius * 2}px`, height: `${radius * 2}px`, transform }}
       >
-        {decorationProgressbar}
-        <div
-          className={cx('DdgNodeContent--core', {
-            'is-decorated': decorationValue,
-            'is-focalNode': isFocalNode,
-            'is-missingDecoration': typeof decorationValue === 'string',
-            'is-positioned': isPositioned,
-          })}
-          onClick={this.handleClick}
-          role="button"
-          style={{ width: `${radius * 2}px`, height: `${radius * 2}px`, transform }}
-        >
-          <div className="DdgNodeContent--labelWrapper">
-            <h4
+        <div className="DdgNodeContent--labelWrapper">
+          <h4
+            className="DdgNodeContent--label"
+            style={{ marginTop: `${svcMarginTop}px`, width: `${svcWidth}px` }}
+          >
+            <BreakableText text={service} wordRegexp={WORD_RX} />
+          </h4>
+          {operation && (
+            <div
               className="DdgNodeContent--label"
-              style={{ marginTop: `${svcMarginTop}px`, width: `${svcWidth}px` }}
+              style={{ paddingTop: `${OP_PADDING_TOP}px`, width: `${opWidth}px` }}
             >
-              <BreakableText text={service} wordRegexp={WORD_RX} />
-            </h4>
-            {operation && (
-              <div
-                className="DdgNodeContent--label"
-                style={{ paddingTop: `${OP_PADDING_TOP}px`, width: `${opWidth}px` }}
-              >
-                {Array.isArray(operation) ? (
-                  <Popover
-                    content={<FilteredList options={operation} value={null} setValue={this.setOperation} />}
-                    placement="bottom"
-                    title="Select Operation to Filter Graph"
-                  >
-                    <span>{`${operation.length} Operations`}</span>
-                  </Popover>
-                ) : (
-                  <BreakableText text={operation} wordRegexp={WORD_RX} />
-                )}
-              </div>
-            )}
-          </div>
+              {Array.isArray(operation) ? (
+                <Popover
+                  content={<FilteredList options={operation} value={null} setValue={setOperation} />}
+                  placement="bottom"
+                  title="Select Operation to Filter Graph"
+                >
+                  <span>{`${operation.length} Operations`}</span>
+                </Popover>
+              ) : (
+                <BreakableText text={operation} wordRegexp={WORD_RX} />
+              )}
+            </div>
+          )}
         </div>
-        <ActionsMenu
-          items={menuItems}
-          className={cx('DdgNodeContent--actionsWrapper', {
-            'DdgNodeContent--actionsWrapper-below': this.state.shouldPositionTooltipBelow,
-          })}
-        />
       </div>
-    );
-  }
-}
+      <ActionsMenu
+        items={menuItems}
+        className={cx('DdgNodeContent--actionsWrapper', {
+          'DdgNodeContent--actionsWrapper-below': state.shouldPositionTooltipBelow,
+        })}
+      />
+    </div>
+  );
+});
 
 export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
   const { getDecoration } = bindActionCreators(padActions, dispatch);
@@ -397,17 +410,23 @@ export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchPro
   };
 }
 
-const ConnectedDdgNodeContent = connect(
-  extractDecorationFromState,
-  mapDispatchToProps
-)(UnconnectedDdgNodeContent);
-
-// search is always injected from useLocation(); callers cannot supply it.
-type DdgNodeContentProps = Omit<React.ComponentProps<typeof ConnectedDdgNodeContent>, 'search'>;
+type DdgNodeContentProps = Omit<TProps, keyof TDispatchProps | keyof TDecorationFromState | 'search'>;
 
 function DdgNodeContent(props: DdgNodeContentProps) {
   const { search } = useLocation();
-  return <ConnectedDdgNodeContent {...props} search={search} />;
+  const dispatch = useDispatch();
+  const dispatchProps = React.useMemo(() => mapDispatchToProps(dispatch as Dispatch<ReduxState>), [dispatch]);
+  const decorationProps = useSelector(
+    (state: ReduxState) =>
+      extractDecorationFromState(state, {
+        service: props.service,
+        operation: props.operation,
+        search,
+      }),
+    shallowEqual
+  );
+
+  return <UnconnectedDdgNodeContent {...props} {...dispatchProps} {...decorationProps} />;
 }
 
 export default DdgNodeContent;


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3377

## Description of the changes
- Refactors `DdgNodeContent` from a class component to a functional component using React hooks.
- Replaces `connect` with `useSelector` and `useDispatch`.
- Preserves `PureComponent` behavior with `React.memo`.
- Updates tests that relied on component instances to use DOM/event assertions instead.

## How was this change tested?
- `npm run fmt`
- `npm test -w packages/jaeger-ui -- src/components/DeepDependencies/Graph/DdgNodeContent/index.test.jsx`
- `npm run fmt-lint`
- `npm run tsc-lint`
- `npm run build`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes