### PR TITLE
chore(claude): Expand Claude Code permissions in shared settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run *)",
+      "Bash(npm test)",
+      "Bash(npm test *)",
+      "Bash(npm start)",
+      "Bash(npm show *)",
+      "Bash(npm install *)",
+      "Bash(npm ci *)",
+      "Bash(npm --version)",
+      "Bash(npx oxlint *)",
+      "Bash(npx oxc-transform *)",
+      "Bash(npx oxc-parser *)",
+      "Bash(npx vp *)",
+      "Bash(npx @typescript/native-preview *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ npm-debug.log
 # scripts
 scripts/release-notes.py
 scripts/draft-release.py
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Consolidates Claude Code allowed commands into `.claude/settings.json` (shared/committed)
- Expands `npm run *` wildcard to replace individual `npm run <cmd>` entries
- Adds `npx` tool permissions (oxlint, oxc-transform, oxc-parser, vp, @typescript/native-preview)
- Adds `npm show`, `npm install`, `npm ci`, `npm --version`
- Adds `.claude/settings.local.json` to `.gitignore` to prevent personal overrides from being committed

## Test plan

- [ ] Verify Claude Code picks up the new permissions without prompting for the listed commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)