### PR TITLE
refactor(ids): normalize trace/span IDs at API boundary

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -319,6 +319,23 @@ describe('JaegerClient', () => {
       expect(summary.services).toEqual(mockApiSummary.services);
     });
 
+    it('normalizes traceId: strips leading zeros and lowercases', async () => {
+      const paddedSummary = {
+        ...mockApiSummary,
+        traceId: '0000BBBBCCCCDDDD0000111122223333',
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ summaries: [paddedSummary] }),
+      });
+
+      const promise = client.fetchTraceSummaries(query);
+      vi.runAllTimers();
+      const [summary] = await promise;
+
+      expect(summary.traceID).toBe('bbbbccccdddd0000111122223333');
+    });
+
     it('falls back to defaults for all optional fields when absent', async () => {
       // Only traceId is required; everything else including timestamps is optional.
       const minimal = { traceId: 'aaaabbbbccccdddd0000111122223333' };

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -10,6 +10,7 @@
 
 import prefixUrl from '../../utils/prefix-url';
 import { ServicesResponseSchema, OperationsResponseSchema, TraceSummariesResponseSchema } from './schemas';
+import { normalizeId } from '../../model/transform-trace-data';
 import type { SearchQuery } from '../../types/search';
 import type { TraceSummary, ServiceSummary } from '../../types/trace-summary';
 import type { Microseconds } from '../../types/units';
@@ -104,7 +105,7 @@ export class JaegerClient {
         errorSpanCount: svc.errorSpanCount,
       }));
       return {
-        traceID: s.traceId,
+        traceID: s.traceId ? normalizeId(s.traceId) : '',
         traceName:
           rootServiceName && rootOperationName
             ? `${rootServiceName}: ${rootOperationName}`

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test1.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test1.js
@@ -22,12 +22,12 @@ const testTrace = {
   traceID: 'test1-trace',
   spans: [
     {
-      spanID: 'span-E',
+      spanID: 'span-e',
       operationName: 'operation E',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-C',
+          spanID: 'span-c',
         },
       ],
       startTime: 50,
@@ -35,7 +35,7 @@ const testTrace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-C',
+      spanID: 'span-c',
       operationName: 'operation C',
       references: [],
       startTime: 1,
@@ -43,12 +43,12 @@ const testTrace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-D',
+      spanID: 'span-d',
       operationName: 'operation D',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-C',
+          spanID: 'span-c',
         },
       ],
       startTime: 20,
