### PR TITLE
feat(genai): Classify tool spans and ignore bare gen_ai.tool.call.id

### DIFF
--- a/packages/jaeger-ui/src/constants/span-attributes.ts
+++ b/packages/jaeger-ui/src/constants/span-attributes.ts
@@ -6,3 +6,9 @@ export const GEN_AI_NAMESPACE = 'gen_ai.';
 export const GEN_AI_OPERATION_NAME = 'gen_ai.operation.name';
 
 export const GEN_AI_REQUEST_MODEL = 'gen_ai.request.model';
+
+export const GEN_AI_TOOL_NAME = 'gen_ai.tool.name';
+
+// A tool call's cross-span reference. Present on spans that merely *mention* a
+// tool call, so on its own it does not make a span a GenAI span.
+export const GEN_AI_TOOL_CALL_ID = 'gen_ai.tool.call.id';

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -71,6 +71,46 @@ describe('classifySpan', () => {
   it('returns undefined for a span with empty attributes', () => {
     expect(classifySpan(makeSpan([]))).toBeUndefined();
   });
+
+  it('classifies gen_ai.tool.name as TOOL_CALL when operation.name is absent', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.tool.name', value: 'get_weather' }]))).toBe('TOOL_CALL');
+  });
+
+  it('lets a recognized operation.name win over gen_ai.tool.name', () => {
+    const span = makeSpan([
+      { key: 'gen_ai.tool.name', value: 'get_weather' },
+      { key: 'gen_ai.operation.name', value: 'chat' },
+    ]);
+    expect(classifySpan(span)).toBe('LLM_CALL');
+  });
+
+  it('falls back to a secondary signal for an unrecognized operation.name', () => {
+    const span = makeSpan([
+      { key: 'gen_ai.operation.name', value: 'some_new_op' },
+      { key: 'gen_ai.tool.name', value: 'get_weather' },
+    ]);
+    expect(classifySpan(span)).toBe('TOOL_CALL');
+  });
+
+  it('returns undefined for gen_ai.tool.call.id alone', () => {
+    expect(classifySpan(makeSpan([{ key: 'gen_ai.tool.call.id', value: 'abc-123' }]))).toBeUndefined();
+  });
+
+  it('returns TOOL_CALL when gen_ai.tool.call.id is paired with gen_ai.tool.name', () => {
+    const span = makeSpan([
+      { key: 'gen_ai.tool.call.id', value: 'abc-123' },
+      { key: 'gen_ai.tool.name', value: 'get_weather' },
+    ]);
+    expect(classifySpan(span)).toBe('TOOL_CALL');
+  });
+
+  it('still returns UNKNOWN_GENAI when tool.call.id accompanies another gen_ai.* key', () => {
+    const span = makeSpan([
+      { key: 'gen_ai.tool.call.id', value: 'abc-123' },
+      { key: 'gen_ai.system', value: 'openai' },
+    ]);
+    expect(classifySpan(span)).toBe('UNKNOWN_GENAI');
+  });
 });
 
 describe('isGenAISpan', () => {

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { IAttributes, GenAISpanKind } from '../../types/otel';
-import { GEN_AI_NAMESPACE, GEN_AI_OPERATION_NAME } from '../../constants/span-attributes';
+import {
+  GEN_AI_NAMESPACE,
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_TOOL_CALL_ID,
+  GEN_AI_TOOL_NAME,
+} from '../../constants/span-attributes';
 
 type SpanAttrs = { attributes: IAttributes };
 
@@ -18,15 +23,36 @@ const OPERATION_TO_KIND: Partial<Record<string, GenAISpanKind>> = {
   retrieval: 'RETRIEVAL',
 };
 
+/**
+ * Signals that identify a span kind when gen_ai.operation.name is absent or
+ * carries a value we don't recognize. Deliberately consulted *after* the
+ * operation name: that attribute is the spec's own discriminator, so a
+ * recognized value always wins over these heuristics.
+ */
+function classifyBySecondarySignals(attributes: IAttributes): GenAISpanKind | undefined {
+  if (attributes.has(GEN_AI_TOOL_NAME)) return 'TOOL_CALL';
+  return undefined;
+}
+
 // Looks for gen_ai.operation.name while also tracking whether any gen_ai.*
 // attribute was seen, so a span with GenAI attributes but an unrecognized
 // (or missing) operation name still maps to UNKNOWN_GENAI instead of undefined.
 export function classifySpan(span: SpanAttrs): GenAISpanKind | undefined {
-  const operation = span.attributes.getValue(GEN_AI_OPERATION_NAME);
+  const { attributes } = span;
+  const operation = attributes.getValue(GEN_AI_OPERATION_NAME);
   if (typeof operation === 'string') {
-    return OPERATION_TO_KIND[operation] ?? 'UNKNOWN_GENAI';
+    return OPERATION_TO_KIND[operation] ?? classifyBySecondarySignals(attributes) ?? 'UNKNOWN_GENAI';
   }
-  const hasGenAI = span.attributes.keys().some(key => key.startsWith(GEN_AI_NAMESPACE));
+
+  const secondary = classifyBySecondarySignals(attributes);
+  if (secondary) return secondary;
+
+  // gen_ai.tool.call.id is excluded: it is a reference to a tool call made
+  // elsewhere, so a span carrying only that key describes someone else's work
+  // and is not itself a GenAI span.
+  const hasGenAI = attributes
+    .keys()
+    .some(key => key.startsWith(GEN_AI_NAMESPACE) && key !== GEN_AI_TOOL_CALL_ID);
   return hasGenAI ? 'UNKNOWN_GENAI' : undefined;
 }
 


### PR DESCRIPTION
#### Context

This PR is part A of the decomposition of #3887, which was closed after review feedback that a 1000+ line PR was not acceptable and the change was clearly decomposable.

Since that decomposition was proposed, upstream has landed the bulk of the GenAI work independently — `utils/genai/detect.ts` (#3856), span type icons (#3857, #4238, #4239), the GenAI tab (#4122, #4191, #4213), and the `IAttributes` refactor (#4211). **This PR has therefore been rewritten.** It no longer adds a new `utils/gen-ai/` utility layer, as originally proposed; it is now a small extension of the detector that already exists in `utils/genai/detect.ts`.

#### What this changes

Two refinements to `classifySpan`, both affecting only spans whose `gen_ai.operation.name` is absent or carries a value we don't recognize:

1. **`gen_ai.tool.name` → `TOOL_CALL`.** Previously such a span fell through to `UNKNOWN_GENAI` via the `gen_ai.*` namespace scan.
2. **A bare `gen_ai.tool.call.id` no longer marks a span as GenAI.** That attribute is a reference to a tool call recorded on another span, so a span carrying only that key describes someone else's work. It previously matched the namespace scan and returned `UNKNOWN_GENAI`.

Plus two attribute-key constants in `constants/span-attributes.ts` (`GEN_AI_TOOL_NAME`, `GEN_AI_TOOL_CALL_ID`), both consumed by the above.

#### Judgment call: precedence — please push back if you disagree

The new signal is consulted **after** `gen_ai.operation.name`, not before. `operation.name` is the spec's own discriminator, so a recognized value wins over the heuristic.

This is a deliberate reversal of what the original #3887 detector did, and it is a behavior change worth reviewing on its own. Concretely, a span carrying both `gen_ai.tool.name=get_weather` and `gen_ai.operation.name=chat` was classified `'tool'` under the old ordering; it is now `LLM_CALL`. The reasoning is that an instrumentation library that explicitly declares `operation.name=chat` is telling us what the span *is*, whereas `tool.name` may be present merely because the chat call has a tool bound to it.

I think spec-first is the right default, but I hold it loosely — if you'd rather `tool.name` win, it's a two-line reorder.

#### Changes relative to the earlier version of this PR

For anyone who reviewed the previous diff — these are differences from what this PR used to propose, not changes to `main`:

- **Span kind values** are now upstream's `LLM_CALL | TOOL_CALL | AGENT | RETRIEVAL | UNKNOWN_GENAI`, replacing the `'llm' | 'tool' | 'retrieval' | 'agent'` union this PR previously introduced.
- **`isGenAITrace` keeps upstream's signature**, `(spans: ReadonlyArray<{attributes}>)`, rather than the `(trace: IOtelTrace)` form this PR previously added. The duplicate implementation is gone.
- Everything is written against the `IAttributes` collection from #4211, using `getValue`/`has`/`keys`, so there are no linear attribute scans.

#### Deliberately dropped

- **`detectMediaType`** — no consumer until the renderers land. **`getAttr`/`getAttrsByPrefix`** — superseded by `IAttributes.getValue`/`has`/`keys`.
- Plus the attribute constants and the OTLP fixture with no consumer in this PR.

#### Follow-up, not in this PR

Two further signals — `db.system=vector` → `RETRIEVAL` and `agent.episode_id` → `AGENT` — are held back for a follow-up PR. Both fire on spans carrying no `gen_ai.*` attributes at all, so they change what `isGenAITrace` reports as a GenAI trace. That's a redefinition rather than a classification fix and deserves its own review. Nothing in this PR widens `isGenAITrace`; the `tool.call.id` exclusion narrows it slightly.

#### Testing

Six new unit tests in `utils/genai/detect.test.ts` covering the tool-name signal, the precedence rule in both directions, and the three `tool.call.id` cases (alone, paired with `tool.name`, alongside another `gen_ai.*` key). Full suite green: 3618 tests, `tsc --noEmit` clean, oxlint clean on changed files.
