### PR TITLE
fix(assistant): Wrap fetch passed to HttpAgent

### DIFF
--- a/packages/jaeger-ui/src/components/App/JaegerAssistantContext.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantContext.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+import { HttpAgent } from '@ag-ui/client';
 import {
   JaegerAssistantProvider,
   useJaegerAssistant,
@@ -135,6 +136,28 @@ describe('JaegerAssistantContext', () => {
     expect(screen.getByTestId('bootstrap')).toHaveTextContent('hello');
     fireEvent.click(screen.getByRole('button', { name: 'clear' }));
     expect(screen.getByTestId('bootstrap')).toHaveTextContent('none');
+  });
+
+  it('passes a fetch wrapper to HttpAgent that survives method-style invocation', async () => {
+    // Regression: @ag-ui/client's HttpAgent stores the supplied `fetch` as
+    // `this.fetch` and later invokes it as `this.fetch(...)`. Passing the bare
+    // global `fetch` would then be called with `this === HttpAgent`, which throws
+    // "Illegal invocation" in browsers. The provider must supply a wrapper that
+    // detaches the receiver.
+    agUiMock.configured = true;
+    render(
+      <JaegerAssistantProvider>
+        <span />
+      </JaegerAssistantProvider>
+    );
+    expect(HttpAgent).toHaveBeenCalledTimes(1);
+    const opts = HttpAgent.mock.calls[0][0];
+    expect(typeof opts.fetch).toBe('function');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(undefined);
+    const receiver = { fetch: opts.fetch };
+    await receiver.fetch('/x', { method: 'POST' });
+    expect(fetchSpy).toHaveBeenCalledWith('/x', { method: 'POST' });
+    fetchSpy.mockRestore();
   });
 
   it('useAgUiRuntime onError logs AG-UI errors (lines 29–30)', () => {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantContext.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantContext.tsx
@@ -23,7 +23,13 @@ const JaegerAssistantContext = React.createContext<IJaegerAssistantContextValue 
 /** Inner provider that creates the long-lived AG-UI runtime (only mounted when the assistant capability is on). */
 function JaegerAssistantRuntimeProvider({ children }: { children: React.ReactNode }) {
   const url = getJaegerAGUIUrl();
-  const agent = React.useMemo(() => new HttpAgent({ url }), [url]);
+  // HttpAgent stores the supplied fetch as `this.fetch` and later invokes it as a method,
+  // so the bare global `fetch` would be called with `this === HttpAgent` and throw
+  // "Illegal invocation". Wrap it to detach the receiver.
+  const agent = React.useMemo(
+    () => new HttpAgent({ url, fetch: (input, init) => fetch(input, init) }),
+    [url]
+  );
   const runtime = useAgUiRuntime({
     agent,
     showThinking: true,


### PR DESCRIPTION
## Which problem is this PR solving?

The Jaeger AI assistant panel renders empty against a working backend, and the browser console fills with:

```
[jaeger-assistant] AG-UI error TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
```

The dep-bump in #4040 brought in `@ag-ui/client@0.0.54`, whose `HttpAgent` stores the supplied `fetch` as an instance property and later invokes it as a method:

```js
// node_modules/@ag-ui/client/dist/index.js
constructor(e) { ...; this.fetch = e.fetch ?? fetch }
run(e)        { return j(O(() => this.fetch(this.url, this.requestInit(e))), ...) }
```

When `JaegerAssistantContext` constructs `new HttpAgent({ url })` without a custom `fetch`, the agent ends up calling the bare global `fetch` with `this === HttpAgent`. Browsers reject that — `fetch` requires its receiver to be the `Window`.

## Description of the changes

- **`JaegerAssistantContext.tsx`** — pass an explicit `fetch: (input, init) => fetch(input, init)` wrapper to `HttpAgent`. The wrapper looks up the module-scoped `fetch` at call time without carrying the receiver, so `this.fetch(...)` inside `HttpAgent` no longer routes the bad `this` to the global fetch.

## How was this change tested?

- [x] `npm run fmt && npm run lint && npm test && npm run build` all pass (3,058 unit tests).
- [x] Added a regression test in `JaegerAssistantContext.test.jsx` (`passes a fetch wrapper to HttpAgent that survives method-style invocation`) that captures the option `HttpAgent` receives and verifies it still resolves to the global `fetch` when called as a method on an unrelated receiver. The test would fail if someone reverts to the bare-`fetch` form.
- [x] Manual: start a local Jaeger with the assistant enabled, open the assistant panel from this branch, send a prompt "hi", and confirm a request reaches `/api/ai/chat` instead of the `Illegal invocation` console error.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes