### PR TITLE
fix(husky): Propagate personal hook exit code correctly

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 # Allow contributors to add personal pre-commit logic (e.g. branch guards)
 # without modifying this file. The personal hook is never committed to the repo.
-[ -x "${HOME}/.config/git/hooks/pre-commit" ] && "${HOME}/.config/git/hooks/pre-commit"
+if [ -x "${HOME}/.config/git/hooks/pre-commit" ]; then
+  "${HOME}/.config/git/hooks/pre-commit" || exit $?
+fi
 npx lint-staged


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #3989: the `&&` shorthand did not propagate the personal hook's exit code — if the hook exited non-zero, execution continued to `npx lint-staged` and the commit was not blocked.

The fix uses an explicit `if / || exit $?` form, which is the only safe pattern here: `[ -x ] && hook || exit $?` would also call `exit` when the file is absent (because `[ -x ]` returns 1, `&&` skips the hook, and then `||` fires).

## Test plan
- [ ] With `~/.config/git/hooks/pre-commit` absent: commit proceeds normally
- [ ] With the file present returning 0: commit proceeds normally  
- [ ] With the file present returning non-zero: commit is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)