### PR TITLE
chore(dev): Expand Vite warmup to include search and root pages

### DIFF
--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -230,9 +230,13 @@ export default defineConfig({
       '/qualitymetrics-v2': proxyConfig,
     },
     warmup: {
-      // Pre-transform TracePage in the background on startup so the first
-      // navigation to a trace doesn't block on cold Vite transforms.
-      clientFiles: ['./src/components/TracePage/index.tsx'],
+      // Pre-transform the two most-visited pages in the background on startup
+      // so cold Vite transforms don't block the first hard refresh.
+      clientFiles: [
+        './src/index.tsx',
+        './src/components/SearchTracePage/index.tsx',
+        './src/components/TracePage/index.tsx',
+      ],
     },
   },
   base: './',

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -230,7 +230,7 @@ export default defineConfig({
       '/qualitymetrics-v2': proxyConfig,
     },
     warmup: {
-      // Pre-transform the two most-visited pages in the background on startup
+      // Pre-transform the most-visited pages in the background on startup
       // so cold Vite transforms don't block the first hard refresh.
       clientFiles: [
         './src/index.tsx',


### PR DESCRIPTION
## Summary

- Adds `./src/index.tsx` and `./src/components/SearchTracePage/index.tsx` to the Vite `warmup.clientFiles` list
- Updates the comment to reflect that all most-visited pages are now pre-transformed

## Test plan

- [x] Dev server starts normally
- [x] No regressions on cold page loads for search and trace pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)