### PR TITLE
refactor(ui): Share time range options

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { MonitorATMServicesViewImpl as MonitorATMServicesView, mapStateToProps, mapDispatchToProps } from '.';
-import { getLoopbackInterval, yAxisTickFormat } from './timeFrameUtils';
+import { getLoopbackInterval, timeFrameOptions, yAxisTickFormat } from './timeFrameUtils';
 import { useServices } from '../../../hooks/useTraceDiscovery';
 import {
   originInitialState,
@@ -803,6 +803,23 @@ describe('getLoopbackInterval()', () => {
 
   it('timeframe exists', () => {
     expect(getLoopbackInterval(48 * 3600000)).toBe('last 2 days');
+  });
+});
+
+describe('timeFrameOptions', () => {
+  it('includes shared search time ranges through 2 days', () => {
+    expect(timeFrameOptions.map(({ value }) => value)).toEqual([
+      5 * 60_000,
+      15 * 60_000,
+      30 * 60_000,
+      3600000,
+      2 * 3600000,
+      3 * 3600000,
+      6 * 3600000,
+      12 * 3600000,
+      24 * 3600000,
+      48 * 3600000,
+    ]);
   });
 });
 

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom';
 import { MonitorATMServicesViewImpl as MonitorATMServicesView, mapStateToProps, mapDispatchToProps } from '.';
 import { getLoopbackInterval, timeFrameOptions, yAxisTickFormat } from './timeFrameUtils';
 import { useServices } from '../../../hooks/useTraceDiscovery';
+import { ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
 import {
   originInitialState,
   serviceMetrics,
@@ -808,18 +809,12 @@ describe('getLoopbackInterval()', () => {
 
 describe('timeFrameOptions', () => {
   it('includes shared search time ranges through 2 days', () => {
-    expect(timeFrameOptions.map(({ value }) => value)).toEqual([
-      5 * 60_000,
-      15 * 60_000,
-      30 * 60_000,
-      3600000,
-      2 * 3600000,
-      3 * 3600000,
-      6 * 3600000,
-      12 * 3600000,
-      24 * 3600000,
-      48 * 3600000,
-    ]);
+    const maxMonitorTimeframe = 48 * ONE_HOUR_MS;
+    const expectedValues = TIME_RANGE_OPTIONS.filter(({ valueMs }) => valueMs <= maxMonitorTimeframe).map(
+      ({ valueMs }) => valueMs
+    );
+
+    expect(timeFrameOptions.map(({ value }) => value)).toEqual(expectedValues);
   });
 });
 

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ONE_HOUR_MS as SHARED_ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
+import { ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
 import { convertToTimeUnit } from '../../../utils/date';
 
-export const ONE_HOUR_MS = SHARED_ONE_HOUR_MS;
+export { ONE_HOUR_MS };
 const MAX_MONITOR_TIMEFRAME = 48 * ONE_HOUR_MS;
 
 const formatMonitorLabel = (label: string, valueMs: number) =>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
@@ -1,22 +1,23 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ONE_HOUR_MS as SHARED_ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
 import { convertToTimeUnit } from '../../../utils/date';
 
-export const ONE_HOUR_MS = 3600000;
-const ONE_MINUTE_MS = 60_000;
+export const ONE_HOUR_MS = SHARED_ONE_HOUR_MS;
+const MAX_MONITOR_TIMEFRAME = 48 * ONE_HOUR_MS;
 
-export const timeFrameOptions = [
-  { label: 'Last 5 minutes', value: 5 * ONE_MINUTE_MS },
-  { label: 'Last 15 minutes', value: 15 * ONE_MINUTE_MS },
-  { label: 'Last 30 minutes', value: 30 * ONE_MINUTE_MS },
-  { label: 'Last Hour', value: ONE_HOUR_MS },
-  { label: 'Last 2 hours', value: 2 * ONE_HOUR_MS },
-  { label: 'Last 6 hours', value: 6 * ONE_HOUR_MS },
-  { label: 'Last 12 hours', value: 12 * ONE_HOUR_MS },
-  { label: 'Last 24 hours', value: 24 * ONE_HOUR_MS },
-  { label: 'Last 2 days', value: 48 * ONE_HOUR_MS },
-];
+const formatMonitorLabel = (label: string) =>
+  label === 'Hour'
+    ? 'Last Hour'
+    : `Last ${label.replace(/\b(Minutes|Hours|Days|Weeks)\b$/, word => word.toLowerCase())}`;
+
+export const timeFrameOptions = TIME_RANGE_OPTIONS.filter(
+  ({ valueMs }) => valueMs <= MAX_MONITOR_TIMEFRAME
+).map(({ label, valueMs }) => ({
+  label: formatMonitorLabel(label),
+  value: valueMs,
+}));
 
 export const getLoopbackInterval = (interval?: number) => {
   if (interval === undefined) return '';

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
@@ -7,15 +7,15 @@ import { convertToTimeUnit } from '../../../utils/date';
 export const ONE_HOUR_MS = SHARED_ONE_HOUR_MS;
 const MAX_MONITOR_TIMEFRAME = 48 * ONE_HOUR_MS;
 
-const formatMonitorLabel = (label: string) =>
-  label === 'Hour'
+const formatMonitorLabel = (label: string, valueMs: number) =>
+  valueMs === ONE_HOUR_MS
     ? 'Last Hour'
     : `Last ${label.replace(/\b(Minutes|Hours|Days|Weeks)\b$/, word => word.toLowerCase())}`;
 
 export const timeFrameOptions = TIME_RANGE_OPTIONS.filter(
   ({ valueMs }) => valueMs <= MAX_MONITOR_TIMEFRAME
 ).map(({ label, valueMs }) => ({
-  label: formatMonitorLabel(label),
+  label: formatMonitorLabel(label, valueMs),
   value: valueMs,
 }));
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -203,6 +203,14 @@ describe('lookback utils', () => {
         }
       });
     });
+
+    it('falls back to default lookback for unsupported units', () => {
+      expect(nowInMicroseconds - lookbackToTimestamp('99x', now)).toBe(hourInMicroseconds);
+    });
+
+    it('falls back to default lookback for invalid amounts', () => {
+      expect(nowInMicroseconds - lookbackToTimestamp('xh', now)).toBe(hourInMicroseconds);
+    });
   });
 
   describe('applyAdjustTime', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -5,7 +5,7 @@ import React, { useState, useCallback, useMemo, ComponentProps } from 'react';
 import { Input, Button, Tooltip, Select, Row, Col, Form, Switch } from 'antd';
 import logfmtParser from 'logfmt/lib/logfmt_parser';
 import { stringify as logfmtStringify } from 'logfmt/lib/stringify';
-import dayjs from 'dayjs';
+import dayjs, { ManipulateType } from 'dayjs';
 import memoizeOne from 'memoize-one';
 import queryString from 'query-string';
 import { IoHelp } from 'react-icons/io5';
@@ -29,11 +29,19 @@ import { useConfig } from '../../hooks/useConfig';
 import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { ReduxState } from '../../types';
 import { SearchQuery } from '../../types/search';
+import { TIME_RANGE_OPTIONS } from '../../constants/time-range-options';
 
 const FormItem = Form.Item;
 const Option = Select.Option;
 
 const ADJUST_TIME_ENABLED_KEY = 'jaeger-ui/search-adjust-time-enabled';
+const LOOKBACK_UNIT_BY_SUFFIX: Record<string, ManipulateType> = {
+  s: 'second',
+  m: 'minute',
+  h: 'hour',
+  d: 'day',
+  w: 'week',
+};
 
 interface TimeStampParams {
   startDate: string;
@@ -78,7 +86,10 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
 }
 
 export function lookbackToTimestamp(lookback: string, from: Date | number): number {
-  const unit = lookback.substr(-1) as any; // dayjs ManipulateType
+  const unit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
+  if (!unit) {
+    throw new Error(`Unsupported lookback unit: ${lookback}`);
+  }
   return dayjs(from).subtract(parseInt(lookback, 10), unit).valueOf() * 1000;
 }
 
@@ -87,72 +98,10 @@ interface ILookbackOption {
   value: string;
 }
 
-const lookbackOptions: ILookbackOption[] = [
-  {
-    label: '5 Minutes',
-    value: '5m',
-  },
-  {
-    label: '15 Minutes',
-    value: '15m',
-  },
-  {
-    label: '30 Minutes',
-    value: '30m',
-  },
-  {
-    label: 'Hour',
-    value: '1h',
-  },
-  {
-    label: '2 Hours',
-    value: '2h',
-  },
-  {
-    label: '3 Hours',
-    value: '3h',
-  },
-  {
-    label: '6 Hours',
-    value: '6h',
-  },
-  {
-    label: '12 Hours',
-    value: '12h',
-  },
-  {
-    label: '24 Hours',
-    value: '24h',
-  },
-  {
-    label: '2 Days',
-    value: '2d',
-  },
-  {
-    label: '3 Days',
-    value: '3d',
-  },
-  {
-    label: '5 Days',
-    value: '5d',
-  },
-  {
-    label: '7 Days',
-    value: '7d',
-  },
-  {
-    label: '2 Weeks',
-    value: '2w',
-  },
-  {
-    label: '3 Weeks',
-    value: '3w',
-  },
-  {
-    label: '4 Weeks',
-    value: '4w',
-  },
-];
+const lookbackOptions: ILookbackOption[] = TIME_RANGE_OPTIONS.map(({ label, lookback }) => ({
+  label,
+  value: lookback,
+}));
 
 export const optionsWithinMaxLookback = memoizeOne((maxLookback: ILookbackOption) => {
   const now = new Date();

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -42,6 +42,8 @@ const LOOKBACK_UNIT_BY_SUFFIX: Record<string, ManipulateType> = {
   d: 'day',
   w: 'week',
 };
+const DEFAULT_LOOKBACK_VALUE = parseInt(DEFAULT_LOOKBACK, 10);
+const DEFAULT_LOOKBACK_UNIT = LOOKBACK_UNIT_BY_SUFFIX[DEFAULT_LOOKBACK.slice(-1)] ?? 'hour';
 
 interface TimeStampParams {
   startDate: string;
@@ -86,11 +88,11 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
 }
 
 export function lookbackToTimestamp(lookback: string, from: Date | number): number {
-  const unit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
-  if (!unit) {
-    throw new Error(`Unsupported lookback unit: ${lookback}`);
-  }
-  return dayjs(from).subtract(parseInt(lookback, 10), unit).valueOf() * 1000;
+  const parsedValue = parseInt(lookback, 10);
+  const parsedUnit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
+  const value = parsedUnit && !Number.isNaN(parsedValue) ? parsedValue : DEFAULT_LOOKBACK_VALUE;
+  const unit = parsedUnit ?? DEFAULT_LOOKBACK_UNIT;
+  return dayjs(from).subtract(value, unit).valueOf() * 1000;
 }
 
 interface ILookbackOption {

--- a/packages/jaeger-ui/src/constants/time-range-options.test.ts
+++ b/packages/jaeger-ui/src/constants/time-range-options.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ONE_HOUR_MS, TIME_RANGE_OPTIONS } from './time-range-options';
+
+describe('TIME_RANGE_OPTIONS', () => {
+  it('keeps lookback values and millisecond values aligned', () => {
+    const unitMs = {
+      m: 60_000,
+      h: ONE_HOUR_MS,
+      d: 24 * ONE_HOUR_MS,
+      w: 7 * 24 * ONE_HOUR_MS,
+    };
+
+    TIME_RANGE_OPTIONS.forEach(({ lookback, valueMs }) => {
+      const match = lookback.match(/^(\d+)([mhdw])$/);
+      expect(match).not.toBeNull();
+
+      const [, amount, unit] = match!;
+      expect(valueMs).toBe(Number(amount) * unitMs[unit as keyof typeof unitMs]);
+    });
+  });
+
+  it('lists options from shortest to longest', () => {
+    const values = TIME_RANGE_OPTIONS.map(({ valueMs }) => valueMs);
+    const sortedValues = [...values].sort((a, b) => a - b);
+
+    expect(values).toEqual(sortedValues);
+  });
+});

--- a/packages/jaeger-ui/src/constants/time-range-options.ts
+++ b/packages/jaeger-ui/src/constants/time-range-options.ts
@@ -3,14 +3,16 @@
 
 const ONE_MINUTE_MS = 60_000;
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+const ONE_WEEK_MS = 7 * ONE_DAY_MS;
 
 export interface ITimeRangeOption {
-  label: string;
-  lookback: string;
-  valueMs: number;
+  readonly label: string;
+  readonly lookback: string;
+  readonly valueMs: number;
 }
 
-export const TIME_RANGE_OPTIONS: ITimeRangeOption[] = [
+export const TIME_RANGE_OPTIONS: readonly ITimeRangeOption[] = Object.freeze([
   {
     label: '5 Minutes',
     lookback: '5m',
@@ -59,36 +61,36 @@ export const TIME_RANGE_OPTIONS: ITimeRangeOption[] = [
   {
     label: '2 Days',
     lookback: '2d',
-    valueMs: 48 * ONE_HOUR_MS,
+    valueMs: 2 * ONE_DAY_MS,
   },
   {
     label: '3 Days',
     lookback: '3d',
-    valueMs: 72 * ONE_HOUR_MS,
+    valueMs: 3 * ONE_DAY_MS,
   },
   {
     label: '5 Days',
     lookback: '5d',
-    valueMs: 120 * ONE_HOUR_MS,
+    valueMs: 5 * ONE_DAY_MS,
   },
   {
     label: '7 Days',
     lookback: '7d',
-    valueMs: 168 * ONE_HOUR_MS,
+    valueMs: 7 * ONE_DAY_MS,
   },
   {
     label: '2 Weeks',
     lookback: '2w',
-    valueMs: 14 * 24 * ONE_HOUR_MS,
+    valueMs: 2 * ONE_WEEK_MS,
   },
   {
     label: '3 Weeks',
     lookback: '3w',
-    valueMs: 21 * 24 * ONE_HOUR_MS,
+    valueMs: 3 * ONE_WEEK_MS,
   },
   {
     label: '4 Weeks',
     lookback: '4w',
-    valueMs: 28 * 24 * ONE_HOUR_MS,
+    valueMs: 4 * ONE_WEEK_MS,
   },
-];
+]);

--- a/packages/jaeger-ui/src/constants/time-range-options.ts
+++ b/packages/jaeger-ui/src/constants/time-range-options.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+const ONE_MINUTE_MS = 60_000;
+export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+
+export interface ITimeRangeOption {
+  label: string;
+  lookback: string;
+  valueMs: number;
+}
+
+export const TIME_RANGE_OPTIONS: ITimeRangeOption[] = [
+  {
+    label: '5 Minutes',
+    lookback: '5m',
+    valueMs: 5 * ONE_MINUTE_MS,
+  },
+  {
+    label: '15 Minutes',
+    lookback: '15m',
+    valueMs: 15 * ONE_MINUTE_MS,
+  },
+  {
+    label: '30 Minutes',
+    lookback: '30m',
+    valueMs: 30 * ONE_MINUTE_MS,
+  },
+  {
+    label: 'Hour',
+    lookback: '1h',
+    valueMs: ONE_HOUR_MS,
+  },
+  {
+    label: '2 Hours',
+    lookback: '2h',
+    valueMs: 2 * ONE_HOUR_MS,
+  },
+  {
+    label: '3 Hours',
+    lookback: '3h',
+    valueMs: 3 * ONE_HOUR_MS,
+  },
+  {
+    label: '6 Hours',
+    lookback: '6h',
+    valueMs: 6 * ONE_HOUR_MS,
+  },
+  {
+    label: '12 Hours',
+    lookback: '12h',
+    valueMs: 12 * ONE_HOUR_MS,
+  },
+  {
+    label: '24 Hours',
+    lookback: '24h',
+    valueMs: 24 * ONE_HOUR_MS,
+  },
+  {
+    label: '2 Days',
+    lookback: '2d',
+    valueMs: 48 * ONE_HOUR_MS,
+  },
+  {
+    label: '3 Days',
+    lookback: '3d',
+    valueMs: 72 * ONE_HOUR_MS,
+  },
+  {
+    label: '5 Days',
+    lookback: '5d',
+    valueMs: 120 * ONE_HOUR_MS,
+  },
+  {
+    label: '7 Days',
+    lookback: '7d',
+    valueMs: 168 * ONE_HOUR_MS,
+  },
+  {
+    label: '2 Weeks',
+    lookback: '2w',
+    valueMs: 14 * 24 * ONE_HOUR_MS,
+  },
+  {
+    label: '3 Weeks',
+    lookback: '3w',
+    valueMs: 21 * 24 * ONE_HOUR_MS,
+  },
+  {
+    label: '4 Weeks',
+    lookback: '4w',
+    valueMs: 28 * 24 * ONE_HOUR_MS,
+  },
+];


### PR DESCRIPTION
Fixes #3954.

This pulls the trace search lookback list and the Monitor services timeframe list from the same source of truth.

I kept Monitor's current 2-day ceiling instead of widening it to every longer search range. The only visible Monitor addition should be `3 hours`, which was already in Search and naturally falls inside that 2-day window.

What changed:
- Added a shared `TIME_RANGE_OPTIONS` list with both Search lookback values and millisecond values.
- Made `SearchForm` derive its lookback options from that shared list.
- Made Monitor derive its timeframe options from the same list while keeping the existing label style and 2-day cap.
- Added a regression test for the Monitor-derived option values, so this does not drift again quietly.

Checks I ran:
- `npm test`
- `npm run tsc-lint`
- `npm run build -w packages/plexus`
- `npx vite build` from `packages/jaeger-ui` with production env vars set in PowerShell
- `npx vp lint` on the changed files
- `npx vp fmt --check` on the changed files
- `scripts/check-license.sh`
- `scripts/check-copyright-year.sh`
- `scripts/check-tsx-naming.sh`
- `scripts/check-overrides.sh`