### PR TITLE
docs(tracking): Add console analytics example and improve custom analytics docs

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -65,6 +65,9 @@ const config: KnipConfig = {
         // AUTO-GENERATED from the Jaeger OpenAPI spec (`npm run generate:api-types`).
         // Treat as an entry point so knip considers all its exports intentionally public.
         'src/api/v3/generated-client.ts',
+        // Example UI config file; not imported by source but consumed directly by the
+        // jaeger binary and the Vite dev server.
+        'jaeger-ui.config.console-analytics.js',
       ],
     },
     'packages/plexus': {

--- a/packages/jaeger-ui/README.md
+++ b/packages/jaeger-ui/README.md
@@ -22,7 +22,7 @@ When the config file has `.json` extension, Jaeger looks for the statement `JAEG
 
 ### Configuration as Javascript
 
-When the config file has `.js` extension, the Jaeger backend looks for the comment `// JAEGER_CONFIG_JS` and replaces it with a function `UIConfig()` whose body is the content of the loaded file, which must contain a valid Javascript code that returns a Config object. This allows more complex integrations by actually executing some custom code. For example, `tracking.customWebAnalytics` allows to hook up a different implementation of the tracking component.
+When the config file has `.js` extension, the `jaeger` binary looks for the comment `// JAEGER_CONFIG_JS` and replaces it with the verbatim content of the loaded file. The file **must define a top-level `UIConfig()` function** that returns a `Config` object. This allows more complex integrations by actually executing some custom code. For example, `tracking.customWebAnalytics` allows to hook up a different implementation of the tracking component.
 
 ### Configuration for Local Development
 
@@ -41,26 +41,32 @@ When running the UI in development mode via `npm start`, you can provide custom 
    }
    ```
 
-2. **`jaeger-ui.config.js`** - A JavaScript file that returns a config object (supports more complex configurations):
+2. **`jaeger-ui.config.js`** - A JavaScript file that defines a `UIConfig()` function (supports more complex configurations):
 
    ```javascript
-   return {
-     dependencies: {
-       menuEnabled: true,
-     },
-     tracking: {
-       customWebAnalytics: function (config) {
-         // Custom analytics implementation
-         return {
-           init: function () {},
-           trackPageView: function (pathname, search) {},
-           trackError: function (description) {},
-           trackEvent: function (category, action, labelOrValue, value) {},
-         };
+   function UIConfig() {
+     return {
+       dependencies: {
+         menuEnabled: true,
        },
-     },
-   };
+       tracking: {
+         customWebAnalytics: function (config, versionShort, versionLong) {
+           // Custom analytics implementation
+           return {
+             init: function () {},
+             isEnabled: function () { return true; },
+             context: null,
+             trackPageView: function (pathname, search) {},
+             trackError: function (description) {},
+             trackEvent: function (category, action, labelOrValue, value) {},
+           };
+         },
+       },
+     };
+   }
    ```
+
+   A working example that logs all events to the browser console is provided at [jaeger-ui.config.console-analytics.js](./jaeger-ui.config.console-analytics.js).
 
 **Note:** If both files exist, `jaeger-ui.config.js` takes priority (same behavior as `query-service`).
 

--- a/packages/jaeger-ui/README.md
+++ b/packages/jaeger-ui/README.md
@@ -54,7 +54,9 @@ When running the UI in development mode via `npm start`, you can provide custom 
            // Custom analytics implementation
            return {
              init: function () {},
-             isEnabled: function () { return true; },
+             isEnabled: function () {
+               return true;
+             },
              context: null,
              trackPageView: function (pathname, search) {},
              trackError: function (description) {},

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -13,7 +13,7 @@
 //     ui:
 //       config_file: /etc/jaeger/config-ui.json
 
-function consoleAnalytics(config, versionShort) {
+function consoleAnalytics(config, versionShort, versionLong) {
   function log(method, label, data) {
     console[method]('[analytics]', label, data !== undefined ? data : '');
   }

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -9,7 +9,7 @@
 //
 //   jaeger_query:
 //     ui:
-//       config_file: ./cmd/jaeger/config-ui.json
+//       config_file: /etc/jaeger/config-ui.json
 
 function consoleAnalytics(config, versionShort) {
   function log(method, label, data) {

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -20,7 +20,8 @@ function consoleAnalytics(config, versionShort, versionLong) {
 
   return {
     init: function () {
-      log('log', 'init — version:', versionShort + ' / ' + versionLong);
+      // versionShort/versionLong are 'unknown' when REACT_APP_VSN_STATE is not set (e.g. plain npm start)
+      log('log', 'init — version:', versionLong);
     },
 
     // Return true to activate the Redux tracking middleware.

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Example Jaeger UI config using the customWebAnalytics API to log all
-// tracking events to the browser console. JavaScript config (not JSON) is required because customWebAnalytics is a function reference.
+// tracking events to the browser console. JavaScript config (not JSON)
+// is required because customWebAnalytics is a function reference.
 //
 // Usage: copy/rename to jaeger-ui.config.js and point the `jaeger` binary to it
 // via the jaeger_query extension in Jaeger's YAML configuration file:
 //
+// extensions:
 //   jaeger_query:
 //     ui:
 //       config_file: /etc/jaeger/config-ui.json

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -11,7 +11,7 @@
 // extensions:
 //   jaeger_query:
 //     ui:
-//       config_file: /etc/jaeger/config-ui.json
+//       config_file: /etc/jaeger/config-ui.js
 
 function consoleAnalytics(config, versionShort, versionLong) {
   function log(method, label, data) {

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -20,8 +20,7 @@ function consoleAnalytics(config, versionShort, versionLong) {
 
   return {
     init: function () {
-      // versionShort/versionLong are 'unknown' when REACT_APP_VSN_STATE is not set (e.g. plain npm start)
-      log('log', 'init — version:', versionLong);
+      log('log', 'init — version:', versionShort + ' / ' + versionLong);
     },
 
     // Return true to activate the Redux tracking middleware.

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Example Jaeger UI config using the customWebAnalytics API to log all
+// tracking events to the browser console.
+//
+// Usage: copy/rename to jaeger-ui.config.js and serve alongside Jaeger Query.
+// JavaScript (not JSON) is required because customWebAnalytics is a function.
+
+function UIConfig() {
+  return {
+    tracking: {
+      // customWebAnalytics takes priority over gaID; both should not be set.
+      customWebAnalytics: function consoleAnalyticsFactory(config, versionShort, versionLong) {
+        return {
+          // Called once when the app starts.
+          init: function () {
+            console.log('[analytics] init — version:', versionShort);
+          },
+
+          // Return true to activate the Redux tracking middleware.
+          isEnabled: function () {
+            return true;
+          },
+
+          // Set to true to enable error breadcrumb capture, false/null to disable.
+          context: true,
+
+          trackPageView: function (pathname, search) {
+            console.log('[analytics] pageView', pathname + (search || ''));
+          },
+
+          trackError: function (description) {
+            console.error('[analytics] error', description);
+          },
+
+          // labelOrValue may be a string label or a numeric value depending on the call site.
+          trackEvent: function (category, action, labelOrValue, value) {
+            console.log('[analytics] event', { category, action, labelOrValue, value });
+          },
+        };
+      },
+    },
+  };
+}

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Example Jaeger UI config using the customWebAnalytics API to log all
-// tracking events to the browser console.
+// tracking events to the browser console. JavaScript config (not JSON) is required because customWebAnalytics is a function reference.
 //
 // Usage: copy/rename to jaeger-ui.config.js and point the `jaeger` binary to it
-// via the query.ui-config setting in jaeger's YAML configuration file.
-// JavaScript (not JSON) is required because customWebAnalytics is a function reference.
+// via the jaeger_query extension in Jaeger's YAML configuration file:
+//
+//   jaeger_query:
+//     ui:
+//       config_file: ./cmd/jaeger/config-ui.json
+//
+// Note: this file is injected as the *body* of a UIConfig() function by both
+// the `jaeger` binary and the Vite dev server. Do not wrap it in UIConfig() yourself.
 
 function consoleAnalytics(config, versionShort) {
   function log(method, label, data) {
@@ -41,29 +47,27 @@ function consoleAnalytics(config, versionShort) {
   };
 }
 
-function UIConfig() {
-  return {
-    dependencies: {
-      menuEnabled: true,
+return {
+  dependencies: {
+    menuEnabled: true,
+  },
+  monitor: {
+    menuEnabled: true,
+  },
+  tracking: {
+    // customWebAnalytics takes priority over gaID; both should not be set.
+    customWebAnalytics: consoleAnalytics,
+  },
+  linkPatterns: [
+    {
+      type: 'process',
+      key: 'jaeger.version',
+      url: 'https://github.com/jaegertracing/jaeger-client-java/releases/tag/#{jaeger.version}',
+      text: 'Information about Jaeger SDK release #{jaeger.version}',
     },
-    monitor: {
-      menuEnabled: true,
-    },
-    tracking: {
-      // customWebAnalytics takes priority over gaID; both should not be set.
-      customWebAnalytics: consoleAnalytics,
-    },
-    linkPatterns: [
-      {
-        type: 'process',
-        key: 'jaeger.version',
-        url: 'https://github.com/jaegertracing/jaeger-client-java/releases/tag/#{jaeger.version}',
-        text: 'Information about Jaeger SDK release #{jaeger.version}',
-      },
-    ],
-    storageCapabilities: {
-      archiveStorage: false,
-      metricsStorage: true,
-    },
-  };
-}
+  ],
+  storageCapabilities: {
+    archiveStorage: false,
+    metricsStorage: true,
+  },
+};

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -4,9 +4,9 @@
 // Example Jaeger UI config using the customWebAnalytics API to log all
 // tracking events to the browser console.
 //
-// Usage: copy/rename to jaeger-ui.config.js and pass to the Jaeger binary via
-// --query.ui-config flag. JavaScript (not JSON) is required because
-// customWebAnalytics is a function reference.
+// Usage: copy/rename to jaeger-ui.config.js and point the `jaeger` binary to it
+// via the query.ui-config setting in jaeger's YAML configuration file.
+// JavaScript (not JSON) is required because customWebAnalytics is a function reference.
 
 function consoleAnalytics(config, versionShort) {
   function log(method, label, data) {

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -10,9 +10,6 @@
 //   jaeger_query:
 //     ui:
 //       config_file: ./cmd/jaeger/config-ui.json
-//
-// Note: this file is injected as the *body* of a UIConfig() function by both
-// the `jaeger` binary and the Vite dev server. Do not wrap it in UIConfig() yourself.
 
 function consoleAnalytics(config, versionShort) {
   function log(method, label, data) {
@@ -47,27 +44,29 @@ function consoleAnalytics(config, versionShort) {
   };
 }
 
-return {
-  dependencies: {
-    menuEnabled: true,
-  },
-  monitor: {
-    menuEnabled: true,
-  },
-  tracking: {
-    // customWebAnalytics takes priority over gaID; both should not be set.
-    customWebAnalytics: consoleAnalytics,
-  },
-  linkPatterns: [
-    {
-      type: 'process',
-      key: 'jaeger.version',
-      url: 'https://github.com/jaegertracing/jaeger-client-java/releases/tag/#{jaeger.version}',
-      text: 'Information about Jaeger SDK release #{jaeger.version}',
+function UIConfig() {
+  return {
+    dependencies: {
+      menuEnabled: true,
     },
-  ],
-  storageCapabilities: {
-    archiveStorage: false,
-    metricsStorage: true,
-  },
-};
+    monitor: {
+      menuEnabled: true,
+    },
+    tracking: {
+      // customWebAnalytics takes priority over gaID; both should not be set.
+      customWebAnalytics: consoleAnalytics,
+    },
+    linkPatterns: [
+      {
+        type: 'process',
+        key: 'jaeger.version',
+        url: 'https://github.com/jaegertracing/jaeger-client-java/releases/tag/#{jaeger.version}',
+        text: 'Information about Jaeger SDK release #{jaeger.version}',
+      },
+    ],
+    storageCapabilities: {
+      archiveStorage: false,
+      metricsStorage: true,
+    },
+  };
+}

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -20,7 +20,7 @@ function consoleAnalytics(config, versionShort, versionLong) {
 
   return {
     init: function () {
-      log('log', 'init — version:', versionShort);
+      log('log', 'init — version:', versionShort + ' / ' + versionLong);
     },
 
     // Return true to activate the Redux tracking middleware.

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -4,8 +4,9 @@
 // Example Jaeger UI config using the customWebAnalytics API to log all
 // tracking events to the browser console.
 //
-// Usage: copy/rename to jaeger-ui.config.js and serve alongside Jaeger Query.
-// JavaScript (not JSON) is required because customWebAnalytics is a function.
+// Usage: copy/rename to jaeger-ui.config.js and pass to the Jaeger binary via
+// --query.ui-config flag. JavaScript (not JSON) is required because
+// customWebAnalytics is a function reference.
 
 function consoleAnalytics(config, versionShort) {
   function log(method, label, data) {

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -7,39 +7,62 @@
 // Usage: copy/rename to jaeger-ui.config.js and serve alongside Jaeger Query.
 // JavaScript (not JSON) is required because customWebAnalytics is a function.
 
+function consoleAnalytics(config, versionShort) {
+  function log(method, label, data) {
+    console[method]('[analytics]', label, data !== undefined ? data : '');
+  }
+
+  return {
+    init: function () {
+      log('log', 'init — version:', versionShort);
+    },
+
+    // Return true to activate the Redux tracking middleware.
+    isEnabled: function () {
+      return true;
+    },
+
+    // Set to true to enable error breadcrumb capture, false/null to disable.
+    context: true,
+
+    trackPageView: function (pathname, search) {
+      log('log', 'pageView', pathname + (search || ''));
+    },
+
+    trackError: function (description) {
+      log('error', 'error', description);
+    },
+
+    // labelOrValue may be a string label or a numeric value depending on the call site.
+    trackEvent: function (category, action, labelOrValue, value) {
+      log('log', 'event', { category, action, labelOrValue, value });
+    },
+  };
+}
+
 function UIConfig() {
   return {
+    dependencies: {
+      menuEnabled: true,
+    },
+    monitor: {
+      menuEnabled: true,
+    },
     tracking: {
       // customWebAnalytics takes priority over gaID; both should not be set.
-      customWebAnalytics: function consoleAnalyticsFactory(config, versionShort, versionLong) {
-        return {
-          // Called once when the app starts.
-          init: function () {
-            console.log('[analytics] init — version:', versionShort);
-          },
-
-          // Return true to activate the Redux tracking middleware.
-          isEnabled: function () {
-            return true;
-          },
-
-          // Set to true to enable error breadcrumb capture, false/null to disable.
-          context: true,
-
-          trackPageView: function (pathname, search) {
-            console.log('[analytics] pageView', pathname + (search || ''));
-          },
-
-          trackError: function (description) {
-            console.error('[analytics] error', description);
-          },
-
-          // labelOrValue may be a string label or a numeric value depending on the call site.
-          trackEvent: function (category, action, labelOrValue, value) {
-            console.log('[analytics] event', { category, action, labelOrValue, value });
-          },
-        };
+      customWebAnalytics: consoleAnalytics,
+    },
+    linkPatterns: [
+      {
+        type: 'process',
+        key: 'jaeger.version',
+        url: 'https://github.com/jaegertracing/jaeger-client-java/releases/tag/#{jaeger.version}',
+        text: 'Information about Jaeger SDK release #{jaeger.version}',
       },
+    ],
+    storageCapabilities: {
+      archiveStorage: false,
+      metricsStorage: true,
     },
   };
 }

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -66,11 +66,11 @@ function UIConfig() {
         text: 'Information about Jaeger SDK release #{jaeger.version}',
       },
     ],
-    // NOTE: storageCapabilities is intentionally omitted from JS config files.
-    // Any value set here is silently overridden by getJaegerStorageCapabilities(),
-    // which is always authoritative (set by the backend, not the UI config).
-    // To override storageCapabilities in dev mode, use a JSON config file instead —
-    // the Vite dev server has special handling to inject it into the separate
-    // JAEGER_STORAGE_CAPABILITIES placeholder that feeds getJaegerStorageCapabilities().
+    // NOTE: storageCapabilities is intentionally omitted from this example.
+    // In production, the jaeger binary injects it via a separate search-replace on
+    // JAEGER_STORAGE_CAPABILITIES (independent of UIConfig); the UI config value is ignored.
+    // In dev mode, the Vite plugin evaluates UIConfig() and injects storageCapabilities
+    // into the same placeholder, so setting it here works with `npm start`.
+    // storageCapabilities: { archiveStorage: true }
   };
 }

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -66,9 +66,11 @@ function UIConfig() {
         text: 'Information about Jaeger SDK release #{jaeger.version}',
       },
     ],
-    storageCapabilities: {
-      archiveStorage: false,
-      metricsStorage: true,
-    },
+    // NOTE: storageCapabilities is intentionally omitted from JS config files.
+    // Any value set here is silently overridden by getJaegerStorageCapabilities(),
+    // which is always authoritative (set by the backend, not the UI config).
+    // To override storageCapabilities in dev mode, use a JSON config file instead —
+    // the Vite dev server has special handling to inject it into the separate
+    // JAEGER_STORAGE_CAPABILITIES placeholder that feeds getJaegerStorageCapabilities().
   };
 }

--- a/packages/jaeger-ui/src/utils/tracking/README.md
+++ b/packages/jaeger-ui/src/utils/tracking/README.md
@@ -4,9 +4,11 @@ App analytics (page views and errors) are supported in Jaeger UI through integra
 
 The page-view tracking is pretty basic, so details aren't provided. The GA tracking is configured with [App Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#apptracking) data. These fields, described [below](#app-tracking), can be used as a secondary dimension when viewing event data in GA. The error tracking is described, [below](#error-tracking).
 
-To enable a custom plugin, use the JavaScript version of the configuration file (not JSON, since a function reference is required) and set `customWebAnalytics` instead of `gaID` — the two are mutually exclusive. A working example that logs all events to the browser console is provided in [`jaeger-ui.config.console-analytics.js`](../../../../../packages/jaeger-ui/jaeger-ui.config.console-analytics.js) at the root of the `jaeger-ui` package.
+To enable a custom plugin, use the JavaScript version of the configuration file (not JSON, since a function reference is required) and set `customWebAnalytics` instead of `gaID` — the two are mutually exclusive. A working example that logs all events to the browser console is provided in [`jaeger-ui.config.console-analytics.js`](../../../jaeger-ui.config.console-analytics.js).
 
-The factory function receives three arguments:
+The config file must define a top-level `UIConfig()` function — this is enforced by the `jaeger` binary and matched by the Vite dev server.
+
+The `customWebAnalytics` value is a factory function that receives three arguments:
 
 | Argument | Type | Description |
 |---|---|---|
@@ -14,18 +16,18 @@ The factory function receives three arguments:
 | `versionShort` | `string` | Short version string, e.g. `"0.0.1 \| git status"` |
 | `versionLong` | `string` | Long version string (truncated to 99 chars) |
 
-The returned object must implement the `IWebAnalytics` interface:
+The factory must return an object implementing the `IWebAnalytics` interface:
 
 | Field | Type | Description |
 |---|---|---|
 | `init` | `() => void` | Called once on app start |
-| `isEnabled` | `() => boolean` | Return `true` to activate the Redux tracking middleware |
-| `context` | `boolean \| null` | `true` enables error breadcrumb capture; `null` disables it |
+| `isEnabled` | `() => boolean` | Return `true` to enable tracking; `false` to disable all calls |
+| `context` | `boolean \| null` | `true` enables automatic error breadcrumb capture; `null`/`false` disables it |
 | `trackPageView` | `(pathname, search) => void` | Called on route changes |
 | `trackError` | `(description) => void` | Called when an error is captured |
 | `trackEvent` | `(category, action, labelOrValue?, value?) => void` | Called for UI interaction events |
 
-Minimal skeleton, e.g. in `jaeger-ui.config.js`:
+Minimal skeleton in `jaeger-ui.config.js`:
 
 ```javascript
 function UIConfig() {
@@ -35,7 +37,7 @@ function UIConfig() {
         return {
           init: function () {},
           isEnabled: function () { return true; },
-          context: null,
+          context: true,
           trackPageView: function (pathname, search) {},
           trackError: function (description) {},
           trackEvent: function (category, action, labelOrValue, value) {},

--- a/packages/jaeger-ui/src/utils/tracking/README.md
+++ b/packages/jaeger-ui/src/utils/tracking/README.md
@@ -4,25 +4,45 @@ App analytics (page views and errors) are supported in Jaeger UI through integra
 
 The page-view tracking is pretty basic, so details aren't provided. The GA tracking is configured with [App Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#apptracking) data. These fields, described [below](#app-tracking), can be used as a secondary dimension when viewing event data in GA. The error tracking is described, [below](#error-tracking).
 
-To enable custom plugin, one must use Javascript-version of the configuration and replace the `gaID` field with `customWebAnalytics`, e.g. in `UIconfig.js`:
+To enable a custom plugin, use the JavaScript version of the configuration file (not JSON, since a function reference is required) and set `customWebAnalytics` instead of `gaID` — the two are mutually exclusive. A working example that logs all events to the browser console is provided in [`jaeger-ui.config.console-analytics.js`](../../../../../packages/jaeger-ui/jaeger-ui.config.console-analytics.js) at the root of the `jaeger-ui` package.
+
+The factory function receives three arguments:
+
+| Argument | Type | Description |
+|---|---|---|
+| `config` | `Config` | Full Jaeger UI config object |
+| `versionShort` | `string` | Short version string, e.g. `"0.0.1 \| git status"` |
+| `versionLong` | `string` | Long version string (truncated to 99 chars) |
+
+The returned object must implement the `IWebAnalytics` interface:
+
+| Field | Type | Description |
+|---|---|---|
+| `init` | `() => void` | Called once on app start |
+| `isEnabled` | `() => boolean` | Return `true` to activate the Redux tracking middleware |
+| `context` | `boolean \| null` | `true` enables error breadcrumb capture; `null` disables it |
+| `trackPageView` | `(pathname, search) => void` | Called on route changes |
+| `trackError` | `(description) => void` | Called when an error is captured |
+| `trackEvent` | `(category, action, labelOrValue?, value?) => void` | Called for UI interaction events |
+
+Minimal skeleton, e.g. in `jaeger-ui.config.js`:
 
 ```javascript
 function UIConfig() {
   return {
-     ...other properties
-     tracking: {
-       customWebAnalytics: function () {
-         return {
-           init: () => { /* initialization actions */ },
-           trackPageView: (pathname, search) => {},
-           trackError: (description) => {},
-           trackEvent: (category, action, labelOrValue, value) => {},
-           context: null,
-           isEnabled: () => false,
-         }
-       }
-     }
-  }
+    tracking: {
+      customWebAnalytics: function (config, versionShort, versionLong) {
+        return {
+          init: function () {},
+          isEnabled: function () { return true; },
+          context: null,
+          trackPageView: function (pathname, search) {},
+          trackError: function (description) {},
+          trackEvent: function (category, action, labelOrValue, value) {},
+        };
+      },
+    },
+  };
 }
 ```
 

--- a/packages/jaeger-ui/src/utils/tracking/README.md
+++ b/packages/jaeger-ui/src/utils/tracking/README.md
@@ -10,16 +10,16 @@ The config file must define a top-level `UIConfig()` function.
 
 The `customWebAnalytics` value is a factory function that receives three arguments:
 
-| Argument | Type | Description |
-|---|---|---|
-| `config` | `Config` | Full Jaeger UI config object |
+| Argument       | Type     | Description                                        |
+| -------------- | -------- | -------------------------------------------------- |
+| `config`       | `Config` | Full Jaeger UI config object                       |
 | `versionShort` | `string` | Short version string, e.g. `"0.0.1 \| git status"` |
-| `versionLong` | `string` | Long version string (truncated to 99 chars) |
+| `versionLong`  | `string` | Long version string (truncated to 99 chars)        |
 
 The factory must return an object implementing the `IWebAnalytics` interface:
 
 | Field | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `init` | `() => void` | Called once on app start |
 | `isEnabled` | `() => boolean` | Return `true` to enable tracking; `false` to disable all calls |
 | `context` | `boolean \| null` | `true` enables automatic error breadcrumb capture; `null`/`false` disables it |
@@ -36,7 +36,9 @@ function UIConfig() {
       customWebAnalytics: function (config, versionShort, versionLong) {
         return {
           init: function () {},
-          isEnabled: function () { return true; },
+          isEnabled: function () {
+            return true;
+          },
           context: true,
           trackPageView: function (pathname, search) {},
           trackError: function (description) {},

--- a/packages/jaeger-ui/src/utils/tracking/README.md
+++ b/packages/jaeger-ui/src/utils/tracking/README.md
@@ -2,11 +2,11 @@
 
 App analytics (page views and errors) are supported in Jaeger UI through integration with Google Analytics or via customized plugins. The `tracking` section of the UI config must be provided. See the [documentation](https://www.jaegertracing.io/docs/latest/frontend-ui/) for details on the UI config.
 
-The page-view tracking is pretty basic, so details aren't provided. The GA tracking is configured with [App Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#apptracking) data. These fields, described [below](#app-tracking), can be used as a secondary dimension when viewing event data in GA. The error tracking is described, [below](#error-tracking).
+The GA tracking is configured with [App Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#apptracking) data. These fields, described [below](#app-tracking), can be used as a secondary dimension when viewing event data in GA. The error tracking is described [below](#error-tracking).
 
 To enable a custom plugin, use the JavaScript version of the configuration file (not JSON, since a function reference is required) and set `customWebAnalytics` instead of `gaID` — the two are mutually exclusive. A working example that logs all events to the browser console is provided in [`jaeger-ui.config.console-analytics.js`](../../../jaeger-ui.config.console-analytics.js).
 
-The config file must define a top-level `UIConfig()` function — this is enforced by the `jaeger` binary and matched by the Vite dev server.
+The config file must define a top-level `UIConfig()` function.
 
 The `customWebAnalytics` value is a factory function that receives three arguments:
 

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -188,7 +188,7 @@ function jaegerUiConfigPlugin() {
 export default defineConfig({
   define: {
     __REACT_APP_GA_DEBUG__: JSON.stringify(process.env.REACT_APP_GA_DEBUG || ''),
-    __REACT_APP_VSN_STATE__: JSON.stringify(process.env.REACT_APP_VSN_STATE || ''),
+    __REACT_APP_VSN_STATE__: JSON.stringify(process.env.REACT_APP_VSN_STATE || 'dev'),
     __APP_ENVIRONMENT__: JSON.stringify(process.env.NODE_ENV || 'development'),
   },
   plugins: [

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
+import vm from 'vm';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -140,6 +141,26 @@ function jaegerUiConfigPlugin() {
             // Inject the file verbatim — it must define UIConfig() itself,
             // matching the contract enforced by the jaeger binary.
             html = html.replace('// JAEGER_CONFIG_JS', jsContent);
+
+            // Extract storageCapabilities from the JS config by executing it in a sandbox
+            // and calling UIConfig(), mirroring the JSON config path's special treatment.
+            try {
+              const sandbox: { UIConfig?: () => { storageCapabilities?: Record<string, unknown> } } = {};
+              vm.runInNewContext(jsContent, sandbox);
+              const storageCapabilities = sandbox.UIConfig?.()?.storageCapabilities;
+              if (storageCapabilities) {
+                html = html.replace(
+                  'const JAEGER_STORAGE_CAPABILITIES = DEFAULT_STORAGE_CAPABILITIES;',
+                  `const JAEGER_STORAGE_CAPABILITIES = { ...DEFAULT_STORAGE_CAPABILITIES, ...${JSON.stringify(storageCapabilities)} };`
+                );
+              }
+            } catch (evalErr) {
+              console.warn(
+                '[jaeger-ui-config] Could not evaluate JS config for storageCapabilities:',
+                evalErr
+              );
+            }
+
             console.log('[jaeger-ui-config] Loaded config from jaeger-ui.config.js');
             return html;
           } catch (err) {

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -137,10 +137,9 @@ function jaegerUiConfigPlugin() {
         if (fs.existsSync(jsConfigPath)) {
           try {
             const jsContent = fs.readFileSync(jsConfigPath, 'utf-8');
-            // Replace the JAEGER_CONFIG_JS comment with UIConfig function
-            // This mimics the Go server behavior for .js config files
-            const uiConfigFn = `function UIConfig() { ${jsContent} }`;
-            html = html.replace('// JAEGER_CONFIG_JS', uiConfigFn);
+            // Inject the file verbatim — it must define UIConfig() itself,
+            // matching the contract enforced by the jaeger binary.
+            html = html.replace('// JAEGER_CONFIG_JS', jsContent);
             console.log('[jaeger-ui-config] Loaded config from jaeger-ui.config.js');
             return html;
           } catch (err) {


### PR DESCRIPTION
## Description

- Adds `packages/jaeger-ui/jaeger-ui.config.console-analytics.js` — a ready-to-use example config that logs all analytics events to the browser console, useful as a starting template for custom integrations
- Updates `src/utils/tracking/README.md`:
  - Fixes the factory function signature (was missing `config`, `versionShort`, `versionLong` arguments)
  - Documents the `IWebAnalytics` interface fields in a table
  - Notes that `customWebAnalytics` and `gaID` are mutually exclusive
  - Links to the new example file
- Fixes `packages/jaeger-ui/README.md` "Configuration as Javascript" section: the description was incorrect (old behavior); now correctly documents that the JS config file must define `UIConfig()` at the top level, and updates the local dev example accordingly
- Fixes `vite.config.mts` Vite dev plugin for JS configs:
  - Was incorrectly wrapping the file content inside a generated `UIConfig()` shell; now injects the file verbatim (matching the `jaeger` binary behavior, which requires the file to define `UIConfig()` itself)
  - Bug fix: `storageCapabilities` in a JS config was silently ignored in dev mode; the plugin now evaluates the JS file in a vm sandbox, extracts `storageCapabilities` from `UIConfig()`, and injects it into `JAEGER_STORAGE_CAPABILITIES` — matching the treatment the JSON config path already had
  - Defaults `REACT_APP_VSN_STATE` to `'dev'` so version strings in `npm start` mode are meaningful instead of 'unknown'

> **Note:** The `storageCapabilities` fix only applies to `npm start` (dev mode). In production the `jaeger` binary injects the JS file verbatim without evaluating it, so `storageCapabilities` inside `UIConfig()` is still ignored there.

## Checklist
- [x] I have signed all commits

## AI Usage
This PR was developed with AI assistance (Claude Code).