### PR TITLE
fix(monitor): replace hardcoded light-mode colors with design tokens in operations table

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.css
@@ -13,13 +13,8 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .span-kind-selector-header {
-  padding-left: 10px;
   font-size: 18px;
   font-weight: 800;
-}
-
-.span-kind-selector {
-  padding-left: 10px;
 }
 
 .operations-metrics-text {
@@ -61,6 +56,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .select-operation-column {
+  align-items: flex-end;
   display: inline-flex;
   justify-content: flex-end;
 }
@@ -68,4 +64,18 @@ SPDX-License-Identifier: Apache-2.0
 .select-operation-input {
   font-size: 14px;
   width: 218px;
+}
+
+.service-span-kind-row {
+  flex-wrap: nowrap;
+}
+
+.service-filter-col {
+  flex: 1 1 auto;
+  max-width: 420px;
+}
+
+.span-kind-filter-col {
+  flex: 0 0 auto;
+  width: 200px;
 }

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -242,8 +242,8 @@ export function MonitorATMServicesViewImpl(props: TProps) {
         />
       )}
       <div className="service-view-container">
-        <Row>
-          <Col span={6}>
+        <Row className="service-span-kind-row" gutter={16} align="bottom">
+          <Col className="service-filter-col">
             <h2 className="service-selector-header">Service</h2>
             <SearchableSelect
               value={getSelectedService()}
@@ -260,7 +260,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
               ))}
             </SearchableSelect>
           </Col>
-          <Col span={6}>
+          <Col className="span-kind-filter-col">
             <h2 className="span-kind-selector-header">Span Kind</h2>
             <SearchableSelect
               value={selectedSpanKind}
@@ -364,7 +364,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
             />
           </Col>
         </Row>
-        <Row className="operation-table-block">
+        <Row className="operation-table-block" align="middle">
           <Col span={16}>
             <h2 className="table-header">Operations metrics under {getSelectedService()}</h2>{' '}
             <span className="over-the-last">Last {getLoopbackInterval(selectedTimeFrame)}</span>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.css
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.css
@@ -4,10 +4,10 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 th.header-item {
-  background: rgba(216, 216, 216, 0.7);
-  border-left: 1px solid rgba(216, 216, 216, 1);
-  border-top: 1px solid rgba(216, 216, 216, 1);
-  border-bottom: 1px solid rgba(216, 216, 216, 1);
+  background: var(--surface-tertiary);
+  border-left: 1px solid var(--border-default);
+  border-top: 1px solid var(--border-default);
+  border-bottom: 1px solid var(--border-default);
   border-radius: 0px;
   height: 40px;
   font-size: 14px;
@@ -16,7 +16,7 @@ th.header-item {
 }
 
 th.header-item:last-child {
-  border-right: 1px solid rgba(216, 216, 216, 1);
+  border-right: 1px solid var(--border-default);
 }
 
 th.header-item span {
@@ -26,23 +26,25 @@ th.header-item span {
 
 td.header-item {
   height: 50px;
-  border-bottom: 1px solid rgba(233, 233, 233, 1);
+  border-bottom: 1px solid var(--border-default);
   font-size: 14px;
   font-weight: 500;
   padding: 0 10px !important;
 }
 
-.table-row:hover {
-  background: rgba(247, 247, 247, 1);
+.table-row:hover,
+.table-row--hovered {
+  background: var(--surface-component-background-hover);
 }
 
-.ant-table-tbody > tr.ant-table-row-level-0:hover > td {
-  background: unset;
+.ant-table-tbody > tr.ant-table-row-level-0:not(.ant-table-row-selected):hover > td,
+.ant-table-tbody > tr.table-row--hovered:not(.ant-table-row-selected) > td {
+  background: var(--surface-component-background-hover);
 }
 
 .ant-progress-inner {
   border-radius: 0px;
-  background: rgba(199, 224, 224, 1);
+  background: var(--surface-component-background);
 }
 
 .impact {


### PR DESCRIPTION
Replace hardcoded light-mode colors in the Monitor operations metrics table with design tokens so row hover and headers render correctly in dark mode. Tighten Service and Span Kind filter layout spacing.

## Which problem is this PR solving?
- Resolves #4049

## Description of the changes
- Replace hardcoded `rgba(247,247,247,1)` row hover with `var(--surface-component-background-hover)` in operationDetailsTable/index.css
- Remove `background: unset` on hovered <td> cells that blocked Ant Design dark-mode hover
- Apply `var(--surface-tertiary)` / `var(--border-default)` to header cells
- Apply `var(--surface-component-background)` to progress bar track
- Tighten Service / Span Kind filter spacing via Row gutter={16} and flex columns in ServicesView

## How was this change tested?
- Ran Monitor tab in dark mode, hovered rows — overlay is now translucent, not solid white
- Toggled light mode — hover and headers still render correctly
- Ran `npm run lint`, `npm test`, `npm run build` — all pass

## Screenshot
<img width="1440" height="900" alt="Screenshot 2026-06-09 at 10 44 43 PM" src="https://github.com/user-attachments/assets/118cc7fa-6ef2-4427-a3a8-a4c53bbd2547" />
<img width="1418" height="300" alt="Screenshot 2026-06-09 at 10 44 54 PM" src="https://github.com/user-attachments/assets/dc640a31-3acf-4da8-9455-9083249474cb" />


## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
