### PR TITLE
docs(adr): Update ADR 0004 phase 2d after deps-graph refactor

### DIFF
--- a/docs/adr/0004-state-management-strategy.md
+++ b/docs/adr/0004-state-management-strategy.md
@@ -1,7 +1,7 @@
 # ADR 0004: State Management Strategy for Jaeger UI
 
 **Status**: Proposed  
-**Last Updated**: 2026-04-17 
+**Last Updated**: 2026-05-30 
 **Reviewed**: Pending
 
 ---
@@ -1129,12 +1129,17 @@ export function useSpanNames(service: string | null, spanKind?: string): UseQuer
 
 **New hook** (`src/hooks/useDependenciesQuery.ts`):
 ```typescript
-queryKey: ['dependencies', { endTs, lookback }]
+queryKey: ['dependencies', source, keyEndTs, lookback]
 ```
 
-**Callers** use `useDependenciesQuery()` — not cache key literals. `DependencyGraph` merges API data with dev sample datasets (module-level store unchanged).
+**Hook signature**: `useDependenciesQuery(source: DataSource = 'Backend', { endTs?, lookback? } = {})`.
 
-**Components using hook**: `DependencyGraph` (default export).
+- `source` selects between the real backend (`'Backend'`) and the dev-only canned datasets (`'Small Graph'`, `'Large Graph'`); the dev branches dynamic-import `./sample_data/*.json` under `import.meta.env.DEV` so Vite tree-shakes them out of production bundles. The previous module-level `createSampleDataManager` / `getSampleData` / `useEffectiveDependencies` / `sampleRevision` indirection that bridged a side cache back into React is gone — the dev sources are just alternative React Query entries keyed by `source`.
+- `endTs` is resolved lazily inside `queryFn` (`params.endTs ?? Date.now()`) rather than captured at mount, because the dep-graph page has no user-facing time-window UI. The implicit semantic is "show me up to now", so refetches (incl. `refetchOnWindowFocus`) advance with wall-clock time. Contrast with `useSearchTraces`, where `endTs` is part of the URL/SearchQuery and resolved eagerly because the user owns the window. `keyEndTs` is `params.endTs ?? null` so an unspecified `endTs` is shared across mounts.
+
+**Callers** use `useDependenciesQuery(source)` — not cache key literals.
+
+**Components using hook**: `DependencyGraph` (default export, which is also the single page component after the Redux-era `DependencyGraphPageImpl` / wrapper split was collapsed).
 
 #### ⬜ 2e. Deep Dependencies graph fetch
 


### PR DESCRIPTION
## Which problem is this PR solving?

Related to #3926.

PR #3991 migrated the dependency-graph page off Redux to React Query. PR #3993 then restructured the resulting hook: the dev sample datasets ("Small Graph", "Large Graph") were folded into `useDependenciesQuery` as a `source` argument, the module-level `createSampleDataManager` / `getSampleData` / `useEffectiveDependencies` / `sampleRevision` bridge was deleted, and `endTs` was changed from a `useRef`-captured-at-mount value to a lazy `Date.now()` evaluated inside `queryFn` so refetches walk the time window forward.

Section 2d of ADR 0004 still described the original shape from #3991 — wrong query key, wrong claims about "merges API data with dev sample datasets (module-level store unchanged)", no mention of the lazy `endTs` resolution or the dev-source folding.

## Description of the changes

- Update the `queryKey` example in section 2d from `['dependencies', { endTs, lookback }]` to the new `['dependencies', source, keyEndTs, lookback]` shape.
- Add a "Hook signature" subsection documenting the two structural choices from #3993:
  - `source` folds the dev sample datasets into the query, guarded by `import.meta.env.DEV` so the JSON imports tree-shake out of production bundles. The previous module-level side cache and its React-bridge code is deleted.
  - `endTs` resolves lazily inside `queryFn` because the dep-graph page has no user-facing time-window UI — the implicit semantic is "show me up to now", so refetches must advance with wall-clock time. Cross-reference `useSearchTraces` as the opposite case (URL-owned window, eager resolution).
- Note in "Components using hook" that the `DependencyGraphPageImpl` / wrapper split (a Redux-era artifact) was collapsed in #3993.
- Bump the "Last Updated" date to 2026-05-30.

No code changes; doc-only update so the ADR matches the codebase that just landed.

## How was this change tested?

N/A — documentation-only change.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
- [ ] **None**
- [ ] **Light**
- [ ] **Moderate**
- [x] **Heavy**: ADR audit and rewrite drafted with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)