### PR TITLE
fix(deps-graph): Tidy toolbar layout and clear stale visual issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ npm-debug.log
 .eslintcache
 .envrc
 .vscode
+.playwright-mcp/
 
 # scripts
 scripts/release-notes.py

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.css
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.css
@@ -62,9 +62,21 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .select-a-service-input,
-.layout-selector-input,
-.number-input {
+.layout-selector-input {
   min-width: 200px;
+}
+
+.number-input {
+  min-width: 50px;
+}
+
+.depth-column {
+  width: 60px;
+}
+
+.depth-column .number-input {
+  min-width: 0;
+  width: 100%;
 }
 
 .number-input .ant-input-number-handler-wrap {
@@ -128,12 +140,21 @@ SPDX-License-Identifier: Apache-2.0
 .data-selector {
   margin-left: auto;
   align-self: flex-end;
-  min-width: 200px;
+  min-width: 120px;
+}
+
+.reset-column {
+  /* Reserve the label row height + gap so the button aligns with the
+     input row of the labeled columns. */
+  padding-top: 20px;
+}
+
+.search-column {
+  /* Extra left margin separates the Search group from the Reset button. */
+  margin-left: 24px;
 }
 
 .reset-button {
-  margin-left: 8px;
-  margin-right: 30px;
   height: 32px;
   background-color: var(--surface-secondary);
   border: 1px solid var(--border-default);
@@ -143,7 +164,7 @@ SPDX-License-Identifier: Apache-2.0
   transition: all 0.3s;
 }
 
-.reset-button:hover {
+.reset-button:hover:not(:disabled) {
   background-color: var(--surface-component-background-hover);
   border-color: var(--border-default);
   color: var(--text-primary);

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.test.jsx
@@ -147,12 +147,19 @@ describe('DAGOptions', () => {
   });
 
   it('handles reset button click', () => {
-    render(<DAGOptions {...defaultProps} />);
+    render(<DAGOptions {...defaultProps} selectedService="service-1" />);
 
     const resetButton = screen.getByTestId('reset-button');
     fireEvent.click(resetButton);
 
     expect(defaultProps.onReset).toHaveBeenCalled();
+  });
+
+  it('disables reset button when no service is selected', () => {
+    render(<DAGOptions {...defaultProps} selectedService={null} />);
+
+    const resetButton = screen.getByTestId('reset-button');
+    expect(resetButton).toBeDisabled();
   });
 
   it('disables depth input when no service is selected', () => {

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAGOptions.tsx
@@ -138,7 +138,7 @@ const DAGOptions: React.FC<IDAGOptionsProps> = ({
           ))}
         </SearchableSelect>
       </div>
-      <div className="selector-container">
+      <div className="selector-container depth-column">
         <div className="selector-label-container">
           <span className="selector-label">Depth</span>
           <Popover
@@ -158,28 +158,29 @@ const DAGOptions: React.FC<IDAGOptionsProps> = ({
             <IoHelp className="hint-trigger" data-testid="depth-help-icon" />
           </Popover>
         </div>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <InputNumber
-            className="number-input"
-            value={selectedDepth}
-            onChange={onDepthChange}
-            min={0}
-            placeholder="Enter number"
-            disabled={!selectedService}
-            data-testid="depth-input"
-          />
-          <Button
-            onClick={onReset}
-            data-testid="reset-button"
-            type="default"
-            className="reset-button"
-            size="small"
-          >
-            Reset
-          </Button>
-        </div>
+        <InputNumber
+          className="number-input"
+          value={selectedDepth}
+          onChange={onDepthChange}
+          min={0}
+          placeholder="Enter number"
+          disabled={!selectedService}
+          data-testid="depth-input"
+        />
       </div>
-      <div className="selector-container">
+      <div className="selector-container reset-column">
+        <Button
+          onClick={onReset}
+          data-testid="reset-button"
+          type="default"
+          className="reset-button"
+          size="small"
+          disabled={!selectedService}
+        >
+          Reset
+        </Button>
+      </div>
+      <div className="selector-container search-column">
         <div className="selector-label-container">
           <span className="selector-label">Search</span>
           <Popover
@@ -211,12 +212,12 @@ const DAGOptions: React.FC<IDAGOptionsProps> = ({
       {getAppEnvironment() === 'development' && (
         <div className="selector-container data-selector">
           <div className="selector-label-container">
-            <span className="selector-label">Sample Dataset</span>
+            <span className="selector-label">Dataset Source</span>
           </div>
           <SearchableSelect
             value={selectedSampleDatasetType}
             onChange={onSampleDatasetTypeChange}
-            placeholder="Select Sample Dataset Type"
+            placeholder="Select dataset source"
             className="select-sample-dataset-type-input"
             data-testid="sample-dataset-type-select"
           >

--- a/packages/jaeger-ui/src/components/DependencyGraph/index.css
+++ b/packages/jaeger-ui/src/components/DependencyGraph/index.css
@@ -12,6 +12,16 @@ SPDX-License-Identifier: Apache-2.0
   top: 130px;
 }
 
+/* When the toolbar wraps to a second row (narrow viewports), it would
+   overlap the fixed graph wrapper. Push the wrapper down to clear the
+   wrapped row. The breakpoint matches the width at which the current
+   DAGOptions controls stop fitting on one line. */
+@media (max-width: 1050px) {
+  .DependencyGraph--graphWrapper {
+    top: 190px;
+  }
+}
+
 .rv-force__node {
   fill: #11939a;
   cursor: pointer;


### PR DESCRIPTION
## Which problem is this PR solving?

The Dependency Graph toolbar has several layout issues that compound at typical laptop widths:

- The Depth column is ~290px wide because it secretly contains both the `Depth` `InputNumber` **and** the Reset button laid out side-by-side. The label sits over only the input; Reset just rides along.
- The "Sample Dataset" dropdown's wording is awkward, and its 200px column adds to overflow.
- At common viewports (≤~1180px), `.dag-options` wraps `Dataset Source` to a second row. But `.DependencyGraph--graphWrapper` is `position: fixed; top: 130px;`, so the graph layer paints right over the wrapped row — the second-row controls are present in the DOM but invisible.
- Reset stays enabled and highlight-hovers even when no service is selected and there's nothing to reset.
- `.playwright-mcp/` was being created at the repo root by local browser-automation tooling.

## Description of the changes

- Lift `Reset` out of Depth's `.selector-container` into its own `.reset-column`, with a `padding-top` placeholder so the button aligns with the other inputs (no empty `<div>` in markup).
- Trim widths: `.number-input` 200→50px min-width, plus an explicit `.depth-column { width: 60px }`. `.data-selector` (`Dataset Source`) 200→120px.
- Rename **Sample Dataset → Dataset Source** (label + placeholder).
- Add `disabled={!selectedService}` to the Reset button so it greys out when there's nothing to reset, and scope `.reset-button:hover` to `:not(:disabled)` so it no longer brightens while disabled.
- Add `.search-column { margin-left: 24px }` to visually separate the Search group from Reset.
- Keep `.DependencyGraph--graphWrapper { position: fixed }` (plexus measures-on-mount and needs explicit pixel dimensions), but only bump `top: 130 → 190px` at `max-width: 1050px` — the new wrap threshold given the tighter columns. At wider viewports the graph sits flush under the now single-row toolbar.
- Update the existing reset-button-click test to pass a selected service (so the button is enabled and clickable), and add a new test verifying the disabled state when no service is selected.
- Add `.playwright-mcp/` to `.gitignore`.

## How was this change tested?

- `npm run fmt`, `npm run tsc-lint`, `npm test -w packages/jaeger-ui`, `npm run build` — all pass.
- Manually verified in dev:
  - At 1280px viewport: single-row toolbar, all six controls aligned at `y=64`, graph renders directly below.
  - At ~1040px viewport: `Dataset Source` wraps to a second row and the graph wrapper is pushed down to clear it.
  - Reset disabled on fresh load (no Focal Service), enables after picking a service, disables again after clicking Reset; no hover highlight in the disabled state.

<img width="1163" height="641" alt="image" src="https://github.com/user-attachments/assets/afbe359e-8804-4260-8b50-c75b8d7f8a98" />

## AI Usage in this PR (choose one)
- [ ] **None**
- [ ] **Light**
- [ ] **Moderate**
- [x] **Heavy**: layout debugging and implementation done with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)