### PR TITLE
fix(AttributesTable): add aria-label to LinkValue for accessibility

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -105,7 +105,13 @@ function formatValue(key: string, value: any) {
 }
 
 export const LinkValue = (props: { href: string; title?: string; children: React.ReactNode }) => (
-  <a href={props.href} title={props.title || ''} target="_blank" rel="noopener noreferrer">
+  <a 
+    href={props.href} 
+    title={props.title || ''} 
+    target="_blank" 
+    rel="noopener noreferrer"
+    aria-label={props.title ? props.title : 'Open external link'}
+  >
     {props.children} <IoOpenOutline className="KeyValueTable--linkIcon" />
   </a>
 );


### PR DESCRIPTION
## Description
Adds a dynamic `aria-label` attribute to the `LinkValue` component's anchor tag to fix accessibility issues for screen readers when encountering external link icons.

Fixes #8456
