### PR TITLE
Added genaiPartialtestTrace.json and the genaiTesttrace.json #8490

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/genaiPartialTestTrace.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/genaiPartialTestTrace.json
@@ -1,0 +1,124 @@
+{
+  "data": {
+    "services": [
+      {
+        "name": "partial-genai-service",
+        "numberOfSpans": 2
+      }
+    ],
+    "spans": [
+      {
+        "traceID": "partial-genai-trace-00000001",
+        "spanID": "b1b2b3b4b5b6b7b8",
+        "flags": 1,
+        "operationName": "partial-agent-run",
+        "references": [],
+        "startTime": 1660049722779884,
+        "duration": 800000,
+        "tags": [
+          {
+            "key": "gen_ai.system",
+            "type": "string",
+            "value": "openai"
+          },
+          {
+            "key": "internal.span.format",
+            "type": "string",
+            "value": "jaeger"
+          }
+        ],
+        "logs": [],
+        "processID": "p1",
+        "warnings": [],
+        "process": {
+          "serviceName": "partial-genai-service",
+          "tags": []
+        },
+        "relativeStartTime": 0,
+        "depth": 0,
+        "hasChildren": true
+      },
+      {
+        "traceID": "partial-genai-trace-00000001",
+        "spanID": "c2c3c4c5c6c7c8c9",
+        "flags": 1,
+        "operationName": "partial-llm",
+        "references": [
+          {
+            "refType": "CHILD_OF",
+            "traceID": "partial-genai-trace-00000001",
+            "spanID": "b1b2b3b4b5b6b7b8",
+            "span": {
+              "traceID": "partial-genai-trace-00000001",
+              "spanID": "b1b2b3b4b5b6b7b8",
+              "flags": 1,
+              "operationName": "partial-agent-run",
+              "references": [],
+              "startTime": 1660049722779884,
+              "duration": 800000,
+              "tags": [
+                {
+                  "key": "gen_ai.system",
+                  "type": "string",
+                  "value": "openai"
+                },
+                {
+                  "key": "internal.span.format",
+                  "type": "string",
+                  "value": "jaeger"
+                }
+              ],
+              "logs": [],
+              "processID": "p1",
+              "warnings": [],
+              "process": {
+                "serviceName": "partial-genai-service",
+                "tags": []
+              },
+              "relativeStartTime": 0,
+              "depth": 0,
+              "hasChildren": true
+            }
+          }
+        ],
+        "startTime": 1660049722879884,
+        "duration": 500000,
+        "tags": [
+          {
+            "key": "gen_ai.operation.name",
+            "type": "string",
+            "value": "chat"
+          },
+          {
+            "key": "internal.span.format",
+            "type": "string",
+            "value": "jaeger"
+          }
+        ],
+        "logs": [],
+        "processID": "p1",
+        "warnings": [],
+        "process": {
+          "serviceName": "partial-genai-service",
+          "tags": []
+        },
+        "relativeStartTime": 100000,
+        "depth": 1,
+        "hasChildren": false
+      }
+    ],
+    "traceID": "partial-genai-trace-00000001",
+    "traceName": "partial-genai-service: partial-agent-run",
+    "processes": {
+      "p1": {
+        "serviceName": "partial-genai-service",
+        "tags": []
+      }
+    },
+    "duration": 800000,
+    "startTime": 1660049722779884,
+    "endTime": 1660049723579884
+  },
+  "id": "partial-genai-trace-00000001",
+  "state": "FETCH_DONE"
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/genaiTestTrace.json
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/genaiTestTrace.json
@@ -1,0 +1,124 @@
+{
+  "data": {
+    "services": [
+      {
+        "name": "partial-genai-service",
+        "numberOfSpans": 2
+      }
+    ],
+    "spans": [
+      {
+        "traceID": "partial-genai-trace-00000001",
+        "spanID": "b1b2b3b4b5b6b7b8",
+        "flags": 1,
+        "operationName": "partial-agent-run",
+        "references": [],
+        "startTime": 1660049722779884,
+        "duration": 800000,
+        "tags": [
+          {
+            "key": "gen_ai.system",
+            "type": "string",
+            "value": "openai"
+          },
+          {
+            "key": "internal.span.format",
+            "type": "string",
+            "value": "jaeger"
+          }
+        ],
+        "logs": [],
+        "processID": "p1",
+        "warnings": [],
+        "process": {
+          "serviceName": "partial-genai-service",
+          "tags": []
+        },
+        "relativeStartTime": 0,
+        "depth": 0,
+        "hasChildren": true
+      },
+      {
+        "traceID": "partial-genai-trace-00000001",
+        "spanID": "c2c3c4c5c6c7c8c9",
+        "flags": 1,
+        "operationName": "partial-llm",
+        "references": [
+          {
+            "refType": "CHILD_OF",
+            "traceID": "partial-genai-trace-00000001",
+            "spanID": "b1b2b3b4b5b6b7b8",
+            "span": {
+              "traceID": "partial-genai-trace-00000001",
+              "spanID": "b1b2b3b4b5b6b7b8",
+              "flags": 1,
+              "operationName": "partial-agent-run",
+              "references": [],
+              "startTime": 1660049722779884,
+              "duration": 800000,
+              "tags": [
+                {
+                  "key": "gen_ai.system",
+                  "type": "string",
+                  "value": "openai"
+                },
+                {
+                  "key": "internal.span.format",
+                  "type": "string",
+                  "value": "jaeger"
+                }
+              ],
+              "logs": [],
+              "processID": "p1",
+              "warnings": [],
+              "process": {
+                "serviceName": "partial-genai-service",
+                "tags": []
+              },
+              "relativeStartTime": 0,
+              "depth": 0,
+              "hasChildren": true
+            }
+          }
+        ],
+        "startTime": 1660049722879884,
+        "duration": 500000,
+        "tags": [
+          {
+            "key": "gen_ai.operation.name",
+            "type": "string",
+            "value": "chat"
+          },
+          {
+            "key": "internal.span.format",
+            "type": "string",
+            "value": "jaeger"
+          }
+        ],
+        "logs": [],
+        "processID": "p1",
+        "warnings": [],
+        "process": {
+          "serviceName": "partial-genai-service",
+          "tags": []
+        },
+        "relativeStartTime": 100000,
+        "depth": 1,
+        "hasChildren": false
+      }
+    ],
+    "traceID": "partial-genai-trace-00000001",
+    "traceName": "partial-genai-service: partial-agent-run",
+    "processes": {
+      "p1": {
+        "serviceName": "partial-genai-service",
+        "tags": []
+      }
+    },
+    "duration": 800000,
+    "startTime": 1660049722779884,
+    "endTime": 1660049723579884
+  },
+  "id": "partial-genai-trace-00000001",
+  "state": "FETCH_DONE"
+}


### PR DESCRIPTION
Closes jaegertracing/jaeger#8490

## Which problem is this PR solving?
 feat(genai): add canonical GenAI trace fixture for testing GenAI observability deliverables #8490

## Description of the changes
- Added genaiTestTrace.json and genaiPartialTestTrace.json fixtures for testing GenAI observability workflows in Jaeger UI.
-Added GenAI spans including invoke_agent, chat, http.client, and execute_tool.
-Added GenAI semantic convention tags for AI trace visualization and logical view testing.

## How was this change tested?
- Verified JSON structure and trace hierarchy manually.
-Tested parent-child span relationships for GenAI traces.
-Validated GenAI semantic tags and trace rendering behavior locally.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
