### PR TITLE
chore(husky): Delegate to personal pre-commit hook if present

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,5 @@
 #!/usr/bin/env sh
+# Allow contributors to add personal pre-commit logic (e.g. branch guards)
+# without modifying this file. The personal hook is never committed to the repo.
+[ -x "${HOME}/.config/git/hooks/pre-commit" ] && "${HOME}/.config/git/hooks/pre-commit"
 npx lint-staged


### PR DESCRIPTION
## Summary

- Adds a one-liner to `.husky/pre-commit` that calls `~/.config/git/hooks/pre-commit` before running lint-staged, if the file exists and is executable
- No effect for contributors who don't have that file — the `[ -x ]` guard makes it a no-op

## Motivation

Gives contributors a stable place for personal-only pre-commit logic (e.g. branch guards) that survives `npm install` re-running Husky's `prepare` script, which only resets `core.hooksPath` and never modifies hook file contents.

## Test plan
- [ ] With `~/.config/git/hooks/pre-commit` absent: `git commit` behaves as before
- [ ] With the file present and returning non-zero: commit is blocked
- [ ] `npm install` does not remove the delegate line

🤖 Generated with [Claude Code](https://claude.com/claude-code)