@@ -67,27 +67,27 @@ const transformedTrace = transformTraceData(testTrace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-C',
+    spanID: 'span-c',
     sectionStart: 60,
     sectionEnd: 101,
   },
   {
-    spanID: 'span-E',
+    spanID: 'span-e',
     sectionStart: 50,
     sectionEnd: 60,
   },
   {
-    spanID: 'span-C',
+    spanID: 'span-c',
     sectionStart: 40,
     sectionEnd: 50,
   },
   {
-    spanID: 'span-D',
+    spanID: 'span-d',
     sectionStart: 20,
     sectionEnd: 40,
   },
   {
-    spanID: 'span-C',
+    spanID: 'span-c',
     sectionStart: 1,
     sectionEnd: 20,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test2.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test2.js
@@ -24,7 +24,7 @@ const happyTrace = {
   traceID: 'trace-123',
   spans: [
     {
-      spanID: 'span-X',
+      spanID: 'span-x',
       operationName: 'op1',
       startTime: 1,
       duration: 100,
@@ -34,14 +34,14 @@ const happyTrace = {
       logs: [],
     },
     {
-      spanID: 'span-A',
+      spanID: 'span-a',
       operationName: 'op2',
       startTime: 10,
       duration: 40,
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-X',
+          spanID: 'span-x',
         },
       ],
       processID: 'p1',
@@ -49,14 +49,14 @@ const happyTrace = {
       logs: [],
     },
     {
-      spanID: 'span-C',
+      spanID: 'span-c',
       operationName: 'op3',
       startTime: 20,
       duration: 40,
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-X',
+          spanID: 'span-x',
         },
       ],
       processID: 'p1',
@@ -76,17 +76,17 @@ const transformedTrace = transformTraceData(happyTrace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-X',
+    spanID: 'span-x',
     sectionStart: 60,
     sectionEnd: 101,
   },
   {
-    spanID: 'span-C',
+    spanID: 'span-c',
     sectionStart: 20,
     sectionEnd: 60,
   },
   {
-    spanID: 'span-X',
+    spanID: 'span-x',
     sectionStart: 1,
     sectionEnd: 20,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test3.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test3.js
@@ -23,7 +23,7 @@ const traceStart = 100;
 
 const criticalPathSections = [
   {
-    spanID: '006c3cf93508f205',
+    spanID: '6c3cf93508f205',
     sectionStart: traceStart,
     sectionEnd: traceStart + 40,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test4.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test4.js
@@ -24,7 +24,7 @@ const trace = {
   traceID: 'trace-abc',
   spans: [
     {
-      spanID: 'span-A',
+      spanID: 'span-a',
       operationName: 'op-A',
       references: [],
       startTime: 1,
@@ -32,12 +32,12 @@ const trace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-B',
+      spanID: 'span-b',
       operationName: 'op-B',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-A',
+          spanID: 'span-a',
         },
       ],
       startTime: 40,
@@ -50,7 +50,7 @@ const trace = {
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-B',
+          spanID: 'span-b',
         },
       ],
       startTime: 50,
@@ -69,7 +69,7 @@ const transformedTrace = transformTraceData(trace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-A',
+    spanID: 'span-a',
     sectionStart: 1,
     sectionEnd: 31,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test5.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test5.js
@@ -23,7 +23,7 @@ const trace = {
   traceID: 'trace-abc',
   spans: [
     {
-      spanID: 'span-A',
+      spanID: 'span-a',
       operationName: 'op-A',
       references: [],
       startTime: 1,
@@ -32,12 +32,12 @@ const trace = {
       tags: [{ key: 'span.kind', value: 'producer' }],
     },
     {
-      spanID: 'span-B',
+      spanID: 'span-b',
       operationName: 'op-B',
       references: [
         {
           refType: 'FOLLOWS_FROM',
-          spanID: 'span-A',
+          spanID: 'span-a',
         },
       ],
       startTime: 10,
@@ -46,12 +46,12 @@ const trace = {
       tags: [{ key: 'span.kind', value: 'consumer' }],
     },
     {
-      spanID: 'span-C',
+      spanID: 'span-c',
       operationName: 'op-C',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-B',
+          spanID: 'span-b',
         },
       ],
       startTime: 12,
@@ -70,7 +70,7 @@ const transformedTrace = transformTraceData(trace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-A',
+    spanID: 'span-a',
     sectionStart: 1,
     sectionEnd: 31,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test6.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test6.js
@@ -21,7 +21,7 @@ const trace = {
   traceID: 'trace-abc',
   spans: [
     {
-      spanID: 'span-A',
+      spanID: 'span-a',
       operationName: 'op-A',
       references: [],
       startTime: 1,
@@ -29,12 +29,12 @@ const trace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-B',
+      spanID: 'span-b',
       operationName: 'op-B',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-A',
+          spanID: 'span-a',
         },
       ],
       startTime: 15,
@@ -42,12 +42,12 @@ const trace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-C',
+      spanID: 'span-c',
       operationName: 'op-C',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-B',
+          spanID: 'span-b',
         },
       ],
       startTime: 10,
@@ -66,17 +66,17 @@ const transformedTrace = transformTraceData(trace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-B',
+    spanID: 'span-b',
     sectionStart: 25,
     sectionEnd: 30,
   },
   {
-    spanID: 'span-C',
+    spanID: 'span-c',
     sectionStart: 15,
     sectionEnd: 25,
   },
   {
-    spanID: 'span-A',
+    spanID: 'span-a',
     sectionStart: 1,
     sectionEnd: 15,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test7.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test7.js
@@ -21,7 +21,7 @@ const trace = {
   traceID: 'trace-abc',
   spans: [
     {
-      spanID: 'span-A',
+      spanID: 'span-a',
       operationName: 'op-A',
       references: [],
       startTime: 1,
@@ -29,12 +29,12 @@ const trace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-B',
+      spanID: 'span-b',
       operationName: 'op-B',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-A',
+          spanID: 'span-a',
         },
       ],
       startTime: 15,
@@ -42,12 +42,12 @@ const trace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-C',
+      spanID: 'span-c',
       operationName: 'op-C',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-B',
+          spanID: 'span-b',
         },
       ],
       startTime: 20,
@@ -66,17 +66,17 @@ const transformedTrace = transformTraceData(trace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-C',
+    spanID: 'span-c',
     sectionStart: 20,
     sectionEnd: 30,
   },
   {
-    spanID: 'span-B',
+    spanID: 'span-b',
     sectionStart: 15,
     sectionEnd: 20,
   },
   {
-    spanID: 'span-A',
+    spanID: 'span-a',
     sectionStart: 1,
     sectionEnd: 15,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test8.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test8.js
@@ -17,7 +17,7 @@ const trace = {
   traceID: 'trace-abc',
   spans: [
     {
-      spanID: 'span-A',
+      spanID: 'span-a',
       operationName: 'op-A',
       references: [],
       startTime: 10,
@@ -25,12 +25,12 @@ const trace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-B',
+      spanID: 'span-b',
       operationName: 'op-B',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-A',
+          spanID: 'span-a',
         },
       ],
       startTime: 5,
@@ -49,7 +49,7 @@ const transformedTrace = transformTraceData(trace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-B',
+    spanID: 'span-b',
     sectionStart: 10,
     sectionEnd: 30,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test9.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/testCases/test9.js
@@ -19,7 +19,7 @@ const trace = {
   traceID: 'trace-abc',
   spans: [
     {
-      spanID: 'span-A',
+      spanID: 'span-a',
       operationName: 'op-A',
       references: [],
       startTime: 10,
@@ -27,12 +27,12 @@ const trace = {
       processID: 'p1',
     },
     {
-      spanID: 'span-B',
+      spanID: 'span-b',
       operationName: 'op-B',
       references: [
         {
           refType: 'CHILD_OF',
-          spanID: 'span-A',
+          spanID: 'span-a',
         },
       ],
       startTime: 1,
@@ -51,7 +51,7 @@ const transformedTrace = transformTraceData(trace);
 
 const criticalPathSections = [
   {
-    spanID: 'span-A',
+    spanID: 'span-a',
     sectionStart: 10,
     sectionEnd: 30,
   },

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/utils/findLastFinishingChildSpan.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/utils/findLastFinishingChildSpan.test.js
@@ -12,22 +12,22 @@ describe('findLastFinishingChildSpanId', () => {
     const spanMap = createCPSpanMap(test1.trace.rootSpans[0]);
     const sanitizedSpanMap = sanitizeOverFlowingChildren(spanMap);
 
-    const currentSpan = sanitizedSpanMap.get('span-C');
+    const currentSpan = sanitizedSpanMap.get('span-c');
     let lastFinishingChildSpan = findLastFinishingChildSpanId(sanitizedSpanMap, currentSpan);
-    expect(lastFinishingChildSpan).toStrictEqual(sanitizedSpanMap.get('span-E'));
+    expect(lastFinishingChildSpan).toStrictEqual(sanitizedSpanMap.get('span-e'));
 
     // Second Case to check if it works with spawn time or not
     lastFinishingChildSpan = findLastFinishingChildSpanId(sanitizedSpanMap, currentSpan, 50);
-    expect(lastFinishingChildSpan).toStrictEqual(sanitizedSpanMap.get('span-D'));
+    expect(lastFinishingChildSpan).toStrictEqual(sanitizedSpanMap.get('span-d'));
   });
 
   it('Should find lfc of a span correctly with test2', () => {
     const spanMap = createCPSpanMap(test2.trace.rootSpans[0]);
     const sanitizedSpanMap = sanitizeOverFlowingChildren(spanMap);
 
-    const currentSpan = sanitizedSpanMap.get('span-X');
+    const currentSpan = sanitizedSpanMap.get('span-x');
     let lastFinishingChildSpanId = findLastFinishingChildSpanId(sanitizedSpanMap, currentSpan);
-    expect(lastFinishingChildSpanId).toStrictEqual(sanitizedSpanMap.get('span-C'));
+    expect(lastFinishingChildSpanId).toStrictEqual(sanitizedSpanMap.get('span-c'));
 
     // Second Case to check if it works with spawn time or not
     lastFinishingChildSpanId = findLastFinishingChildSpanId(sanitizedSpanMap, currentSpan, 20);

--- a/packages/jaeger-ui/src/components/TracePage/CriticalPath/utils/sanitizeOverFlowingChildren.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/CriticalPath/utils/sanitizeOverFlowingChildren.test.js
@@ -15,15 +15,15 @@ function getExpectedSanitizedData(spans, test) {
   // Define what the expected modifications are for each test
   const modifications = {
     test6: {
-      'span-B': { duration: 15 },
-      'span-C': { duration: 10, startTime: 15 },
+      'span-b': { duration: 15 },
+      'span-c': { duration: 10, startTime: 15 },
     },
     test7: {
-      'span-B': { duration: 15 },
-      'span-C': { duration: 10 },
+      'span-b': { duration: 15 },
+      'span-c': { duration: 10 },
     },
     test8: {
-      'span-B': { startTime: 10, duration: 20 },
+      'span-b': { startTime: 10, duration: 20 },
     },
   };
 

--- a/packages/jaeger-ui/src/hooks/useTraceLoading.ts
+++ b/packages/jaeger-ui/src/hooks/useTraceLoading.ts
@@ -10,6 +10,10 @@ import { queryClient } from '../query/app-query-client';
 import { FetchedTrace } from '../types';
 import type { IOtelTrace } from '../types/otel';
 
+// IDs are normalized once at the API boundary (transform-trace-data.ts) and
+// treated as opaque strings from then on -- no further transformation here.
+// Short/abbreviated IDs a user types are resolved by the backend, which
+// redirects the URL to the canonical ID (see useNormalizeTraceId.ts).
 const TRACE_QUERY_KEY = (id: string) => ['trace', id] as const;
 
 // TODO: remove once callers (duck.track.ts, TraceDiff) are migrated off Redux/non-hook paths

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import traceGenerator from '../demo/trace-generators';
-import transformTraceData, { orderTags, deduplicateTags } from './transform-trace-data';
+import transformTraceData, { orderTags, deduplicateTags, normalizeId } from './transform-trace-data';
 
 describe('orderTags()', () => {
   it('correctly orders tags', () => {
@@ -23,6 +23,24 @@ describe('orderTags()', () => {
       { key: 'http.Status_code', value: '200' },
       { key: 'b.ip', value: '8.8.4.4' },
     ]);
+  });
+});
+
+describe('normalizeId()', () => {
+  it('lowercases the ID', () => {
+    expect(normalizeId('ABCD1234')).toBe('abcd1234');
+  });
+  it('strips leading zeros', () => {
+    expect(normalizeId('0000abc123')).toBe('abc123');
+  });
+  it('strips leading zeros and lowercases in the same call', () => {
+    expect(normalizeId('000ABC')).toBe('abc');
+  });
+  it('leaves an all-zero ID as a single zero, not an empty string', () => {
+    expect(normalizeId('0000')).toBe('0');
+  });
+  it('leaves an already-normalized ID unchanged', () => {
+    expect(normalizeId('abc123')).toBe('abc123');
   });
 });
 
@@ -124,6 +142,24 @@ describe('transformTraceData()', () => {
       tags: [],
     },
   };
+
+  it('normalizes traceID and spanIDs from the backend: strips leading zeros and lowercases', () => {
+    const paddedTraceID = `00${traceID.toUpperCase()}`;
+    const rawSpan = {
+      traceID: paddedTraceID,
+      spanID: `00${rootSpanID.toUpperCase()}`,
+      operationName: rootOperationName,
+      references: [],
+      startTime,
+      duration,
+      tags: [],
+      logs: [],
+      processID: 'p1',
+    };
+    const result = transformTraceData({ traceID: paddedTraceID, processes, spans: [rawSpan] });
+    expect(result.traceID).toBe(traceID);
+    expect(result.spans[0].spanID).toBe(rootSpanID);
+  });
 
   it('should return null for trace without traceID', () => {
     const traceData = {
@@ -403,7 +439,7 @@ describe('transformTraceData()', () => {
       };
       const grandChild1 = {
         ...spans[0],
-        spanID: 'grandChild1',
+        spanID: 'grandchild1',
         startTime: tStart + 15,
         references: [{ refType: 'CHILD_OF', traceID, spanID: 'child1' }],
       };
@@ -428,18 +464,18 @@ describe('transformTraceData()', () => {
       const map = result.spanMap;
       expect(map.get('root').depth).toBe(0);
       expect(map.get('child1').depth).toBe(1);
-      expect(map.get('grandChild1').depth).toBe(2);
+      expect(map.get('grandchild1').depth).toBe(2);
       expect(map.get('child2').depth).toBe(1);
 
       // Check hasChildren
       expect(map.get('root').hasChildren).toBe(true);
       expect(map.get('child1').hasChildren).toBe(true);
-      expect(map.get('grandChild1').hasChildren).toBe(false);
+      expect(map.get('grandchild1').hasChildren).toBe(false);
       expect(map.get('child2').hasChildren).toBe(false);
 
       // Check flat spans order (DFS)
       const ids = result.spans.map(s => s.spanID);
-      expect(ids).toEqual(['root', 'child1', 'grandChild1', 'child2']);
+      expect(ids).toEqual(['root', 'child1', 'grandchild1', 'child2']);
     });
   });
 

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -57,14 +57,23 @@ export function orderTags(spanTags: KeyValuePair[], topPrefixes?: readonly strin
 }
 
 /**
+ * Converts a trace or span ID to its canonical form: lower-case, no leading zeros.
+ * The `|| '0'` guard handles the pathological all-zero input without returning an empty string.
+ */
+export function normalizeId(id: string): string {
+  return id.replace(/^0+/, '').toLowerCase() || '0';
+}
+
+/**
  * NOTE: Mutates `data` - Transform the HTTP response data into the form the app
  * generally requires.
  */
 export default function transformTraceData(data: TraceData & { spans: SpanData[] }): Trace | null {
-  const { traceID } = data;
-  if (!traceID) {
+  const { traceID: rawTraceID } = data;
+  if (!rawTraceID) {
     return null;
   }
+  const traceID = normalizeId(rawTraceID);
 
   let traceEndTime = 0;
   let traceStartTime = Number.MAX_SAFE_INTEGER;
@@ -80,7 +89,8 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
     // We populate/fix all properties below.
     const span: Span = data.spans[i] as Span;
     const { startTime, duration, processID } = span;
-    let spanID = span.spanID;
+    let spanID = normalizeId(span.spanID);
+    span.spanID = spanID;
     // make sure span IDs are unique
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
@@ -102,6 +112,9 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
       log.fields = log.fields || [];
     });
     span.references = span.references || [];
+    span.references.forEach(ref => {
+      ref.spanID = normalizeId(ref.spanID);
+    });
     span.childSpans = [];
     span.subsidiarilyReferencedBy = [];
 


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #3963

Trace and span IDs from the Jaeger backend have historically been returned both with and without leading zeros (e.g. `0000abcd…` vs `abcd…`), so the same trace/span could be looked up under two different string keys. This PR adds a single `normalizeId` helper and calls it at the two places IDs actually enter the app (`transformTraceData`, the v1/legacy API boundary, and the v3 client), so every ID has one canonical form from there on.

**Canonical form: strip, not pad.** `normalizeId(id) = id.replace(/^0+/, '').toLowerCase() || '0'`. IDs are treated as opaque hex blobs — this only removes the padding-vs-not-padding ambiguity and case ambiguity, it does not reinterpret the ID as a number.

## Description of the changes

**`model/transform-trace-data.ts`** — `normalizeId(id)` strips leading zeros and lowercases (the `|| '0'` guard avoids returning an empty string for an all-zero input). `transformTraceData` now applies it to:
- `traceID`
- `span.spanID`, in the first pass, before the dedup map (`spanIdCounts`) and `spanMap` are seeded
- `ref.spanID` for every reference on every span, in the same pass, so the second-pass `spanMap.get(ref.spanID)` parent/child lookups always hit

**`api/v3/client.ts`** — `fetchTraceSummaries` now normalizes `s.traceId` before it becomes `TraceSummary.traceID`, so search results and navigation see the canonical form too.

## Test changes

- `transform-trace-data.test.js` — `normalizeId()` unit tests now cover strip+lowercase (previously only lowercase); the integration test that asserted IDs pass through **unchanged** is replaced with one that builds a padded/uppercase ID and asserts it comes back stripped and lowercased.
- `CriticalPath/testCases/test1,2,4-9.js` + `findLastFinishingChildSpan.test.js` + `sanitizeOverFlowingChildren.test.js` — span IDs lowercased consistently on both the input and expected sides, since `transformTraceData` now actually lowercases them.
- `CriticalPath/testCases/test3.js` — its span ID fixture has a genuine leading `00...`; the expected `criticalPathSections[0].spanID` is updated to the stripped form.
- `api/v3/client.test.ts` — added a test that feeds a padded/uppercase `traceId` through `fetchTraceSummaries` and asserts the stripped/lowercased result, so the v3 boundary is actually exercised.

## What changed since the last review

- `normalizeId` previously had zero callers anywhere in source — it was defined and unit-tested but never wired into `transformTraceData` or the v3 client, so no normalization happened at either API boundary and `Closes #3963` wasn't accurate. It's now called at both sites described above.
- Dropped the unexplained `testTimeout: 30000` bump in `vitest.config.ts` — unrelated to this change and unjustified.
- Reverted the `SearchResults/index.test.jsx` edit that rewrote object keys to identical literal strings — `SearchResults` isn't touched by this PR's production code, so that edit was a no-op.
- Rebased onto latest `main`; `reducers/trace.ts`/`trace.test.js` (the Redux trace slice) was deleted upstream in the meantime, so this PR's edit to `trace.test.js` was dropped along with the file.

## How was this change tested?

- `npm test` — full suite passes
- `npx tsc -p packages/jaeger-ui/tsconfig.json` — no new type errors in any file this PR touches

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
