### PR TITLE
refactor(TraceGraph): Migrate to functional component

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
@@ -90,8 +90,7 @@ describe('<TraceGraph>', () => {
     expect(screen.getByText('No trace found')).toBeInTheDocument();
   });
 
-  it('switches node mode when clicking mode buttons - with state verification', async () => {
-    const setStateSpy = jest.spyOn(TraceGraph.prototype, 'setState');
+  it('switches node mode when clicking mode buttons', async () => {
     render(<TraceGraph {...props} />);
 
     // Initial mode should be service
@@ -102,20 +101,15 @@ describe('<TraceGraph>', () => {
 
     // Switch to time
     await userEvent.click(timeButton);
-    expect(setStateSpy).toHaveBeenCalledWith({ mode: MODE_TIME }); // Verify state change
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_TIME);
 
     // Switch to selftime
     await userEvent.click(selftimeButton);
-    expect(setStateSpy).toHaveBeenCalledWith({ mode: MODE_SELFTIME });
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_SELFTIME);
 
     // Switch back to service
     await userEvent.click(serviceButton);
-    expect(setStateSpy).toHaveBeenCalledWith({ mode: MODE_SERVICE });
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_SERVICE);
-
-    setStateSpy.mockRestore();
   });
 
   it('shows help', async () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -32,10 +32,6 @@ type Props = {
   traceGraphConfig?: TraceGraphConfig;
   useOtelTerms: boolean;
 };
-type State = {
-  showHelp: boolean;
-  mode: string;
-};
 
 const { classNameIsSmall, scaleOpacity, scaleStrokeOpacity } = Digraph.propsFactories;
 
@@ -104,162 +100,149 @@ const getHelpContent = (useOtelTerms: boolean) => (
   </div>
 );
 
-export default class TraceGraph extends React.PureComponent<Props, State> {
-  state: State;
+function TraceGraph({
+  headerHeight,
+  ev = null,
+  uiFind,
+  uiFindVertexKeys,
+  traceGraphConfig,
+  useOtelTerms,
+}: Props) {
+  const [showHelp, setShowHelp] = React.useState(false);
+  const [mode, setMode] = React.useState(MODE_SERVICE);
 
-  layoutManager: LayoutManager;
-
-  static defaultProps = {
-    ev: null,
-  };
-
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      showHelp: false,
-      mode: MODE_SERVICE,
-    };
-    this.layoutManager = new LayoutManager({
-      totalMemory: props.traceGraphConfig?.layoutManagerMemory,
+  const layoutManagerRef = React.useRef<LayoutManager | null>(null);
+  if (layoutManagerRef.current === null) {
+    layoutManagerRef.current = new LayoutManager({
+      totalMemory: traceGraphConfig?.layoutManagerMemory,
       useDotEdges: true,
       splines: 'polyline',
     });
   }
 
-  componentWillUnmount() {
-    this.layoutManager.stopAndRelease();
+  React.useEffect(() => {
+    const manager = layoutManagerRef.current;
+    return () => {
+      manager?.stopAndRelease();
+    };
+  }, []);
+
+  if (!ev) {
+    return <h1 className="u-mt-vast u-tx-muted ub-tx-center">No trace found</h1>;
   }
 
-  toggleNodeMode(newMode: string) {
-    this.setState({ mode: newMode });
-  }
+  const wrapperClassName = cx('TraceGraph--graphWrapper', { 'is-uiFind-mode': uiFind });
 
-  showHelp = () => {
-    this.setState({ showHelp: true });
-  };
-
-  closeSidebar = () => {
-    this.setState({ showHelp: false });
-  };
-
-  render() {
-    const { ev, headerHeight, uiFind, uiFindVertexKeys, useOtelTerms } = this.props;
-    const { showHelp, mode } = this.state;
-    if (!ev) {
-      return <h1 className="u-mt-vast u-tx-muted ub-tx-center">No trace found</h1>;
-    }
-
-    const wrapperClassName = cx('TraceGraph--graphWrapper', { 'is-uiFind-mode': uiFind });
-
-    return (
-      <div className={wrapperClassName} style={{ paddingTop: headerHeight + 47 }}>
-        <Digraph<TDagPlexusVertex<TSumSpan & TDenseSpanMembers>>
-          minimap
-          zoom
-          className="TraceGraph--dag"
-          minimapClassName="u-miniMap"
-          layoutManager={this.layoutManager}
-          measurableNodesKey="nodes"
-          layers={[
-            {
-              key: 'node-find-emphasis',
-              layerType: 'svg',
-              renderNode: getNodeFindEmphasisRenderer(uiFindVertexKeys),
-            },
-            {
-              key: 'edges',
-              edges: true,
-              layerType: 'svg',
-              defs: [{ localId: 'arrow' }],
-              markerEndId: 'arrow',
-              setOnContainer: [scaleOpacity, scaleStrokeOpacity],
-              setOnEdge: setOnEdgePath,
-            },
-            {
-              key: 'nodes-borders',
-              layerType: 'svg',
-              setOnContainer: scaleStrokeOpacity,
-              renderNode: renderNodeVectorBorder,
-            },
-            {
-              key: 'nodes',
-              layerType: 'html',
-              measurable: true,
-              renderNode: cacheAs(`trace-graph/nodes/render/${mode}`, getNodeRenderer(mode, useOtelTerms)),
-            },
-          ]}
-          setOnGraph={classNameIsSmall}
-          edges={ev.edges}
-          vertices={ev.vertices}
-        />
-        <a
-          className="TraceGraph--experimental"
-          href="https://github.com/jaegertracing/jaeger-ui/issues/293"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Experimental
-        </a>
-        <div className="TraceGraph--sidebar-container">
-          <ul className="TraceGraph--menu">
-            <li>
-              <IoHelpCircleOutline onClick={this.showHelp} data-testid="help-icon" />
-            </li>
-            <li>
-              <Tooltip placement="left" title="Service">
-                <Button
-                  className={cx('TraceGraph--btn-service', { active: mode === MODE_SERVICE })}
-                  htmlType="button"
-                  shape="circle"
-                  size="small"
-                  onClick={() => this.toggleNodeMode(MODE_SERVICE)}
-                >
-                  S
-                </Button>
-              </Tooltip>
-            </li>
-            <li>
-              <Tooltip placement="left" title="Time">
-                <Button
-                  className={cx('TraceGraph--btn-time', { active: mode === MODE_TIME })}
-                  htmlType="button"
-                  shape="circle"
-                  size="small"
-                  onClick={() => this.toggleNodeMode(MODE_TIME)}
-                >
-                  T
-                </Button>
-              </Tooltip>
-            </li>
-            <li>
-              <Tooltip placement="left" title="Selftime">
-                <Button
-                  className={cx('TraceGraph--btn-selftime', { active: mode === MODE_SELFTIME })}
-                  htmlType="button"
-                  shape="circle"
-                  size="small"
-                  onClick={() => this.toggleNodeMode(MODE_SELFTIME)}
-                >
-                  ST
-                </Button>
-              </Tooltip>
-            </li>
-          </ul>
-          {showHelp && (
-            <Card
-              title="Help"
-              bordered={false}
-              extra={
-                <a onClick={this.closeSidebar} role="button" aria-label="Close">
-                  <IoClose />
-                </a>
-              }
-            >
-              {getHelpContent(useOtelTerms)}
-            </Card>
-          )}
-        </div>
+  return (
+    <div className={wrapperClassName} style={{ paddingTop: headerHeight + 47 }}>
+      <Digraph<TDagPlexusVertex<TSumSpan & TDenseSpanMembers>>
+        minimap
+        zoom
+        className="TraceGraph--dag"
+        minimapClassName="u-miniMap"
+        layoutManager={layoutManagerRef.current}
+        measurableNodesKey="nodes"
+        layers={[
+          {
+            key: 'node-find-emphasis',
+            layerType: 'svg',
+            renderNode: getNodeFindEmphasisRenderer(uiFindVertexKeys),
+          },
+          {
+            key: 'edges',
+            edges: true,
+            layerType: 'svg',
+            defs: [{ localId: 'arrow' }],
+            markerEndId: 'arrow',
+            setOnContainer: [scaleOpacity, scaleStrokeOpacity],
+            setOnEdge: setOnEdgePath,
+          },
+          {
+            key: 'nodes-borders',
+            layerType: 'svg',
+            setOnContainer: scaleStrokeOpacity,
+            renderNode: renderNodeVectorBorder,
+          },
+          {
+            key: 'nodes',
+            layerType: 'html',
+            measurable: true,
+            renderNode: cacheAs(`trace-graph/nodes/render/${mode}`, getNodeRenderer(mode, useOtelTerms)),
+          },
+        ]}
+        setOnGraph={classNameIsSmall}
+        edges={ev.edges}
+        vertices={ev.vertices}
+      />
+      <a
+        className="TraceGraph--experimental"
+        href="https://github.com/jaegertracing/jaeger-ui/issues/293"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Experimental
+      </a>
+      <div className="TraceGraph--sidebar-container">
+        <ul className="TraceGraph--menu">
+          <li>
+            <IoHelpCircleOutline onClick={() => setShowHelp(true)} data-testid="help-icon" />
+          </li>
+          <li>
+            <Tooltip placement="left" title="Service">
+              <Button
+                className={cx('TraceGraph--btn-service', { active: mode === MODE_SERVICE })}
+                htmlType="button"
+                shape="circle"
+                size="small"
+                onClick={() => setMode(MODE_SERVICE)}
+              >
+                S
+              </Button>
+            </Tooltip>
+          </li>
+          <li>
+            <Tooltip placement="left" title="Time">
+              <Button
+                className={cx('TraceGraph--btn-time', { active: mode === MODE_TIME })}
+                htmlType="button"
+                shape="circle"
+                size="small"
+                onClick={() => setMode(MODE_TIME)}
+              >
+                T
+              </Button>
+            </Tooltip>
+          </li>
+          <li>
+            <Tooltip placement="left" title="Selftime">
+              <Button
+                className={cx('TraceGraph--btn-selftime', { active: mode === MODE_SELFTIME })}
+                htmlType="button"
+                shape="circle"
+                size="small"
+                onClick={() => setMode(MODE_SELFTIME)}
+              >
+                ST
+              </Button>
+            </Tooltip>
+          </li>
+        </ul>
+        {showHelp && (
+          <Card
+            title="Help"
+            bordered={false}
+            extra={
+              <a onClick={() => setShowHelp(false)} role="button" aria-label="Close">
+                <IoClose />
+              </a>
+            }
+          >
+            {getHelpContent(useOtelTerms)}
+          </Card>
+        )}
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+export default React.memo(TraceGraph);


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3369 
## Description of the changes
- Converted `TraceGraph` from a class component (`React.PureComponent`) to a functional component wrapped in `React.memo`
- Replaced `this.state` with `useState` hooks for `showHelp` and `mode`
- Replaced `componentWillUnmount` with `useEffect` cleanup for `LayoutManager.stopAndRelease()`
- Replaced class instance field `this.layoutManager` with `useRef`
- Replaced `static defaultProps` with default parameter value (`ev = null`)
- Refactored test to remove `jest.spyOn(TraceGraph.prototype, 'setState')` now verifies mode switching purely through DOM assertions
## How was this change tested?
- All 10 existing `TraceGraph` tests pass
- Full test suite passes (3059/3059 tests, 248 test files)
- `npm run fmt` — passed
- `npm run lint` — no new lint errors
- `npm run build` — production build succeeded
## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`
## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes