### PR TITLE
feat(config): Add ai.enabled flag (default false) for AI-assisted UI

### DIFF
--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -10,6 +10,9 @@ import { version } from '../../package.json';
 import { Config } from '../types/config';
 
 const defaultConfig: Config = {
+  ai: {
+    enabled: false,
+  },
   archiveEnabled: true,
   criticalPathEnabled: true,
   dependencies: {
@@ -125,8 +128,8 @@ const defaultConfig: Config = {
 };
 
 // Fields that should be merged with user-supplied config values rather than overwritten.
-type TMergeField = 'dependencies' | 'monitor' | 'search' | 'tracking';
-export const mergeFields: readonly TMergeField[] = ['dependencies', 'monitor', 'search', 'tracking'];
+type TMergeField = 'ai' | 'dependencies' | 'monitor' | 'search' | 'tracking';
+export const mergeFields: readonly TMergeField[] = ['ai', 'dependencies', 'monitor', 'search', 'tracking'];
 
 export default deepFreeze(defaultConfig);
 

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -82,6 +82,17 @@ export type StorageCapabilities = {
 
 // Default values are provided in packages/jaeger-ui/src/constants/default-config.tsx
 export type Config = {
+  // ai gates AI-assisted UI features (e.g. the in-app assistant).
+  // The UI does not enable these features unless the operator opts in via
+  // `ai.enabled: true`, because the Query Service does not yet ship a
+  // matching backend. Defaults to disabled.
+  ai?: {
+    // enabled turns on AI-assisted features in the UI. When false (the
+    // default), all AI surfaces are hidden regardless of whether the
+    // backend supports them.
+    enabled?: boolean;
+  };
+
   //
   // archiveEnabled enables the Archive Trace button in the trace view.
   // Requires Query Service to be configured with "archive" storage backend.


### PR DESCRIPTION
## Which problem is this PR solving?

Related to #3930 (in-app \"Ask Jaeger\" assistant).

The assistant UI in #3930 would be visible regardless of whether the Query Service ships a matching backend. Since the backend support isn't there yet, we want the UI to default to hiding the assistant surfaces and require operators to opt in via a config flag — same shape we already use for other backend-dependent features (\`monitor.menuEnabled\`, \`dependencies.menuEnabled\`, \`deepDependencies.menuEnabled\`).

## Description of the changes

- Add an \`ai\` section to \`Config\` (\`packages/jaeger-ui/src/types/config.ts\`) with an \`enabled\` boolean. Comment notes it gates AI-assisted UI features and is off by default until the backend lands.
- Set \`ai: { enabled: false }\` in \`defaultConfig\` (\`packages/jaeger-ui/src/constants/default-config.ts\`).
- Add \`ai\` to \`mergeFields\` so user-supplied \`ai.*\` sub-keys merge with the defaults rather than overwriting the whole section. Same convention as \`dependencies\`, \`monitor\`, \`search\`, \`tracking\`.

No code consumes the flag yet — that wiring lands when #3930 (or its follow-up) reads \`config.ai?.enabled\` to gate the assistant surfaces.

## How was this change tested?

- \`npm run fmt\`, \`npm run tsc-lint\`, \`npm run build\`, and the config-utility test suite all pass.
- The existing \`mergeFields\` tests in \`get-config.test.js\` exercise the merging behaviour for any key in that list, so adding \`ai\` is covered without a new test.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
- [ ] **None**
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**
- [ ] **Heavy**

🤖 Generated with [Claude Code](https://claude.com/claude-code)