### PR TITLE
fix(deps): bump @assistant-ui/tap resolution to ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
     "vitest": "4.1.4"
   },
   "overrides": {
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
-    "yaml": "2.9.0",
+    "@assistant-ui/tap": "0.6.0",
     "@exodus/bytes": {
       "@noble/hashes": "$@noble/hashes"
-    }
+    },
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "yaml": "2.9.0"
   },
   "workspaces": [
     "packages/plexus",


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Resolves #4055

## Description of the changes
- fresh clone + yarn install + yarn start was broken
- @assistant-ui/tap@0.5.14 gets installed but @assistant-ui/react needs 0.6.0 which has the ./react-shim export
- added resolutions field to root package.json to force @assistant-ui/tap@ 0.6.0


## How was this change tested?
- reproduced on fresh clone — yarn start fails with react-shim error
- after adding resolution, version mismatch is resolved

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
