### PR TITLE
fix(search): Hide unsupported trace summary columns

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -317,6 +317,8 @@ describe('JaegerClient', () => {
       expect(summary.errorSpanCount).toBe(1);
       expect(summary.orphanSpanCount).toBe(0);
       expect(summary.services).toEqual(mockApiSummary.services);
+      expect(summary.serviceSummariesSupported).toBe(true);
+      expect(summary.errorSpanCountSupported).toBe(true);
     });
 
     it('falls back to defaults for all optional fields when absent', async () => {
@@ -338,6 +340,40 @@ describe('JaegerClient', () => {
       expect(summary.errorSpanCount).toBe(0);
       expect(summary.orphanSpanCount).toBe(0);
       expect(summary.services).toEqual([]);
+      expect(summary.serviceSummariesSupported).toBe(false);
+      expect(summary.errorSpanCountSupported).toBe(false);
+    });
+
+    it('marks service summaries unsupported when the API returns only empty service lists', async () => {
+      const unsupportedServices = {
+        ...mockApiSummary,
+        errorSpanCount: undefined,
+        orphanSpanCount: undefined,
+        services: [],
+      };
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ summaries: [unsupportedServices] }) });
+
+      const promise = client.fetchTraceSummaries(query);
+      vi.runAllTimers();
+      const [summary] = await promise;
+
+      expect(summary.services).toEqual([]);
+      expect(summary.errorSpanCount).toBe(0);
+      expect(summary.serviceSummariesSupported).toBe(false);
+      expect(summary.errorSpanCountSupported).toBe(false);
+    });
+
+    it('keeps error counts supported when clean summaries include service summaries', async () => {
+      const cleanWithServices = { ...mockApiSummary, errorSpanCount: undefined };
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ summaries: [cleanWithServices] }) });
+
+      const promise = client.fetchTraceSummaries(query);
+      vi.runAllTimers();
+      const [summary] = await promise;
+
+      expect(summary.errorSpanCount).toBe(0);
+      expect(summary.serviceSummariesSupported).toBe(true);
+      expect(summary.errorSpanCountSupported).toBe(true);
     });
 
     it('clamps duration to 0 when only minStartTimeUnixNano is present', async () => {

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -103,6 +103,7 @@ export class JaegerClient {
         spanCount: svc.spanCount ?? 0,
         errorSpanCount: svc.errorSpanCount ?? 0,
       }));
+      const hasServiceSummaries = services.length > 0;
       return {
         traceID: s.traceId,
         traceName:
@@ -117,6 +118,9 @@ export class JaegerClient {
         errorSpanCount: s.errorSpanCount ?? 0,
         orphanSpanCount: s.orphanSpanCount ?? 0,
         services,
+        serviceSummariesSupported: hasServiceSummaries,
+        errorSpanCountSupported:
+          s.errorSpanCount !== undefined || s.orphanSpanCount !== undefined || hasServiceSummaries,
       };
     });
   }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
@@ -133,6 +133,66 @@ describe('TraceTable', () => {
     );
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
+
+  it('hides service and error columns when trace summaries mark them unsupported', () => {
+    const traces = [
+      {
+        ...makeTrace('unsupported'),
+        services: [],
+        errorSpanCount: 0,
+        serviceSummariesSupported: false,
+        errorSpanCountSupported: false,
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} traceSummaries={traces} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('columnheader', { name: 'Services' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Errors' })).not.toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Spans' })).toBeInTheDocument();
+  });
+
+  it('keeps supported zero-error columns visible', () => {
+    const traces = [{ ...makeTrace('zero-error'), services: [], errorSpanCount: 0 }];
+
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} traceSummaries={traces} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('columnheader', { name: 'Services' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Errors' })).toBeInTheDocument();
+  });
+
+  it('renders unsupported error counts as unknown when mixed with supported summaries', () => {
+    const traces = [
+      makeTrace('supported'),
+      {
+        ...makeTrace('unsupported'),
+        services: [],
+        errorSpanCount: 0,
+        serviceSummariesSupported: false,
+        errorSpanCountSupported: false,
+      },
+    ];
+
+    const { container } = render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} traceSummaries={traces} />
+      </MemoryRouter>
+    );
+
+    const rows = container.querySelectorAll('tbody tr');
+    const unsupported = Array.from(rows).find(r => r.textContent?.includes('Trace unsupported'));
+    expect(unsupported).toBeTruthy();
+    const cells = unsupported!.querySelectorAll('td');
+    expect(within(cells[3] as HTMLElement).getByText('-')).toBeInTheDocument();
+  });
 });
 
 describe('sort onChange wiring', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -96,6 +96,12 @@ export default function TraceTable({
 }: TraceTableProps) {
   const navigate = useNavigate();
   const { key: sortKey, order: sortOrder } = fromOrderBy(sortBy);
+  const showServicesColumn =
+    traceSummaries.length === 0 ||
+    traceSummaries.some(trace => trace.services.length > 0 || trace.serviceSummariesSupported !== false);
+  const showErrorsColumn =
+    traceSummaries.length === 0 ||
+    traceSummaries.some(trace => trace.errorSpanCount > 0 || trace.errorSpanCountSupported !== false);
 
   const columns: ColumnsType<TraceSummary> = useMemo(() => {
     const cols: ColumnsType<TraceSummary> = [
@@ -127,14 +133,6 @@ export default function TraceTable({
         },
       },
       {
-        title: 'Services',
-        key: 'services',
-        width: '35%',
-        onCell: () => ({ style: { overflow: 'hidden' } }),
-        render: (_: unknown, trace: TraceSummary) =>
-          trace.services.length > 0 ? <ServicePills services={trace.services} /> : '-',
-      },
-      {
         title: 'Spans',
         key: 'spans',
         width: '5rem',
@@ -143,27 +141,6 @@ export default function TraceTable({
         sorter: true,
         sortOrder: sortKey === 'spans' ? sortOrder : undefined,
         sortDirections: ['ascend', 'descend'],
-      },
-      {
-        title: 'Errors',
-        key: 'errors',
-        width: '5rem',
-        align: 'center',
-        render: (_: unknown, trace: TraceSummary) =>
-          trace.errorSpanCount > 0 ? (
-            <Tag
-              variant="outlined"
-              style={{
-                margin: 0,
-                color: 'var(--feedback-error-text)',
-                borderColor: 'var(--feedback-error-text)',
-              }}
-            >
-              {trace.errorSpanCount}
-            </Tag>
-          ) : (
-            0
-          ),
       },
       {
         title: 'Duration',
@@ -212,6 +189,43 @@ export default function TraceTable({
       },
     ];
 
+    if (showServicesColumn) {
+      cols.splice(1, 0, {
+        title: 'Services',
+        key: 'services',
+        width: '35%',
+        onCell: () => ({ style: { overflow: 'hidden' } }),
+        render: (_: unknown, trace: TraceSummary) =>
+          trace.services.length > 0 ? <ServicePills services={trace.services} /> : '-',
+      });
+    }
+
+    if (showErrorsColumn) {
+      cols.splice(showServicesColumn ? 3 : 2, 0, {
+        title: 'Errors',
+        key: 'errors',
+        width: '5rem',
+        align: 'center',
+        render: (_: unknown, trace: TraceSummary) =>
+          trace.errorSpanCountSupported === false ? (
+            '-'
+          ) : trace.errorSpanCount > 0 ? (
+            <Tag
+              variant="outlined"
+              style={{
+                margin: 0,
+                color: 'var(--feedback-error-text)',
+                borderColor: 'var(--feedback-error-text)',
+              }}
+            >
+              {trace.errorSpanCount}
+            </Tag>
+          ) : (
+            0
+          ),
+      });
+    }
+
     if (!disableComparisons) {
       cols.unshift({
         key: 'compare',
@@ -236,7 +250,17 @@ export default function TraceTable({
     }
 
     return cols;
-  }, [sortKey, sortOrder, maxTraceDuration, getLink, disableComparisons, cohortIds, toggleComparison]);
+  }, [
+    sortKey,
+    sortOrder,
+    maxTraceDuration,
+    getLink,
+    showServicesColumn,
+    showErrorsColumn,
+    disableComparisons,
+    cohortIds,
+    toggleComparison,
+  ]);
 
   const onChange: TableProps<TraceSummary>['onChange'] = (_pagination, _filters, sorter) => {
     const s = Array.isArray(sorter) ? sorter[0] : (sorter as SorterResult<TraceSummary>);

--- a/packages/jaeger-ui/src/model/trace-summary.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.ts
@@ -37,5 +37,7 @@ export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
     errorSpanCount,
     orphanSpanCount: trace.orphanSpanCount,
     services,
+    serviceSummariesSupported: true,
+    errorSpanCountSupported: true,
   };
 }

--- a/packages/jaeger-ui/src/types/trace-summary.ts
+++ b/packages/jaeger-ui/src/types/trace-summary.ts
@@ -20,4 +20,6 @@ export type TraceSummary = {
   errorSpanCount: number;
   orphanSpanCount: number;
   services: ServiceSummary[];
+  serviceSummariesSupported?: boolean;
+  errorSpanCountSupported?: boolean;
 };


### PR DESCRIPTION
## Summary

- Track whether v3 trace summaries include service summaries and supplemental error/count data.
- Hide Services and Errors columns when a partial storage backend does not provide those fields.
- Render unsupported row-level error counts as unknown when mixed with supported summaries.

Fixes #4005

## Verification

- PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run fmt
- PATH=/opt/homebrew/opt/node@24/bin:$PATH npm test -w packages/jaeger-ui -- src/api/v3/client.test.ts src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
- PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run lint
- PATH=/opt/homebrew/opt/node@24/bin:$PATH npm test
- PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run build
- review-fix-loop clean
