### PR TITLE
feat(config): Replace storageCapabilities with backendCapabilities

### DIFF
--- a/packages/jaeger-ui/README.md
+++ b/packages/jaeger-ui/README.md
@@ -6,7 +6,7 @@
 
 1. **Base-path detection** — an inline `<script>` inspects `window.location.pathname` and injects a `<base href="…">` element so that relative asset URLs resolve correctly regardless of the URL prefix under which Jaeger is served. This makes the UI work behind a reverse proxy that exposes it at an arbitrary path (e.g. `/jaeger/`) without any backend configuration. See [ADR-009](https://github.com/jaegertracing/jaeger/blob/main/docs/adr/009-ui-base-path-auto-detection.md) for the design rationale.
 
-2. **Runtime configuration** — three JavaScript functions (`getJaegerUiConfig`, `getJaegerStorageCapabilities`, `getJaegerVersion`) are defined with stub return values. The Jaeger backend replaces those stubs with real data via search-and-replace before serving the file, injecting deployment-specific configuration without a separate API round-trip.
+2. **Runtime configuration** — three JavaScript functions (`getJaegerUiConfig`, `getJaegerBackendCapabilities`, `getJaegerVersion`) are defined with stub return values. The Jaeger backend replaces those stubs with real data via search-and-replace before serving the file, injecting deployment-specific configuration without a separate API round-trip. (A private `_getJaegerStorageCapabilities` helper retains the legacy `JAEGER_STORAGE_CAPABILITIES` search-replace pattern so older backends keep working unchanged.)
 
 3. **SPA mount fallback** — if the React application fails to mount (e.g. due to an unresolvable asset path or an invalid URL), a plain-text error message is shown in `#jaeger-ui-root` instead of a blank page.
 
@@ -76,16 +76,18 @@ An example JSON config file is provided at [jaeger-ui.config.example.json](./jae
 
 These local config files are ignored by git (see `.gitignore`).
 
-### Ask Jaeger assistant (`ai`)
+### Ask Jaeger assistant
 
-AI features are **off by default** (`ai.enabled: false`). Enable in UI config for local dev or production:
+AI assistant visibility is driven by the backend-advertised capability `backendCapabilities.aiAssistant`. The Jaeger backend turns this flag on when a live AI sidecar is reachable; the UI then surfaces the Ask Jaeger panel and sparkles icon. Otherwise the header shows **Lookup by Trace ID…** only.
+
+For local development without a sidecar, set the capability in your local config so the UI renders the panel:
 
 ```json
 {
-  "ai": {
-    "enabled": true
+  "backendCapabilities": {
+    "aiAssistant": true
   }
 }
 ```
 
-When disabled, the header shows **Lookup by Trace ID…** only (no sparkles / Ask Jaeger panel). When enabled, the UI uses `/api/ai/chat` by default, or `VITE_JAEGER_AG_UI_URL` at build time.
+When enabled, the UI uses `/api/ai/chat` by default, or `VITE_JAEGER_AG_UI_URL` at build time.

--- a/packages/jaeger-ui/index.html
+++ b/packages/jaeger-ui/index.html
@@ -73,11 +73,25 @@
         const JAEGER_CONFIG = DEFAULT_CONFIG;
         return JAEGER_CONFIG;
       }
-      // Jaeger storage compabilities data is embedded by the query-service via search-replace.
-      function getJaegerStorageCapabilities() {
+      // Legacy storage-only capabilities injection used by older Jaeger backends.
+      // Kept as a private helper so existing search-replace on the
+      // JAEGER_STORAGE_CAPABILITIES pattern still works; new code reads
+      // getJaegerBackendCapabilities() below.
+      function _getJaegerStorageCapabilities() {
         const DEFAULT_STORAGE_CAPABILITIES = { archiveStorage: false, metricsStorage: false };
+        // Important! Do not alter the following line; Jaeger looks for that exact pattern.
         const JAEGER_STORAGE_CAPABILITIES = DEFAULT_STORAGE_CAPABILITIES;
         return JAEGER_STORAGE_CAPABILITIES;
+      }
+      // Unified backend capabilities, embedded by the query-service via search-replace.
+      // Composes the legacy storage flags with newer capability fields (e.g. aiAssistant)
+      // so a legacy backend that only injects JAEGER_STORAGE_CAPABILITIES still produces
+      // a sensible result here.
+      function getJaegerBackendCapabilities() {
+        const DEFAULT_BACKEND_CAPABILITIES = { ..._getJaegerStorageCapabilities(), aiAssistant: false };
+        // Important! Do not alter the following line; Jaeger looks for that exact pattern.
+        const JAEGER_BACKEND_CAPABILITIES = DEFAULT_BACKEND_CAPABILITIES;
+        return JAEGER_BACKEND_CAPABILITIES;
       }
       // Jaeger version data is embedded by Jaeger backend via search/replace.
       function getJaegerVersion() {

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -66,11 +66,12 @@ function UIConfig() {
         text: 'Information about Jaeger SDK release #{jaeger.version}',
       },
     ],
-    // NOTE: storageCapabilities is intentionally omitted from this example.
+    // NOTE: backendCapabilities is intentionally omitted from this example.
     // In production, the jaeger binary injects it via a separate search-replace on
-    // JAEGER_STORAGE_CAPABILITIES (independent of UIConfig); the UI config value is ignored.
-    // In dev mode, the Vite plugin evaluates UIConfig() and injects storageCapabilities
+    // JAEGER_BACKEND_CAPABILITIES (independent of UIConfig); the UI config value is ignored.
+    // In dev mode, the Vite plugin evaluates UIConfig() and injects backendCapabilities
     // into the same placeholder, so setting it here works with `npm start`.
-    // storageCapabilities: { archiveStorage: true }
+    // (Legacy `storageCapabilities` is also accepted for backwards compatibility.)
+    // backendCapabilities: { archiveStorage: true, aiAssistant: true }
   };
 }

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -71,7 +71,6 @@ function UIConfig() {
     // JAEGER_BACKEND_CAPABILITIES (independent of UIConfig); the UI config value is ignored.
     // In dev mode, the Vite plugin evaluates UIConfig() and injects backendCapabilities
     // into the same placeholder, so setting it here works with `npm start`.
-    // (Legacy `storageCapabilities` is also accepted for backwards compatibility.)
     // backendCapabilities: { archiveStorage: true, aiAssistant: true }
   };
 }

