### PR TITLE
Fix/infinite loader

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -27,10 +27,10 @@ export class JaegerClient {
     // Parse once. Jaeger v3 may return 200 OK with an errors array in the body.
     const data = await response.json();
 
-    if (data?.errors?.length > 0) {
+    if (data?.errors && Array.isArray(data.errors) && data.errors.length > 0) {
       // Aggregate all error messages so no detail is lost
-      const messages = data.errors.map((e: any) => e.msg).join(', ');
-      throw new Error(`[fetchServices] ${messages}`);
+      const messages = data.errors.map((e: { msg: string }) => e.msg).join(', ');
+      throw new Error(`Failed to fetch services: ${messages}`);
     }
 
     const validated = ServicesResponseSchema.parse(data);
@@ -47,18 +47,15 @@ export class JaegerClient {
       `${this.apiRoot}/operations?service=${encodeURIComponent(service)}`
     );
 
-    // In your current code, it only throws if !response.ok
-    // But we need to check the JSON body for "hidden" errors
+    // Jaeger v3 may return HTTP 200 with an 'errors' array in the response body; treat that as a failure.
     const data = await response.json();
 
-    // ADD THIS: The "Melonps" logic to handle 200 OK with error bodies
-    if (data?.errors?.length > 0) {
+    if (data?.errors && Array.isArray(data.errors) && data.errors.length > 0) {
       // Aggregate all error messages for this specific service
-      const messages = data.errors.map((e: any) => e.msg).join(', ');
-      throw new Error(`[fetchSpanNames] Failed for "${service}": ${messages}`);
+      const messages = data.errors.map((e: { msg: string }) => e.msg).join(', ');
+      throw new Error(`Failed to fetch span names for service "${service}": ${messages}`);
     }
 
-    // Runtime validation with Zod
     const validated = OperationsResponseSchema.parse(data);
     return validated.operations;
   }
@@ -137,16 +134,16 @@ export class JaegerClient {
       if (!response.ok) {
         let errorDetail = response.statusText;
         try {
-          // Attempt to extract the specific backend error (e.g., "trace not found")
           const errorBody = await response.json();
-          if (errorBody?.errors?.length > 0) {
+          // Safely check if errors is an array before mapping
+          if (errorBody?.errors && Array.isArray(errorBody.errors) && errorBody.errors.length > 0) {
             errorDetail = errorBody.errors.map((e: any) => e.msg).join(', ');
           }
         } catch {
-          // If the body isn't JSON, we just use the default statusText
+          /* Fallback to statusText if body isn't JSON */
         }
 
-        throw new Error(`HTTP ${response.status}: ${errorDetail}`);
+        throw new Error(`${response.status} ${errorDetail}`);
       }
 
       return response;

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -23,12 +23,16 @@ export class JaegerClient {
    */
   async fetchServices(): Promise<string[]> {
     const response = await this.fetchWithTimeout(`${this.apiRoot}/services`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch services: ${response.status} ${response.statusText}`);
-    }
+
+    // Parse once. Jaeger v3 may return 200 OK with an errors array in the body.
     const data = await response.json();
 
-    // Runtime validation with Zod
+    if (data?.errors?.length > 0) {
+      // Aggregate all error messages so no detail is lost
+      const messages = data.errors.map((e: any) => e.msg).join(', ');
+      throw new Error(`[fetchServices] ${messages}`);
+    }
+
     const validated = ServicesResponseSchema.parse(data);
     return validated.services;
   }
@@ -42,12 +46,17 @@ export class JaegerClient {
     const response = await this.fetchWithTimeout(
       `${this.apiRoot}/operations?service=${encodeURIComponent(service)}`
     );
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch span names for service "${service}": ${response.status} ${response.statusText}`
-      );
-    }
+
+    // In your current code, it only throws if !response.ok
+    // But we need to check the JSON body for "hidden" errors
     const data = await response.json();
+
+    // ADD THIS: The "Melonps" logic to handle 200 OK with error bodies
+    if (data?.errors?.length > 0) {
+      // Aggregate all error messages for this specific service
+      const messages = data.errors.map((e: any) => e.msg).join(', ');
+      throw new Error(`[fetchSpanNames] Failed for "${service}": ${messages}`);
+    }
 
     // Runtime validation with Zod
     const validated = OperationsResponseSchema.parse(data);
@@ -124,6 +133,22 @@ export class JaegerClient {
 
     try {
       const response = await fetch(url, { signal: controller.signal });
+
+      if (!response.ok) {
+        let errorDetail = response.statusText;
+        try {
+          // Attempt to extract the specific backend error (e.g., "trace not found")
+          const errorBody = await response.json();
+          if (errorBody?.errors?.length > 0) {
+            errorDetail = errorBody.errors.map((e: any) => e.msg).join(', ');
+          }
+        } catch {
+          // If the body isn't JSON, we just use the default statusText
+        }
+
+        throw new Error(`HTTP ${response.status}: ${errorDetail}`);
+      }
+
       return response;
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3079

## Description of the changes
This PR resolves the infinite loading state observed when the Jaeger v3 API returns an error (both 4xx/5xx and 200 OK with an error body).

**Changes:**
- Modified fetchWithTimeout to explicitly throw an Error when !response.ok, ensuring React Query transitions to an error state
- Implemented internal error checking in fetchServices and fetchSpanNames to catch "hidden" errors in the JSON body (closing the blind spot identified in #3161)
- Added proper error context and stack trace preservation
- Verified: Confirmed with a 404 response for non-existent Trace IDs (now displays error UI instead of spinning)

## How was this change tested?
- Manual testing with 404 responses for non-existent Trace IDs
- Verified error UI displays correctly instead of infinite loading spinner
- Tested with various API error scenarios (4xx, 5xx, 200 with errors array)

## Checklist
- [x] I have read the contributing guidelines
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully

## AI Usage in this PR
- [x] **Moderate**: AI (Copilot) helped with code review and error handling improvements