### PR TITLE
fix: Fix sidepanel resize when timeline is hidden

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -173,7 +173,7 @@ describe('<TimelineHeaderRow>', () => {
       expect(screen.queryByTestId('timeline-viewing-layer')).not.toBeInTheDocument();
     });
 
-    it('does not render the VerticalResizer', () => {
+    it('does not render the VerticalResizer when sidePanel is hidden', () => {
       render(<TimelineHeaderRow {...barsHiddenProps} />);
       expect(screen.queryByTestId('vertical-resizer')).not.toBeInTheDocument();
     });
@@ -183,6 +183,23 @@ describe('<TimelineHeaderRow>', () => {
       const cells = container.querySelectorAll('.TimelineRow--cellMock');
       expect(cells).toHaveLength(1);
       expect(cells[0]).toHaveAttribute('data-width', '1');
+    });
+
+    describe('with side panel visible', () => {
+      const treeOnlySidePanelProps = {
+        ...barsHiddenProps,
+        sidePanelVisible: true,
+        sidePanelWidth: 0.3,
+        sidePanelLabel: 'Span Details',
+        resizerMax: 0.8,
+      };
+
+      it('renders the VerticalResizer', () => {
+        render(<TimelineHeaderRow {...treeOnlySidePanelProps} />);
+        const resizer = screen.getByTestId('vertical-resizer');
+        expect(resizer).toBeInTheDocument();
+        expect(resizer).toHaveAttribute('data-max', '0.8');
+      });
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -10,6 +10,7 @@ import Ticks from '../Ticks';
 import TimelineRow from '../TimelineRow';
 import { TUpdateViewRangeTimeFunction, IViewRangeTime, ViewRangeTimeUpdate } from '../../types';
 import { IOtelSpan } from '../../../../types/otel';
+import { SPAN_NAME_COLUMN_WIDTH_MIN } from '../store.constants';
 
 import './TimelineHeaderRow.css';
 
@@ -77,23 +78,23 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
         />
       </TimelineRow.Cell>
       {timelineBarsVisible && (
-        <>
-          <TimelineRow.Cell width={timelineColumnWidth}>
-            <TimelineViewingLayer
-              boundsInvalidator={nameColumnWidth}
-              updateNextViewRangeTime={updateNextViewRangeTime}
-              updateViewRangeTime={updateViewRangeTime}
-              viewRangeTime={viewRangeTime}
-            />
-            <Ticks numTicks={numTicks} startTime={startTime} endTime={endTime} showLabels />
-          </TimelineRow.Cell>
-          <VerticalResizer
-            position={nameColumnWidth}
-            onChange={onColummWidthChange}
-            min={0.15}
-            max={resizerMax}
+        <TimelineRow.Cell width={timelineColumnWidth}>
+          <TimelineViewingLayer
+            boundsInvalidator={nameColumnWidth}
+            updateNextViewRangeTime={updateNextViewRangeTime}
+            updateViewRangeTime={updateViewRangeTime}
+            viewRangeTime={viewRangeTime}
           />
-        </>
+          <Ticks numTicks={numTicks} startTime={startTime} endTime={endTime} showLabels />
+        </TimelineRow.Cell>
+      )}
+      {(timelineBarsVisible || sidePanelVisible) && (
+        <VerticalResizer
+          position={nameColumnWidth}
+          onChange={onColummWidthChange}
+          min={SPAN_NAME_COLUMN_WIDTH_MIN}
+          max={resizerMax}
+        />
       )}
       {sidePanelVisible && (
         <TimelineRow.Cell className="ub-flex ub-px2 TimelineHeaderRow--sidePanelCell" width={sidePanelWidth}>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
@@ -80,6 +80,13 @@ describe('TraceTimelineViewer/duck', () => {
     expect(store.getState().spanNameColumnWidth).toBeCloseTo(0.575);
   });
 
+  it('clamps spanNameColumnWidth to leave room for side panel when timeline is hidden', () => {
+    store.dispatch(actions.setTimelineBarsVisible(false));
+    store.dispatch(actions.setDetailPanelMode('sidepanel'));
+    store.dispatch(actions.setSpanNameColumnWidth(0.99));
+    expect(store.getState().spanNameColumnWidth).toBeCloseTo(1 - SIDE_PANEL_WIDTH_MIN);
+  });
+
   describe('focusUiFindMatches', () => {
     const uiFind = 'uiFind';
     const action = actions.focusUiFindMatches(trace, uiFind);
@@ -563,6 +570,13 @@ describe('TraceTimelineViewer/duck', () => {
       const retained = store.getState().detailStates.get(spanA);
       expect(retained.isAttributesOpen).toBe(true);
       expect(retained.isResourceOpen).toBe(true);
+    });
+
+    it('clamps spanNameColumnWidth to leave room for side panel when timeline is hidden', () => {
+      store.dispatch(actions.setSpanNameColumnWidth(SPAN_NAME_COLUMN_WIDTH_MAX));
+      store.dispatch(actions.setTimelineBarsVisible(false));
+      store.dispatch(actions.setDetailPanelMode('sidepanel'));
+      expect(store.getState().spanNameColumnWidth).toBeCloseTo(1 - SIDE_PANEL_WIDTH_MIN);
     });
 
     it('does not persist mode to localStorage (persistence moved to useTraceTimelineStore)', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
@@ -243,11 +243,14 @@ function setTrace(state: TTraceTimeline, { uiFind, trace }: TTraceUiFindValue) {
 }
 
 function setColumnWidth(state: TTraceTimeline, { width }: TWidthValue): TTraceTimeline {
-  // In side-panel mode the name column must leave room for both the side panel and timeline bars.
-  const maxWidth =
-    state.detailPanelMode === 'sidepanel'
-      ? Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, 1 - state.sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH)
-      : SPAN_NAME_COLUMN_WIDTH_MAX;
+  // In side-panel mode the name column must leave room for the side panel and, when visible, timeline bars.
+  let maxWidth = SPAN_NAME_COLUMN_WIDTH_MAX;
+  if (state.detailPanelMode === 'sidepanel') {
+    const availableWidth = state.timelineBarsVisible
+      ? 1 - state.sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
+      : 1 - SIDE_PANEL_WIDTH_MIN;
+    maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
+  }
   const spanNameColumnWidth = Math.min(Math.max(width, SPAN_NAME_COLUMN_WIDTH_MIN), maxWidth);
   return { ...state, spanNameColumnWidth };
 }
@@ -352,15 +355,14 @@ function setDetailPanelMode(state: TTraceTimeline, { mode }: TDetailPanelModeVal
     const firstKey = detailStates.keys().next().value as string;
     detailStates = new Map([[firstKey, DetailState.forDetailPanelMode('sidepanel')]]);
   }
-  // When switching to sidepanel mode, ensure spanNameColumnWidth leaves room for the side panel and
-  // the minimum timeline column. A wide name column stored in inline mode would otherwise produce a
-  // zero/negative timeline column width as soon as the side panel is enabled.
+  // When switching to sidepanel mode, ensure spanNameColumnWidth leaves room for the side panel
+  // and, when visible, the minimum timeline column.
   let { spanNameColumnWidth } = state;
   if (mode === 'sidepanel') {
-    const maxWidth = Math.min(
-      SPAN_NAME_COLUMN_WIDTH_MAX,
-      1 - state.sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
-    );
+    const availableWidth = state.timelineBarsVisible
+      ? 1 - state.sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
+      : 1 - SIDE_PANEL_WIDTH_MIN;
+    const maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
     spanNameColumnWidth = Math.min(spanNameColumnWidth, maxWidth);
   }
   return { ...state, detailPanelMode: mode, detailStates, spanNameColumnWidth };

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
@@ -21,6 +21,7 @@ import {
   SIDE_PANEL_WIDTH_MAX,
   MIN_TIMELINE_COLUMN_WIDTH,
 } from './store.constants';
+import { getMaxNameColumnWidth } from './store.layout';
 
 // payloads
 export type TSpanIdLogValue = { logItem: IEvent; spanID: string };
@@ -244,13 +245,7 @@ function setTrace(state: TTraceTimeline, { uiFind, trace }: TTraceUiFindValue) {
 
 function setColumnWidth(state: TTraceTimeline, { width }: TWidthValue): TTraceTimeline {
   // In side-panel mode the name column must leave room for the side panel and, when visible, timeline bars.
-  let maxWidth = SPAN_NAME_COLUMN_WIDTH_MAX;
-  if (state.detailPanelMode === 'sidepanel') {
-    const availableWidth = state.timelineBarsVisible
-      ? 1 - state.sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
-      : 1 - SIDE_PANEL_WIDTH_MIN;
-    maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
-  }
+  const maxWidth = getMaxNameColumnWidth(state);
   const spanNameColumnWidth = Math.min(Math.max(width, SPAN_NAME_COLUMN_WIDTH_MIN), maxWidth);
   return { ...state, spanNameColumnWidth };
 }
@@ -356,13 +351,11 @@ function setDetailPanelMode(state: TTraceTimeline, { mode }: TDetailPanelModeVal
     detailStates = new Map([[firstKey, DetailState.forDetailPanelMode('sidepanel')]]);
   }
   // When switching to sidepanel mode, ensure spanNameColumnWidth leaves room for the side panel
-  // and, when visible, the minimum timeline column.
+  // and, when visible, the minimum timeline column. A wide name column stored in inline mode would
+  // otherwise produce a zero/negative timeline column width as soon as the side panel is enabled.
   let { spanNameColumnWidth } = state;
   if (mode === 'sidepanel') {
-    const availableWidth = state.timelineBarsVisible
-      ? 1 - state.sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
-      : 1 - SIDE_PANEL_WIDTH_MIN;
-    const maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
+    const maxWidth = getMaxNameColumnWidth({ ...state, detailPanelMode: mode });
     spanNameColumnWidth = Math.min(spanNameColumnWidth, maxWidth);
   }
   return { ...state, detailPanelMode: mode, detailStates, spanNameColumnWidth };

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -25,6 +25,12 @@ SPDX-License-Identifier: Apache-2.0
   overflow-y: auto;
   position: fixed;
   right: 0;
+  z-index: 3;
+}
+
+/* Ensure the side-panel-width resizer paints above the fixed side panel (z-index: 3). */
+.TraceTimelineViewer--sidePanelLayout > .VerticalResizer {
+  z-index: 4;
 }
 
 /* Show a permanent column divider for all VerticalResizers within the trace timeline,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -12,6 +12,7 @@ import {
   SIDE_PANEL_WIDTH_MAX,
   SIDE_PANEL_WIDTH_MIN,
   SPAN_NAME_COLUMN_WIDTH_MAX,
+  SPAN_NAME_COLUMN_WIDTH_MIN,
   useLayoutPrefsStore,
   useTraceTimelineStore,
 } from './store';
@@ -156,7 +157,15 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   // Equals spanNameColumnWidth when bars are visible (the round-trip through mainFraction cancels).
   // When bars are hidden with no side panel, the name column spans the full page.
   const headerNameWidth = nameColumnWidth * mainFraction;
-  const resizerMax = sidePanelActive ? mainFraction - MIN_TIMELINE_COLUMN_WIDTH : SPAN_NAME_COLUMN_WIDTH_MAX;
+  let resizerMax: number;
+  if (sidePanelActive && timelineBarsVisible) {
+    resizerMax = mainFraction - MIN_TIMELINE_COLUMN_WIDTH;
+  } else if (sidePanelActive && !timelineBarsVisible) {
+    resizerMax = 1 - SIDE_PANEL_WIDTH_MIN;
+  } else {
+    resizerMax = SPAN_NAME_COLUMN_WIDTH_MAX;
+  }
+  resizerMax = Math.max(SPAN_NAME_COLUMN_WIDTH_MIN, Math.min(resizerMax, 1));
 
   // Column header label: "Trace Root" when showing the root span (explicit or fallback),
   // "Span Details" for any other selected span.

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
@@ -93,11 +93,14 @@ export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()((set,
   ...getInitialLayoutState(),
 
   setSpanNameColumnWidth: (width: number) => {
-    const { detailPanelMode, sidePanelWidth } = get();
-    const maxWidth =
-      detailPanelMode === 'sidepanel'
-        ? Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH)
-        : SPAN_NAME_COLUMN_WIDTH_MAX;
+    const { detailPanelMode, sidePanelWidth, timelineBarsVisible } = get();
+    let maxWidth = SPAN_NAME_COLUMN_WIDTH_MAX;
+    if (detailPanelMode === 'sidepanel') {
+      const availableWidth = timelineBarsVisible
+        ? 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
+        : 1 - SIDE_PANEL_WIDTH_MIN;
+      maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
+    }
     const spanNameColumnWidth = Math.min(Math.max(width, SPAN_NAME_COLUMN_WIDTH_MIN), maxWidth);
     localStorage.setItem('spanNameColumnWidth', spanNameColumnWidth.toString());
     set({ spanNameColumnWidth });
@@ -116,9 +119,12 @@ export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()((set,
 
   applyDetailPanelModeToLayout: (mode: SpanDetailPanelMode) => {
     localStorage.setItem('detailPanelMode', mode);
-    let { spanNameColumnWidth, sidePanelWidth } = get();
+    let { spanNameColumnWidth, sidePanelWidth, timelineBarsVisible } = get();
     if (mode === 'sidepanel') {
-      const maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH);
+      const availableWidth = timelineBarsVisible
+        ? 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
+        : 1 - SIDE_PANEL_WIDTH_MIN;
+      const maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
       spanNameColumnWidth = Math.min(spanNameColumnWidth, maxWidth);
     }
     set({ detailPanelMode: mode, spanNameColumnWidth });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
@@ -12,6 +12,20 @@ import {
   SPAN_NAME_COLUMN_WIDTH_MIN,
 } from './store.constants';
 
+export function getMaxNameColumnWidth(opts: {
+  detailPanelMode: string;
+  timelineBarsVisible: boolean;
+  sidePanelWidth: number;
+}): number {
+  if (opts.detailPanelMode !== 'sidepanel') {
+    return SPAN_NAME_COLUMN_WIDTH_MAX;
+  }
+  const availableWidth = opts.timelineBarsVisible
+    ? 1 - opts.sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
+    : 1 - SIDE_PANEL_WIDTH_MIN;
+  return Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
+}
+
 type TraceTimelineLayoutPrefsStore = {
   spanNameColumnWidth: number;
   sidePanelWidth: number;
@@ -94,13 +108,7 @@ export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()((set,
 
   setSpanNameColumnWidth: (width: number) => {
     const { detailPanelMode, sidePanelWidth, timelineBarsVisible } = get();
-    let maxWidth = SPAN_NAME_COLUMN_WIDTH_MAX;
-    if (detailPanelMode === 'sidepanel') {
-      const availableWidth = timelineBarsVisible
-        ? 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
-        : 1 - SIDE_PANEL_WIDTH_MIN;
-      maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
-    }
+    const maxWidth = getMaxNameColumnWidth({ detailPanelMode, sidePanelWidth, timelineBarsVisible });
     const spanNameColumnWidth = Math.min(Math.max(width, SPAN_NAME_COLUMN_WIDTH_MIN), maxWidth);
     localStorage.setItem('spanNameColumnWidth', spanNameColumnWidth.toString());
     set({ spanNameColumnWidth });
@@ -121,10 +129,7 @@ export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()((set,
     localStorage.setItem('detailPanelMode', mode);
     let { spanNameColumnWidth, sidePanelWidth, timelineBarsVisible } = get();
     if (mode === 'sidepanel') {
-      const availableWidth = timelineBarsVisible
-        ? 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
-        : 1 - SIDE_PANEL_WIDTH_MIN;
-      const maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, availableWidth);
+      const maxWidth = getMaxNameColumnWidth({ detailPanelMode: mode, sidePanelWidth, timelineBarsVisible });
       spanNameColumnWidth = Math.min(spanNameColumnWidth, maxWidth);
     }
     set({ detailPanelMode: mode, spanNameColumnWidth });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.test.ts
@@ -178,6 +178,16 @@ describe('trace timeline zustand stores', () => {
         useLayoutPrefsStore.getState().setSpanNameColumnWidth(0.99);
         expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(0.65);
       });
+
+      it('clamps to leave room for side panel when timeline is hidden', () => {
+        useLayoutPrefsStore.setState({
+          detailPanelMode: 'sidepanel',
+          sidePanelWidth: 0.7,
+          timelineBarsVisible: false,
+        });
+        useLayoutPrefsStore.getState().setSpanNameColumnWidth(0.99);
+        expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(1 - SIDE_PANEL_WIDTH_MIN);
+      });
     });
 
     describe('setSidePanelWidth', () => {
@@ -236,6 +246,16 @@ describe('trace timeline zustand stores', () => {
       useLayoutPrefsStore.setState({ spanNameColumnWidth: 0.8, sidePanelWidth: 0.3 });
       setDetailPanelMode('sidepanel');
       expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(0.65);
+    });
+
+    it('clamps spanNameColumnWidth when switching to sidepanel with timeline hidden', () => {
+      useLayoutPrefsStore.setState({
+        spanNameColumnWidth: SPAN_NAME_COLUMN_WIDTH_MAX,
+        sidePanelWidth: 0.7,
+        timelineBarsVisible: false,
+      });
+      setDetailPanelMode('sidepanel');
+      expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(1 - SIDE_PANEL_WIDTH_MIN);
     });
 
     it('does not clamp spanNameColumnWidth when switching to inline', () => {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4045 

## Description of the changes
- Updated the render condition for `VerticalResizer` in `TimelineHeaderRow.tsx` to ensure it remains visible and active when either the timeline bars OR the side panel are visible.
- Adjusted the `resizerMax` calculation logic in `TraceTimelineViewer/index.tsx` to properly account for the available layout width (`1 - SIDE_PANEL_WIDTH_MIN`) when the timeline is disabled but the side panel is open, preventing negative or invalid resize boundaries.

## How was this change tested?

https://github.com/user-attachments/assets/2f0f20b4-8486-44ec-b71a-0d0ef6f6362e


- Ran the existing automated test suite (`npm run fmt`, `npm run lint`, `npm test`, `npm run build`) to ensure no regressions.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes