### PR TITLE
feat(trace): Add span type icons

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -194,6 +194,13 @@ SPDX-License-Identifier: Apache-2.0
   /* Adjust padding since border adds 1.5px */
 }
 
+.SpanBarRow--spanTypeIcon {
+  color: var(--text-secondary);
+  font-size: 0.95em;
+  margin-right: 0.25rem;
+  vertical-align: -0.125em;
+}
+
 .SpanBarRow--rpcColorMarker {
   border-radius: 6.5px;
   display: inline-block;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom';
 
 import SpanBarRow from './SpanBarRow';
 import SpanBar from './SpanBar';
+import { SpanKind } from '../../../types/otel';
 
 vi.mock('./SpanTreeOffset', () => ({
   default: jest.fn(({ span, childrenVisible, onClick }) => (
@@ -215,7 +216,7 @@ describe('<SpanBarRow>', () => {
     const span = {
       ...defaultProps.span,
       attributes: [],
-      kind: 'INTERNAL',
+      kind: SpanKind.INTERNAL,
     };
 
     render(<SpanBarRow {...defaultProps} span={span} />);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -201,6 +201,27 @@ describe('<SpanBarRow>', () => {
     expect(document.querySelector('.SpanBarRow--errorIcon')).toBeInTheDocument();
   });
 
+  it('renders a span type icon for classified spans', () => {
+    const span = {
+      ...defaultProps.span,
+      attributes: [{ key: 'db.system', value: 'postgresql' }],
+    };
+
+    render(<SpanBarRow {...defaultProps} span={span} />);
+    expect(screen.getByLabelText('Span type: Database call')).toBeVisible();
+  });
+
+  it('does not render a span type icon for unclassified spans', () => {
+    const span = {
+      ...defaultProps.span,
+      attributes: [],
+      kind: 'INTERNAL',
+    };
+
+    render(<SpanBarRow {...defaultProps} span={span} />);
+    expect(screen.queryByLabelText(/Span type:/)).not.toBeInTheDocument();
+  });
+
   it('applies is-detail-expanded class when isDetailExpanded is true', () => {
     const props = {
       ...defaultProps,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -12,6 +12,7 @@ import {
   IoChatbubbleEllipsesOutline,
   IoGlobeOutline,
 } from 'react-icons/io5';
+import { IconType } from 'react-icons';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDurationCompact, ViewedBoundsFunctionType } from './utils';
@@ -64,7 +65,7 @@ type SpanBarRowProps = {
   useOtelTerms: boolean;
 };
 
-function getSpanTypeIcon(classification: ISpanClassification) {
+function getSpanTypeIcon(classification: ISpanClassification): IconType | null {
   switch (classification.type) {
     case SpanType.Database:
       return IoServerOutline;
@@ -197,6 +198,8 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
                 <SpanTypeIcon
                   aria-label={`Span type: ${spanClassification.label}`}
                   className="SpanBarRow--spanTypeIcon"
+                  focusable="false"
+                  role="img"
                   title={`Span type: ${spanClassification.label}`}
                 />
               )}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback } from 'react';
-import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
+import {
+  IoAlert,
+  IoGitNetwork,
+  IoCloudUploadOutline,
+  IoArrowForward,
+  IoServerOutline,
+  IoSparklesOutline,
+  IoChatbubbleEllipsesOutline,
+  IoGlobeOutline,
+} from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDurationCompact, ViewedBoundsFunctionType } from './utils';
@@ -13,6 +22,7 @@ import Ticks from './Ticks';
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
+import { classifySpan, ISpanClassification, SpanType } from '../../../model/span-classification';
 
 import './SpanBarRow.css';
 
@@ -53,6 +63,23 @@ type SpanBarRowProps = {
   traceDuration: number;
   useOtelTerms: boolean;
 };
+
+function getSpanTypeIcon(classification: ISpanClassification) {
+  switch (classification.type) {
+    case SpanType.Database:
+      return IoServerOutline;
+    case SpanType.GenAI:
+    case SpanType.MCP:
+      return IoSparklesOutline;
+    case SpanType.Messaging:
+      return IoChatbubbleEllipsesOutline;
+    case SpanType.HTTP:
+    case SpanType.RPC:
+      return IoGlobeOutline;
+    default:
+      return null;
+  }
+}
 
 /**
  * This was originally a stateless function, but changing to a PureComponent
@@ -129,6 +156,8 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   // Show the references button if there's at least one link.
   const hasLinks = span.links && span.links.length > 0;
   const hasInboundLinks = span.inboundLinks && span.inboundLinks.length > 0;
+  const spanClassification = classifySpan(span);
+  const SpanTypeIcon = spanClassification ? getSpanTypeIcon(spanClassification) : null;
 
   return (
     <TimelineRow
@@ -163,6 +192,13 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               {hasOwnError && <IoAlert className="SpanBarRow--errorIcon" />}
               {!hasOwnError && hasChildError && (
                 <IoAlert className="SpanBarRow--errorIcon SpanBarRow--errorIcon--hollow" />
+              )}
+              {SpanTypeIcon && spanClassification && (
+                <SpanTypeIcon
+                  aria-label={`Span type: ${spanClassification.label}`}
+                  className="SpanBarRow--spanTypeIcon"
+                  title={`Span type: ${spanClassification.label}`}
+                />
               )}
               {serviceName}{' '}
               {rpc && (

--- a/packages/jaeger-ui/src/model/span-classification.test.ts
+++ b/packages/jaeger-ui/src/model/span-classification.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IAttribute, IOtelSpan, SpanKind, StatusCode } from '../types/otel';
+import { Microseconds } from '../types/units';
+import { classifySpan, getAttribute, hasAttributePrefix, SpanType } from './span-classification';
+
+const microseconds = (value: number) => value as Microseconds;
+
+const createSpan = ({
+  attributes = [],
+  kind = SpanKind.INTERNAL,
+  name = 'operation',
+}: {
+  attributes?: IAttribute[];
+  kind?: SpanKind;
+  name?: string;
+} = {}): IOtelSpan => ({
+  traceID: 'trace-id',
+  spanID: 'span-id',
+  name,
+  kind,
+  startTime: microseconds(0),
+  endTime: microseconds(1),
+  duration: microseconds(1),
+  attributes,
+  events: [],
+  links: [],
+  status: { code: StatusCode.OK },
+  resource: { attributes: [], serviceName: 'service' },
+  instrumentationScope: { name: 'scope' },
+  depth: 0,
+  hasChildren: false,
+  childSpans: [],
+  relativeStartTime: microseconds(0),
+  inboundLinks: [],
+  warnings: null,
+});
+
+describe('span-classification', () => {
+  it('finds an attribute by key', () => {
+    const attribute = { key: 'db.system', value: 'postgresql' };
+    const span = createSpan({ attributes: [attribute] });
+
+    expect(getAttribute(span, 'db.system')).toBe(attribute);
+  });
+
+  it('detects attribute prefixes', () => {
+    const span = createSpan({ attributes: [{ key: 'gen_ai.request.model', value: 'gpt-4' }] });
+
+    expect(hasAttributePrefix(span, 'gen_ai.')).toBe(true);
+  });
+
+  it('classifies database spans from semantic attributes', () => {
+    const span = createSpan({ attributes: [{ key: 'db.system', value: 'postgresql' }] });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.Database, label: 'Database call' });
+  });
+
+  it('classifies database spans from legacy db.type', () => {
+    const span = createSpan({ attributes: [{ key: 'db.type', value: 'sql' }] });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.Database, label: 'Database call' });
+  });
+
+  it('classifies GenAI spans from semantic attribute prefixes', () => {
+    const span = createSpan({ attributes: [{ key: 'gen_ai.request.model', value: 'gpt-4' }] });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.GenAI, label: 'GenAI step' });
+  });
+
+  it('classifies MCP tool calls before generic GenAI spans', () => {
+    const span = createSpan({
+      attributes: [
+        { key: 'gen_ai.request.model', value: 'gpt-4' },
+        { key: 'gen_ai.tool.name', value: 'search_docs' },
+      ],
+    });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.MCP, label: 'MCP tool call' });
+  });
+
+  it('classifies MCP tool calls from operation names as a fallback', () => {
+    const span = createSpan({ name: 'mcp tool call search_docs' });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.MCP, label: 'MCP tool call' });
+  });
+
+  it('classifies messaging spans', () => {
+    const span = createSpan({ attributes: [{ key: 'messaging.system', value: 'kafka' }] });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.Messaging, label: 'Messaging span' });
+  });
+
+  it('classifies HTTP spans before generic RPC spans', () => {
+    const span = createSpan({
+      attributes: [{ key: 'http.request.method', value: 'GET' }],
+      kind: SpanKind.CLIENT,
+    });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.HTTP, label: 'HTTP span' });
+  });
+
+  it('classifies RPC spans from attributes', () => {
+    const span = createSpan({ attributes: [{ key: 'rpc.system', value: 'grpc' }] });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.RPC, label: 'RPC span' });
+  });
+
+  it('classifies client and server spans as RPC fallback', () => {
+    const span = createSpan({ kind: SpanKind.CLIENT });
+
+    expect(classifySpan(span)).toEqual({ type: SpanType.RPC, label: 'RPC span' });
+  });
+
+  it('returns null when no heuristic matches', () => {
+    expect(classifySpan(createSpan())).toBeNull();
+  });
+});

--- a/packages/jaeger-ui/src/model/span-classification.ts
+++ b/packages/jaeger-ui/src/model/span-classification.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IAttribute, IOtelSpan, SpanKind } from '../types/otel';
+
+export enum SpanType {
+  Database = 'database',
+  GenAI = 'genai',
+  MCP = 'mcp',
+  Messaging = 'messaging',
+  RPC = 'rpc',
+  HTTP = 'http',
+}
+
+export interface ISpanClassification {
+  type: SpanType;
+  label: string;
+}
+
+const DATABASE_ATTRIBUTE_KEYS = new Set(['db.system', 'db.name', 'db.statement', 'db.type']);
+
+const MCP_ATTRIBUTE_KEYS = new Set(['mcp.tool.name', 'mcp.method', 'gen_ai.tool.name']);
+
+const MESSAGING_ATTRIBUTE_KEYS = new Set(['messaging.system', 'messaging.destination.name']);
+
+const HTTP_ATTRIBUTE_KEYS = new Set(['http.method', 'http.request.method', 'url.full']);
+
+const RPC_ATTRIBUTE_KEYS = new Set(['rpc.system', 'rpc.service']);
+
+export function getAttribute(span: IOtelSpan, key: string): IAttribute | undefined {
+  return span.attributes.find(attribute => attribute.key === key);
+}
+
+export function hasAttributePrefix(span: IOtelSpan, prefix: string): boolean {
+  return span.attributes.some(attribute => attribute.key.startsWith(prefix));
+}
+
+function hasAnyAttribute(span: IOtelSpan, keys: ReadonlySet<string>): boolean {
+  return span.attributes.some(attribute => keys.has(attribute.key));
+}
+
+function hasMcpOperationName(span: IOtelSpan): boolean {
+  const operationName = span.name.toLowerCase();
+  return operationName.includes('mcp') && operationName.includes('tool');
+}
+
+export function classifySpan(span: IOtelSpan): ISpanClassification | null {
+  if (hasAnyAttribute(span, MCP_ATTRIBUTE_KEYS) || hasMcpOperationName(span)) {
+    return { type: SpanType.MCP, label: 'MCP tool call' };
+  }
+
+  if (hasAttributePrefix(span, 'gen_ai.') || hasAttributePrefix(span, 'llm.')) {
+    return { type: SpanType.GenAI, label: 'GenAI step' };
+  }
+
+  if (hasAnyAttribute(span, DATABASE_ATTRIBUTE_KEYS)) {
+    return { type: SpanType.Database, label: 'Database call' };
+  }
+
+  if (hasAnyAttribute(span, MESSAGING_ATTRIBUTE_KEYS)) {
+    return { type: SpanType.Messaging, label: 'Messaging span' };
+  }
+
+  if (hasAnyAttribute(span, HTTP_ATTRIBUTE_KEYS)) {
+    return { type: SpanType.HTTP, label: 'HTTP span' };
+  }
+
+  if (
+    hasAnyAttribute(span, RPC_ATTRIBUTE_KEYS) ||
+    span.kind === SpanKind.CLIENT ||
+    span.kind === SpanKind.SERVER
+  ) {
+    return { type: SpanType.RPC, label: 'RPC span' };
+  }
+
+  return null;
+}

--- a/packages/jaeger-ui/src/model/span-classification.ts
+++ b/packages/jaeger-ui/src/model/span-classification.ts
@@ -35,41 +35,50 @@ export function hasAttributePrefix(span: IOtelSpan, prefix: string): boolean {
   return span.attributes.some(attribute => attribute.key.startsWith(prefix));
 }
 
-function hasAnyAttribute(span: IOtelSpan, keys: ReadonlySet<string>): boolean {
-  return span.attributes.some(attribute => keys.has(attribute.key));
-}
-
 function hasMcpOperationName(span: IOtelSpan): boolean {
   const operationName = span.name.toLowerCase();
   return operationName.includes('mcp') && operationName.includes('tool');
 }
 
 export function classifySpan(span: IOtelSpan): ISpanClassification | null {
-  if (hasAnyAttribute(span, MCP_ATTRIBUTE_KEYS) || hasMcpOperationName(span)) {
+  let hasDatabaseAttribute = false;
+  let hasMcpAttribute = false;
+  let hasGenAIAttribute = false;
+  let hasMessagingAttribute = false;
+  let hasHttpAttribute = false;
+  let hasRpcAttribute = false;
+
+  for (const attribute of span.attributes) {
+    const { key } = attribute;
+    hasDatabaseAttribute ||= DATABASE_ATTRIBUTE_KEYS.has(key);
+    hasMcpAttribute ||= MCP_ATTRIBUTE_KEYS.has(key);
+    hasGenAIAttribute ||= key.startsWith('gen_ai.') || key.startsWith('llm.');
+    hasMessagingAttribute ||= MESSAGING_ATTRIBUTE_KEYS.has(key);
+    hasHttpAttribute ||= HTTP_ATTRIBUTE_KEYS.has(key);
+    hasRpcAttribute ||= RPC_ATTRIBUTE_KEYS.has(key);
+  }
+
+  if (hasMcpAttribute || hasMcpOperationName(span)) {
     return { type: SpanType.MCP, label: 'MCP tool call' };
   }
 
-  if (hasAttributePrefix(span, 'gen_ai.') || hasAttributePrefix(span, 'llm.')) {
+  if (hasGenAIAttribute) {
     return { type: SpanType.GenAI, label: 'GenAI step' };
   }
 
-  if (hasAnyAttribute(span, DATABASE_ATTRIBUTE_KEYS)) {
+  if (hasDatabaseAttribute) {
     return { type: SpanType.Database, label: 'Database call' };
   }
 
-  if (hasAnyAttribute(span, MESSAGING_ATTRIBUTE_KEYS)) {
+  if (hasMessagingAttribute) {
     return { type: SpanType.Messaging, label: 'Messaging span' };
   }
 
-  if (hasAnyAttribute(span, HTTP_ATTRIBUTE_KEYS)) {
+  if (hasHttpAttribute) {
     return { type: SpanType.HTTP, label: 'HTTP span' };
   }
 
-  if (
-    hasAnyAttribute(span, RPC_ATTRIBUTE_KEYS) ||
-    span.kind === SpanKind.CLIENT ||
-    span.kind === SpanKind.SERVER
-  ) {
+  if (hasRpcAttribute || span.kind === SpanKind.CLIENT || span.kind === SpanKind.SERVER) {
     return { type: SpanType.RPC, label: 'RPC span' };
   }
 


### PR DESCRIPTION
## Summary

This PR adds visual span type indicators to the trace timeline tree. It introduces a reusable span classification layer that assigns span types from OTEL and legacy span attributes, then renders compact accessible icons beside span service names.

The initial classification heuristics cover:

- MCP tool calls via `mcp.*`, `gen_ai.tool.name`, and low-priority MCP/tool operation-name fallback
- GenAI spans via `gen_ai.*` and `llm.*`
- Database spans via `db.system`, `db.name`, `db.statement`, and legacy `db.type`
- Messaging spans via `messaging.system` and `messaging.destination.name`
- HTTP/RPC spans via semantic attributes and client/server span kind fallback

## Testing

Validated from the repository root:

- `npm run fmt`
- `npm run lint`
- `npm test`
- `npm run build`

Note: validation was run with temporary Node 24/npm 11 tooling to match the repository engine requirements.
