### PR TITLE
refactor(ui): Share time range options between Search and Monitor

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { MonitorATMServicesViewImpl as MonitorATMServicesView, mapStateToProps, mapDispatchToProps } from '.';
-import { getLoopbackInterval, yAxisTickFormat } from './timeFrameUtils';
+import { getLoopbackInterval, timeFrameOptions, yAxisTickFormat } from './timeFrameUtils';
 import { useServices } from '../../../hooks/useTraceDiscovery';
 import {
   originInitialState,
@@ -803,6 +803,23 @@ describe('getLoopbackInterval()', () => {
 
   it('timeframe exists', () => {
     expect(getLoopbackInterval(48 * 3600000)).toBe('last 2 days');
+  });
+});
+
+describe('timeFrameOptions', () => {
+  it('includes shared search time ranges through 2 days', () => {
+    expect(timeFrameOptions.map(({ value }) => value)).toEqual([
+      5 * 60_000,
+      15 * 60_000,
+      30 * 60_000,
+      3600000,
+      2 * 3600000,
+      3 * 3600000,
+      6 * 3600000,
+      12 * 3600000,
+      24 * 3600000,
+      48 * 3600000,
+    ]);
   });
 });
 

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -543,7 +543,7 @@ describe('<MonitorATMServicesView>', () => {
       await user.selectOptions(timeframeSelect, String(2 * 3600000));
 
       await waitFor(() => {
-        expect(trackSelectTimeframeSpy).toHaveBeenCalledWith('Last 2 hours');
+        expect(trackSelectTimeframeSpy).toHaveBeenCalledWith('2 Hours');
       });
 
       expect(mockFetchAllServiceMetrics).toHaveBeenCalled();
@@ -803,7 +803,7 @@ describe('getLoopbackInterval()', () => {
   });
 
   it('timeframe exists', () => {
-    expect(getLoopbackInterval(48 * 3600000)).toBe('last 2 days');
+    expect(getLoopbackInterval(48 * 3600000)).toBe('2 days');
   });
 });
 

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom';
 import { MonitorATMServicesViewImpl as MonitorATMServicesView, mapStateToProps, mapDispatchToProps } from '.';
 import { getLoopbackInterval, timeFrameOptions, yAxisTickFormat } from './timeFrameUtils';
 import { useServices } from '../../../hooks/useTraceDiscovery';
+import { ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
 import {
   originInitialState,
   serviceMetrics,
@@ -808,18 +809,12 @@ describe('getLoopbackInterval()', () => {
 
 describe('timeFrameOptions', () => {
   it('includes shared search time ranges through 2 days', () => {
-    expect(timeFrameOptions.map(({ value }) => value)).toEqual([
-      5 * 60_000,
-      15 * 60_000,
-      30 * 60_000,
-      3600000,
-      2 * 3600000,
-      3 * 3600000,
-      6 * 3600000,
-      12 * 3600000,
-      24 * 3600000,
-      48 * 3600000,
-    ]);
+    const maxMonitorTimeframe = 48 * ONE_HOUR_MS;
+    const expectedValues = TIME_RANGE_OPTIONS.filter(({ valueMs }) => valueMs <= maxMonitorTimeframe).map(
+      ({ valueMs }) => valueMs
+    );
+
+    expect(timeFrameOptions.map(({ value }) => value)).toEqual(expectedValues);
   });
 });
 

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -543,7 +543,7 @@ describe('<MonitorATMServicesView>', () => {
       await user.selectOptions(timeframeSelect, String(2 * 3600000));
 
       await waitFor(() => {
-        expect(trackSelectTimeframeSpy).toHaveBeenCalledWith('2 Hours');
+        expect(trackSelectTimeframeSpy).toHaveBeenCalledWith('2 hours');
       });
 
       expect(mockFetchAllServiceMetrics).toHaveBeenCalled();

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -308,7 +308,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
             >
               {timeFrameOptions.map(option => (
                 <Option key={option.value} value={option.value}>
-                  {option.label}
+                  {`Last ${option.label}`}
                 </Option>
               ))}
             </SearchableSelect>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -367,7 +367,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
         <Row className="operation-table-block">
           <Col span={16}>
             <h2 className="table-header">Operations metrics under {getSelectedService()}</h2>{' '}
-            <span className="over-the-last">Over the {getLoopbackInterval(selectedTimeFrame)}</span>
+            <span className="over-the-last">Last {getLoopbackInterval(selectedTimeFrame)}</span>
           </Col>
           <Col span={8} className="select-operation-column">
             <Search

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
@@ -7,17 +7,9 @@ import { convertToTimeUnit } from '../../../utils/date';
 export { ONE_HOUR_MS };
 const MAX_MONITOR_TIMEFRAME = 48 * ONE_HOUR_MS;
 
-const formatMonitorLabel = (label: string, valueMs: number) =>
-  valueMs === ONE_HOUR_MS
-    ? 'Last Hour'
-    : `Last ${label.replace(/\b(Minutes|Hours|Days|Weeks)\b$/, word => word.toLowerCase())}`;
-
 export const timeFrameOptions = TIME_RANGE_OPTIONS.filter(
   ({ valueMs }) => valueMs <= MAX_MONITOR_TIMEFRAME
-).map(({ label, valueMs }) => ({
-  label: formatMonitorLabel(label, valueMs),
-  value: valueMs,
-}));
+).map(({ label, valueMs }) => ({ label, value: valueMs }));
 
 export const getLoopbackInterval = (interval?: number) => {
   if (interval === undefined) return '';

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ONE_HOUR_MS as SHARED_ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
+import { ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
 import { convertToTimeUnit } from '../../../utils/date';
 
-export const ONE_HOUR_MS = SHARED_ONE_HOUR_MS;
+export { ONE_HOUR_MS };
 const MAX_MONITOR_TIMEFRAME = 48 * ONE_HOUR_MS;
 
 const formatMonitorLabel = (label: string, valueMs: number) =>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
@@ -1,22 +1,23 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ONE_HOUR_MS as SHARED_ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../constants/time-range-options';
 import { convertToTimeUnit } from '../../../utils/date';
 
-export const ONE_HOUR_MS = 3600000;
-const ONE_MINUTE_MS = 60_000;
+export const ONE_HOUR_MS = SHARED_ONE_HOUR_MS;
+const MAX_MONITOR_TIMEFRAME = 48 * ONE_HOUR_MS;
 
-export const timeFrameOptions = [
-  { label: 'Last 5 minutes', value: 5 * ONE_MINUTE_MS },
-  { label: 'Last 15 minutes', value: 15 * ONE_MINUTE_MS },
-  { label: 'Last 30 minutes', value: 30 * ONE_MINUTE_MS },
-  { label: 'Last Hour', value: ONE_HOUR_MS },
-  { label: 'Last 2 hours', value: 2 * ONE_HOUR_MS },
-  { label: 'Last 6 hours', value: 6 * ONE_HOUR_MS },
-  { label: 'Last 12 hours', value: 12 * ONE_HOUR_MS },
-  { label: 'Last 24 hours', value: 24 * ONE_HOUR_MS },
-  { label: 'Last 2 days', value: 48 * ONE_HOUR_MS },
-];
+const formatMonitorLabel = (label: string) =>
+  label === 'Hour'
+    ? 'Last Hour'
+    : `Last ${label.replace(/\b(Minutes|Hours|Days|Weeks)\b$/, word => word.toLowerCase())}`;
+
+export const timeFrameOptions = TIME_RANGE_OPTIONS.filter(
+  ({ valueMs }) => valueMs <= MAX_MONITOR_TIMEFRAME
+).map(({ label, valueMs }) => ({
+  label: formatMonitorLabel(label),
+  value: valueMs,
+}));
 
 export const getLoopbackInterval = (interval?: number) => {
   if (interval === undefined) return '';

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/timeFrameUtils.ts
@@ -7,15 +7,15 @@ import { convertToTimeUnit } from '../../../utils/date';
 export const ONE_HOUR_MS = SHARED_ONE_HOUR_MS;
 const MAX_MONITOR_TIMEFRAME = 48 * ONE_HOUR_MS;
 
-const formatMonitorLabel = (label: string) =>
-  label === 'Hour'
+const formatMonitorLabel = (label: string, valueMs: number) =>
+  valueMs === ONE_HOUR_MS
     ? 'Last Hour'
     : `Last ${label.replace(/\b(Minutes|Hours|Days|Weeks)\b$/, word => word.toLowerCase())}`;
 
 export const timeFrameOptions = TIME_RANGE_OPTIONS.filter(
   ({ valueMs }) => valueMs <= MAX_MONITOR_TIMEFRAME
 ).map(({ label, valueMs }) => ({
-  label: formatMonitorLabel(label),
+  label: formatMonitorLabel(label, valueMs),
   value: valueMs,
 }));
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -203,6 +203,14 @@ describe('lookback utils', () => {
         }
       });
     });
+
+    it('falls back to default lookback for unsupported units', () => {
+      expect(nowInMicroseconds - lookbackToTimestamp('99x', now)).toBe(hourInMicroseconds);
+    });
+
+    it('falls back to default lookback for invalid amounts', () => {
+      expect(nowInMicroseconds - lookbackToTimestamp('xh', now)).toBe(hourInMicroseconds);
+    });
   });
 
   describe('applyAdjustTime', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -23,7 +23,7 @@ vi.mock('../../hooks/useConfig', () => ({
   useConfig: () => ({
     useOpenTelemetryTerms: false,
     search: {
-      maxLookback: { label: '2 Days', value: '2d' },
+      maxLookback: { label: '2 days', value: '2d' },
       adjustEndTime: '1m',
       maxLimit: 1500,
     },
@@ -250,27 +250,27 @@ describe('lookback utils', () => {
   describe('optionsWithinMaxLookback', () => {
     const threeHoursOfExpectedOptions = [
       {
-        label: '5 Minutes',
+        label: '5 minutes',
         value: '5m',
       },
       {
-        label: '15 Minutes',
+        label: '15 minutes',
         value: '15m',
       },
       {
-        label: '30 Minutes',
+        label: '30 minutes',
         value: '30m',
       },
       {
-        label: 'Hour',
+        label: '1 hour',
         value: '1h',
       },
       {
-        label: '2 Hours',
+        label: '2 hours',
         value: '2h',
       },
       {
-        label: '3 Hours',
+        label: '3 hours',
         value: '3h',
       },
     ];

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -87,12 +87,17 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
   return JSON.stringify(data);
 }
 
+function parseLookback(s: string): { value: number; unit: ManipulateType } | null {
+  const value = parseInt(s, 10);
+  const unit = LOOKBACK_UNIT_BY_SUFFIX[s.slice(-1)];
+  return unit !== undefined && !Number.isNaN(value) ? { value, unit } : null;
+}
+
 export function lookbackToTimestamp(lookback: string, from: Date | number): number {
-  const parsedValue = parseInt(lookback, 10);
-  const parsedUnit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
-  const valid = parsedUnit !== undefined && !Number.isNaN(parsedValue);
-  const value = valid ? parsedValue : DEFAULT_LOOKBACK_VALUE;
-  const unit = valid ? parsedUnit : DEFAULT_LOOKBACK_UNIT;
+  const { value, unit } = parseLookback(lookback) ?? {
+    value: DEFAULT_LOOKBACK_VALUE,
+    unit: DEFAULT_LOOKBACK_UNIT,
+  };
   return dayjs(from).subtract(value, unit).valueOf() * 1000;
 }
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -90,8 +90,9 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
 export function lookbackToTimestamp(lookback: string, from: Date | number): number {
   const parsedValue = parseInt(lookback, 10);
   const parsedUnit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
-  const value = parsedUnit && !Number.isNaN(parsedValue) ? parsedValue : DEFAULT_LOOKBACK_VALUE;
-  const unit = parsedUnit ?? DEFAULT_LOOKBACK_UNIT;
+  const valid = parsedUnit !== undefined && !Number.isNaN(parsedValue);
+  const value = valid ? parsedValue : DEFAULT_LOOKBACK_VALUE;
+  const unit = valid ? parsedUnit : DEFAULT_LOOKBACK_UNIT;
   return dayjs(from).subtract(value, unit).valueOf() * 1000;
 }
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -35,7 +35,7 @@ const FormItem = Form.Item;
 const Option = Select.Option;
 
 const ADJUST_TIME_ENABLED_KEY = 'jaeger-ui/search-adjust-time-enabled';
-const LOOKBACK_UNIT_BY_SUFFIX: Record<string, ManipulateType> = {
+const LOOKBACK_UNIT_BY_SUFFIX: Partial<Record<string, ManipulateType>> = {
   s: 'second',
   m: 'minute',
   h: 'hour',

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -5,7 +5,7 @@ import React, { useState, useCallback, useMemo, ComponentProps } from 'react';
 import { Input, Button, Tooltip, Select, Row, Col, Form, Switch } from 'antd';
 import logfmtParser from 'logfmt/lib/logfmt_parser';
 import { stringify as logfmtStringify } from 'logfmt/lib/stringify';
-import dayjs from 'dayjs';
+import dayjs, { ManipulateType } from 'dayjs';
 import memoizeOne from 'memoize-one';
 import queryString from 'query-string';
 import { IoHelp } from 'react-icons/io5';
@@ -29,11 +29,19 @@ import { useConfig } from '../../hooks/useConfig';
 import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { ReduxState } from '../../types';
 import { SearchQuery } from '../../types/search';
+import { TIME_RANGE_OPTIONS } from '../../constants/time-range-options';
 
 const FormItem = Form.Item;
 const Option = Select.Option;
 
 const ADJUST_TIME_ENABLED_KEY = 'jaeger-ui/search-adjust-time-enabled';
+const LOOKBACK_UNIT_BY_SUFFIX: Record<string, ManipulateType> = {
+  s: 'second',
+  m: 'minute',
+  h: 'hour',
+  d: 'day',
+  w: 'week',
+};
 
 interface TimeStampParams {
   startDate: string;
@@ -78,7 +86,10 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
 }
 
 export function lookbackToTimestamp(lookback: string, from: Date | number): number {
-  const unit = lookback.substr(-1) as any; // dayjs ManipulateType
+  const unit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
+  if (!unit) {
+    throw new Error(`Unsupported lookback unit: ${lookback}`);
+  }
   return dayjs(from).subtract(parseInt(lookback, 10), unit).valueOf() * 1000;
 }
 
@@ -87,72 +98,10 @@ interface ILookbackOption {
   value: string;
 }
 
-const lookbackOptions: ILookbackOption[] = [
-  {
-    label: '5 Minutes',
-    value: '5m',
-  },
-  {
-    label: '15 Minutes',
-    value: '15m',
-  },
-  {
-    label: '30 Minutes',
-    value: '30m',
-  },
-  {
-    label: 'Hour',
-    value: '1h',
-  },
-  {
-    label: '2 Hours',
-    value: '2h',
-  },
-  {
-    label: '3 Hours',
-    value: '3h',
-  },
-  {
-    label: '6 Hours',
-    value: '6h',
-  },
-  {
-    label: '12 Hours',
-    value: '12h',
-  },
-  {
-    label: '24 Hours',
-    value: '24h',
-  },
-  {
-    label: '2 Days',
-    value: '2d',
-  },
-  {
-    label: '3 Days',
-    value: '3d',
-  },
-  {
-    label: '5 Days',
-    value: '5d',
-  },
-  {
-    label: '7 Days',
-    value: '7d',
-  },
-  {
-    label: '2 Weeks',
-    value: '2w',
-  },
-  {
-    label: '3 Weeks',
-    value: '3w',
-  },
-  {
-    label: '4 Weeks',
-    value: '4w',
-  },
-];
+const lookbackOptions: ILookbackOption[] = TIME_RANGE_OPTIONS.map(({ label, lookback }) => ({
+  label,
+  value: lookback,
+}));
 
 export const optionsWithinMaxLookback = memoizeOne((maxLookback: ILookbackOption) => {
   const now = new Date();

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -88,9 +88,10 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
 }
 
 function parseLookback(s: string): { value: number; unit: ManipulateType } | null {
-  const value = parseInt(s, 10);
-  const unit = LOOKBACK_UNIT_BY_SUFFIX[s.slice(-1)];
-  return unit !== undefined && !Number.isNaN(value) ? { value, unit } : null;
+  const match = s.match(/^(\d+)([smhdw])$/);
+  if (!match) return null;
+  const unit = LOOKBACK_UNIT_BY_SUFFIX[match[2]];
+  return unit !== undefined ? { value: Number(match[1]), unit } : null;
 }
 
 export function lookbackToTimestamp(lookback: string, from: Date | number): number {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -42,6 +42,8 @@ const LOOKBACK_UNIT_BY_SUFFIX: Record<string, ManipulateType> = {
   d: 'day',
   w: 'week',
 };
+const DEFAULT_LOOKBACK_VALUE = parseInt(DEFAULT_LOOKBACK, 10);
+const DEFAULT_LOOKBACK_UNIT = LOOKBACK_UNIT_BY_SUFFIX[DEFAULT_LOOKBACK.slice(-1)] ?? 'hour';
 
 interface TimeStampParams {
   startDate: string;
@@ -86,11 +88,11 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
 }
 
 export function lookbackToTimestamp(lookback: string, from: Date | number): number {
-  const unit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
-  if (!unit) {
-    throw new Error(`Unsupported lookback unit: ${lookback}`);
-  }
-  return dayjs(from).subtract(parseInt(lookback, 10), unit).valueOf() * 1000;
+  const parsedValue = parseInt(lookback, 10);
+  const parsedUnit = LOOKBACK_UNIT_BY_SUFFIX[lookback.slice(-1)];
+  const value = parsedUnit && !Number.isNaN(parsedValue) ? parsedValue : DEFAULT_LOOKBACK_VALUE;
+  const unit = parsedUnit ?? DEFAULT_LOOKBACK_UNIT;
+  return dayjs(from).subtract(value, unit).valueOf() * 1000;
 }
 
 interface ILookbackOption {

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -61,7 +61,7 @@ const defaultConfig: Config = {
   ],
   search: {
     maxLookback: {
-      label: '2 Days',
+      label: '2 days',
       value: '2d',
     },
     maxLimit: 1500,

--- a/packages/jaeger-ui/src/constants/time-range-options.test.ts
+++ b/packages/jaeger-ui/src/constants/time-range-options.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ONE_HOUR_MS, TIME_RANGE_OPTIONS } from './time-range-options';
+
+describe('TIME_RANGE_OPTIONS', () => {
+  it('keeps lookback values and millisecond values aligned', () => {
+    const unitMs = {
+      m: 60_000,
+      h: ONE_HOUR_MS,
+      d: 24 * ONE_HOUR_MS,
+      w: 7 * 24 * ONE_HOUR_MS,
+    };
+
+    TIME_RANGE_OPTIONS.forEach(({ lookback, valueMs }) => {
+      const match = lookback.match(/^(\d+)([mhdw])$/);
+      expect(match).not.toBeNull();
+
+      const [, amount, unit] = match!;
+      expect(valueMs).toBe(Number(amount) * unitMs[unit as keyof typeof unitMs]);
+    });
+  });
+
+  it('lists options from shortest to longest', () => {
+    const values = TIME_RANGE_OPTIONS.map(({ valueMs }) => valueMs);
+    const sortedValues = [...values].sort((a, b) => a - b);
+
+    expect(values).toEqual(sortedValues);
+  });
+});

--- a/packages/jaeger-ui/src/constants/time-range-options.ts
+++ b/packages/jaeger-ui/src/constants/time-range-options.ts
@@ -14,82 +14,82 @@ export interface ITimeRangeOption {
 
 export const TIME_RANGE_OPTIONS: readonly ITimeRangeOption[] = Object.freeze([
   {
-    label: '5 Minutes',
+    label: '5 minutes',
     lookback: '5m',
     valueMs: 5 * ONE_MINUTE_MS,
   },
   {
-    label: '15 Minutes',
+    label: '15 minutes',
     lookback: '15m',
     valueMs: 15 * ONE_MINUTE_MS,
   },
   {
-    label: '30 Minutes',
+    label: '30 minutes',
     lookback: '30m',
     valueMs: 30 * ONE_MINUTE_MS,
   },
   {
-    label: 'Hour',
+    label: '1 hour',
     lookback: '1h',
     valueMs: ONE_HOUR_MS,
   },
   {
-    label: '2 Hours',
+    label: '2 hours',
     lookback: '2h',
     valueMs: 2 * ONE_HOUR_MS,
   },
   {
-    label: '3 Hours',
+    label: '3 hours',
     lookback: '3h',
     valueMs: 3 * ONE_HOUR_MS,
   },
   {
-    label: '6 Hours',
+    label: '6 hours',
     lookback: '6h',
     valueMs: 6 * ONE_HOUR_MS,
   },
   {
-    label: '12 Hours',
+    label: '12 hours',
     lookback: '12h',
     valueMs: 12 * ONE_HOUR_MS,
   },
   {
-    label: '24 Hours',
+    label: '24 hours',
     lookback: '24h',
     valueMs: 24 * ONE_HOUR_MS,
   },
   {
-    label: '2 Days',
+    label: '2 days',
     lookback: '2d',
     valueMs: 2 * ONE_DAY_MS,
   },
   {
-    label: '3 Days',
+    label: '3 days',
     lookback: '3d',
     valueMs: 3 * ONE_DAY_MS,
   },
   {
-    label: '5 Days',
+    label: '5 days',
     lookback: '5d',
     valueMs: 5 * ONE_DAY_MS,
   },
   {
-    label: '7 Days',
+    label: '7 days',
     lookback: '7d',
     valueMs: 7 * ONE_DAY_MS,
   },
   {
-    label: '2 Weeks',
+    label: '2 weeks',
     lookback: '2w',
     valueMs: 2 * ONE_WEEK_MS,
   },
   {
-    label: '3 Weeks',
+    label: '3 weeks',
     lookback: '3w',
     valueMs: 3 * ONE_WEEK_MS,
   },
   {
-    label: '4 Weeks',
+    label: '4 weeks',
     lookback: '4w',
     valueMs: 4 * ONE_WEEK_MS,
   },

--- a/packages/jaeger-ui/src/constants/time-range-options.ts
+++ b/packages/jaeger-ui/src/constants/time-range-options.ts
@@ -3,14 +3,16 @@
 
 const ONE_MINUTE_MS = 60_000;
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+const ONE_WEEK_MS = 7 * ONE_DAY_MS;
 
 export interface ITimeRangeOption {
-  label: string;
-  lookback: string;
-  valueMs: number;
+  readonly label: string;
+  readonly lookback: string;
+  readonly valueMs: number;
 }
 
-export const TIME_RANGE_OPTIONS: ITimeRangeOption[] = [
+export const TIME_RANGE_OPTIONS: readonly ITimeRangeOption[] = Object.freeze([
   {
     label: '5 Minutes',
     lookback: '5m',
@@ -59,36 +61,36 @@ export const TIME_RANGE_OPTIONS: ITimeRangeOption[] = [
   {
     label: '2 Days',
     lookback: '2d',
-    valueMs: 48 * ONE_HOUR_MS,
+    valueMs: 2 * ONE_DAY_MS,
   },
   {
     label: '3 Days',
     lookback: '3d',
-    valueMs: 72 * ONE_HOUR_MS,
+    valueMs: 3 * ONE_DAY_MS,
   },
   {
     label: '5 Days',
     lookback: '5d',
-    valueMs: 120 * ONE_HOUR_MS,
+    valueMs: 5 * ONE_DAY_MS,
   },
   {
     label: '7 Days',
     lookback: '7d',
-    valueMs: 168 * ONE_HOUR_MS,
+    valueMs: 7 * ONE_DAY_MS,
   },
   {
     label: '2 Weeks',
     lookback: '2w',
-    valueMs: 14 * 24 * ONE_HOUR_MS,
+    valueMs: 2 * ONE_WEEK_MS,
   },
   {
     label: '3 Weeks',
     lookback: '3w',
-    valueMs: 21 * 24 * ONE_HOUR_MS,
+    valueMs: 3 * ONE_WEEK_MS,
   },
   {
     label: '4 Weeks',
     lookback: '4w',
-    valueMs: 28 * 24 * ONE_HOUR_MS,
+    valueMs: 4 * ONE_WEEK_MS,
   },
-];
+]);

--- a/packages/jaeger-ui/src/constants/time-range-options.ts
+++ b/packages/jaeger-ui/src/constants/time-range-options.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+const ONE_MINUTE_MS = 60_000;
+export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+
+export interface ITimeRangeOption {
+  label: string;
+  lookback: string;
+  valueMs: number;
+}
+
+export const TIME_RANGE_OPTIONS: ITimeRangeOption[] = [
+  {
+    label: '5 Minutes',
+    lookback: '5m',
+    valueMs: 5 * ONE_MINUTE_MS,
+  },
+  {
+    label: '15 Minutes',
+    lookback: '15m',
+    valueMs: 15 * ONE_MINUTE_MS,
+  },
+  {
+    label: '30 Minutes',
+    lookback: '30m',
+    valueMs: 30 * ONE_MINUTE_MS,
+  },
+  {
+    label: 'Hour',
+    lookback: '1h',
+    valueMs: ONE_HOUR_MS,
+  },
+  {
+    label: '2 Hours',
+    lookback: '2h',
+    valueMs: 2 * ONE_HOUR_MS,
+  },
+  {
+    label: '3 Hours',
+    lookback: '3h',
+    valueMs: 3 * ONE_HOUR_MS,
+  },
+  {
+    label: '6 Hours',
+    lookback: '6h',
+    valueMs: 6 * ONE_HOUR_MS,
+  },
+  {
+    label: '12 Hours',
+    lookback: '12h',
+    valueMs: 12 * ONE_HOUR_MS,
+  },
+  {
+    label: '24 Hours',
+    lookback: '24h',
+    valueMs: 24 * ONE_HOUR_MS,
+  },
+  {
+    label: '2 Days',
+    lookback: '2d',
+    valueMs: 48 * ONE_HOUR_MS,
+  },
+  {
+    label: '3 Days',
+    lookback: '3d',
+    valueMs: 72 * ONE_HOUR_MS,
+  },
+  {
+    label: '5 Days',
+    lookback: '5d',
+    valueMs: 120 * ONE_HOUR_MS,
+  },
+  {
+    label: '7 Days',
+    lookback: '7d',
+    valueMs: 168 * ONE_HOUR_MS,
+  },
+  {
+    label: '2 Weeks',
+    lookback: '2w',
+    valueMs: 14 * 24 * ONE_HOUR_MS,
+  },
+  {
+    label: '3 Weeks',
+    lookback: '3w',
+    valueMs: 21 * 24 * ONE_HOUR_MS,
+  },
+  {
+    label: '4 Weeks',
+    lookback: '4w',
+    valueMs: 28 * 24 * ONE_HOUR_MS,
+  },
+];

--- a/packages/jaeger-ui/src/hooks/useConfig.test.ts
+++ b/packages/jaeger-ui/src/hooks/useConfig.test.ts
@@ -27,7 +27,7 @@ beforeEach(() => {
 describe('useConfig', () => {
   it('returns config from getConfig()', () => {
     const menu = [{ label: 'About Jaeger', items: [{ label: 'Docs', url: 'https://jaegertracing.io' }] }];
-    const search = { maxLookback: { label: '2 Days', value: '2d' }, maxLimit: 1500 };
+    const search = { maxLookback: { label: '2 days', value: '2d' }, maxLimit: 1500 };
     mockGetConfig.mockReturnValue({ ...baseConfig, menu, search } as any);
 
     const { result } = renderHook(() => useConfig());

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -108,8 +108,8 @@ export type Config = {
   // search section controls some aspects of the Search panel.
   search?: {
     // maxLookback controls how far back in time the search may apply.
-    // By default the Lookback dropdown contains values from "last 1 hour"
-    // to "last 2 days". Setting maxLookback to a shorter time range,
+    // By default the Lookback dropdown contains values from "Last 5 minutes"
+    // to "Last 2 days". Setting maxLookback to a shorter time range,
     // such as "6h" disables the longer ranges.
     maxLookback: {
       // Bare duration label shown in the search form dropdown. The UI prepends "Last "

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -108,11 +108,12 @@ export type Config = {
   // search section controls some aspects of the Search panel.
   search?: {
     // maxLookback controls how far back in time the search may apply.
-    // By default the Lookback dropdown contains values from "last hour"
+    // By default the Lookback dropdown contains values from "last 1 hour"
     // to "last 2 days". Setting maxLookback to a shorter time range,
     // such as "6h" disables the longer ranges.
     maxLookback: {
-      // label to be displayed in the search form dropdown, e.g. "Last 2 days".
+      // Bare duration label shown in the search form dropdown. The UI prepends "Last "
+      // automatically, so use e.g. "2 days" (not "Last 2 days").
       label: string;
 
       // The value submitted in the search query if the label is selected.


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3954
- Closes #3960

## Description of the changes

Based on https://github.com/jaegertracing/jaeger-ui/pull/3960 by @iccccccccccccc. This PR extends that work.

- Adds a shared `TIME_RANGE_OPTIONS` constant (in `src/constants/time-range-options.ts`) with both Search lookback values and millisecond values as the single source of truth.
- Makes `SearchForm` derive its lookback dropdown from the shared list.
- Makes Monitor derive its timeframe options from the same list, filtered to a 2-day ceiling.
- Unifies label style to lowercase (`"2 hours"`, `"5 days"`) and adds `"Last "` prefix at render sites in both UIs.
- Fixes `parseLookback` to validate the full format with a regex and fall back both value and unit together on invalid input.
- Updates `default-config.ts` and `types/config.ts` to reflect the new bare-duration label convention.

The only visible Monitor addition is `3 hours`, which was already in Search and falls within the existing 2-day cap.

## How was this change tested?
- `npm run fmt && npm run lint && npm test && npm run build`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes