### PR TITLE
feat(utils): Add pooledMap async concurrency utility

### DIFF
--- a/packages/jaeger-ui/src/utils/pooledMap.test.ts
+++ b/packages/jaeger-ui/src/utils/pooledMap.test.ts
@@ -59,15 +59,17 @@ describe('pooledMap', () => {
 
   it('rejects when fn throws and does not start further items', async () => {
     const started: number[] = [];
-    const err = new Error('boom');
+    // Item 1 fails immediately; items 2+ are queued but not yet started.
+    // Item 0 is already in-flight (concurrency=2) and runs to completion.
     const fn = async (x: number) => {
       started.push(x);
-      if (x === 2) throw err;
+      if (x === 1) throw new Error('boom');
       await new Promise(r => setTimeout(r, 10));
       return x;
     };
-    await expect(pooledMap([1, 2, 3, 4, 5], fn, 1)).rejects.toThrow('boom');
-    // With concurrency=1, items are processed sequentially: 1, 2 (throws), 3+ never started
-    expect(started).toEqual([1, 2]);
+    await expect(pooledMap([0, 1, 2, 3, 4], fn, 2)).rejects.toThrow('boom');
+    // Items 0 and 1 are dequeued immediately (concurrency=2).
+    // Item 1 throws, setting aborted=true. Items 2+ are never dequeued.
+    expect(started).toEqual([0, 1]);
   });
 });

--- a/packages/jaeger-ui/src/utils/pooledMap.test.ts
+++ b/packages/jaeger-ui/src/utils/pooledMap.test.ts
@@ -50,4 +50,24 @@ describe('pooledMap', () => {
     await expect(pooledMap([1, 2], async x => x, 0)).rejects.toThrow(RangeError);
     await expect(pooledMap([1, 2], async x => x, -1)).rejects.toThrow(RangeError);
   });
+
+  it('throws RangeError for non-integer concurrency', async () => {
+    await expect(pooledMap([1, 2], async x => x, 1.5)).rejects.toThrow(RangeError);
+    await expect(pooledMap([1, 2], async x => x, NaN)).rejects.toThrow(RangeError);
+    await expect(pooledMap([1, 2], async x => x, Infinity)).rejects.toThrow(RangeError);
+  });
+
+  it('rejects when fn throws and does not start further items', async () => {
+    const started: number[] = [];
+    const err = new Error('boom');
+    const fn = async (x: number) => {
+      started.push(x);
+      if (x === 2) throw err;
+      await new Promise(r => setTimeout(r, 10));
+      return x;
+    };
+    await expect(pooledMap([1, 2, 3, 4, 5], fn, 1)).rejects.toThrow('boom');
+    // With concurrency=1, items are processed sequentially: 1, 2 (throws), 3+ never started
+    expect(started).toEqual([1, 2]);
+  });
 });

--- a/packages/jaeger-ui/src/utils/pooledMap.test.ts
+++ b/packages/jaeger-ui/src/utils/pooledMap.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { pooledMap } from './pooledMap';
+
+describe('pooledMap', () => {
+  it('maps all items and preserves order', async () => {
+    const result = await pooledMap([1, 2, 3], async x => x * 2, 2);
+    expect(result).toEqual([2, 4, 6]);
+  });
+
+  it('respects concurrency limit', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fn = async (x: number) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise(r => setTimeout(r, 0));
+      inFlight--;
+      return x;
+    };
+    await pooledMap([1, 2, 3, 4, 5], fn, 2);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+  });
+
+  it('calls onProgress with correct counts', async () => {
+    const calls: [number, number][] = [];
+    await pooledMap(
+      [1, 2, 3],
+      async x => x,
+      2,
+      (done, total) => calls.push([done, total])
+    );
+    expect(calls).toHaveLength(3);
+    expect(calls[calls.length - 1]).toEqual([3, 3]);
+    calls.forEach(([_done, total]) => expect(total).toBe(3));
+  });
+
+  it('handles empty input', async () => {
+    const result = await pooledMap([], async x => x, 4);
+    expect(result).toEqual([]);
+  });
+
+  it('handles concurrency larger than item count', async () => {
+    const result = await pooledMap([1, 2], async x => x * 3, 100);
+    expect(result).toEqual([3, 6]);
+  });
+
+  it('throws RangeError when concurrency is less than 1', async () => {
+    await expect(pooledMap([1, 2], async x => x, 0)).rejects.toThrow(RangeError);
+    await expect(pooledMap([1, 2], async x => x, -1)).rejects.toThrow(RangeError);
+  });
+});

--- a/packages/jaeger-ui/src/utils/pooledMap.ts
+++ b/packages/jaeger-ui/src/utils/pooledMap.ts
@@ -15,8 +15,8 @@ export async function pooledMap<T, R>(
   if (concurrency < 1) throw new RangeError(`pooledMap: concurrency must be >= 1, got ${concurrency}`);
   const results: R[] = Array.from({ length: items.length }) as R[];
   let done = 0;
-  // Shared iterator: each worker pulls the next (index, item) pair atomically via
-  // the JS engine's native iterator protocol, so no two workers can take the same item.
+  // The shared iterator acts as a work queue: each worker pulls the next item when ready.
+  // Iterator.next() is synchronous, so no two workers can dequeue the same item.
   const entries = items.entries();
   const worker = async () => {
     for (const [index, item] of entries) {

--- a/packages/jaeger-ui/src/utils/pooledMap.ts
+++ b/packages/jaeger-ui/src/utils/pooledMap.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Maps `items` through an async `fn` with at most `concurrency` in-flight at once.
+ * Results are returned in input order. `onProgress` is called after each item completes
+ * with the number of items completed so far and the total count.
+ */
+export async function pooledMap<T, R>(
+  items: readonly T[],
+  fn: (item: T, index: number) => Promise<R>,
+  concurrency: number,
+  onProgress?: (done: number, total: number) => void
+): Promise<R[]> {
+  if (concurrency < 1) throw new RangeError(`pooledMap: concurrency must be >= 1, got ${concurrency}`);
+  const results: R[] = Array.from({ length: items.length }) as R[];
+  let done = 0;
+  // Shared iterator: each worker pulls the next (index, item) pair atomically via
+  // the JS engine's native iterator protocol, so no two workers can take the same item.
+  const entries = items.entries();
+  const worker = async () => {
+    for (const [index, item] of entries) {
+      results[index] = await fn(item, index);
+      onProgress?.(++done, items.length);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}

--- a/packages/jaeger-ui/src/utils/pooledMap.ts
+++ b/packages/jaeger-ui/src/utils/pooledMap.ts
@@ -5,6 +5,7 @@
  * Maps `items` through an async `fn` with at most `concurrency` in-flight at once.
  * Results are returned in input order. `onProgress` is called after each item completes
  * with the number of items completed so far and the total count.
+ * If `fn` rejects, the rejection propagates and no further items are started.
  */
 export async function pooledMap<T, R>(
   items: readonly T[],
@@ -12,18 +13,26 @@ export async function pooledMap<T, R>(
   concurrency: number,
   onProgress?: (done: number, total: number) => void
 ): Promise<R[]> {
-  if (concurrency < 1) throw new RangeError(`pooledMap: concurrency must be >= 1, got ${concurrency}`);
-  const results: R[] = Array.from({ length: items.length }) as R[];
+  if (!Number.isInteger(concurrency) || concurrency < 1)
+    throw new RangeError(`pooledMap: concurrency must be a positive integer, got ${concurrency}`);
+  const results: R[] = Array.from({ length: items.length });
   let done = 0;
+  let aborted = false;
   // The shared iterator acts as a work queue: each worker pulls the next item when ready.
   // Iterator.next() is synchronous, so no two workers can dequeue the same item.
   const entries = items.entries();
   const worker = async () => {
     for (const [index, item] of entries) {
+      if (aborted) return;
       results[index] = await fn(item, index);
       onProgress?.(++done, items.length);
     }
   };
-  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  try {
+    await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  } catch (err) {
+    aborted = true;
+    throw err;
+  }
   return results;
 }

--- a/packages/jaeger-ui/src/utils/pooledMap.ts
+++ b/packages/jaeger-ui/src/utils/pooledMap.ts
@@ -5,7 +5,8 @@
  * Maps `items` through an async `fn` with at most `concurrency` in-flight at once.
  * Results are returned in input order. `onProgress` is called after each item completes
  * with the number of items completed so far and the total count.
- * If `fn` rejects, the rejection propagates and no further items are started.
+ * If `fn` rejects, the rejection propagates. Already in-flight items run to completion,
+ * but no further items are dequeued.
  */
 export async function pooledMap<T, R>(
   items: readonly T[],
@@ -24,15 +25,15 @@ export async function pooledMap<T, R>(
   const worker = async () => {
     for (const [index, item] of entries) {
       if (aborted) return;
-      results[index] = await fn(item, index);
-      onProgress?.(++done, items.length);
+      try {
+        results[index] = await fn(item, index);
+        onProgress?.(++done, items.length);
+      } catch (err) {
+        aborted = true;
+        throw err;
+      }
     }
   };
-  try {
-    await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
-  } catch (err) {
-    aborted = true;
-    throw err;
-  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
   return results;
 }


### PR DESCRIPTION
## Summary

- Adds `src/utils/pooledMap.ts`: a generic async utility that maps items through an async function with a bounded concurrency limit, preserving result order
- Adds `src/utils/pooledMap.test.ts` with 6 tests covering order preservation, concurrency limiting, progress callbacks, empty input, and error cases

## Test plan

- [x] All 6 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)