--- a/packages/jaeger-ui/jaeger-ui.config.example.json
+++ b/packages/jaeger-ui/jaeger-ui.config.example.json
@@ -1,7 +1,4 @@
 {
-  "ai": {
-    "enabled": false
-  },
   "dependencies": {
     "menuEnabled": true
   },
@@ -19,8 +16,9 @@
       "text": "Information about Jaeger SDK release #{jaeger.version}"
     }
   ],
-  "storageCapabilities": {
+  "backendCapabilities": {
     "archiveStorage": false,
-    "metricsStorage": true
+    "metricsStorage": true,
+    "aiAssistant": false
   }
 }

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantContext.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantContext.tsx
@@ -20,7 +20,7 @@ interface IJaegerAssistantContextValue {
 
 const JaegerAssistantContext = React.createContext<IJaegerAssistantContextValue | null>(null);
 
-/** Inner provider that creates the long-lived AG-UI runtime (only mounted when ai.enabled is true). */
+/** Inner provider that creates the long-lived AG-UI runtime (only mounted when the assistant capability is on). */
 function JaegerAssistantRuntimeProvider({ children }: { children: React.ReactNode }) {
   const url = getJaegerAGUIUrl();
   const agent = React.useMemo(() => new HttpAgent({ url }), [url]);
@@ -63,7 +63,7 @@ export function JaegerAssistantProvider({ children }: { children: React.ReactNod
   const inner = <JaegerAssistantContext.Provider value={value}>{children}</JaegerAssistantContext.Provider>;
 
   // Only wrap with the runtime provider when the feature is configured so the
-  // HttpAgent is never instantiated when ai.enabled is false.
+  // HttpAgent is never instantiated when the assistant capability is off.
   if (assistantConfigured) {
     return <JaegerAssistantRuntimeProvider>{inner}</JaegerAssistantRuntimeProvider>;
   }

--- a/packages/jaeger-ui/src/components/App/TopNav.test.jsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.test.jsx
@@ -61,7 +61,7 @@ vi.mock('../../utils/config/get-config', async () => {
         menuLabel: 'Quality',
         apiEndpoint: '/quality-metrics',
       },
-      storageCapabilities: { metricsStorage: true },
+      backendCapabilities: { metricsStorage: true },
       themes: { enabled: true },
     })),
   };

--- a/packages/jaeger-ui/src/components/App/TopNav.tsx
+++ b/packages/jaeger-ui/src/components/App/TopNav.tsx
@@ -68,7 +68,7 @@ if (getConfig().qualityMetrics?.menuEnabled) {
   });
 }
 
