### PR TITLE
chore(renovate): Group @rolldown/* upgrades into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,12 @@
       "description": "vite-plus bundles a specific vitest version internally; these must be bumped together to avoid peer-dependency version mismatches"
     },
     {
+      "groupName": "rolldown",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["rolldown", "/^@rolldown//"],
+      "description": "rolldown ships one package per platform binding (@rolldown/binding-*); group them all into a single PR so they bump in lockstep"
+    },
+    {
       "groupName": "do not apply patch upgrades to dependencies",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch", "digest"],


### PR DESCRIPTION
rolldown ships one npm package per platform binding (14 today), so each release produces a flood of separate Renovate PRs (see #2395). Add a package rule grouping the meta package and all @rolldown/* scoped bindings under one PR so they bump in lockstep.
