### PR TITLE
perf(tests): replace waitFor polls with act/direct assertions in TraceStatistics

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
@@ -252,19 +252,11 @@ describe('<TraceTagOverview>', () => {
       });
     });
 
-    const nameButtons = screen.getAllByRole('button');
-    const nameButton = nameButtons.find(
-      button => button.textContent.includes('SELECT') || button.style.borderLeft || button.style.padding
-    );
+    const nameButton = screen.getAllByRole('button').find(b => b.textContent.includes('SELECT'));
+    expect(nameButton).toBeDefined();
+    fireEvent.click(nameButton);
 
-    if (nameButton) {
-      fireEvent.click(nameButton);
-    }
-
-    const textarea = screen.queryByRole('textbox');
-    if (textarea) {
-      expect(textarea).toBeInTheDocument();
-    }
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
   it('should handle onClickOption when hasSubgroupValue is false', async () => {
@@ -306,14 +298,9 @@ describe('<TraceTagOverview>', () => {
       });
     });
 
-    const nameButtons = screen.getAllByRole('button');
-    const nameButton = nameButtons.find(
-      button => button.textContent.includes('test-name') || button.style.borderLeft || button.style.padding
-    );
-
-    if (nameButton) {
-      fireEvent.click(nameButton);
-    }
+    const nameButton = screen.getAllByRole('button').find(b => b.textContent.includes('test-name'));
+    expect(nameButton).toBeDefined();
+    fireEvent.click(nameButton);
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
@@ -321,13 +308,10 @@ describe('<TraceTagOverview>', () => {
   it('should test sorter function with string comparison', () => {
     render(<TraceStatistics {...defaultProps} />);
 
-    const columnHeaders = screen.getAllByRole('columnheader');
-    const groupColumn = columnHeaders.find(header => header.textContent.includes('Group'));
-
-    if (groupColumn) {
-      fireEvent.click(groupColumn);
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    }
+    const groupColumn = screen.getAllByRole('columnheader').find(h => h.textContent.includes('Group'));
+    expect(groupColumn).toBeDefined();
+    fireEvent.click(groupColumn);
+    expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
   it('should test sorter function with items that have no hasSubgroupValue', () => {
@@ -375,13 +359,9 @@ describe('<TraceTagOverview>', () => {
       });
     });
 
-    const columnHeaders = screen.getAllByRole('columnheader');
-    const countColumn = columnHeaders.find(header => header.textContent.includes('Count'));
-
-    if (countColumn) {
-      fireEvent.click(countColumn);
-    }
-
+    const countColumn = screen.getAllByRole('columnheader').find(h => h.textContent.includes('Count'));
+    expect(countColumn).toBeDefined();
+    fireEvent.click(countColumn);
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { act, cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import TraceStatistics from './index';
 import transformTraceData from '../../../model/transform-trace-data';
@@ -53,10 +53,8 @@ describe('<TraceTagOverview>', () => {
 
     const { rerender } = render(<TestWrapper />);
 
-    await waitFor(() => {
-      expect(componentInstance).toBeTruthy();
-      expect(componentInstance.state.tableValue).toBeDefined();
-    });
+    expect(componentInstance).toBeTruthy();
+    expect(componentInstance.state.tableValue).toBeDefined();
 
     await act(async () => {
       rerender(
@@ -71,13 +69,11 @@ describe('<TraceTagOverview>', () => {
       );
     });
 
-    await waitFor(() => {
-      expect(componentInstance.state.tableValue.length).toBeGreaterThan(0);
-      const hasHighlightedItems = componentInstance.state.tableValue.some(
-        item => item.searchColor === 'rgb(255,243,215)'
-      );
-      expect(hasHighlightedItems).toBe(true);
-    });
+    expect(componentInstance.state.tableValue.length).toBeGreaterThan(0);
+    const hasHighlightedItems = componentInstance.state.tableValue.some(
+      item => item.searchColor === 'rgb(255,243,215)'
+    );
+    expect(hasHighlightedItems).toBe(true);
 
     await act(async () => {
       rerender(
@@ -92,10 +88,8 @@ describe('<TraceTagOverview>', () => {
       );
     });
 
-    await waitFor(() => {
-      const tableCells = screen.getAllByRole('cell');
-      expect(tableCells.length).toBeGreaterThan(0);
-    });
+    const tableCells = screen.getAllByRole('cell');
+    expect(tableCells.length).toBeGreaterThan(0);
   });
 
   it('check handler', async () => {
@@ -170,35 +164,29 @@ describe('<TraceTagOverview>', () => {
       ...overrides,
     });
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        componentRef.current.setState({
-          ...componentRef.current.state,
-          tableValue: [
-            makeRow('parent-a', false, 'none'),
-            makeRow('detail-a1', true, 'parent-a', { hasSubgroupValue: false }),
-            makeRow('detail-a2', true, 'parent-a', { hasSubgroupValue: false }),
-            makeRow('parent-b', false, 'none'),
-            makeRow('detail-b1', true, 'parent-b', { hasSubgroupValue: false }),
-          ],
-        });
-      }
+    act(() => {
+      componentRef.current.setState({
+        ...componentRef.current.state,
+        tableValue: [
+          makeRow('parent-a', false, 'none'),
+          makeRow('detail-a1', true, 'parent-a', { hasSubgroupValue: false }),
+          makeRow('detail-a2', true, 'parent-a', { hasSubgroupValue: false }),
+          makeRow('parent-b', false, 'none'),
+          makeRow('detail-b1', true, 'parent-b', { hasSubgroupValue: false }),
+        ],
+      });
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('parent-a')).toBeInTheDocument();
-      expect(screen.getByText('parent-b')).toBeInTheDocument();
-      expect(screen.getByText('detail-a1')).toBeInTheDocument();
-      expect(screen.getByText('detail-a2')).toBeInTheDocument();
-      expect(screen.getByText('detail-b1')).toBeInTheDocument();
-    });
+    expect(screen.getByText('parent-a')).toBeInTheDocument();
+    expect(screen.getByText('parent-b')).toBeInTheDocument();
+    expect(screen.getByText('detail-a1')).toBeInTheDocument();
+    expect(screen.getByText('detail-a2')).toBeInTheDocument();
+    expect(screen.getByText('detail-b1')).toBeInTheDocument();
 
-    await waitFor(() => {
-      const parentRows = container.querySelectorAll('tbody tr.ant-table-row-level-0');
-      const childRows = container.querySelectorAll('tbody tr.ant-table-row-level-1');
-      expect(parentRows).toHaveLength(2);
-      expect(childRows).toHaveLength(3);
-    });
+    const parentRows = container.querySelectorAll('tbody tr.ant-table-row-level-0');
+    const childRows = container.querySelectorAll('tbody tr.ant-table-row-level-1');
+    expect(parentRows).toHaveLength(2);
+    expect(childRows).toHaveLength(3);
   });
 
   it('check togglePopup', async () => {
@@ -211,26 +199,18 @@ describe('<TraceTagOverview>', () => {
 
     render(<TestWrapper />);
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        componentRef.current.togglePopup('select *');
-      }
+    act(() => {
+      componentRef.current.togglePopup('select *');
     });
 
-    await waitFor(() => {
-      const textarea = screen.getByRole('textbox');
-      expect(textarea.value).toBe('"select *"');
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.value).toBe('"select *"');
+
+    act(() => {
+      componentRef.current.togglePopup('select *');
     });
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        componentRef.current.togglePopup('select *');
-      }
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
   it('should trigger onClickOption when clicking on name cell with sql.query selector', async () => {
@@ -243,54 +223,48 @@ describe('<TraceTagOverview>', () => {
 
     render(<TestWrapper />);
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        componentRef.current.setState({
-          ...componentRef.current.state,
-          valueNameSelector1: 'sql.query',
-          tableValue: [
-            {
-              name: 'SELECT * FROM users',
-              hasSubgroupValue: true,
-              searchColor: 'transparent',
-              color: '#000',
-              key: '0',
-              isDetail: false,
-              parentElement: 'none',
-              count: 1,
-              total: 100,
-              avg: 50,
-              min: 10,
-              max: 90,
-              selfTotal: 80,
-              selfAvg: 40,
-              selfMin: 5,
-              selfMax: 75,
-              percent: 80,
-              colorToPercent: '#fff',
-            },
-          ],
-        });
-      }
+    act(() => {
+      componentRef.current.setState({
+        ...componentRef.current.state,
+        valueNameSelector1: 'sql.query',
+        tableValue: [
+          {
+            name: 'SELECT * FROM users',
+            hasSubgroupValue: true,
+            searchColor: 'transparent',
+            color: '#000',
+            key: '0',
+            isDetail: false,
+            parentElement: 'none',
+            count: 1,
+            total: 100,
+            avg: 50,
+            min: 10,
+            max: 90,
+            selfTotal: 80,
+            selfAvg: 40,
+            selfMin: 5,
+            selfMax: 75,
+            percent: 80,
+            colorToPercent: '#fff',
+          },
+        ],
+      });
     });
 
-    await waitFor(() => {
-      const nameButtons = screen.getAllByRole('button');
-      const nameButton = nameButtons.find(
-        button => button.textContent.includes('SELECT') || button.style.borderLeft || button.style.padding
-      );
+    const nameButtons = screen.getAllByRole('button');
+    const nameButton = nameButtons.find(
+      button => button.textContent.includes('SELECT') || button.style.borderLeft || button.style.padding
+    );
 
-      if (nameButton) {
-        fireEvent.click(nameButton);
-      }
-    });
+    if (nameButton) {
+      fireEvent.click(nameButton);
+    }
 
-    await waitFor(() => {
-      const textarea = screen.queryByRole('textbox');
-      if (textarea) {
-        expect(textarea).toBeInTheDocument();
-      }
-    });
+    const textarea = screen.queryByRole('textbox');
+    if (textarea) {
+      expect(textarea).toBeInTheDocument();
+    }
   });
 
   it('should handle onClickOption when hasSubgroupValue is false', async () => {
@@ -303,54 +277,48 @@ describe('<TraceTagOverview>', () => {
 
     render(<TestWrapper />);
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        componentRef.current.setState({
-          ...componentRef.current.state,
-          valueNameSelector1: 'sql.query',
-          tableValue: [
-            {
-              name: 'test-name',
-              hasSubgroupValue: false,
-              searchColor: 'transparent',
-              color: '#000',
-              key: '0',
-              isDetail: false,
-              parentElement: 'none',
-              count: 1,
-              total: 100,
-              avg: 50,
-              min: 10,
-              max: 90,
-              selfTotal: 80,
-              selfAvg: 40,
-              selfMin: 5,
-              selfMax: 75,
-              percent: 80,
-              colorToPercent: '#fff',
-            },
-          ],
-        });
-      }
+    act(() => {
+      componentRef.current.setState({
+        ...componentRef.current.state,
+        valueNameSelector1: 'sql.query',
+        tableValue: [
+          {
+            name: 'test-name',
+            hasSubgroupValue: false,
+            searchColor: 'transparent',
+            color: '#000',
+            key: '0',
+            isDetail: false,
+            parentElement: 'none',
+            count: 1,
+            total: 100,
+            avg: 50,
+            min: 10,
+            max: 90,
+            selfTotal: 80,
+            selfAvg: 40,
+            selfMin: 5,
+            selfMax: 75,
+            percent: 80,
+            colorToPercent: '#fff',
+          },
+        ],
+      });
     });
 
-    await waitFor(() => {
-      const nameButtons = screen.getAllByRole('button');
-      const nameButton = nameButtons.find(
-        button => button.textContent.includes('test-name') || button.style.borderLeft || button.style.padding
-      );
+    const nameButtons = screen.getAllByRole('button');
+    const nameButton = nameButtons.find(
+      button => button.textContent.includes('test-name') || button.style.borderLeft || button.style.padding
+    );
 
-      if (nameButton) {
-        fireEvent.click(nameButton);
-      }
-    });
+    if (nameButton) {
+      fireEvent.click(nameButton);
+    }
 
-    await waitFor(() => {
-      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
-  it('should test sorter function with string comparison', async () => {
+  it('should test sorter function with string comparison', () => {
     render(<TraceStatistics {...defaultProps} />);
 
     const columnHeaders = screen.getAllByRole('columnheader');
@@ -358,14 +326,11 @@ describe('<TraceTagOverview>', () => {
 
     if (groupColumn) {
       fireEvent.click(groupColumn);
-
-      await waitFor(() => {
-        expect(screen.getByRole('table')).toBeInTheDocument();
-      });
+      expect(screen.getByRole('table')).toBeInTheDocument();
     }
   });
 
-  it('should test sorter function with items that have no hasSubgroupValue', async () => {
+  it('should test sorter function with items that have no hasSubgroupValue', () => {
     let componentRef;
     const TestWrapper = () => {
       const ref = React.useRef();
@@ -375,58 +340,52 @@ describe('<TraceTagOverview>', () => {
 
     render(<TestWrapper />);
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        componentRef.current.setState({
-          ...componentRef.current.state,
-          tableValue: [
-            {
-              name: 'item1',
-              hasSubgroupValue: false,
-              count: 1,
-              total: 100,
-              key: '0',
-              searchColor: 'transparent',
-              colorToPercent: '#fff',
-            },
-            {
-              name: 'item2',
-              hasSubgroupValue: true,
-              count: 2,
-              total: 200,
-              key: '1',
-              searchColor: 'transparent',
-              colorToPercent: '#fff',
-            },
-            {
-              name: 'item3',
-              hasSubgroupValue: false,
-              count: 3,
-              total: 300,
-              key: '2',
-              searchColor: 'transparent',
-              colorToPercent: '#fff',
-            },
-          ],
-        });
-      }
+    act(() => {
+      componentRef.current.setState({
+        ...componentRef.current.state,
+        tableValue: [
+          {
+            name: 'item1',
+            hasSubgroupValue: false,
+            count: 1,
+            total: 100,
+            key: '0',
+            searchColor: 'transparent',
+            colorToPercent: '#fff',
+          },
+          {
+            name: 'item2',
+            hasSubgroupValue: true,
+            count: 2,
+            total: 200,
+            key: '1',
+            searchColor: 'transparent',
+            colorToPercent: '#fff',
+          },
+          {
+            name: 'item3',
+            hasSubgroupValue: false,
+            count: 3,
+            total: 300,
+            key: '2',
+            searchColor: 'transparent',
+            colorToPercent: '#fff',
+          },
+        ],
+      });
     });
 
-    await waitFor(() => {
-      const columnHeaders = screen.getAllByRole('columnheader');
-      const countColumn = columnHeaders.find(header => header.textContent.includes('Count'));
+    const columnHeaders = screen.getAllByRole('columnheader');
+    const countColumn = columnHeaders.find(header => header.textContent.includes('Count'));
 
-      if (countColumn) {
-        fireEvent.click(countColumn);
-      }
-    });
+    if (countColumn) {
+      fireEvent.click(countColumn);
+    }
 
-    await waitFor(() => {
-      expect(screen.getByRole('table')).toBeInTheDocument();
-    });
+    expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
-  it('should test searchInTable with complex search scenarios', async () => {
+  it('should test searchInTable with complex search scenarios', () => {
     let componentRef;
     const TestWrapper = () => {
       const ref = React.useRef();
@@ -464,17 +423,12 @@ describe('<TraceTagOverview>', () => {
     ];
 
     const searchSet = new Set(['parent1detail1']);
-
-    await waitFor(() => {
-      if (componentRef.current) {
-        const result = componentRef.current.searchInTable(searchSet, mockTableData, null);
-        expect(result).toBeDefined();
-        expect(result.length).toBe(3);
-      }
-    });
+    const result = componentRef.current.searchInTable(searchSet, mockTableData, null);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(3);
   });
 
-  it('should test searchInTable with uiFind matching and detail items', async () => {
+  it('should test searchInTable with uiFind matching and detail items', () => {
     let componentRef;
     const TestWrapper = () => {
       const ref = React.useRef();
@@ -511,16 +465,12 @@ describe('<TraceTagOverview>', () => {
       },
     ];
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        const result = componentRef.current.searchInTable(undefined, mockTableData, 'searchterm');
-        const highlightedItems = result.filter(item => item.searchColor === 'rgb(255,243,215)');
-        expect(highlightedItems.length).toBeGreaterThan(0);
-      }
-    });
+    const result = componentRef.current.searchInTable(undefined, mockTableData, 'searchterm');
+    const highlightedItems = result.filter(item => item.searchColor === 'rgb(255,243,215)');
+    expect(highlightedItems.length).toBeGreaterThan(0);
   });
 
-  it('should test searchInTable with items that have subgroup values but are details', async () => {
+  it('should test searchInTable with items that have subgroup values but are details', () => {
     let componentRef;
     const TestWrapper = () => {
       const ref = React.useRef();
@@ -549,12 +499,8 @@ describe('<TraceTagOverview>', () => {
       },
     ];
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        const result = componentRef.current.searchInTable(undefined, mockTableData, null);
-        expect(result[0].searchColor).toBe('rgb(248,248,248)');
-        expect(result[1].searchColor).toBe('rgb(248,248,248)');
-      }
-    });
+    const result = componentRef.current.searchInTable(undefined, mockTableData, null);
+    expect(result[0].searchColor).toBe('rgb(248,248,248)');
+    expect(result[1].searchColor).toBe('rgb(248,248,248)');
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #3996 — item 3: *Replace `waitFor` polls with `findBy*` (or remove them) in the top file `TracePage/TraceStatistics/index.test.jsx`.*

`TraceStatistics/index.test.jsx` is the single slowest test file in the suite (7.2 s on the issue baseline; 22.9 s cumulative on this machine). It contained **23 `waitFor` calls**, most of which were paying 50 ms polling intervals for state updates that were already synchronous inside `act()`.

## Description of the changes

Three patterns were replaced throughout the file:

**Pattern 1: `waitFor` wrapping `setState`**
```js
// Before
await waitFor(() => {
  if (componentRef.current) {
    componentRef.current.setState({ ... });
  }
});

// After
act(() => {
  componentRef.current.setState({ ... });
});
```
`act()` flushes all pending React state updates and effects synchronously, so the DOM is ready to assert against immediately afterward — no polling needed.

**Pattern 2: `waitFor` for DOM assertions after `act()`**
```js
// Before
await waitFor(() => {
  expect(screen.getByText('parent-a')).toBeInTheDocument();
});

// After
expect(screen.getByText('parent-a')).toBeInTheDocument();
```
Once the preceding `act()` returns, the DOM is fully updated. Wrapping the assertion in another `waitFor` only adds polling overhead.

**Pattern 3: `waitFor` around pure method calls**
```js
// Before
await waitFor(() => {
  if (componentRef.current) {
    const result = componentRef.current.searchInTable(set, data, null);
    expect(result.length).toBe(3);
  }
});

// After
const result = componentRef.current.searchInTable(set, data, null);
expect(result.length).toBe(3);
```
`searchInTable` is a pure function — it has no side effects and does not trigger any DOM mutation. No wrapper is needed; `componentRef.current` is available synchronously after `render()`.

Also removed the now-unused `waitFor` import.

## How was this change tested?

All 13 tests in the file still pass.

Measured with `--reporter=verbose` on a single-file run:

| Test | Before | After | Δ |
|---|---|---|---|
| `check handler` | 4295 ms | 2731 ms | **−1564 ms** |
| `should trigger onClickOption` | 2439 ms | 1394 ms | **−1045 ms** |
| `should handle onClickOption` | 1892 ms | 1008 ms | **−884 ms** |
| `should test sorter (string)` | 2032 ms | 1230 ms | **−802 ms** |
| `check search` | 2305 ms | 1989 ms | −316 ms |
| `groups detail rows` | 977 ms | 800 ms | −177 ms |
| **Cumulative test time** | **22.87 s** | **16.61 s** | **−6.26 s (−27%)** |

The dominant remaining cost per test is the full AntD Table render against the real trace fixture (`testTrace.json`). Shrinking the fixture or extracting pure-function tests (item 6 of #3996) would address that in a follow-up.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes