### PR TITLE
feat(search): Add Reset button to clear the search form

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.css
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.css
@@ -24,6 +24,10 @@ SPDX-License-Identifier: Apache-2.0
   margin-top: 0.5em;
 }
 
+.SearchForm--reset {
+  float: left;
+}
+
 .SearchForm--submit {
   background-color: var(--interactive-primary);
   color: var(--text-inverse);

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -737,6 +737,50 @@ describe('submitting state from useIsSearchFetching', () => {
     const submitBtn = container.querySelector(`[data-test="${markers.SUBMIT_BTN}"]`);
     expect(submitBtn).toBeDisabled();
   });
+
+  describe('Reset button', () => {
+    it('clears tags and duration fields', () => {
+      const { container } = renderForm(
+        <SearchForm
+          {...defaultProps}
+          initialValues={{ service: 'svcA', tags: 'http.status=200', minDuration: '1ms', maxDuration: '1s' }}
+        />
+      );
+
+      const tagsInput = container.querySelector('input[name="tags"]');
+      const minInput = container.querySelector('input[name="minDuration"]');
+      const maxInput = container.querySelector('input[name="maxDuration"]');
+      expect(tagsInput.value).toBe('http.status=200');
+
+      fireEvent.click(container.querySelector('.SearchForm--reset'));
+
+      expect(tagsInput.value).toBe('');
+      expect(minInput.value).toBe('');
+      expect(maxInput.value).toBe('');
+    });
+
+    it('restores default limit after reset', () => {
+      const { container } = renderForm(
+        <SearchForm {...defaultProps} initialValues={{ service: 'svcA', resultsLimit: '500' }} />
+      );
+
+      const limitInput = container.querySelector('input[name="resultsLimit"]');
+      expect(limitInput.value).toBe('500');
+
+      fireEvent.click(container.querySelector('.SearchForm--reset'));
+
+      expect(limitInput.value).toBe(String(20)); // DEFAULT_LIMIT
+    });
+
+    it('preserves service selection after reset', () => {
+      renderForm(<SearchForm {...defaultProps} initialValues={{ service: 'svcA' }} />);
+
+      fireEvent.click(document.querySelector('.SearchForm--reset'));
+
+      // service select retains its value — the mock captures the last onChange value
+      expect(SearchableSelect.onChangeFns.service).toBeDefined();
+    });
+  });
 });
 
 describe('handleAdjustTimeToggle', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -773,12 +773,14 @@ describe('submitting state from useIsSearchFetching', () => {
     });
 
     it('preserves service selection after reset', () => {
-      renderForm(<SearchForm {...defaultProps} initialValues={{ service: 'svcA' }} />);
+      const { container } = renderForm(<SearchForm {...defaultProps} initialValues={{ service: 'svcA' }} />);
 
-      fireEvent.click(document.querySelector('.SearchForm--reset'));
+      fireEvent.click(container.querySelector('.SearchForm--reset'));
 
-      // service select retains its value — the mock captures the last onChange value
-      expect(SearchableSelect.onChangeFns.service).toBeDefined();
+      expect(container.querySelector('[data-testid="mock-select-service"]')).toHaveAttribute(
+        'data-value',
+        'svcA'
+      );
     });
   });
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -772,14 +772,24 @@ describe('submitting state from useIsSearchFetching', () => {
       expect(limitInput.value).toBe(String(20)); // DEFAULT_LIMIT
     });
 
-    it('preserves service selection after reset', () => {
-      const { container } = renderForm(<SearchForm {...defaultProps} initialValues={{ service: 'svcA' }} />);
+    it('preserves service and restores operation and lookback to defaults', () => {
+      const { container } = renderForm(
+        <SearchForm {...defaultProps} initialValues={{ service: 'svcA', operation: 'op1', lookback: '2d' }} />
+      );
 
       fireEvent.click(container.querySelector('.SearchForm--reset'));
 
       expect(container.querySelector('[data-testid="mock-select-service"]')).toHaveAttribute(
         'data-value',
         'svcA'
+      );
+      expect(container.querySelector('[data-testid="mock-select-operation"]')).toHaveAttribute(
+        'data-value',
+        'all'
+      );
+      expect(container.querySelector('[data-testid="mock-select-lookback"]')).toHaveAttribute(
+        'data-value',
+        '1h'
       );
     });
   });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -360,7 +360,11 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   );
 
   const handleReset = useCallback(() => {
-    setFormData(prev => ({ service: prev.service, lookback: DEFAULT_LOOKBACK }));
+    setFormData(prev => ({
+      service: prev.service,
+      operation: DEFAULT_OPERATION,
+      lookback: DEFAULT_LOOKBACK,
+    }));
   }, []);
 
   const { service: selectedService, lookback: selectedLookback } = formData;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -289,16 +289,19 @@ function defaultFormData(
   initialValues: Partial<ISearchFormFields> | undefined,
   configLookback: string | undefined
 ): Partial<ISearchFormFields> {
+  const nowInMicroseconds = dayjs().valueOf() * 1000;
+  const today = formatDate(nowInMicroseconds);
+  const currentTime = formatTime(nowInMicroseconds);
   return {
     service: initialValues?.service,
     operation: initialValues?.operation ?? DEFAULT_OPERATION,
     resultsLimit: initialValues?.resultsLimit ?? String(DEFAULT_LIMIT),
     lookback: initialValues?.lookback ?? asValidConfigLookback(configLookback) ?? DEFAULT_LOOKBACK,
     tags: initialValues?.tags,
-    startDate: initialValues?.startDate,
-    startDateTime: initialValues?.startDateTime,
-    endDate: initialValues?.endDate,
-    endDateTime: initialValues?.endDateTime,
+    startDate: initialValues?.startDate ?? today,
+    startDateTime: initialValues?.startDateTime ?? '00:00',
+    endDate: initialValues?.endDate ?? today,
+    endDateTime: initialValues?.endDateTime ?? currentTime,
     minDuration: initialValues?.minDuration,
     maxDuration: initialValues?.maxDuration,
   };
@@ -667,7 +670,7 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
         />
       </FormItem>
 
-      <Button className="SearchForm--reset" disabled={submitting} onClick={handleReset}>
+      <Button htmlType="button" className="SearchForm--reset" disabled={submitting} onClick={handleReset}>
         Reset
       </Button>
       <Button

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -285,6 +285,25 @@ interface ISearchFormImplProps {
   ) => string;
 }
 
+function defaultFormData(
+  initialValues: Partial<ISearchFormFields> | undefined,
+  configLookback: string | undefined
+): Partial<ISearchFormFields> {
+  return {
+    service: initialValues?.service,
+    operation: initialValues?.operation ?? DEFAULT_OPERATION,
+    resultsLimit: initialValues?.resultsLimit ?? String(DEFAULT_LIMIT),
+    lookback: initialValues?.lookback ?? asValidConfigLookback(configLookback) ?? DEFAULT_LOOKBACK,
+    tags: initialValues?.tags,
+    startDate: initialValues?.startDate,
+    startDateTime: initialValues?.startDateTime,
+    endDate: initialValues?.endDate,
+    endDateTime: initialValues?.endDateTime,
+    minDuration: initialValues?.minDuration,
+    maxDuration: initialValues?.maxDuration,
+  };
+}
+
 export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   invalid = false,
   initialValues,
@@ -296,19 +315,9 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   const { useOpenTelemetryTerms: useOtelTerms, search: searchConfig } = useConfig();
   const searchMaxLookback: ILookbackOption | undefined = searchConfig?.maxLookback;
   const searchAdjustEndTime: string | undefined = searchConfig?.adjustEndTime;
-  const [formData, setFormData] = useState<Partial<ISearchFormFields>>(() => ({
-    service: initialValues?.service,
-    operation: initialValues?.operation,
-    tags: initialValues?.tags,
-    lookback: initialValues?.lookback,
-    startDate: initialValues?.startDate,
-    startDateTime: initialValues?.startDateTime,
-    endDate: initialValues?.endDate,
-    endDateTime: initialValues?.endDateTime,
-    minDuration: initialValues?.minDuration,
-    maxDuration: initialValues?.maxDuration,
-    resultsLimit: initialValues?.resultsLimit,
-  }));
+  const [formData, setFormData] = useState<Partial<ISearchFormFields>>(() =>
+    defaultFormData(initialValues, searchConfig?.defaultLookback)
+  );
 
   // Fetch services using React Query
   const { data: services = [], isLoading: isLoadingServices, error: servicesError } = useServices();
@@ -360,13 +369,8 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   );
 
   const handleReset = useCallback(() => {
-    setFormData(prev => ({
-      service: prev.service,
-      operation: DEFAULT_OPERATION,
-      lookback: DEFAULT_LOOKBACK,
-      resultsLimit: DEFAULT_LIMIT,
-    }));
-  }, []);
+    setFormData(prev => defaultFormData({ service: prev.service }, searchConfig?.defaultLookback));
+  }, [searchConfig?.defaultLookback]);
 
   const { service: selectedService, lookback: selectedLookback } = formData;
   const noSelectedService = selectedService === '-' || !selectedService;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -297,13 +297,13 @@ function defaultFormData(
     operation: initialValues?.operation ?? DEFAULT_OPERATION,
     resultsLimit: initialValues?.resultsLimit ?? String(DEFAULT_LIMIT),
     lookback: initialValues?.lookback ?? asValidConfigLookback(configLookback) ?? DEFAULT_LOOKBACK,
-    tags: initialValues?.tags,
+    tags: initialValues?.tags ?? '',
     startDate: initialValues?.startDate ?? today,
     startDateTime: initialValues?.startDateTime ?? '00:00',
     endDate: initialValues?.endDate ?? today,
     endDateTime: initialValues?.endDateTime ?? currentTime,
-    minDuration: initialValues?.minDuration,
-    maxDuration: initialValues?.maxDuration,
+    minDuration: initialValues?.minDuration ?? '',
+    maxDuration: initialValues?.maxDuration ?? '',
   };
 }
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -196,9 +196,9 @@ interface ISearchFormFields {
   endDate: string;
   endDateTime: string;
   operation: string;
-  tags?: string;
-  minDuration?: string;
-  maxDuration?: string;
+  tags: string;
+  minDuration: string;
+  maxDuration: string;
   lookback: string;
 }
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -364,6 +364,7 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
       service: prev.service,
       operation: DEFAULT_OPERATION,
       lookback: DEFAULT_LOOKBACK,
+      resultsLimit: DEFAULT_LIMIT,
     }));
   }, []);
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -360,7 +360,7 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   );
 
   const handleReset = useCallback(() => {
-    setFormData({});
+    setFormData(prev => ({ service: prev.service, lookback: DEFAULT_LOOKBACK }));
   }, []);
 
   const { service: selectedService, lookback: selectedLookback } = formData;

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -359,6 +359,10 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
     [formData, searchAdjustEndTime, adjustTimeEnabled, submitFormHandler, navigate, clearUploadedTraces]
   );
 
+  const handleReset = useCallback(() => {
+    setFormData({});
+  }, []);
+
   const { service: selectedService, lookback: selectedLookback } = formData;
   const noSelectedService = selectedService === '-' || !selectedService;
   const tz = selectedLookback === 'custom' ? new Date().toTimeString().replace(/^.*?GMT/, 'UTC') : null;
@@ -654,6 +658,9 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
         />
       </FormItem>
 
+      <Button className="SearchForm--reset" disabled={submitting} onClick={handleReset}>
+        Reset
+      </Button>
       <Button
         htmlType="submit"
         className="SearchForm--submit"


### PR DESCRIPTION
## Problem

Clicking the Jaeger logo or Search nav link used to clear the search form as a side-effect of the URL being cleared. That behaviour is gone now that the URL is preserved across navigation (introduced in #4008).

## Changes

- Add a **Reset** button flushed left in the form's button row (opposite Find Traces)
- Reset clears all fields except Service (preserved) and restores defaults for Operation (All), Lookback, and Limit Results
- Extract `defaultFormData()` helper — single source of truth for default field values, used by both the `useState` initializer on load and the Reset handler