-if (getConfig().storageCapabilities?.metricsStorage) {
+if (getConfig().backendCapabilities?.metricsStorage) {
   NAV_LINKS.push({
     to: monitorATMUrl.getUrl(),
     matches: monitorATMUrl.matches,

--- a/packages/jaeger-ui/src/components/Monitor/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/index.test.jsx
@@ -20,7 +20,7 @@ vi.mock('../../actions/jaeger-api');
 vi.mock('../../utils/config/get-config', () => ({
   default: jest.fn(() => ({
     qualityMetrics: { apiEndpoint: '/api/quality-metrics' },
-    storageCapabilities: { metricsStorage: true },
+    backendCapabilities: { metricsStorage: true },
   })),
 }));
 // Mock the storage utility
@@ -129,7 +129,7 @@ describe('<MonitorATMPage>', () => {
   it('renders EmptyState when metricsStorage is disabled in config', () => {
     getConfig.mockImplementation(() => ({
       qualityMetrics: { apiEndpoint: '/api/quality-metrics' },
-      storageCapabilities: { metricsStorage: false },
+      backendCapabilities: { metricsStorage: false },
     }));
     try {
       const emptyStateStore = createStore(rootReducer, initialState);
@@ -151,7 +151,7 @@ describe('<MonitorATMPage>', () => {
     } finally {
       getConfig.mockImplementation(() => ({
         qualityMetrics: { apiEndpoint: '/api/quality-metrics' },
-        storageCapabilities: { metricsStorage: true },
+        backendCapabilities: { metricsStorage: true },
       }));
     }
   });

--- a/packages/jaeger-ui/src/components/Monitor/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/index.tsx
@@ -7,6 +7,6 @@ import MonitorATMEmptyState from './EmptyState';
 import getConfig from '../../utils/config/get-config';
 
 const MonitorATMPage = () =>
-  getConfig().storageCapabilities?.metricsStorage ? <MonitorATMServicesView /> : <MonitorATMEmptyState />;
+  getConfig().backendCapabilities?.metricsStorage ? <MonitorATMServicesView /> : <MonitorATMEmptyState />;
 
 export default MonitorATMPage;

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -631,8 +631,8 @@ describe('<TracePage>', () => {
 
     describe('showArchiveButton', () => {
       it('shows archive button based on conditions', () => {
-        const getShowArchiveButton = (embedded, archiveEnabled, storageCapabilities) => {
-          const hasStorage = storageCapabilities && storageCapabilities.archiveStorage;
+        const getShowArchiveButton = (embedded, archiveEnabled, backendCapabilities) => {
+          const hasStorage = backendCapabilities && backendCapabilities.archiveStorage;
           return !embedded && archiveEnabled && hasStorage;
         };
 
@@ -640,25 +640,25 @@ describe('<TracePage>', () => {
           {
             embedded: undefined,
             archiveEnabled: true,
-            storageCapabilities: { archiveStorage: true },
+            backendCapabilities: { archiveStorage: true },
             showArchiveButton: getShowArchiveButton(undefined, true, { archiveStorage: true }),
           },
           {
             embedded: { timeline: {} },
             archiveEnabled: true,
-            storageCapabilities: { archiveStorage: true },
+            backendCapabilities: { archiveStorage: true },
             showArchiveButton: getShowArchiveButton({ timeline: {} }, true, { archiveStorage: true }),
           },
           {
             embedded: undefined,
             archiveEnabled: false,
-            storageCapabilities: { archiveStorage: true },
+            backendCapabilities: { archiveStorage: true },
             showArchiveButton: getShowArchiveButton(undefined, false, { archiveStorage: true }),
           },
           {
             embedded: undefined,
             archiveEnabled: true,
-            storageCapabilities: { archiveStorage: false },
+            backendCapabilities: { archiveStorage: false },
             showArchiveButton: getShowArchiveButton(undefined, true, { archiveStorage: false }),
           },
         ];

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -54,7 +54,7 @@ import TraceStatistics from './TraceStatistics/index';
 import TraceSpanView from './TraceSpanView/index';
 import TraceFlamegraph from './TraceFlamegraph/index';
 import TraceLogsView from './TraceLogsView/index';
-import type { SpanDetailPanelMode, StorageCapabilities, TraceGraphConfig } from '../../types/config';
+import type { BackendCapabilities, SpanDetailPanelMode, TraceGraphConfig } from '../../types/config';
 
 import './index.css';
 import memoizedTraceCriticalPath from './CriticalPath/index';
@@ -71,7 +71,7 @@ type TOwnProps = {
   params: { id: string };
   archiveEnabled: boolean;
   enableSidePanel: boolean;
-  storageCapabilities: StorageCapabilities | TNil;
+  backendCapabilities: BackendCapabilities | TNil;
   criticalPathEnabled: boolean;
   disableJsonView: boolean;
   traceGraphConfig?: TraceGraphConfig;
@@ -148,7 +148,7 @@ export function TracePageImpl(props: TProps) {
     params,
     setDetailPanelMode: reduxSetDetailPanelMode,
     setTimelineBarsVisible: reduxSetTimelineBarsVisible,
-    storageCapabilities,
+    backendCapabilities,
     traceGraphConfig,
     uiFind,
     useOtelTerms,
@@ -381,7 +381,7 @@ export function TracePageImpl(props: TProps) {
 
   const locationState = location.state;
   const isEmbedded = Boolean(embedded);
-  const hasArchiveStorage = Boolean(storageCapabilities?.archiveStorage);
+  const hasArchiveStorage = Boolean(backendCapabilities?.archiveStorage);
   const headerProps = {
     focusUiFindMatches,
     slimView,
@@ -524,7 +524,7 @@ const TracePage = (props: TracePageProps) => {
       params={{ ...props.params, id: normalizedTraceID }}
       archiveEnabled={Boolean(config.archiveEnabled)}
       enableSidePanel={Boolean(config.traceTimeline?.enableSidePanel)}
-      storageCapabilities={config.storageCapabilities}
+      backendCapabilities={config.backendCapabilities}
       criticalPathEnabled={config.criticalPathEnabled}
       disableJsonView={config.disableJsonView}
       traceGraphConfig={config.traceGraph}

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -10,9 +10,6 @@ import { version } from '../../package.json';
 import { Config } from '../types/config';
 
 const defaultConfig: Config = {
-  ai: {
-    enabled: false,
-  },
   archiveEnabled: true,
   criticalPathEnabled: true,
   dependencies: {
@@ -70,9 +67,10 @@ const defaultConfig: Config = {
     maxLimit: 1500,
   },
   traceIdDisplayLength: 7,
-  storageCapabilities: {
+  backendCapabilities: {
     archiveStorage: false,
     metricsStorage: false,
+    aiAssistant: false,
   },
   tracking: {
     gaID: null,
@@ -128,8 +126,8 @@ const defaultConfig: Config = {
 };
 
 // Fields that should be merged with user-supplied config values rather than overwritten.
-type TMergeField = 'ai' | 'dependencies' | 'monitor' | 'search' | 'tracking';
-export const mergeFields: readonly TMergeField[] = ['ai', 'dependencies', 'monitor', 'search', 'tracking'];
+type TMergeField = 'dependencies' | 'monitor' | 'search' | 'tracking';
+export const mergeFields: readonly TMergeField[] = ['dependencies', 'monitor', 'search', 'tracking'];
 
 export default deepFreeze(defaultConfig);
 

--- a/packages/jaeger-ui/src/hooks/useConfig.ts
+++ b/packages/jaeger-ui/src/hooks/useConfig.ts
@@ -8,7 +8,7 @@ import { Config } from '../types/config';
  * Returns the application configuration.
  *
  * Config is static after app boot (assembled once from window.getJaegerUiConfig
- * and window.getJaegerStorageCapabilities, then memoized). This hook is a thin
+ * and window.getJaegerBackendCapabilities, then memoized). This hook is a thin
  * wrapper so component code never imports getConfig directly — the backing
  * implementation can change without touching call sites.
  */

--- a/packages/jaeger-ui/src/hooks/useJaegerAssistant.test.ts
+++ b/packages/jaeger-ui/src/hooks/useJaegerAssistant.test.ts
@@ -22,7 +22,7 @@ const baseConfig = {
   themes: { enabled: true },
   useOpenTelemetryTerms: false,
   menu: [],
-  ai: { enabled: false },
+  backendCapabilities: { aiAssistant: false },
 };
 
 describe('useJaegerAssistant', () => {
@@ -32,32 +32,41 @@ describe('useJaegerAssistant', () => {
   });
 
   describe('useJaegerAssistantEnabled', () => {
-    it('is false when ai.enabled is false', () => {
+    it('is false when backendCapabilities.aiAssistant is false', () => {
       const { result } = renderHook(() => useJaegerAssistantEnabled());
       expect(result.current).toBe(false);
     });
 
-    it('is true when ai.enabled is true', () => {
-      mockUseConfig.mockReturnValue({ ...baseConfig, ai: { enabled: true } } as ReturnType<typeof useConfig>);
+    it('is true when backendCapabilities.aiAssistant is true', () => {
+      mockUseConfig.mockReturnValue({
+        ...baseConfig,
+        backendCapabilities: { aiAssistant: true },
+      } as ReturnType<typeof useConfig>);
       const { result } = renderHook(() => useJaegerAssistantEnabled());
       expect(result.current).toBe(true);
     });
   });
 
   describe('useJaegerAssistantConfigured', () => {
-    it('is false when ai.enabled is false', () => {
+    it('is false when the capability is off', () => {
       const { result } = renderHook(() => useJaegerAssistantConfigured());
       expect(result.current).toBe(false);
     });
 
-    it('is true when ai.enabled is true and URL is set', () => {
-      mockUseConfig.mockReturnValue({ ...baseConfig, ai: { enabled: true } } as ReturnType<typeof useConfig>);
+    it('is true when the capability is on and URL is set', () => {
+      mockUseConfig.mockReturnValue({
+        ...baseConfig,
+        backendCapabilities: { aiAssistant: true },
+      } as ReturnType<typeof useConfig>);
       const { result } = renderHook(() => useJaegerAssistantConfigured());
       expect(result.current).toBe(true);
     });
 
-    it('is false when ai.enabled is true but URL is empty', () => {
-      mockUseConfig.mockReturnValue({ ...baseConfig, ai: { enabled: true } } as ReturnType<typeof useConfig>);
+    it('is false when the capability is on but URL is empty', () => {
+      mockUseConfig.mockReturnValue({
+        ...baseConfig,
+        backendCapabilities: { aiAssistant: true },
+      } as ReturnType<typeof useConfig>);
       mockGetJaegerAgUiUrl.mockReturnValue('');
       const { result } = renderHook(() => useJaegerAssistantConfigured());
       expect(result.current).toBe(false);

--- a/packages/jaeger-ui/src/hooks/useJaegerAssistant.ts
+++ b/packages/jaeger-ui/src/hooks/useJaegerAssistant.ts
@@ -4,15 +4,19 @@
 import { getJaegerAGUIUrl } from '../components/App/jaeger-AG-UI';
 import { useConfig } from './useConfig';
 
-// Whether the operator enabled AI features via UI config (`ai.enabled`).
+/**
+ * Whether the AI assistant should be visible.
+ * Driven entirely by the backend-advertised `backendCapabilities.aiAssistant`
+ * flag, which the backend turns on when a live AI sidecar is reachable.
+ */
 export function useJaegerAssistantEnabled(): boolean {
-  const { ai } = useConfig();
-  return ai?.enabled === true;
+  const { backendCapabilities } = useConfig();
+  return backendCapabilities?.aiAssistant === true;
 }
 
 /**
  * Whether Ask Jaeger UI and the AG-UI client should be active.
- * Strictly opt-in: requires `ai.enabled` in UI config and a non-empty endpoint URL.
+ * Requires the assistant to be enabled and a non-empty endpoint URL.
  */
 export function useJaegerAssistantConfigured(): boolean {
   const enabled = useJaegerAssistantEnabled();

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -73,26 +73,24 @@ export type TraceGraphConfig = {
   layoutManagerMemory?: number;
 };
 
-export type StorageCapabilities = {
+// BackendCapabilities is the unified capability blob advertised by the
+// backend via window.getJaegerBackendCapabilities. It supersedes the older
+// storage-only shape and adds non-storage flags such as `aiAssistant`. The
+// legacy `storageCapabilities` shape (just `archiveStorage` + `metricsStorage`)
+// is still accepted in user UI configs for backwards compatibility and is
+// folded into this blob at config-load time.
+export type BackendCapabilities = {
   // archiveStorage indicates whether the query service supports archive storage.
   archiveStorage?: boolean;
   // metricsStorage indicates whether the query service supports metrics storage (for Monitor/SPM tab).
   metricsStorage?: boolean;
+  // aiAssistant indicates whether the in-app AI assistant should be available.
+  // The backend advertises this when a live AI sidecar is reachable.
+  aiAssistant?: boolean;
 };
 
 // Default values are provided in packages/jaeger-ui/src/constants/default-config.tsx
 export type Config = {
-  // ai gates AI-assisted UI features (e.g. the in-app assistant).
-  // The UI does not enable these features unless the operator opts in via
-  // `ai.enabled: true`, because the Query Service does not yet ship a
-  // matching backend. Defaults to disabled.
-  ai?: {
-    // enabled turns on AI-assisted features in the UI. When false (the
-    // default), all AI surfaces are hidden regardless of whether the
-    // backend supports them.
-    enabled?: boolean;
-  };
-
   //
   // archiveEnabled enables the Archive Trace button in the trace view.
   // Requires Query Service to be configured with "archive" storage backend.
@@ -157,8 +155,16 @@ export type Config = {
   // traceIdDisplayLength controls the length of the trace ID displayed in the UI.
   traceIdDisplayLength?: number;
 
-  // storage capabilities given by the query service.
-  storageCapabilities?: StorageCapabilities;
+  // Deprecated: storage capabilities advertised by older backends.
+  // Retained so existing user UI configs that set this field still work; at
+  // load time the values are folded into `backendCapabilities` (the backend
+  // injection remains authoritative). Shape: { archiveStorage?, metricsStorage? }.
+  storageCapabilities?: Pick<BackendCapabilities, 'archiveStorage' | 'metricsStorage'>;
+
+  // backendCapabilities is the unified capability blob advertised by the
+  // backend. Internal UI code should read this field; the legacy
+  // `storageCapabilities` is merged in for backwards compatibility.
+  backendCapabilities?: BackendCapabilities;
 
   // topTagPrefixes defines a set of prefixes for span tag names that are considered
   // "important" and cause the matching tags to appear higher in the list of tags.

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -73,12 +73,10 @@ export type TraceGraphConfig = {
   layoutManagerMemory?: number;
 };
 
-// BackendCapabilities is the unified capability blob advertised by the
-// backend via window.getJaegerBackendCapabilities. It supersedes the older
-// storage-only shape and adds non-storage flags such as `aiAssistant`. The
-// legacy `storageCapabilities` shape (just `archiveStorage` + `metricsStorage`)
-// is still accepted in user UI configs for backwards compatibility and is
-// folded into this blob at config-load time.
+// BackendCapabilities is the capability blob advertised by the backend via
+// window.getJaegerBackendCapabilities. The backend overlays this on top of
+// the user UI config independently, so the user UI config cannot set these
+// values in production.
 export type BackendCapabilities = {
   // archiveStorage indicates whether the query service supports archive storage.
   archiveStorage?: boolean;
@@ -155,15 +153,9 @@ export type Config = {
   // traceIdDisplayLength controls the length of the trace ID displayed in the UI.
   traceIdDisplayLength?: number;
 
-  // Deprecated: storage capabilities advertised by older backends.
-  // Retained so existing user UI configs that set this field still work; at
-  // load time the values are folded into `backendCapabilities` (the backend
-  // injection remains authoritative). Shape: { archiveStorage?, metricsStorage? }.
-  storageCapabilities?: Pick<BackendCapabilities, 'archiveStorage' | 'metricsStorage'>;
-
-  // backendCapabilities is the unified capability blob advertised by the
-  // backend. Internal UI code should read this field; the legacy
-  // `storageCapabilities` is merged in for backwards compatibility.
+  // backendCapabilities is the capability blob advertised by the backend
+  // (overlaid on top of any embedded UI config at index.html boot). Internal
+  // UI code reads this field.
   backendCapabilities?: BackendCapabilities;
 
   // topTagPrefixes defines a set of prefixes for span tag names that are considered

--- a/packages/jaeger-ui/src/utils/config/get-config.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-config.test.js
@@ -27,7 +27,7 @@ describe('getConfig()', () => {
   describe('index functions are not yet injected by backend', () => {
     beforeAll(() => {
       window.getJaegerUiConfig = undefined;
-      window.getJaegerStorageCapabilities = undefined;
+      window.getJaegerBackendCapabilities = undefined;
     });
 
     it('warns once', () => {
@@ -42,43 +42,67 @@ describe('getConfig()', () => {
     });
   });
 
-  describe('storageCapabilities', () => {
+  describe('backendCapabilities', () => {
     beforeEach(() => {
       // Reset memoization before each test
       getConfig.apply({}, []);
     });
 
-    it('uses storageCapabilities from getJaegerStorageCapabilities when injected', () => {
+    it('uses backendCapabilities from getJaegerBackendCapabilities when injected', () => {
       // This is the normal production path: the backend (or Vite plugin in dev) injects
-      // storageCapabilities via window.getJaegerStorageCapabilities, independently of
+      // backendCapabilities via window.getJaegerBackendCapabilities, independently of
       // the main UI config.
       window.getJaegerUiConfig = jest.fn(() => ({}));
-      window.getJaegerStorageCapabilities = jest.fn(() => ({
+      window.getJaegerBackendCapabilities = jest.fn(() => ({
         archiveStorage: true,
         metricsStorage: true,
+        aiAssistant: true,
       }));
-      expect(getConfig().storageCapabilities).toEqual({ archiveStorage: true, metricsStorage: true });
+      expect(getConfig().backendCapabilities).toEqual({
+        archiveStorage: true,
+        metricsStorage: true,
+        aiAssistant: true,
+      });
     });
 
-    it('falls back to defaultConfig.storageCapabilities when getJaegerStorageCapabilities is not injected', () => {
+    it('falls back to defaultConfig.backendCapabilities when getJaegerBackendCapabilities is not injected', () => {
       // When neither the backend nor the Vite plugin has injected the capabilities function,
-      // the default (metricsStorage: false) is used.
+      // the defaults are used.
       window.getJaegerUiConfig = jest.fn(() => ({}));
-      window.getJaegerStorageCapabilities = undefined;
-      expect(getConfig().storageCapabilities).toEqual(defaultConfig.storageCapabilities);
+      window.getJaegerBackendCapabilities = undefined;
+      expect(getConfig().backendCapabilities).toEqual(defaultConfig.backendCapabilities);
     });
 
-    it('getJaegerStorageCapabilities takes precedence over storageCapabilities in the UI config', () => {
-      // storageCapabilities in the main UI config object is always overridden by
-      // getJaegerStorageCapabilities so the backend remains authoritative.
+    it('getJaegerBackendCapabilities takes precedence over backendCapabilities in the UI config', () => {
+      // backendCapabilities in the main UI config object is always overridden by
+      // getJaegerBackendCapabilities so the backend remains authoritative.
+      window.getJaegerUiConfig = jest.fn(() => ({
+        backendCapabilities: { archiveStorage: true, metricsStorage: true, aiAssistant: true },
+      }));
+      window.getJaegerBackendCapabilities = jest.fn(() => ({
+        archiveStorage: false,
+        metricsStorage: false,
+        aiAssistant: false,
+      }));
+      expect(getConfig().backendCapabilities).toEqual({
+        archiveStorage: false,
+        metricsStorage: false,
+        aiAssistant: false,
+      });
+    });
+
+    it('folds legacy storageCapabilities from the UI config into backendCapabilities', () => {
+      // Backwards compatibility: existing user configs that set `storageCapabilities`
+      // should continue to work when the backend has not (yet) injected its own values.
       window.getJaegerUiConfig = jest.fn(() => ({
         storageCapabilities: { archiveStorage: true, metricsStorage: true },
       }));
-      window.getJaegerStorageCapabilities = jest.fn(() => ({
-        archiveStorage: false,
-        metricsStorage: false,
-      }));
-      expect(getConfig().storageCapabilities).toEqual({ archiveStorage: false, metricsStorage: false });
+      window.getJaegerBackendCapabilities = undefined;
+      expect(getConfig().backendCapabilities).toEqual({
+        archiveStorage: true,
+        metricsStorage: true,
+        aiAssistant: false,
+      });
     });
   });
 
@@ -90,8 +114,8 @@ describe('getConfig()', () => {
       getConfig.apply({}, []);
       embedded = {};
       window.getJaegerUiConfig = jest.fn(() => embedded);
-      capabilities = defaultConfig.storageCapabilities;
-      window.getJaegerStorageCapabilities = jest.fn(() => capabilities);
+      capabilities = defaultConfig.backendCapabilities;
+      window.getJaegerBackendCapabilities = jest.fn(() => capabilities);
     });
 
     it('returns the default config when the embedded config is `null`', () => {
@@ -99,22 +123,24 @@ describe('getConfig()', () => {
       expect(getConfig()).toEqual(defaultConfig);
     });
 
-    it('merges the defaultConfig with the embedded config and storage capabilities', () => {
+    it('merges the defaultConfig with the embedded config and backend capabilities', () => {
       embedded = { novel: 'prop' };
-      capabilities = { archiveStorage: true, metricsStorage: false };
-      expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, storageCapabilities: capabilities });
+      capabilities = { archiveStorage: true, metricsStorage: false, aiAssistant: false };
+      expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, backendCapabilities: capabilities });
     });
 
     describe('overwriting precedence and merging', () => {
       describe('fields not in mergeFields', () => {
         it('gives precedence to the embedded config', () => {
           const mergeFieldsSet = new Set(mergeFields);
-          const keys = Object.keys(defaultConfig).filter(k => !mergeFieldsSet.has(k));
+          const keys = Object.keys(defaultConfig).filter(
+            k => !mergeFieldsSet.has(k) && k !== 'backendCapabilities'
+          );
           embedded = {};
           keys.forEach(key => {
             embedded[key] = key;
           });
-          expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, storageCapabilities: capabilities });
+          expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, backendCapabilities: capabilities });
         });
       });
 
@@ -124,7 +150,7 @@ describe('getConfig()', () => {
           mergeFields.forEach((k, i) => {
             embedded[k] = i ? true : null;
           });
-          expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, storageCapabilities: capabilities });
+          expect(getConfig()).toEqual({ ...defaultConfig, ...embedded, backendCapabilities: capabilities });
         });
 
         it('merges object values', () => {
@@ -136,7 +162,7 @@ describe('getConfig()', () => {
           embedded[key] = { a: true, b: false };
           const expected = { ...defaultConfig, ...embedded };
           expected[key] = { ...defaultConfig[key], ...embedded[key] };
-          expect(getConfig()).toEqual({ ...expected, storageCapabilities: capabilities });
+          expect(getConfig()).toEqual({ ...expected, backendCapabilities: capabilities });
         });
       });
     });

--- a/packages/jaeger-ui/src/utils/config/get-config.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-config.test.js
@@ -119,9 +119,7 @@ describe('getConfig()', () => {
       describe('fields not in mergeFields', () => {
         it('gives precedence to the embedded config', () => {
           const mergeFieldsSet = new Set(mergeFields);
-          const keys = Object.keys(defaultConfig).filter(
-            k => !mergeFieldsSet.has(k) && k !== 'backendCapabilities'
-          );
+          const keys = Object.keys(defaultConfig).filter(k => !mergeFieldsSet.has(k));
           embedded = {};
           keys.forEach(key => {
             embedded[key] = key;

--- a/packages/jaeger-ui/src/utils/config/get-config.test.js
+++ b/packages/jaeger-ui/src/utils/config/get-config.test.js
@@ -90,20 +90,6 @@ describe('getConfig()', () => {
         aiAssistant: false,
       });
     });
-
-    it('folds legacy storageCapabilities from the UI config into backendCapabilities', () => {
-      // Backwards compatibility: existing user configs that set `storageCapabilities`
-      // should continue to work when the backend has not (yet) injected its own values.
-      window.getJaegerUiConfig = jest.fn(() => ({
-        storageCapabilities: { archiveStorage: true, metricsStorage: true },
-      }));
-      window.getJaegerBackendCapabilities = undefined;
-      expect(getConfig().backendCapabilities).toEqual({
-        archiveStorage: true,
-        metricsStorage: true,
-        aiAssistant: false,
-      });
-    });
   });
 
   describe('index functions are injected by backend', () => {

--- a/packages/jaeger-ui/src/utils/config/get-config.ts
+++ b/packages/jaeger-ui/src/utils/config/get-config.ts
@@ -56,6 +56,8 @@ const getConfig = memoizeOne(function getConfig(): Config {
       rv[key] = { ...defaultConfig[key], ...embedded[key] };
     }
   });
+  // backendCapabilities always comes from getJaegerBackendCapabilities(), overriding anything
+  // that may be present in the UI config, so the backend remains authoritative.
   return { ...rv, backendCapabilities };
 });
 

--- a/packages/jaeger-ui/src/utils/config/get-config.ts
+++ b/packages/jaeger-ui/src/utils/config/get-config.ts
@@ -18,10 +18,9 @@ function getUiConfig() {
 
 // getBackendCapabilities reads the capability blob injected by the
 // query-service backend via window.getJaegerBackendCapabilities
-// (search-replaced into index.html). Returns null when the function has not
-// been injected (e.g. in tests or before the backend rewrites index.html)
-// so the merge step in getConfig can distinguish "no backend signal" from
-// "backend says everything is false".
+// (search-replaced into index.html). index.html defines this function
+// unconditionally, so a non-function value only appears in environments
+// that don't load index.html (e.g. unit tests).
 function getBackendCapabilities(): BackendCapabilities | null {
   const getter = window.getJaegerBackendCapabilities;
   return typeof getter === 'function' ? getter() : null;

--- a/packages/jaeger-ui/src/utils/config/get-config.ts
+++ b/packages/jaeger-ui/src/utils/config/get-config.ts
@@ -34,25 +34,16 @@ function getBackendCapabilities(): BackendCapabilities | null {
  * The final config is assembled from three sources, in increasing priority:
  *   1. defaultConfig  — compile-time defaults
  *   2. getJaegerUiConfig()  — injected into index.html by query-service (or Vite plugin in dev)
- *   3. getJaegerBackendCapabilities()  — injected separately by query-service; always wins for
- *      backendCapabilities so the backend's authoritative knowledge of its own capabilities
- *      cannot be overridden by the UI config file. For backwards compatibility with older
- *      user configs, a `storageCapabilities` field in the embedded config is folded into
- *      `backendCapabilities` before the backend override is applied.
+ *   3. getJaegerBackendCapabilities()  — injected separately by query-service; always wins
+ *      for backendCapabilities so the backend's authoritative knowledge of its own
+ *      capabilities cannot be overridden by the UI config file.
  */
 const getConfig = memoizeOne(function getConfig(): Config {
-  const backendInjected = getBackendCapabilities();
+  const backendCapabilities = { ...defaultConfig.backendCapabilities, ...getBackendCapabilities() };
   const embedded = getUiConfig();
 
-  const mergedCapabilities: BackendCapabilities = {
-    ...defaultConfig.backendCapabilities,
-    ...embedded?.storageCapabilities,
-    ...embedded?.backendCapabilities,
-    ...backendInjected,
-  };
-
   if (!embedded) {
-    return { ...defaultConfig, backendCapabilities: mergedCapabilities };
+    return { ...defaultConfig, backendCapabilities };
   }
   // check for deprecated config values
   if (Array.isArray(deprecations)) {
@@ -65,7 +56,7 @@ const getConfig = memoizeOne(function getConfig(): Config {
       rv[key] = { ...defaultConfig[key], ...embedded[key] };
     }
   });
-  return { ...rv, backendCapabilities: mergedCapabilities };
+  return { ...rv, backendCapabilities };
 });
 
 export default getConfig;

--- a/packages/jaeger-ui/src/utils/config/get-config.ts
+++ b/packages/jaeger-ui/src/utils/config/get-config.ts
@@ -3,7 +3,7 @@
 
 import memoizeOne from 'memoize-one';
 
-import { Config } from '../../types/config';
+import { BackendCapabilities, Config } from '../../types/config';
 import processDeprecation from './process-deprecation';
 import defaultConfig, { deprecations, mergeFields } from '../../constants/default-config';
 
@@ -16,14 +16,15 @@ function getUiConfig() {
   return getter();
 }
 
-// getCapabilities reads storage capabilities injected by the query-service backend
-// via window.getJaegerStorageCapabilities (search-replaced into index.html).
-// In development, the Vite plugin replicates this injection from jaeger-ui.config.json.
-// Falls back to the default config when the function is not present.
-function getCapabilities() {
-  const getter = window.getJaegerStorageCapabilities;
-  const capabilities = typeof getter === 'function' ? getter() : null;
-  return capabilities ?? defaultConfig.storageCapabilities;
+// getBackendCapabilities reads the capability blob injected by the
+// query-service backend via window.getJaegerBackendCapabilities
+// (search-replaced into index.html). Returns null when the function has not
+// been injected (e.g. in tests or before the backend rewrites index.html)
+// so the merge step in getConfig can distinguish "no backend signal" from
+// "backend says everything is false".
+function getBackendCapabilities(): BackendCapabilities | null {
+  const getter = window.getJaegerBackendCapabilities;
+  return typeof getter === 'function' ? getter() : null;
 }
 
 /**
@@ -33,16 +34,25 @@ function getCapabilities() {
  * The final config is assembled from three sources, in increasing priority:
  *   1. defaultConfig  — compile-time defaults
  *   2. getJaegerUiConfig()  — injected into index.html by query-service (or Vite plugin in dev)
- *   3. getJaegerStorageCapabilities()  — injected separately by query-service; always wins for
- *      storageCapabilities so the backend's authoritative knowledge of its own capabilities
- *      cannot be overridden by the UI config file.
+ *   3. getJaegerBackendCapabilities()  — injected separately by query-service; always wins for
+ *      backendCapabilities so the backend's authoritative knowledge of its own capabilities
+ *      cannot be overridden by the UI config file. For backwards compatibility with older
+ *      user configs, a `storageCapabilities` field in the embedded config is folded into
+ *      `backendCapabilities` before the backend override is applied.
  */
 const getConfig = memoizeOne(function getConfig(): Config {
-  const capabilities = getCapabilities();
-
+  const backendInjected = getBackendCapabilities();
   const embedded = getUiConfig();
+
+  const mergedCapabilities: BackendCapabilities = {
+    ...defaultConfig.backendCapabilities,
+    ...embedded?.storageCapabilities,
+    ...embedded?.backendCapabilities,
+    ...backendInjected,
+  };
+
   if (!embedded) {
-    return { ...defaultConfig, storageCapabilities: capabilities };
+    return { ...defaultConfig, backendCapabilities: mergedCapabilities };
   }
   // check for deprecated config values
   if (Array.isArray(deprecations)) {
@@ -55,9 +65,7 @@ const getConfig = memoizeOne(function getConfig(): Config {
       rv[key] = { ...defaultConfig[key], ...embedded[key] };
     }
   });
-  // storageCapabilities always comes from getJaegerStorageCapabilities(), overriding anything
-  // that may be present in the UI config, so the backend remains authoritative.
-  return { ...rv, storageCapabilities: capabilities };
+  return { ...rv, backendCapabilities: mergedCapabilities };
 });
 
 export default getConfig;

--- a/packages/jaeger-ui/test/vitest-setup.ts
+++ b/packages/jaeger-ui/test/vitest-setup.ts
@@ -50,7 +50,7 @@ global.ResizeObserver = vi.fn().mockImplementation(function () {
 // Calls to get-config.tsx and get-version.tsx warn if these globals are not functions.
 // This file is executed before each test file, so they may be overridden safely.
 (window as any).getJaegerUiConfig = () => ({});
-(window as any).getJaegerStorageCapabilities = () => ({});
+(window as any).getJaegerBackendCapabilities = () => ({});
 (window as any).getJaegerVersion = () => ({
   gitCommit: '',
   gitVersion: '',

--- a/packages/jaeger-ui/typings/custom.d.ts
+++ b/packages/jaeger-ui/typings/custom.d.ts
@@ -9,7 +9,7 @@ declare interface Window {
   __webpack_public_path__: string;
   // For getting ui config
   getJaegerUiConfig?: () => Record<string, any>;
-  getJaegerStorageCapabilities?: () => Record<string, any>;
+  getJaegerBackendCapabilities?: () => Record<string, any>;
   getJaegerVersion?: () => Record<string, any>;
 }
 

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -120,6 +120,23 @@ function jaegerUiConfigPlugin() {
   const jsConfigPath = path.resolve(__dirname, 'jaeger-ui.config.js');
   const jsonConfigPath = path.resolve(__dirname, 'jaeger-ui.config.json');
 
+  // Merge legacy `storageCapabilities` and new `backendCapabilities` into a single
+  // capability blob and inject it at the JAEGER_BACKEND_CAPABILITIES swap point.
+  // Mirrors how a post-RFC-0003 Jaeger backend will inject the same field; until
+  // then, the index.html composer also falls back to JAEGER_STORAGE_CAPABILITIES
+  // for the archive/metrics flags, so legacy backends keep working unchanged.
+  function injectBackendCapabilities(
+    html: string,
+    config: { storageCapabilities?: Record<string, unknown>; backendCapabilities?: Record<string, unknown> }
+  ) {
+    const merged = { ...config.storageCapabilities, ...config.backendCapabilities };
+    if (Object.keys(merged).length === 0) return html;
+    return html.replace(
+      'const JAEGER_BACKEND_CAPABILITIES = DEFAULT_BACKEND_CAPABILITIES;',
+      `const JAEGER_BACKEND_CAPABILITIES = { ...DEFAULT_BACKEND_CAPABILITIES, ...${JSON.stringify(merged)} };`
+    );
+  }
+
   return {
     name: 'jaeger-ui-config',
     configureServer(server) {
@@ -142,23 +159,20 @@ function jaegerUiConfigPlugin() {
             // matching the contract enforced by the jaeger binary.
             html = html.replace('// JAEGER_CONFIG_JS', jsContent);
 
-            // Extract storageCapabilities from the JS config by executing it in a sandbox
+            // Extract capabilities from the JS config by executing it in a sandbox
             // and calling UIConfig(), mirroring the JSON config path's special treatment.
             try {
-              const sandbox: { UIConfig?: () => { storageCapabilities?: Record<string, unknown> } } = {};
+              const sandbox: {
+                UIConfig?: () => {
+                  storageCapabilities?: Record<string, unknown>;
+                  backendCapabilities?: Record<string, unknown>;
+                };
+              } = {};
               vm.runInNewContext(jsContent, sandbox);
-              const storageCapabilities = sandbox.UIConfig?.()?.storageCapabilities;
-              if (storageCapabilities) {
-                html = html.replace(
-                  'const JAEGER_STORAGE_CAPABILITIES = DEFAULT_STORAGE_CAPABILITIES;',
-                  `const JAEGER_STORAGE_CAPABILITIES = { ...DEFAULT_STORAGE_CAPABILITIES, ...${JSON.stringify(storageCapabilities)} };`
-                );
-              }
+              const cfg = sandbox.UIConfig?.() ?? {};
+              html = injectBackendCapabilities(html, cfg);
             } catch (evalErr) {
-              console.warn(
-                '[jaeger-ui-config] Could not evaluate JS config for storageCapabilities:',
-                evalErr
-              );
+              console.warn('[jaeger-ui-config] Could not evaluate JS config for capabilities:', evalErr);
             }
 
             console.log('[jaeger-ui-config] Loaded config from jaeger-ui.config.js');
@@ -181,16 +195,11 @@ function jaegerUiConfigPlugin() {
               `const JAEGER_CONFIG = ${JSON.stringify(parsedConfig)};`
             );
 
-            // Inject storageCapabilities if present in the config file.
-            // The Go server injects this separately via its own search-replace on
-            // JAEGER_STORAGE_CAPABILITIES; the Vite plugin must replicate that here so that
-            // setting storageCapabilities in jaeger-ui.config.json works in dev mode too.
-            if (parsedConfig.storageCapabilities) {
-              html = html.replace(
-                'const JAEGER_STORAGE_CAPABILITIES = DEFAULT_STORAGE_CAPABILITIES;',
-                `const JAEGER_STORAGE_CAPABILITIES = { ...DEFAULT_STORAGE_CAPABILITIES, ...${JSON.stringify(parsedConfig.storageCapabilities)} };`
-              );
-            }
+            // Inject backendCapabilities (and legacy storageCapabilities) if present in
+            // the config file. The Go server injects this separately via its own
+            // search-replace; the Vite plugin replicates that here so capability
+            // overrides in jaeger-ui.config.json work with `npm start`.
+            html = injectBackendCapabilities(html, parsedConfig);
 
             console.log('[jaeger-ui-config] Loaded config from jaeger-ui.config.json');
             return html;

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -120,20 +120,17 @@ function jaegerUiConfigPlugin() {
   const jsConfigPath = path.resolve(__dirname, 'jaeger-ui.config.js');
   const jsonConfigPath = path.resolve(__dirname, 'jaeger-ui.config.json');
 
-  // Merge legacy `storageCapabilities` and new `backendCapabilities` into a single
-  // capability blob and inject it at the JAEGER_BACKEND_CAPABILITIES swap point.
-  // Mirrors how a post-RFC-0003 Jaeger backend will inject the same field; until
-  // then, the index.html composer also falls back to JAEGER_STORAGE_CAPABILITIES
-  // for the archive/metrics flags, so legacy backends keep working unchanged.
+  // Inject `backendCapabilities` from the local dev config at the
+  // JAEGER_BACKEND_CAPABILITIES swap point. Mirrors how the Jaeger backend
+  // overlays its capability blob in production.
   function injectBackendCapabilities(
     html: string,
-    config: { storageCapabilities?: Record<string, unknown>; backendCapabilities?: Record<string, unknown> }
+    config: { backendCapabilities?: Record<string, unknown> }
   ) {
-    const merged = { ...config.storageCapabilities, ...config.backendCapabilities };
-    if (Object.keys(merged).length === 0) return html;
+    if (!config.backendCapabilities) return html;
     return html.replace(
       'const JAEGER_BACKEND_CAPABILITIES = DEFAULT_BACKEND_CAPABILITIES;',
-      `const JAEGER_BACKEND_CAPABILITIES = { ...DEFAULT_BACKEND_CAPABILITIES, ...${JSON.stringify(merged)} };`
+      `const JAEGER_BACKEND_CAPABILITIES = { ...DEFAULT_BACKEND_CAPABILITIES, ...${JSON.stringify(config.backendCapabilities)} };`
     );
   }
 
@@ -163,10 +160,7 @@ function jaegerUiConfigPlugin() {
             // and calling UIConfig(), mirroring the JSON config path's special treatment.
             try {
               const sandbox: {
-                UIConfig?: () => {
-                  storageCapabilities?: Record<string, unknown>;
-                  backendCapabilities?: Record<string, unknown>;
-                };
+                UIConfig?: () => { backendCapabilities?: Record<string, unknown> };
               } = {};
               vm.runInNewContext(jsContent, sandbox);
               const cfg = sandbox.UIConfig?.() ?? {};
@@ -195,10 +189,10 @@ function jaegerUiConfigPlugin() {
               `const JAEGER_CONFIG = ${JSON.stringify(parsedConfig)};`
             );
 
-            // Inject backendCapabilities (and legacy storageCapabilities) if present in
-            // the config file. The Go server injects this separately via its own
-            // search-replace; the Vite plugin replicates that here so capability
-            // overrides in jaeger-ui.config.json work with `npm start`.
+            // Inject backendCapabilities if present in the config file. The Go server
+            // injects this separately via its own search-replace; the Vite plugin
+            // replicates that here so capability overrides in jaeger-ui.config.json
+            // work with `npm start`.
             html = injectBackendCapabilities(html, parsedConfig);
 
             console.log('[jaeger-ui-config] Loaded config from jaeger-ui.config.json');


### PR DESCRIPTION
## Summary

- Switches the UI's capability channel from the storage-only `storageCapabilities` blob (`window.getJaegerStorageCapabilities`) to a unified `backendCapabilities` blob (`window.getJaegerBackendCapabilities`) that adds non-storage flags such as `aiAssistant`.
- AI assistant visibility is now driven entirely by `backendCapabilities.aiAssistant`; the `Config.ai.enabled` UI-config field is removed (it had not shipped in a released version).
- Internal UI callers (`Monitor`, `TopNav`, `TracePage`, `useJaegerAssistant`) now read `backendCapabilities.*`. `TracePage`'s prop was renamed `storageCapabilities → backendCapabilities`.

## Backwards compatibility with old Jaeger backends

`index.html` keeps a private `_getJaegerStorageCapabilities()` helper that retains the legacy `JAEGER_STORAGE_CAPABILITIES = …` search-replace pattern, so an old Jaeger backend continues to inject `archiveStorage`/`metricsStorage` unchanged. The new `getJaegerBackendCapabilities()` composes those storage flags with `aiAssistant: false` until a newer backend overrides the unified blob via the new `JAEGER_BACKEND_CAPABILITIES = …` pattern.

No UI-side back-compat is kept for user UI configs: in production the backend overlays its capability blob on top of the embedded UI config independently, so a user's `storageCapabilities` field was already shadowed on every page load — the fold-in path was dead. The Vite dev injector likewise accepts only `backendCapabilities`; dev configs live alongside the source and are updated with it.

## Test plan

- [x] `npm run fmt`
- [x] `npm run lint`
- [x] `npm test` — 3,058 tests pass
- [x] `npm run build`
- [ ] Manual: chat surface stays hidden against an old Jaeger backend (no `aiAssistant`)
- [ ] Manual: chat surface lights up when local `jaeger-ui.config.json` sets `{ "backendCapabilities": { "aiAssistant": true } }`
- [ ] Manual: Monitor tab still gates on `metricsStorage` against an old backend (still injected via `JAEGER_STORAGE_CAPABILITIES`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)