### PR TITLE
fix(search): Support legacy lookback-only search URLs

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -78,7 +78,7 @@ import { CHANGE_SERVICE_ACTION_TYPE } from '../../constants/search-form';
 import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { AppQueryClientProvider } from '../../query/app-query-client';
 import getConfig from '../../utils/config/get-config';
-import { lookbackToStartTimeMicros } from '../../utils/time-range-options';
+import { lookbackToTimestampMicros } from '../../utils/time-range-options';
 
 function makeDateParams(dateOffset = 0) {
   const date = new Date();
@@ -172,14 +172,14 @@ describe('conversion utils', () => {
 });
 
 describe('lookback utils', () => {
-  describe('lookbackToStartTimeMicros', () => {
+  describe('lookbackToTimestampMicros', () => {
     const hourInMicroseconds = 60 * 60 * 1000 * 1000;
     const now = new Date();
     const nowInMicroseconds = now * 1000;
 
     it('creates timestamp for hours ago', () => {
       [1, 2, 4, 7].forEach(lookbackNum => {
-        expect(nowInMicroseconds - lookbackToStartTimeMicros(`${lookbackNum}h`, now)).toBe(
+        expect(nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}h`, now)).toBe(
           lookbackNum * hourInMicroseconds
         );
       });
@@ -187,7 +187,7 @@ describe('lookback utils', () => {
 
     it('creates timestamp for days ago', () => {
       [1, 2, 4, 7].forEach(lookbackNum => {
-        const actual = nowInMicroseconds - lookbackToStartTimeMicros(`${lookbackNum}d`, now);
+        const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}d`, now);
         const expected = lookbackNum * 24 * hourInMicroseconds;
         try {
           expect(actual).toBe(expected);
@@ -199,7 +199,7 @@ describe('lookback utils', () => {
 
     it('creates timestamp for weeks ago', () => {
       [1, 2, 4, 7].forEach(lookbackNum => {
-        const actual = nowInMicroseconds - lookbackToStartTimeMicros(`${lookbackNum}w`, now);
+        const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}w`, now);
         try {
           expect(actual).toBe(lookbackNum * 7 * 24 * hourInMicroseconds);
         } catch (_e) {
@@ -209,11 +209,11 @@ describe('lookback utils', () => {
     });
 
     it('falls back to default lookback for unsupported units', () => {
-      expect(nowInMicroseconds - lookbackToStartTimeMicros('99x', now)).toBe(hourInMicroseconds);
+      expect(nowInMicroseconds - lookbackToTimestampMicros('99x', now)).toBe(hourInMicroseconds);
     });
 
     it('falls back to default lookback for invalid amounts', () => {
-      expect(nowInMicroseconds - lookbackToStartTimeMicros('xh', now)).toBe(hourInMicroseconds);
+      expect(nowInMicroseconds - lookbackToTimestampMicros('xh', now)).toBe(hourInMicroseconds);
     });
   });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -78,7 +78,6 @@ import { CHANGE_SERVICE_ACTION_TYPE } from '../../constants/search-form';
 import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { AppQueryClientProvider } from '../../query/app-query-client';
 import getConfig from '../../utils/config/get-config';
-import { lookbackToTimestampMicros } from '../../utils/time-range-options';
 
 function makeDateParams(dateOffset = 0) {
   const date = new Date();
@@ -172,51 +171,6 @@ describe('conversion utils', () => {
 });
 
 describe('lookback utils', () => {
-  describe('lookbackToTimestampMicros', () => {
-    const hourInMicroseconds = 60 * 60 * 1000 * 1000;
-    const now = new Date();
-    const nowInMicroseconds = now * 1000;
-
-    it('creates timestamp for hours ago', () => {
-      [1, 2, 4, 7].forEach(lookbackNum => {
-        expect(nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}h`, now)).toBe(
-          lookbackNum * hourInMicroseconds
-        );
-      });
-    });
-
-    it('creates timestamp for days ago', () => {
-      [1, 2, 4, 7].forEach(lookbackNum => {
-        const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}d`, now);
-        const expected = lookbackNum * 24 * hourInMicroseconds;
-        try {
-          expect(actual).toBe(expected);
-        } catch (_e) {
-          expect(Math.abs(actual - expected)).toBe(hourInMicroseconds);
-        }
-      });
-    });
-
-    it('creates timestamp for weeks ago', () => {
-      [1, 2, 4, 7].forEach(lookbackNum => {
-        const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}w`, now);
-        try {
-          expect(actual).toBe(lookbackNum * 7 * 24 * hourInMicroseconds);
-        } catch (_e) {
-          expect(Math.abs(actual - lookbackNum * 7 * 24 * hourInMicroseconds)).toBe(hourInMicroseconds);
-        }
-      });
-    });
-
-    it('falls back to default lookback for unsupported units', () => {
-      expect(nowInMicroseconds - lookbackToTimestampMicros('99x', now)).toBe(hourInMicroseconds);
-    });
-
-    it('falls back to default lookback for invalid amounts', () => {
-      expect(nowInMicroseconds - lookbackToTimestampMicros('xh', now)).toBe(hourInMicroseconds);
-    });
-  });
-
   describe('applyAdjustTime', () => {
     const minuteInMicroseconds = 60 * 1000 * 1000;
     const now = new Date();

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -65,7 +65,6 @@ import {
   convertQueryParamsToFormDates,
   convTagsLogfmt,
   getUnixTimeStampInMSFromForm,
-  lookbackToTimestamp,
   mapDispatchToProps,
   mapStateToProps,
   optionsWithinMaxLookback,
@@ -79,6 +78,7 @@ import { CHANGE_SERVICE_ACTION_TYPE } from '../../constants/search-form';
 import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { AppQueryClientProvider } from '../../query/app-query-client';
 import getConfig from '../../utils/config/get-config';
+import { lookbackToStartTimeMicros } from '../../utils/time-range-options';
 
 function makeDateParams(dateOffset = 0) {
   const date = new Date();
@@ -172,14 +172,14 @@ describe('conversion utils', () => {
 });
 
 describe('lookback utils', () => {
-  describe('lookbackToTimestamp', () => {
+  describe('lookbackToStartTimeMicros', () => {
     const hourInMicroseconds = 60 * 60 * 1000 * 1000;
     const now = new Date();
     const nowInMicroseconds = now * 1000;
 
     it('creates timestamp for hours ago', () => {
       [1, 2, 4, 7].forEach(lookbackNum => {
-        expect(nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}h`, now)).toBe(
+        expect(nowInMicroseconds - lookbackToStartTimeMicros(`${lookbackNum}h`, now)).toBe(
           lookbackNum * hourInMicroseconds
         );
       });
@@ -187,7 +187,7 @@ describe('lookback utils', () => {
 
     it('creates timestamp for days ago', () => {
       [1, 2, 4, 7].forEach(lookbackNum => {
-        const actual = nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}d`, now);
+        const actual = nowInMicroseconds - lookbackToStartTimeMicros(`${lookbackNum}d`, now);
         const expected = lookbackNum * 24 * hourInMicroseconds;
         try {
           expect(actual).toBe(expected);
@@ -199,7 +199,7 @@ describe('lookback utils', () => {
 
     it('creates timestamp for weeks ago', () => {
       [1, 2, 4, 7].forEach(lookbackNum => {
-        const actual = nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}w`, now);
+        const actual = nowInMicroseconds - lookbackToStartTimeMicros(`${lookbackNum}w`, now);
         try {
           expect(actual).toBe(lookbackNum * 7 * 24 * hourInMicroseconds);
         } catch (_e) {
@@ -209,11 +209,11 @@ describe('lookback utils', () => {
     });
 
     it('falls back to default lookback for unsupported units', () => {
-      expect(nowInMicroseconds - lookbackToTimestamp('99x', now)).toBe(hourInMicroseconds);
+      expect(nowInMicroseconds - lookbackToStartTimeMicros('99x', now)).toBe(hourInMicroseconds);
     });
 
     it('falls back to default lookback for invalid amounts', () => {
-      expect(nowInMicroseconds - lookbackToTimestamp('xh', now)).toBe(hourInMicroseconds);
+      expect(nowInMicroseconds - lookbackToStartTimeMicros('xh', now)).toBe(hourInMicroseconds);
     });
   });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -33,7 +33,7 @@ import { SearchQuery } from '../../types/search';
 import {
   TIME_RANGE_OPTIONS,
   asValidConfigLookback,
-  lookbackToTimestampMicros,
+  lookbackToTimestamp,
 } from '../../utils/time-range-options';
 
 const FormItem = Form.Item;
@@ -95,17 +95,17 @@ const lookbackOptions: ILookbackOption[] = TIME_RANGE_OPTIONS.map(({ label, look
 
 export const optionsWithinMaxLookback = memoizeOne((maxLookback: ILookbackOption) => {
   const now = new Date();
-  const minTimestamp = lookbackToTimestampMicros(maxLookback.value, now);
-  const lookbackToTimestampMicrosMap = new Map<string, number>();
+  const minTimestamp = lookbackToTimestamp(maxLookback.value, now);
+  const lookbackToTimestampMap = new Map<string, number>();
   const options = lookbackOptions.filter(({ value }) => {
-    const lookbackTimestamp = lookbackToTimestampMicros(value, now);
-    lookbackToTimestampMicrosMap.set(value, lookbackTimestamp);
+    const lookbackTimestamp = lookbackToTimestamp(value, now);
+    lookbackToTimestampMap.set(value, lookbackTimestamp);
     return lookbackTimestamp >= minTimestamp;
   });
   const lastInRangeIndex = options.length - 1;
   const lastInRangeOption = options[lastInRangeIndex];
   if (lastInRangeOption.label !== maxLookback.label) {
-    if (lookbackToTimestampMicrosMap.get(lastInRangeOption.value) !== minTimestamp) {
+    if (lookbackToTimestampMap.get(lastInRangeOption.value) !== minTimestamp) {
       options.push(maxLookback);
     } else {
       options.splice(lastInRangeIndex, 1, maxLookback);
@@ -184,7 +184,7 @@ export function applyAdjustTime(endTimestamp: number, adjustTime: string | null 
   if (!adjustTime) {
     return endTimestamp;
   }
-  const adjustedEnd = lookbackToTimestampMicros(adjustTime, endTimestamp / 1000);
+  const adjustedEnd = lookbackToTimestamp(adjustTime, endTimestamp / 1000);
   return adjustedEnd;
 }
 
@@ -225,7 +225,7 @@ function buildSearchQuery(
   let end: number;
   if (lookback !== 'custom') {
     const now = new Date();
-    start = String(lookbackToTimestampMicros(lookback, now));
+    start = String(lookbackToTimestamp(lookback, now));
     end = now.valueOf() * 1000;
   } else {
     const times = getUnixTimeStampInMSFromForm({

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -33,7 +33,7 @@ import { SearchQuery } from '../../types/search';
 import {
   TIME_RANGE_OPTIONS,
   asValidConfigLookback,
-  lookbackToStartTimeMicros,
+  lookbackToTimestampMicros,
 } from '../../utils/time-range-options';
 
 const FormItem = Form.Item;
@@ -95,17 +95,17 @@ const lookbackOptions: ILookbackOption[] = TIME_RANGE_OPTIONS.map(({ label, look
 
 export const optionsWithinMaxLookback = memoizeOne((maxLookback: ILookbackOption) => {
   const now = new Date();
-  const minTimestamp = lookbackToStartTimeMicros(maxLookback.value, now);
-  const lookbackToStartTimeMicrosMap = new Map<string, number>();
+  const minTimestamp = lookbackToTimestampMicros(maxLookback.value, now);
+  const lookbackToTimestampMicrosMap = new Map<string, number>();
   const options = lookbackOptions.filter(({ value }) => {
-    const lookbackTimestamp = lookbackToStartTimeMicros(value, now);
-    lookbackToStartTimeMicrosMap.set(value, lookbackTimestamp);
+    const lookbackTimestamp = lookbackToTimestampMicros(value, now);
+    lookbackToTimestampMicrosMap.set(value, lookbackTimestamp);
     return lookbackTimestamp >= minTimestamp;
   });
   const lastInRangeIndex = options.length - 1;
   const lastInRangeOption = options[lastInRangeIndex];
   if (lastInRangeOption.label !== maxLookback.label) {
-    if (lookbackToStartTimeMicrosMap.get(lastInRangeOption.value) !== minTimestamp) {
+    if (lookbackToTimestampMicrosMap.get(lastInRangeOption.value) !== minTimestamp) {
       options.push(maxLookback);
     } else {
       options.splice(lastInRangeIndex, 1, maxLookback);
@@ -184,7 +184,7 @@ export function applyAdjustTime(endTimestamp: number, adjustTime: string | null 
   if (!adjustTime) {
     return endTimestamp;
   }
-  const adjustedEnd = lookbackToStartTimeMicros(adjustTime, endTimestamp / 1000);
+  const adjustedEnd = lookbackToTimestampMicros(adjustTime, endTimestamp / 1000);
   return adjustedEnd;
 }
 
@@ -225,7 +225,7 @@ function buildSearchQuery(
   let end: number;
   if (lookback !== 'custom') {
     const now = new Date();
-    start = String(lookbackToStartTimeMicros(lookback, now));
+    start = String(lookbackToTimestampMicros(lookback, now));
     end = now.valueOf() * 1000;
   } else {
     const times = getUnixTimeStampInMSFromForm({

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -5,7 +5,7 @@ import React, { useState, useCallback, useMemo, ComponentProps } from 'react';
 import { Input, Button, Tooltip, Select, Row, Col, Form, Switch } from 'antd';
 import logfmtParser from 'logfmt/lib/logfmt_parser';
 import { stringify as logfmtStringify } from 'logfmt/lib/stringify';
-import dayjs, { ManipulateType } from 'dayjs';
+import dayjs from 'dayjs';
 import memoizeOne from 'memoize-one';
 import queryString from 'query-string';
 import { IoHelp } from 'react-icons/io5';
@@ -30,21 +30,16 @@ import { useConfig } from '../../hooks/useConfig';
 import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { ReduxState } from '../../types';
 import { SearchQuery } from '../../types/search';
-import { TIME_RANGE_OPTIONS, asValidConfigLookback } from '../../utils/time-range-options';
+import {
+  TIME_RANGE_OPTIONS,
+  asValidConfigLookback,
+  lookbackToStartTimeMicros,
+} from '../../utils/time-range-options';
 
 const FormItem = Form.Item;
 const Option = Select.Option;
 
 const ADJUST_TIME_ENABLED_KEY = 'jaeger-ui/search-adjust-time-enabled';
-const LOOKBACK_UNIT_BY_SUFFIX: Partial<Record<string, ManipulateType>> = {
-  s: 'second',
-  m: 'minute',
-  h: 'hour',
-  d: 'day',
-  w: 'week',
-};
-const DEFAULT_LOOKBACK_VALUE = parseInt(DEFAULT_LOOKBACK, 10);
-const DEFAULT_LOOKBACK_UNIT = LOOKBACK_UNIT_BY_SUFFIX[DEFAULT_LOOKBACK.slice(-1)] ?? 'hour';
 
 interface TimeStampParams {
   startDate: string;
@@ -88,21 +83,6 @@ export function convTagsLogfmt(tags: string | null | undefined): string | null {
   return JSON.stringify(data);
 }
 
-function parseLookback(s: string): { value: number; unit: ManipulateType } | null {
-  const match = s.match(/^(\d+)([smhdw])$/);
-  if (!match) return null;
-  const unit = LOOKBACK_UNIT_BY_SUFFIX[match[2]];
-  return unit !== undefined ? { value: Number(match[1]), unit } : null;
-}
-
-export function lookbackToTimestamp(lookback: string, from: Date | number): number {
-  const { value, unit } = parseLookback(lookback) ?? {
-    value: DEFAULT_LOOKBACK_VALUE,
-    unit: DEFAULT_LOOKBACK_UNIT,
-  };
-  return dayjs(from).subtract(value, unit).valueOf() * 1000;
-}
-
 interface ILookbackOption {
   label: string;
   value: string;
@@ -115,17 +95,17 @@ const lookbackOptions: ILookbackOption[] = TIME_RANGE_OPTIONS.map(({ label, look
 
 export const optionsWithinMaxLookback = memoizeOne((maxLookback: ILookbackOption) => {
   const now = new Date();
-  const minTimestamp = lookbackToTimestamp(maxLookback.value, now);
-  const lookbackToTimestampMap = new Map<string, number>();
+  const minTimestamp = lookbackToStartTimeMicros(maxLookback.value, now);
+  const lookbackToStartTimeMicrosMap = new Map<string, number>();
   const options = lookbackOptions.filter(({ value }) => {
-    const lookbackTimestamp = lookbackToTimestamp(value, now);
-    lookbackToTimestampMap.set(value, lookbackTimestamp);
+    const lookbackTimestamp = lookbackToStartTimeMicros(value, now);
+    lookbackToStartTimeMicrosMap.set(value, lookbackTimestamp);
     return lookbackTimestamp >= minTimestamp;
   });
   const lastInRangeIndex = options.length - 1;
   const lastInRangeOption = options[lastInRangeIndex];
   if (lastInRangeOption.label !== maxLookback.label) {
-    if (lookbackToTimestampMap.get(lastInRangeOption.value) !== minTimestamp) {
+    if (lookbackToStartTimeMicrosMap.get(lastInRangeOption.value) !== minTimestamp) {
       options.push(maxLookback);
     } else {
       options.splice(lastInRangeIndex, 1, maxLookback);
@@ -204,7 +184,7 @@ export function applyAdjustTime(endTimestamp: number, adjustTime: string | null 
   if (!adjustTime) {
     return endTimestamp;
   }
-  const adjustedEnd = lookbackToTimestamp(adjustTime, endTimestamp / 1000);
+  const adjustedEnd = lookbackToStartTimeMicros(adjustTime, endTimestamp / 1000);
   return adjustedEnd;
 }
 
@@ -245,7 +225,7 @@ function buildSearchQuery(
   let end: number;
   if (lookback !== 'custom') {
     const now = new Date();
-    start = String(lookbackToTimestamp(lookback, now));
+    start = String(lookbackToStartTimeMicros(lookback, now));
     end = now.valueOf() * 1000;
   } else {
     const times = getUnixTimeStampInMSFromForm({

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
@@ -66,6 +66,17 @@ export function SearchTracePageImpl() {
     }
   }, [searchQuery, searchData?.query, navigate]);
 
+  // Upgrade legacy URLs that carry only `lookback` without `start`/`end`
+  // (e.g. links from HotROD). searchQueryFromUrl derives the timestamps in
+  // memory so the API call succeeds, then we rewrite the URL to the canonical
+  // form so the link becomes repeatable and shareable.
+  const rawUrlState = useMemo(() => getUrlState(location.search), [location.search]);
+  useEffect(() => {
+    if (searchQuery?.start && searchQuery?.end && !rawUrlState.start && !rawUrlState.end) {
+      navigate(getUrl(searchQueryToUrlState(searchQuery)), { replace: true });
+    }
+  }, [searchQuery, rawUrlState, navigate]);
+
   const { uploadedSummaries, uploadedRawTraces, handleTracesLoaded } = useUploadedTraces();
 
   // Merge API and uploaded summaries, deduplicating by traceID (API results take precedence).

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.test.js
@@ -280,5 +280,22 @@ describe('SearchTracePage/url', () => {
       const result = searchQueryFromUrl('?service=svc');
       expect(result?.lookback).toBe('');
     });
+
+    it('derives start/end from lookback when old-style URL omits timestamps', () => {
+      const before = Date.now();
+      const result = searchQueryFromUrl(
+        '?service=frontend&lookback=1h&limit=20&tags=%7B%22driver%22%3A%22T789090C%22%7D'
+      );
+      const after = Date.now();
+      expect(result).not.toBeNull();
+      expect(result?.lookback).toBe('1h');
+      const startUs = Number(result?.start);
+      const endUs = Number(result?.end);
+      // end should be approximately now (within 1 second)
+      expect(endUs).toBeGreaterThanOrEqual(before * 1000);
+      expect(endUs).toBeLessThanOrEqual(after * 1000 + 1000 * 1000);
+      // start should be 1 hour before end
+      expect(endUs - startUs).toBeCloseTo(60 * 60 * 1_000_000, -6);
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.ts
@@ -13,7 +13,7 @@ import parseQuery from '../../utils/parseQuery';
 import {
   asValidLookback,
   lookbackFromDuration,
-  lookbackToStartTimeMicros,
+  lookbackToTimestampMicros,
 } from '../../utils/time-range-options';
 
 export { isSameQuery, isQueryEmpty } from '../../utils/search-query';
@@ -153,7 +153,7 @@ export function searchQueryFromUrl(search: string): SearchQuery | null {
   if ((!startStr || startStr === '0') && (!endStr || endStr === '0') && lookback && lookback !== 'custom') {
     const now = new Date();
     endStr = String(now.valueOf() * 1000);
-    startStr = String(lookbackToStartTimeMicros(lookback, now));
+    startStr = String(lookbackToTimestampMicros(lookback, now));
   }
 
   return {

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.ts
@@ -10,11 +10,7 @@ import { MAX_LENGTH } from '../DeepDependencies/Graph/DdgNodeContent/constants';
 
 import { SearchQuery } from '../../types/search';
 import parseQuery from '../../utils/parseQuery';
-import {
-  asValidLookback,
-  lookbackFromDuration,
-  lookbackToTimestampMicros,
-} from '../../utils/time-range-options';
+import { asValidLookback, lookbackFromDuration, lookbackToTimestamp } from '../../utils/time-range-options';
 
 export { isSameQuery, isQueryEmpty } from '../../utils/search-query';
 
@@ -153,7 +149,7 @@ export function searchQueryFromUrl(search: string): SearchQuery | null {
   if ((!startStr || startStr === '0') && (!endStr || endStr === '0') && lookback && lookback !== 'custom') {
     const now = new Date();
     endStr = String(now.valueOf() * 1000);
-    startStr = String(lookbackToTimestampMicros(lookback, now));
+    startStr = String(lookbackToTimestamp(lookback, now));
   }
 
   return {

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.ts
@@ -11,6 +11,7 @@ import { MAX_LENGTH } from '../DeepDependencies/Graph/DdgNodeContent/constants';
 import { SearchQuery } from '../../types/search';
 import parseQuery from '../../utils/parseQuery';
 import { asValidLookback, lookbackFromDuration, lookbackToTimestamp } from '../../utils/time-range-options';
+import type { Microseconds } from '../../types/units';
 
 export { isSameQuery, isQueryEmpty } from '../../utils/search-query';
 
@@ -111,7 +112,7 @@ function lookbackFromUrlState(q: TUrlState): string {
   if (lookback) return lookback;
   const startUs = Number(firstOf(q.start));
   const endUs = Number(firstOf(q.end));
-  if (startUs > 0 && endUs > startUs) return lookbackFromDuration((endUs - startUs) / 1000);
+  if (startUs > 0 && endUs > startUs) return lookbackFromDuration((endUs - startUs) as Microseconds);
   return '';
 }
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/url.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/url.ts
@@ -10,7 +10,11 @@ import { MAX_LENGTH } from '../DeepDependencies/Graph/DdgNodeContent/constants';
 
 import { SearchQuery } from '../../types/search';
 import parseQuery from '../../utils/parseQuery';
-import { asValidLookback, lookbackFromDuration } from '../../utils/time-range-options';
+import {
+  asValidLookback,
+  lookbackFromDuration,
+  lookbackToStartTimeMicros,
+} from '../../utils/time-range-options';
 
 export { isSameQuery, isQueryEmpty } from '../../utils/search-query';
 
@@ -138,10 +142,19 @@ export function searchQueryFromUrl(search: string): SearchQuery | null {
   const q = getUrlState(search);
   if (!q.service && !q.start && !q.end) return null;
 
-  const startStr = firstOf(q.start) ?? '';
-  const endStr = firstOf(q.end) ?? '';
+  let startStr = firstOf(q.start) ?? '';
+  let endStr = firstOf(q.end) ?? '';
 
   const lookback = lookbackFromUrlState(q);
+
+  // Old-style URLs (e.g. from HotROD) carry only `lookback` without explicit
+  // `start`/`end`.  Derive concrete timestamps so the v3 API call always
+  // receives the required startTimeMin/startTimeMax.
+  if ((!startStr || startStr === '0') && (!endStr || endStr === '0') && lookback && lookback !== 'custom') {
+    const now = new Date();
+    endStr = String(now.valueOf() * 1000);
+    startStr = String(lookbackToStartTimeMicros(lookback, now));
+  }
 
   return {
     service: firstOf(q?.service),

--- a/packages/jaeger-ui/src/types/units.ts
+++ b/packages/jaeger-ui/src/types/units.ts
@@ -6,3 +6,8 @@
  * This provides type safety to ensure time values are not confused with other numeric values.
  */
 export type Microseconds = number & { readonly __brand: unique symbol };
+
+/**
+ * A branded type representing time values in milliseconds.
+ */
+export type Milliseconds = number & { readonly __brand: unique symbol };

--- a/packages/jaeger-ui/src/utils/time-range-options.test.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.test.ts
@@ -5,7 +5,7 @@ import {
   ONE_HOUR_MS,
   TIME_RANGE_OPTIONS,
   lookbackFromDuration,
-  lookbackToTimestampMicros,
+  lookbackToTimestamp,
 } from './time-range-options';
 
 describe('TIME_RANGE_OPTIONS', () => {
@@ -59,14 +59,14 @@ describe('lookbackFromDuration', () => {
   });
 });
 
-describe('lookbackToTimestampMicros', () => {
+describe('lookbackToTimestamp', () => {
   const hourInMicroseconds = 60 * 60 * 1000 * 1000;
   const now = new Date();
   const nowInMicroseconds = now.valueOf() * 1000;
 
   it('creates timestamp for hours ago', () => {
     [1, 2, 4, 7].forEach(lookbackNum => {
-      expect(nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}h`, now)).toBe(
+      expect(nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}h`, now)).toBe(
         lookbackNum * hourInMicroseconds
       );
     });
@@ -74,7 +74,7 @@ describe('lookbackToTimestampMicros', () => {
 
   it('creates timestamp for days ago', () => {
     [1, 2, 4, 7].forEach(lookbackNum => {
-      const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}d`, now);
+      const actual = nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}d`, now);
       const expected = lookbackNum * 24 * hourInMicroseconds;
       try {
         expect(actual).toBe(expected);
@@ -86,7 +86,7 @@ describe('lookbackToTimestampMicros', () => {
 
   it('creates timestamp for weeks ago', () => {
     [1, 2, 4, 7].forEach(lookbackNum => {
-      const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}w`, now);
+      const actual = nowInMicroseconds - lookbackToTimestamp(`${lookbackNum}w`, now);
       try {
         expect(actual).toBe(lookbackNum * 7 * 24 * hourInMicroseconds);
       } catch {
@@ -96,10 +96,10 @@ describe('lookbackToTimestampMicros', () => {
   });
 
   it('falls back to 1h for unsupported units', () => {
-    expect(nowInMicroseconds - lookbackToTimestampMicros('99x', now)).toBe(hourInMicroseconds);
+    expect(nowInMicroseconds - lookbackToTimestamp('99x', now)).toBe(hourInMicroseconds);
   });
 
   it('falls back to 1h for invalid amounts', () => {
-    expect(nowInMicroseconds - lookbackToTimestampMicros('xh', now)).toBe(hourInMicroseconds);
+    expect(nowInMicroseconds - lookbackToTimestamp('xh', now)).toBe(hourInMicroseconds);
   });
 });

--- a/packages/jaeger-ui/src/utils/time-range-options.test.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Microseconds } from '../types/units';
 import {
   ONE_HOUR_MS,
   TIME_RANGE_OPTIONS,
@@ -34,28 +35,30 @@ describe('TIME_RANGE_OPTIONS', () => {
   });
 });
 
+const ONE_HOUR_US = ONE_HOUR_MS * 1000;
+
 describe('lookbackFromDuration', () => {
   it('returns the exact matching option when duration equals a bucket', () => {
-    expect(lookbackFromDuration(ONE_HOUR_MS)).toBe('1h');
-    expect(lookbackFromDuration(15 * 60_000)).toBe('15m');
-    expect(lookbackFromDuration(2 * 24 * ONE_HOUR_MS)).toBe('2d');
+    expect(lookbackFromDuration(ONE_HOUR_US as Microseconds)).toBe('1h');
+    expect(lookbackFromDuration((15 * 60_000 * 1000) as Microseconds)).toBe('15m');
+    expect(lookbackFromDuration((2 * 24 * ONE_HOUR_US) as Microseconds)).toBe('2d');
   });
 
   it('snaps up to the next bucket when duration falls between two options', () => {
     // 70 minutes is between 1h and 2h → should snap up to 2h
-    expect(lookbackFromDuration(70 * 60_000)).toBe('2h');
+    expect(lookbackFromDuration((70 * 60_000 * 1000) as Microseconds)).toBe('2h');
     // 1 minute is less than 5m → should return 5m (smallest bucket)
-    expect(lookbackFromDuration(60_000)).toBe('5m');
+    expect(lookbackFromDuration((60_000 * 1000) as Microseconds)).toBe('5m');
   });
 
   it('returns "custom" when duration exceeds the largest option', () => {
-    const largestMs = TIME_RANGE_OPTIONS[TIME_RANGE_OPTIONS.length - 1].valueMs;
-    expect(lookbackFromDuration(largestMs + 1)).toBe('custom');
-    expect(lookbackFromDuration(365 * 24 * ONE_HOUR_MS)).toBe('custom');
+    const largestUs = TIME_RANGE_OPTIONS[TIME_RANGE_OPTIONS.length - 1].valueMs * 1000;
+    expect(lookbackFromDuration((largestUs + 1) as Microseconds)).toBe('custom');
+    expect(lookbackFromDuration((365 * 24 * ONE_HOUR_US) as Microseconds)).toBe('custom');
   });
 
   it('returns the smallest option for duration of 0', () => {
-    expect(lookbackFromDuration(0)).toBe(TIME_RANGE_OPTIONS[0].lookback);
+    expect(lookbackFromDuration(0 as Microseconds)).toBe(TIME_RANGE_OPTIONS[0].lookback);
   });
 });
 

--- a/packages/jaeger-ui/src/utils/time-range-options.test.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ONE_HOUR_MS, TIME_RANGE_OPTIONS, lookbackFromDuration } from './time-range-options';
+import {
+  ONE_HOUR_MS,
+  TIME_RANGE_OPTIONS,
+  lookbackFromDuration,
+  lookbackToTimestampMicros,
+} from './time-range-options';
 
 describe('TIME_RANGE_OPTIONS', () => {
   it('keeps lookback values and millisecond values aligned', () => {
@@ -51,5 +56,50 @@ describe('lookbackFromDuration', () => {
 
   it('returns the smallest option for duration of 0', () => {
     expect(lookbackFromDuration(0)).toBe(TIME_RANGE_OPTIONS[0].lookback);
+  });
+});
+
+describe('lookbackToTimestampMicros', () => {
+  const hourInMicroseconds = 60 * 60 * 1000 * 1000;
+  const now = new Date();
+  const nowInMicroseconds = now.valueOf() * 1000;
+
+  it('creates timestamp for hours ago', () => {
+    [1, 2, 4, 7].forEach(lookbackNum => {
+      expect(nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}h`, now)).toBe(
+        lookbackNum * hourInMicroseconds
+      );
+    });
+  });
+
+  it('creates timestamp for days ago', () => {
+    [1, 2, 4, 7].forEach(lookbackNum => {
+      const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}d`, now);
+      const expected = lookbackNum * 24 * hourInMicroseconds;
+      try {
+        expect(actual).toBe(expected);
+      } catch {
+        expect(Math.abs(actual - expected)).toBe(hourInMicroseconds);
+      }
+    });
+  });
+
+  it('creates timestamp for weeks ago', () => {
+    [1, 2, 4, 7].forEach(lookbackNum => {
+      const actual = nowInMicroseconds - lookbackToTimestampMicros(`${lookbackNum}w`, now);
+      try {
+        expect(actual).toBe(lookbackNum * 7 * 24 * hourInMicroseconds);
+      } catch {
+        expect(Math.abs(actual - lookbackNum * 7 * 24 * hourInMicroseconds)).toBe(hourInMicroseconds);
+      }
+    });
+  });
+
+  it('falls back to 1h for unsupported units', () => {
+    expect(nowInMicroseconds - lookbackToTimestampMicros('99x', now)).toBe(hourInMicroseconds);
+  });
+
+  it('falls back to 1h for invalid amounts', () => {
+    expect(nowInMicroseconds - lookbackToTimestampMicros('xh', now)).toBe(hourInMicroseconds);
   });
 });

--- a/packages/jaeger-ui/src/utils/time-range-options.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.ts
@@ -2,100 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import dayjs, { type ManipulateType } from 'dayjs';
-import type { Microseconds } from '../types/units';
+import type { Microseconds, Milliseconds } from '../types/units';
 
-const ONE_MINUTE_MS = 60_000;
-export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
-const ONE_DAY_MS = 24 * ONE_HOUR_MS;
-const ONE_WEEK_MS = 7 * ONE_DAY_MS;
+const ONE_MINUTE_MS = 60_000 as Milliseconds;
+export const ONE_HOUR_MS = (60 * ONE_MINUTE_MS) as Milliseconds;
+const ONE_DAY_MS = (24 * ONE_HOUR_MS) as Milliseconds;
+const ONE_WEEK_MS = (7 * ONE_DAY_MS) as Milliseconds;
 
 export interface ITimeRangeOption {
   readonly label: string;
   readonly lookback: string;
-  readonly valueMs: number;
+  readonly valueMs: Milliseconds;
 }
 
 export const TIME_RANGE_OPTIONS: readonly ITimeRangeOption[] = Object.freeze([
-  {
-    label: '5 minutes',
-    lookback: '5m',
-    valueMs: 5 * ONE_MINUTE_MS,
-  },
-  {
-    label: '15 minutes',
-    lookback: '15m',
-    valueMs: 15 * ONE_MINUTE_MS,
-  },
-  {
-    label: '30 minutes',
-    lookback: '30m',
-    valueMs: 30 * ONE_MINUTE_MS,
-  },
-  {
-    label: '1 hour',
-    lookback: '1h',
-    valueMs: ONE_HOUR_MS,
-  },
-  {
-    label: '2 hours',
-    lookback: '2h',
-    valueMs: 2 * ONE_HOUR_MS,
-  },
-  {
-    label: '3 hours',
-    lookback: '3h',
-    valueMs: 3 * ONE_HOUR_MS,
-  },
-  {
-    label: '6 hours',
-    lookback: '6h',
-    valueMs: 6 * ONE_HOUR_MS,
-  },
-  {
-    label: '12 hours',
-    lookback: '12h',
-    valueMs: 12 * ONE_HOUR_MS,
-  },
-  {
-    label: '24 hours',
-    lookback: '24h',
-    valueMs: 24 * ONE_HOUR_MS,
-  },
-  {
-    label: '2 days',
-    lookback: '2d',
-    valueMs: 2 * ONE_DAY_MS,
-  },
-  {
-    label: '3 days',
-    lookback: '3d',
-    valueMs: 3 * ONE_DAY_MS,
-  },
-  {
-    label: '5 days',
-    lookback: '5d',
-    valueMs: 5 * ONE_DAY_MS,
-  },
-  {
-    label: '7 days',
-    lookback: '7d',
-    valueMs: 7 * ONE_DAY_MS,
-  },
-  {
-    label: '2 weeks',
-    lookback: '2w',
-    valueMs: 2 * ONE_WEEK_MS,
-  },
-  {
-    label: '3 weeks',
-    lookback: '3w',
-    valueMs: 3 * ONE_WEEK_MS,
-  },
-  {
-    label: '4 weeks',
-    lookback: '4w',
-    valueMs: 4 * ONE_WEEK_MS,
-  },
+  { label: '5 minutes', lookback: '5m', valueMs: (5 * ONE_MINUTE_MS) as Milliseconds },
+  { label: '15 minutes', lookback: '15m', valueMs: (15 * ONE_MINUTE_MS) as Milliseconds },
+  { label: '30 minutes', lookback: '30m', valueMs: (30 * ONE_MINUTE_MS) as Milliseconds },
+  { label: '1 hour', lookback: '1h', valueMs: ONE_HOUR_MS },
+  { label: '2 hours', lookback: '2h', valueMs: (2 * ONE_HOUR_MS) as Milliseconds },
+  { label: '3 hours', lookback: '3h', valueMs: (3 * ONE_HOUR_MS) as Milliseconds },
+  { label: '6 hours', lookback: '6h', valueMs: (6 * ONE_HOUR_MS) as Milliseconds },
+  { label: '12 hours', lookback: '12h', valueMs: (12 * ONE_HOUR_MS) as Milliseconds },
+  { label: '24 hours', lookback: '24h', valueMs: (24 * ONE_HOUR_MS) as Milliseconds },
+  { label: '2 days', lookback: '2d', valueMs: (2 * ONE_DAY_MS) as Milliseconds },
+  { label: '3 days', lookback: '3d', valueMs: (3 * ONE_DAY_MS) as Milliseconds },
+  { label: '5 days', lookback: '5d', valueMs: (5 * ONE_DAY_MS) as Milliseconds },
+  { label: '7 days', lookback: '7d', valueMs: (7 * ONE_DAY_MS) as Milliseconds },
+  { label: '2 weeks', lookback: '2w', valueMs: (2 * ONE_WEEK_MS) as Milliseconds },
+  { label: '3 weeks', lookback: '3w', valueMs: (3 * ONE_WEEK_MS) as Milliseconds },
+  { label: '4 weeks', lookback: '4w', valueMs: (4 * ONE_WEEK_MS) as Milliseconds },
 ]);
 
 /**

--- a/packages/jaeger-ui/src/utils/time-range-options.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.ts
@@ -120,13 +120,13 @@ export function asValidConfigLookback(value: string | undefined): string | undef
 }
 
 /**
- * Given a duration in milliseconds, return the lookback string of the smallest
- * TIME_RANGE_OPTIONS entry whose window is >= durationMs.
- * Returns 'custom' if durationMs exceeds the largest option.
+ * Given a duration in microseconds, return the lookback string of the smallest
+ * TIME_RANGE_OPTIONS entry whose window covers the duration.
+ * Returns 'custom' if the duration exceeds the largest option.
  */
-export function lookbackFromDuration(durationMs: number): string {
+export function lookbackFromDuration(durationUs: Microseconds): string {
   for (const option of TIME_RANGE_OPTIONS) {
-    if (option.valueMs >= durationMs) return option.lookback;
+    if (option.valueMs * 1000 >= durationUs) return option.lookback;
   }
   return 'custom';
 }

--- a/packages/jaeger-ui/src/utils/time-range-options.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import dayjs, { type ManipulateType } from 'dayjs';
+
 const ONE_MINUTE_MS = 60_000;
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
@@ -126,4 +128,30 @@ export function lookbackFromDuration(durationMs: number): string {
     if (option.valueMs >= durationMs) return option.lookback;
   }
   return 'custom';
+}
+
+const LOOKBACK_UNIT_BY_SUFFIX: Partial<Record<string, ManipulateType>> = {
+  s: 'second',
+  m: 'minute',
+  h: 'hour',
+  d: 'day',
+  w: 'week',
+};
+
+function parseLookback(s: string): { value: number; unit: ManipulateType } | null {
+  const match = s.match(/^(\d+)([smhdw])$/);
+  if (!match) return null;
+  const unit = LOOKBACK_UNIT_BY_SUFFIX[match[2]];
+  return unit !== undefined ? { value: Number(match[1]), unit } : null;
+}
+
+/**
+ * Given a lookback string (e.g. "1h", "2d") and a reference point in time,
+ * returns the start timestamp in microseconds (epoch µs) that corresponds to
+ * "now − lookback". Falls back to 1h when the string is unrecognised.
+ */
+export function lookbackToStartTimeMicros(lookback: string, now: Date | number = new Date()): number {
+  const parsed = parseLookback(lookback);
+  const { value, unit } = parsed ?? { value: 1, unit: 'hour' as ManipulateType };
+  return dayjs(now).subtract(value, unit).valueOf() * 1000;
 }

--- a/packages/jaeger-ui/src/utils/time-range-options.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.ts
@@ -150,7 +150,7 @@ function parseLookback(s: string): { value: number; unit: ManipulateType } | nul
  * returns the start timestamp in microseconds (epoch µs) that corresponds to
  * "now − lookback". Falls back to 1h when the string is unrecognised.
  */
-export function lookbackToStartTimeMicros(lookback: string, now: Date | number = new Date()): number {
+export function lookbackToTimestampMicros(lookback: string, now: Date | number = new Date()): number {
   const parsed = parseLookback(lookback);
   const { value, unit } = parsed ?? { value: 1, unit: 'hour' as ManipulateType };
   return dayjs(now).subtract(value, unit).valueOf() * 1000;

--- a/packages/jaeger-ui/src/utils/time-range-options.ts
+++ b/packages/jaeger-ui/src/utils/time-range-options.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import dayjs, { type ManipulateType } from 'dayjs';
+import type { Microseconds } from '../types/units';
 
 const ONE_MINUTE_MS = 60_000;
 export const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
@@ -145,13 +146,8 @@ function parseLookback(s: string): { value: number; unit: ManipulateType } | nul
   return unit !== undefined ? { value: Number(match[1]), unit } : null;
 }
 
-/**
- * Given a lookback string (e.g. "1h", "2d") and a reference point in time,
- * returns the start timestamp in microseconds (epoch µs) that corresponds to
- * "now − lookback". Falls back to 1h when the string is unrecognised.
- */
-export function lookbackToTimestampMicros(lookback: string, now: Date | number = new Date()): number {
+export function lookbackToTimestamp(lookback: string, now: Date | number = new Date()): Microseconds {
   const parsed = parseLookback(lookback);
   const { value, unit } = parsed ?? { value: 1, unit: 'hour' as ManipulateType };
-  return dayjs(now).subtract(value, unit).valueOf() * 1000;
+  return (dayjs(now).subtract(value, unit).valueOf() * 1000) as Microseconds;
 }


### PR DESCRIPTION
## Problem

Old-style URLs (e.g. links generated by HotROD) use `?lookback=1h` without explicit `start`/`end` params. The v3 `/api/trace-summaries` endpoint requires `startTimeMin`/`startTimeMax`, so these URLs produced a 400 error:

```
Failed to fetch trace summaries: 400 Bad Request
{"error":{"httpCode":400,"message":"query.startTimeMin and query.startTimeMax are required"}}
```

## Changes

- **Fix**: when `searchQueryFromUrl` parses a URL that has `lookback` but no `start`/`end`, it now derives concrete timestamps — the same arithmetic `SearchForm` already does on submit
- **URL upgrade**: a `useEffect` in `SearchTracePageImpl` rewrites the address bar to the canonical `?...&start=<µs>&end=<µs>` form after load, so the link becomes repeatable and shareable
- **Refactor**: moved `parseLookback`/`lookbackToTimestamp` from `SearchForm.tsx` into `time-range-options.ts` (the function was needed in `url.ts` and importing from `SearchForm` would have been circular); tests moved accordingly
- **Types**: `lookbackToTimestamp` returns `Microseconds`; `lookbackFromDuration` accepts `Microseconds`; added `Milliseconds` branded type to `units.ts` and used it for `ITimeRangeOption.valueMs`

## How was this tested?

- All existing tests pass (`npm test`)
- Verified manually that `http://localhost:16686/search?limit=20&lookback=1h&service=frontend&tags=...` loads correctly and the URL is rewritten to include `start`/`end`