### PR TITLE
fix(search): suppress trace summary columns unsupported by storage

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -385,7 +385,9 @@ describe('JaegerClient', () => {
       const promise = client.fetchTraceSummaries(query);
       vi.runAllTimers();
       const [summary] = await promise;
-      expect(summary.services).toEqual([{ name: 'partial-svc', spanCount: undefined, errorSpanCount: undefined }]);
+      expect(summary.services).toEqual([
+        { name: 'partial-svc', spanCount: undefined, errorSpanCount: undefined },
+      ]);
     });
 
     it('throws ZodError when traceId is missing', async () => {

--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -334,9 +334,9 @@ describe('JaegerClient', () => {
       expect(summary.rootOperationName).toBe('');
       expect(summary.startTime).toBe(0);
       expect(summary.duration).toBe(0);
-      expect(summary.spanCount).toBe(0);
-      expect(summary.errorSpanCount).toBe(0);
-      expect(summary.orphanSpanCount).toBe(0);
+      expect(summary.spanCount).toBeUndefined();
+      expect(summary.errorSpanCount).toBeUndefined();
+      expect(summary.orphanSpanCount).toBeUndefined();
       expect(summary.services).toEqual([]);
     });
 
@@ -385,7 +385,7 @@ describe('JaegerClient', () => {
       const promise = client.fetchTraceSummaries(query);
       vi.runAllTimers();
       const [summary] = await promise;
-      expect(summary.services).toEqual([{ name: 'partial-svc', spanCount: 0, errorSpanCount: 0 }]);
+      expect(summary.services).toEqual([{ name: 'partial-svc', spanCount: undefined, errorSpanCount: undefined }]);
     });
 
     it('throws ZodError when traceId is missing', async () => {

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -100,8 +100,8 @@ export class JaegerClient {
       // Internal TraceSummary uses `traceID` (Jaeger convention) to match legacy code.
       const services: ServiceSummary[] = (s.services ?? []).map(svc => ({
         name: svc.name ?? '',
-        spanCount: svc.spanCount ?? 0,
-        errorSpanCount: svc.errorSpanCount ?? 0,
+        spanCount: svc.spanCount,
+        errorSpanCount: svc.errorSpanCount,
       }));
       return {
         traceID: s.traceId,
@@ -113,9 +113,9 @@ export class JaegerClient {
         rootOperationName,
         startTime: Number(startNs / 1000n) as Microseconds,
         duration: Number((endNs - startNs) / 1000n) as Microseconds,
-        spanCount: s.spanCount ?? 0,
-        errorSpanCount: s.errorSpanCount ?? 0,
-        orphanSpanCount: s.orphanSpanCount ?? 0,
+        spanCount: s.spanCount,
+        errorSpanCount: s.errorSpanCount,
+        orphanSpanCount: s.orphanSpanCount,
         services,
       };
     });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
@@ -179,7 +179,7 @@ it('calls trackConversions on click', () => {
   expect(spy).toHaveBeenCalledWith(tracking.EAltViewActions.Traces);
 });
 
-it('<ResultItem /> renders - when spanCount is undefined', () => {
+it('<ResultItem /> hides span tag when spanCount is undefined', () => {
   const summary = {
     ...traceSummary,
     spanCount: undefined,
@@ -196,5 +196,5 @@ it('<ResultItem /> renders - when spanCount is undefined', () => {
       disableComparision={false}
     />
   );
-  expect(screen.getByTestId(markers.NUM_SPANS)).toHaveTextContent('-');
+  expect(screen.queryByTestId(markers.NUM_SPANS)).not.toBeInTheDocument();
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
@@ -180,7 +180,12 @@ it('calls trackConversions on click', () => {
 });
 
 it('<ResultItem /> renders - when spanCount is undefined', () => {
-  const summary = { ...traceSummary, spanCount: undefined, errorSpanCount: undefined, orphanSpanCount: undefined };
+  const summary = {
+    ...traceSummary,
+    spanCount: undefined,
+    errorSpanCount: undefined,
+    orphanSpanCount: undefined,
+  };
   renderWithRouter(
     <ResultItem
       traceSummary={summary}

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
@@ -178,3 +178,18 @@ it('calls trackConversions on click', () => {
   buttons[0].click();
   expect(spy).toHaveBeenCalledWith(tracking.EAltViewActions.Traces);
 });
+
+it('<ResultItem /> renders - when spanCount is undefined', () => {
+  const summary = { ...traceSummary, spanCount: undefined, errorSpanCount: undefined, orphanSpanCount: undefined };
+  renderWithRouter(
+    <ResultItem
+      traceSummary={summary}
+      durationPercent={50}
+      linkTo={{ pathname: '/' }}
+      toggleComparison={() => {}}
+      isInDiffCohort={false}
+      disableComparision={false}
+    />
+  );
+  expect(screen.getByTestId(markers.NUM_SPANS)).toHaveTextContent('-');
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -75,9 +75,9 @@ export default function ResultItem({
       <Link to={{ pathname: linkTo.pathname, search: linkTo.search }} state={linkTo.state}>
         <Row>
           <Col xs={24} sm={4} className="ub-p2">
-            {Boolean(spanCount) && (
+            {spanCount !== undefined && (
               <Tag className="ub-m1" data-testid={markers.NUM_SPANS} variant="outlined">
-                {spanCount} Span{spanCount! > 1 && 's'}
+                {spanCount} Span{spanCount > 1 && 's'}
               </Tag>
             )}
             {Boolean(errorSpanCount) && (

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -75,15 +75,17 @@ export default function ResultItem({
       <Link to={{ pathname: linkTo.pathname, search: linkTo.search }} state={linkTo.state}>
         <Row>
           <Col xs={24} sm={4} className="ub-p2">
-            <Tag className="ub-m1" data-testid={markers.NUM_SPANS} variant="outlined">
-              {spanCount ?? '-'} Span{(spanCount ?? 0) > 1 && 's'}
-            </Tag>
+            {Boolean(spanCount) && (
+              <Tag className="ub-m1" data-testid={markers.NUM_SPANS} variant="outlined">
+                {spanCount} Span{spanCount! > 1 && 's'}
+              </Tag>
+            )}
             {Boolean(errorSpanCount) && (
               <Tag className="ub-m1" color="red" variant="outlined">
                 {errorSpanCount} Error{(errorSpanCount ?? 0) > 1 && 's'}
               </Tag>
             )}
-            {(orphanSpanCount ?? 0) > 0 && (
+            {Boolean(orphanSpanCount) && (
               <Tooltip title={getIncompleteTraceTooltip(orphanSpanCount ?? 0)}>
                 <Tag className="ub-m1" color="orange">
                   <IoWarning className="ResultItem--warningIcon" />

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -76,15 +76,15 @@ export default function ResultItem({
         <Row>
           <Col xs={24} sm={4} className="ub-p2">
             <Tag className="ub-m1" data-testid={markers.NUM_SPANS} variant="outlined">
-              {spanCount} Span{spanCount > 1 && 's'}
+              {spanCount ?? '-'} Span{(spanCount ?? 0) > 1 && 's'}
             </Tag>
             {Boolean(errorSpanCount) && (
               <Tag className="ub-m1" color="red" variant="outlined">
-                {errorSpanCount} Error{errorSpanCount > 1 && 's'}
+                {errorSpanCount} Error{(errorSpanCount ?? 0) > 1 && 's'}
               </Tag>
             )}
-            {orphanSpanCount > 0 && (
-              <Tooltip title={getIncompleteTraceTooltip(orphanSpanCount)}>
+            {(orphanSpanCount ?? 0) > 0 && (
+              <Tooltip title={getIncompleteTraceTooltip(orphanSpanCount ?? 0)}>
                 <Tag className="ub-m1" color="orange">
                   <IoWarning className="ResultItem--warningIcon" />
                   Incomplete

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ServicePills.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ServicePills.tsx
@@ -18,8 +18,8 @@ function ServicePill({ service }: { service: ServiceEntry }) {
       style={{ borderLeftColor: colorGenerator.getColorByKey(service.name) }}
       variant="outlined"
     >
-      {service.errorSpanCount > 0 && <IoAlert className="ServicePills--errorIcon" />}
-      {service.name} ({service.spanCount})
+      {(service.errorSpanCount ?? 0) > 0 && <IoAlert className="ServicePills--errorIcon" />}
+      {service.name} ({service.spanCount ?? '-'})
     </Tag>
   );
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ServicePills.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ServicePills.tsx
@@ -19,7 +19,8 @@ function ServicePill({ service }: { service: ServiceEntry }) {
       variant="outlined"
     >
       {Boolean(service.errorSpanCount) && <IoAlert className="ServicePills--errorIcon" />}
-      {service.name} ({service.spanCount})
+      {service.name}
+      {service.spanCount !== undefined && ` (${service.spanCount})`}
     </Tag>
   );
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ServicePills.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ServicePills.tsx
@@ -18,8 +18,8 @@ function ServicePill({ service }: { service: ServiceEntry }) {
       style={{ borderLeftColor: colorGenerator.getColorByKey(service.name) }}
       variant="outlined"
     >
-      {(service.errorSpanCount ?? 0) > 0 && <IoAlert className="ServicePills--errorIcon" />}
-      {service.name} ({service.spanCount ?? '-'})
+      {Boolean(service.errorSpanCount) && <IoAlert className="ServicePills--errorIcon" />}
+      {service.name} ({service.spanCount})
     </Tag>
   );
 }

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
@@ -212,3 +212,70 @@ describe('fromOrderBy', () => {
     expect(fromOrderBy(orderBy.MOST_RECENT)).toEqual({ key: 'startTime', order: 'descend' });
   });
 });
+
+describe('column suppression for unsupported backends', () => {
+  const makeUnsupportedTrace = (id: string) => ({
+    traceID: id,
+    traceName: `Trace ${id}`,
+    rootServiceName: 'svc',
+    rootOperationName: 'op',
+    startTime: FIXED_START_TIME,
+    duration: 1000 as Microseconds,
+    spanCount: 10,
+    errorSpanCount: undefined,
+    orphanSpanCount: undefined,
+    services: [],
+  });
+
+  it('hides the Errors column when all summaries have undefined errorSpanCount', () => {
+    const traces = [makeUnsupportedTrace('u1'), makeUnsupportedTrace('u2')];
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} traceSummaries={traces} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('Errors')).not.toBeInTheDocument();
+  });
+
+  it('hides the Services column when all summaries have empty services', () => {
+    const traces = [makeUnsupportedTrace('u1'), makeUnsupportedTrace('u2')];
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} traceSummaries={traces} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('Services')).not.toBeInTheDocument();
+  });
+
+  it('shows the Errors column and renders - for unsupported rows in mixed results', () => {
+    const supported = makeTrace('s1', 2);
+    const unsupported = makeUnsupportedTrace('u1');
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} traceSummaries={[supported, unsupported]} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    const rows = document.querySelectorAll('tbody tr');
+    const unsupportedRow = Array.from(rows).find(r => r.textContent?.includes('Trace u1'));
+    expect(unsupportedRow).toBeTruthy();
+    // Find the Errors column index from the header, then check same index in the data row
+    const headers = Array.from(document.querySelectorAll('thead th'));
+    const errorsIndex = headers.findIndex(h => h.textContent?.includes('Errors'));
+    expect(errorsIndex).toBeGreaterThan(-1);
+    const cells = unsupportedRow!.querySelectorAll('td');
+    expect(cells[errorsIndex].textContent).toBe('-');
+  });
+
+  it('shows both columns when at least one summary has services and errorSpanCount', () => {
+    const supported = makeTrace('s1', 0);
+    const unsupported = makeUnsupportedTrace('u1');
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} traceSummaries={[supported, unsupported]} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Services')).toBeInTheDocument();
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -97,6 +97,14 @@ export default function TraceTable({
   const navigate = useNavigate();
   const { key: sortKey, order: sortOrder } = fromOrderBy(sortBy);
 
+  // Hide columns when no summary in the result set supports them.
+  // A backend that omits errorSpanCount/spanCount leaves those fields undefined;
+  // a backend that genuinely returned 0 will have a numeric value.
+  const showServicesColumn =
+    traceSummaries.length === 0 || traceSummaries.some(t => t.services.length > 0);
+  const showErrorsColumn =
+    traceSummaries.length === 0 || traceSummaries.some(t => t.errorSpanCount !== undefined);
+
   const columns: ColumnsType<TraceSummary> = useMemo(() => {
     const cols: ColumnsType<TraceSummary> = [
       {
@@ -126,14 +134,18 @@ export default function TraceTable({
           );
         },
       },
-      {
-        title: 'Services',
-        key: 'services',
-        width: '35%',
-        onCell: () => ({ style: { overflow: 'hidden' } }),
-        render: (_: unknown, trace: TraceSummary) =>
-          trace.services.length > 0 ? <ServicePills services={trace.services} /> : '-',
-      },
+      ...(showServicesColumn
+        ? [
+            {
+              title: 'Services',
+              key: 'services',
+              width: '35%',
+              onCell: () => ({ style: { overflow: 'hidden' } }),
+              render: (_: unknown, trace: TraceSummary) =>
+                trace.services.length > 0 ? <ServicePills services={trace.services} /> : '-',
+            } as const,
+          ]
+        : []),
       {
         title: 'Spans',
         key: 'spans',
@@ -144,27 +156,33 @@ export default function TraceTable({
         sortOrder: sortKey === 'spans' ? sortOrder : undefined,
         sortDirections: ['ascend', 'descend'],
       },
-      {
-        title: 'Errors',
-        key: 'errors',
-        width: '5rem',
-        align: 'center',
-        render: (_: unknown, trace: TraceSummary) =>
-          trace.errorSpanCount > 0 ? (
-            <Tag
-              variant="outlined"
-              style={{
-                margin: 0,
-                color: 'var(--feedback-error-text)',
-                borderColor: 'var(--feedback-error-text)',
-              }}
-            >
-              {trace.errorSpanCount}
-            </Tag>
-          ) : (
-            0
-          ),
-      },
+      ...(showErrorsColumn
+        ? [
+            {
+              title: 'Errors',
+              key: 'errors',
+              width: '5rem',
+              align: 'center' as const,
+              render: (_: unknown, trace: TraceSummary) =>
+                trace.errorSpanCount === undefined ? (
+                  '-'
+                ) : trace.errorSpanCount > 0 ? (
+                  <Tag
+                    variant="outlined"
+                    style={{
+                      margin: 0,
+                      color: 'var(--feedback-error-text)',
+                      borderColor: 'var(--feedback-error-text)',
+                    }}
+                  >
+                    {trace.errorSpanCount}
+                  </Tag>
+                ) : (
+                  0
+                ),
+            },
+          ]
+        : []),
       {
         title: 'Duration',
         key: 'duration',
@@ -236,7 +254,7 @@ export default function TraceTable({
     }
 
     return cols;
-  }, [sortKey, sortOrder, maxTraceDuration, getLink, disableComparisons, cohortIds, toggleComparison]);
+  }, [sortKey, sortOrder, maxTraceDuration, getLink, disableComparisons, cohortIds, toggleComparison, showServicesColumn, showErrorsColumn]);
 
   const onChange: TableProps<TraceSummary>['onChange'] = (_pagination, _filters, sorter) => {
     const s = Array.isArray(sorter) ? sorter[0] : (sorter as SorterResult<TraceSummary>);

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -100,9 +100,8 @@ export default function TraceTable({
   // Hide columns when no summary in the result set supports them.
   // A backend that omits errorSpanCount/spanCount leaves those fields undefined;
   // a backend that genuinely returned 0 will have a numeric value.
-  const showServicesColumn = traceSummaries.length === 0 || traceSummaries.some(t => t.services.length > 0);
-  const showErrorsColumn =
-    traceSummaries.length === 0 || traceSummaries.some(t => t.errorSpanCount !== undefined);
+  const showServicesColumn = traceSummaries.some(t => t.services.length > 0);
+  const showErrorsColumn = traceSummaries.some(t => t.errorSpanCount !== undefined);
 
   const columns: ColumnsType<TraceSummary> = useMemo(() => {
     const cols: ColumnsType<TraceSummary> = [

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -100,8 +100,7 @@ export default function TraceTable({
   // Hide columns when no summary in the result set supports them.
   // A backend that omits errorSpanCount/spanCount leaves those fields undefined;
   // a backend that genuinely returned 0 will have a numeric value.
-  const showServicesColumn =
-    traceSummaries.length === 0 || traceSummaries.some(t => t.services.length > 0);
+  const showServicesColumn = traceSummaries.length === 0 || traceSummaries.some(t => t.services.length > 0);
   const showErrorsColumn =
     traceSummaries.length === 0 || traceSummaries.some(t => t.errorSpanCount !== undefined);
 
@@ -254,7 +253,17 @@ export default function TraceTable({
     }
 
     return cols;
-  }, [sortKey, sortOrder, maxTraceDuration, getLink, disableComparisons, cohortIds, toggleComparison, showServicesColumn, showErrorsColumn]);
+  }, [
+    sortKey,
+    sortOrder,
+    maxTraceDuration,
+    getLink,
+    disableComparisons,
+    cohortIds,
+    toggleComparison,
+    showServicesColumn,
+    showErrorsColumn,
+  ]);
 
   const onChange: TableProps<TraceSummary>['onChange'] = (_pagination, _filters, sorter) => {
     const s = Array.isArray(sorter) ? sorter[0] : (sorter as SorterResult<TraceSummary>);

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.tsx
@@ -197,10 +197,10 @@ export function UnconnectedSearchResults({
                   x: t.startTime,
                   y: t.duration,
                   traceID: t.traceID,
-                  spanCount: t.spanCount,
+                  spanCount: t.spanCount ?? 0,
                   serviceCount: t.services.length,
                   name: t.traceName,
-                  color: t.errorSpanCount > 0 ? 'red' : '#12939A',
+                  color: (t.errorSpanCount ?? 0) > 0 ? 'red' : '#12939A',
                 };
               })}
               onValueClick={(t: { traceID: string }) => {

--- a/packages/jaeger-ui/src/model/search.ts
+++ b/packages/jaeger-ui/src/model/search.ts
@@ -31,8 +31,8 @@ const summaryComparators: Record<string, (a: TraceSummary, b: TraceSummary) => n
   [MOST_RECENT]: (a, b) => +(b.startTime > a.startTime) || +(a.startTime === b.startTime) - 1,
   [SHORTEST_FIRST]: (a, b) => +(a.duration > b.duration) || +(a.duration === b.duration) - 1,
   [LONGEST_FIRST]: (a, b) => +(b.duration > a.duration) || +(a.duration === b.duration) - 1,
-  [MOST_SPANS]: (a, b) => +(b.spanCount > a.spanCount) || +(a.spanCount === b.spanCount) - 1,
-  [LEAST_SPANS]: (a, b) => +(a.spanCount > b.spanCount) || +(a.spanCount === b.spanCount) - 1,
+  [MOST_SPANS]: (a, b) => +((b.spanCount ?? 0) > (a.spanCount ?? 0)) || +((a.spanCount ?? 0) === (b.spanCount ?? 0)) - 1,
+  [LEAST_SPANS]: (a, b) => +((a.spanCount ?? 0) > (b.spanCount ?? 0)) || +((a.spanCount ?? 0) === (b.spanCount ?? 0)) - 1,
 };
 
 /**

--- a/packages/jaeger-ui/src/model/search.ts
+++ b/packages/jaeger-ui/src/model/search.ts
@@ -31,8 +31,10 @@ const summaryComparators: Record<string, (a: TraceSummary, b: TraceSummary) => n
   [MOST_RECENT]: (a, b) => +(b.startTime > a.startTime) || +(a.startTime === b.startTime) - 1,
   [SHORTEST_FIRST]: (a, b) => +(a.duration > b.duration) || +(a.duration === b.duration) - 1,
   [LONGEST_FIRST]: (a, b) => +(b.duration > a.duration) || +(a.duration === b.duration) - 1,
-  [MOST_SPANS]: (a, b) => +((b.spanCount ?? 0) > (a.spanCount ?? 0)) || +((a.spanCount ?? 0) === (b.spanCount ?? 0)) - 1,
-  [LEAST_SPANS]: (a, b) => +((a.spanCount ?? 0) > (b.spanCount ?? 0)) || +((a.spanCount ?? 0) === (b.spanCount ?? 0)) - 1,
+  [MOST_SPANS]: (a, b) =>
+    +((b.spanCount ?? 0) > (a.spanCount ?? 0)) || +((a.spanCount ?? 0) === (b.spanCount ?? 0)) - 1,
+  [LEAST_SPANS]: (a, b) =>
+    +((a.spanCount ?? 0) > (b.spanCount ?? 0)) || +((a.spanCount ?? 0) === (b.spanCount ?? 0)) - 1,
 };
 
 /**

--- a/packages/jaeger-ui/src/types/trace-summary.ts
+++ b/packages/jaeger-ui/src/types/trace-summary.ts
@@ -5,8 +5,8 @@ import { Microseconds } from './units';
 
 export type ServiceSummary = {
   name: string;
-  spanCount: number;
-  errorSpanCount: number;
+  spanCount: number | undefined;
+  errorSpanCount: number | undefined;
 };
 
 export type TraceSummary = {
@@ -16,8 +16,8 @@ export type TraceSummary = {
   rootOperationName: string;
   startTime: Microseconds;
   duration: Microseconds;
-  spanCount: number;
-  errorSpanCount: number;
-  orphanSpanCount: number;
+  spanCount: number | undefined;
+  errorSpanCount: number | undefined;
+  orphanSpanCount: number | undefined;
   services: ServiceSummary[];
 };

--- a/packages/jaeger-ui/src/types/trace-summary.ts
+++ b/packages/jaeger-ui/src/types/trace-summary.ts
@@ -5,8 +5,8 @@ import { Microseconds } from './units';
 
 export type ServiceSummary = {
   name: string;
-  spanCount: number | undefined;
-  errorSpanCount: number | undefined;
+  spanCount?: number;
+  errorSpanCount?: number;
 };
 
 export type TraceSummary = {
@@ -16,8 +16,8 @@ export type TraceSummary = {
   rootOperationName: string;
   startTime: Microseconds;
   duration: Microseconds;
-  spanCount: number | undefined;
-  errorSpanCount: number | undefined;
-  orphanSpanCount: number | undefined;
+  spanCount?: number;
+  errorSpanCount?: number;
+  orphanSpanCount?: number;
   services: ServiceSummary[];
 };


### PR DESCRIPTION
Fixes #4005

Alternative implementation addressing the review feedback on #4006.
Happy to close this if #4006 moves forward.

## Changes
- Relaxed `spanCount`, `errorSpanCount`, `orphanSpanCount` to `number | undefined` in `TraceSummary` and `ServiceSummary` types — preserving the distinction between "backend returned 0" and "field not supported"
- Removed `?? 0` defaults in `client.ts` so `undefined` is preserved through to the view
- Computed `showServicesColumn` and `showErrorsColumn` in `TraceTable` as a view concern across all rows — hides the column when no summary supports it, shows `-` for unsupported rows in mixed results
- Updated all call sites to handle `number | undefined` safely

## How was this tested?
- `npx tsc --noEmit` — zero errors
- 328 tests passing across all affected files

## AI Usage
- [x] Moderate: AI helped with code generation and debugging