### PR TITLE
refactor(timeline): extract critical path logic into helper module

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
@@ -8,11 +8,7 @@ import SpanBarRow from './SpanBarRow';
 import DetailState from './SpanDetail/DetailState';
 import SpanDetailRow from './SpanDetailRow';
 
-import {
-  buildCriticalPathIndex,
-  buildPrunedCriticalPaths,
-  getVisibleCriticalPathSections,
-} from './criticalPath';
+import { makeCriticalPathContext } from './criticalPath';
 import { DEFAULT_HEIGHTS, VirtualizedTraceViewImpl } from './VirtualizedTraceView';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
@@ -153,11 +149,6 @@ describe('<VirtualizedTraceViewImpl>', () => {
 
   it('renders without exploding', () => {
     const { container } = render(<VirtualizedTraceViewImpl {...mockProps} />);
-    expect(container).toBeTruthy();
-  });
-
-  it('renders when a trace is not set', () => {
-    const { container } = render(<VirtualizedTraceViewImpl {...mockProps} trace={null} />);
     expect(container).toBeTruthy();
   });
 
@@ -472,13 +463,6 @@ describe('<VirtualizedTraceViewImpl>', () => {
       });
     });
 
-    it('renderSpanBarRow returns null if trace is falsy', () => {
-      const { listViewProps } = renderAndCapture({ ...mockProps, trace: null });
-      // With no trace, getRowStates returns [] so no rows exist to render.
-      // Verify the component still renders without errors.
-      expect(listViewProps.dataLength).toBe(0);
-    });
-
     it('renderSpanBarRow passes isSelected=true for the span selected in side panel mode', () => {
       const selectedSpan = trace.spans[0];
       const { listViewProps } = renderAndCapture({ ...mockProps, selectedSpanID: selectedSpan.spanID });
@@ -532,15 +516,8 @@ describe('<VirtualizedTraceViewImpl>', () => {
     it('returns [] from mergeChildrenCriticalPath when criticalPath is falsy', () => {
       const span = trace.spans[0];
 
-      const result = getVisibleCriticalPathSections(
-        true,
-        false,
-        trace,
-        span,
-        undefined,
-        buildCriticalPathIndex([]),
-        new Map()
-      );
+      const context = makeCriticalPathContext(trace, undefined, new Set());
+      const result = context.sectionsFor(span, true, false);
       expect(result).toEqual([]);
     });
 
@@ -570,15 +547,8 @@ describe('<VirtualizedTraceViewImpl>', () => {
         { spanID: 'child', sectionStart: 0, sectionEnd: 10 },
       ];
 
-      const result = getVisibleCriticalPathSections(
-        true,
-        false,
-        customTrace,
-        parentSpan,
-        fakeCriticalPath,
-        buildCriticalPathIndex(fakeCriticalPath),
-        new Map()
-      );
+      const context = makeCriticalPathContext(customTrace, fakeCriticalPath, new Set());
+      const result = context.sectionsFor(parentSpan, true, false);
 
       expect(result).toEqual([{ spanID: 'parent', sectionStart: 0, sectionEnd: 20 }]);
     });
@@ -609,13 +579,11 @@ describe('<VirtualizedTraceViewImpl>', () => {
         { spanID: 'grandchild', sectionStart: 20, sectionEnd: 30 },
       ];
 
-      const result = buildPrunedCriticalPaths(
-        buildCriticalPathIndex(fakeCriticalPath),
-        new Set(['svc-pruned']),
-        [parentSpan, prunedChild, grandchildSpan]
-      );
+      const customTrace = { ...trace, spans: [parentSpan, prunedChild, grandchildSpan] };
+      const context = makeCriticalPathContext(customTrace, fakeCriticalPath, new Set(['svc-pruned']));
+      const result = context.sectionsFor(parentSpan, false, true);
 
-      expect(result.get('parent')).toEqual(fakeCriticalPath);
+      expect(result).toEqual(fakeCriticalPath);
     });
 
     it('merges only pruned subtree critical path when hasPrunedChildren is true', () => {
@@ -645,17 +613,8 @@ describe('<VirtualizedTraceViewImpl>', () => {
         { spanID: 'pruned-child', sectionStart: 10, sectionEnd: 20 },
         { spanID: 'visible-child', sectionStart: 20, sectionEnd: 30 },
       ];
-      const pathBySpanID = buildCriticalPathIndex(fakeCriticalPath);
-
-      const result = getVisibleCriticalPathSections(
-        false,
-        true,
-        customTrace,
-        parentSpan,
-        fakeCriticalPath,
-        pathBySpanID,
-        buildPrunedCriticalPaths(pathBySpanID, new Set(['svc-pruned']), customTrace.spans)
-      );
+      const context = makeCriticalPathContext(customTrace, fakeCriticalPath, new Set(['svc-pruned']));
+      const result = context.sectionsFor(parentSpan, false, true);
       const spanIDs = result.map(s => s.spanID);
       expect(spanIDs).toContain('parent');
       expect(spanIDs).toContain('pruned-child');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
@@ -7,7 +7,13 @@ import '@testing-library/jest-dom';
 import SpanBarRow from './SpanBarRow';
 import DetailState from './SpanDetail/DetailState';
 import SpanDetailRow from './SpanDetailRow';
-import { DEFAULT_HEIGHTS, VirtualizedTraceViewImpl, getCriticalPathSections } from './VirtualizedTraceView';
+
+import {
+  buildCriticalPathIndex,
+  buildPrunedCriticalPaths,
+  getVisibleCriticalPathSections,
+} from './criticalPath';
+import { DEFAULT_HEIGHTS, VirtualizedTraceViewImpl } from './VirtualizedTraceView';
 import traceGenerator from '../../../demo/trace-generators';
 import transformTraceData from '../../../model/transform-trace-data';
 import updateUiFindSpy from '../../../utils/update-ui-find';
@@ -525,7 +531,16 @@ describe('<VirtualizedTraceViewImpl>', () => {
 
     it('returns [] from mergeChildrenCriticalPath when criticalPath is falsy', () => {
       const span = trace.spans[0];
-      const result = getCriticalPathSections(true, false, trace, span, undefined, new Set());
+
+      const result = getVisibleCriticalPathSections(
+        true,
+        false,
+        trace,
+        span,
+        undefined,
+        buildCriticalPathIndex([]),
+        new Map()
+      );
       expect(result).toEqual([]);
     });
 
@@ -556,13 +571,15 @@ describe('<VirtualizedTraceViewImpl>', () => {
         { spanID: 'pruned-child', sectionStart: 10, sectionEnd: 20 },
         { spanID: 'visible-child', sectionStart: 20, sectionEnd: 30 },
       ];
-      const result = getCriticalPathSections(
+
+      const result = getVisibleCriticalPathSections(
         false,
         true,
         customTrace,
         parentSpan,
         fakeCriticalPath,
-        new Set(['svc-pruned'])
+        buildCriticalPathIndex(fakeCriticalPath),
+        buildPrunedCriticalPaths(fakeCriticalPath, new Set(['svc-pruned']), customTrace.spans)
       );
       const spanIDs = result.map(s => s.spanID);
       expect(spanIDs).toContain('parent');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
@@ -544,6 +544,80 @@ describe('<VirtualizedTraceViewImpl>', () => {
       expect(result).toEqual([]);
     });
 
+    it('merges consecutive child and parent critical path sections when row is collapsed', () => {
+      const childSpan = {
+        ...trace.spans[1],
+        spanID: 'child',
+        hasChildren: false,
+        childSpans: [],
+      };
+      const parentSpan = {
+        ...trace.spans[0],
+        spanID: 'parent',
+        hasChildren: true,
+        childSpans: [childSpan],
+      };
+      const customTrace = {
+        ...trace,
+        spans: [parentSpan, childSpan],
+        spanMap: new Map([
+          [parentSpan.spanID, parentSpan],
+          [childSpan.spanID, childSpan],
+        ]),
+      };
+      const fakeCriticalPath = [
+        { spanID: 'parent', sectionStart: 10, sectionEnd: 20 },
+        { spanID: 'child', sectionStart: 0, sectionEnd: 10 },
+      ];
+
+      const result = getVisibleCriticalPathSections(
+        true,
+        false,
+        customTrace,
+        parentSpan,
+        fakeCriticalPath,
+        buildCriticalPathIndex(fakeCriticalPath),
+        new Map()
+      );
+
+      expect(result).toEqual([{ spanID: 'parent', sectionStart: 0, sectionEnd: 20 }]);
+    });
+
+    it('collects critical path sections from descendants of pruned children', () => {
+      const grandchildSpan = {
+        ...trace.spans[2],
+        spanID: 'grandchild',
+        hasChildren: false,
+        childSpans: [],
+        resource: { ...trace.spans[2].resource, serviceName: 'svc-grandchild' },
+      };
+      const prunedChild = {
+        ...trace.spans[1],
+        spanID: 'pruned-child',
+        hasChildren: true,
+        childSpans: [grandchildSpan],
+        resource: { ...trace.spans[1].resource, serviceName: 'svc-pruned' },
+      };
+      const parentSpan = {
+        ...trace.spans[0],
+        spanID: 'parent',
+        hasChildren: true,
+        childSpans: [prunedChild],
+      };
+      const fakeCriticalPath = [
+        { spanID: 'pruned-child', sectionStart: 10, sectionEnd: 20 },
+        { spanID: 'grandchild', sectionStart: 20, sectionEnd: 30 },
+      ];
+
+      const result = buildPrunedCriticalPaths(
+        buildCriticalPathIndex(fakeCriticalPath),
+        new Set(['svc-pruned']),
+        [parentSpan, prunedChild, grandchildSpan]
+      );
+
+      expect(result.get('parent')).toEqual(fakeCriticalPath);
+    });
+
     it('merges only pruned subtree critical path when hasPrunedChildren is true', () => {
       const prunedChild = {
         spanID: 'pruned-child',
@@ -571,6 +645,7 @@ describe('<VirtualizedTraceViewImpl>', () => {
         { spanID: 'pruned-child', sectionStart: 10, sectionEnd: 20 },
         { spanID: 'visible-child', sectionStart: 20, sectionEnd: 30 },
       ];
+      const pathBySpanID = buildCriticalPathIndex(fakeCriticalPath);
 
       const result = getVisibleCriticalPathSections(
         false,
@@ -578,8 +653,8 @@ describe('<VirtualizedTraceViewImpl>', () => {
         customTrace,
         parentSpan,
         fakeCriticalPath,
-        buildCriticalPathIndex(fakeCriticalPath),
-        buildPrunedCriticalPaths(fakeCriticalPath, new Set(['svc-pruned']), customTrace.spans)
+        pathBySpanID,
+        buildPrunedCriticalPaths(pathBySpanID, new Set(['svc-pruned']), customTrace.spans)
       );
       const spanIDs = result.map(s => s.spanID);
       expect(spanIDs).toContain('parent');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -6,11 +6,15 @@ import { useCallback, useEffect, useRef } from 'react';
 import cx from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import _isEqual from 'lodash/isEqual';
-import _groupBy from 'lodash/groupBy';
 
 import memoizeOne from 'memoize-one';
 import type { Location, NavigateFunction } from 'react-router-dom';
 import { actions } from './duck';
+import {
+  buildCriticalPathIndex,
+  buildPrunedCriticalPaths,
+  getVisibleCriticalPathSections,
+} from './criticalPath';
 import generateRowStates, { RowState } from './generateRowStates';
 import ListView from './ListView';
 import PrunedSpanRow from './PrunedSpanRow';
@@ -114,138 +118,17 @@ function getCssClasses(currentViewRange: [number, number]) {
   });
 }
 
-function mergeChildrenCriticalPath(
-  trace: IOtelTrace,
-  spanID: string,
-  criticalPath: CriticalPathSection[]
-): CriticalPathSection[] {
-  if (!criticalPath) {
-    return [];
-  }
-  // Define an array to store the IDs of the span and its descendants (if the span is collapsed)
-  const allRequiredSpanIds = new Set<string>([spanID]);
-
-  // Use pre-built spanMap
-  const spanMap = trace.spanMap;
-
-  // If the span is collapsed, recursively find all of its descendants.
-  const findAllDescendants = (span: IOtelSpan) => {
-    if (span.hasChildren && span.childSpans.length > 0) {
-      span.childSpans.forEach(child => {
-        allRequiredSpanIds.add(child.spanID);
-        findAllDescendants(child);
-      });
-    }
-  };
-
-  // Start from the initially selected span
-  const startingSpan = spanMap.get(spanID);
-  if (startingSpan) {
-    findAllDescendants(startingSpan);
-  }
-
-  const criticalPathSections: CriticalPathSection[] = [];
-  criticalPath.forEach(each => {
-    if (allRequiredSpanIds.has(each.spanID)) {
-      if (criticalPathSections.length !== 0 && each.sectionEnd === criticalPathSections[0].sectionStart) {
-        // Merge Critical Paths if they are consecutive
-        criticalPathSections[0].sectionStart = each.sectionStart;
-      } else {
-        criticalPathSections.unshift({ ...each });
-      }
-    }
-  });
-
-  return criticalPathSections;
-}
-
 const memoizedGenerateRowStates = memoizeOne(generateRowStatesFromTrace);
 const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc, _isEqual);
 const memoizedGetCssClasses = memoizeOne(getCssClasses, _isEqual);
-const memoizedCriticalPathsBySpanID = memoizeOne((criticalPath: CriticalPathSection[]) =>
-  _groupBy(criticalPath, x => x.spanID)
-);
+const memoizedCriticalPathsBySpanID = memoizeOne(buildCriticalPathIndex);
 
 /**
  * Precompute bubbled critical path sections for all parents with pruned children.
  * Returns a map from parent spanID → merged critical path sections from pruned subtrees.
  * Memoized so it runs once per render cycle (when criticalPath/prunedServices/spans change).
  */
-const memoizedPrunedCriticalPaths = memoizeOne(
-  (
-    criticalPath: CriticalPathSection[],
-    prunedServices: Set<string>,
-    spans: ReadonlyArray<IOtelSpan>
-  ): Map<string, CriticalPathSection[]> => {
-    if (prunedServices.size === 0) return new Map();
-    const pathBySpanID = memoizedCriticalPathsBySpanID(criticalPath);
-    const result = new Map<string, CriticalPathSection[]>();
-
-    const collectFromSubtree = (s: IOtelSpan, sections: CriticalPathSection[]) => {
-      const spanSections = pathBySpanID[s.spanID];
-      if (spanSections) {
-        for (const section of spanSections) {
-          sections.push({ ...section });
-        }
-      }
-      for (const child of s.childSpans) {
-        collectFromSubtree(child, sections);
-      }
-    };
-
-    for (const span of spans) {
-      if (!span.hasChildren) continue;
-      const prunedSections: CriticalPathSection[] = [];
-      for (const child of span.childSpans) {
-        if (prunedServices.has(child.resource.serviceName)) {
-          collectFromSubtree(child, prunedSections);
-        }
-      }
-      if (prunedSections.length > 0) {
-        result.set(span.spanID, prunedSections);
-      }
-    }
-    return result;
-  }
-);
-
-/**
- * Critical path display invariant: a span's bar shows the critical path sections of
- * itself and all spans hidden beneath it, whether hidden by collapse or service filter.
- * - Collapsed: mergeChildrenCriticalPath collects the full subtree (pruning-unaware,
- *   which is correct — a collapsed subtree is entirely hidden regardless of filter).
- * - Expanded with pruned direct children: own sections + pruned subtree sections bubbled
- *   up via memoizedPrunedCriticalPaths. Only direct-child pruning needs handling because
- *   the service filter prunes entire subtrees, so the direct parent is always the nearest
- *   visible ancestor of a pruned span.
- */
-// export for tests
-export function getCriticalPathSections(
-  isCollapsed: boolean,
-  hasPrunedChildren: boolean,
-  trace: IOtelTrace,
-  span: IOtelSpan,
-  criticalPath: CriticalPathSection[],
-  prunedServices: Set<string>
-): CriticalPathSection[] {
-  if (isCollapsed) {
-    return mergeChildrenCriticalPath(trace, span.spanID, criticalPath);
-  }
-
-  const pathBySpanID = memoizedCriticalPathsBySpanID(criticalPath);
-  const ownSections = span.spanID in pathBySpanID ? pathBySpanID[span.spanID] : [];
-
-  if (hasPrunedChildren) {
-    // Precomputed map of parent spanID → critical path sections from pruned subtrees.
-    const prunedPaths = memoizedPrunedCriticalPaths(criticalPath, prunedServices, trace.spans);
-    const prunedSections = prunedPaths.get(span.spanID);
-    if (prunedSections && prunedSections.length > 0) {
-      return [...ownSections, ...prunedSections];
-    }
-  }
-
-  return ownSections;
-}
+const memoizedPrunedCriticalPaths = memoizeOne(buildPrunedCriticalPaths);
 
 // export for tests
 export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceViewImpl(
@@ -494,13 +377,16 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
       const hasPrunedChildren =
         prunedServices.size > 0 &&
         span.childSpans.some(child => prunedServices.has(child.resource.serviceName));
-      const criticalPathSections = getCriticalPathSections(
+      const pathBySpanID = memoizedCriticalPathsBySpanID(criticalPath);
+      const prunedPaths = memoizedPrunedCriticalPaths(criticalPath, prunedServices, trace.spans);
+      const criticalPathSections = getVisibleCriticalPathSections(
         isCollapsed,
         hasPrunedChildren,
         trace,
         span,
         criticalPath,
-        prunedServices
+        pathBySpanID,
+        prunedPaths
       );
       // Check for direct child "server" span if the span is a "client" span.
       let rpc = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -122,11 +122,13 @@ const memoizedGenerateRowStates = memoizeOne(generateRowStatesFromTrace);
 const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc, _isEqual);
 const memoizedGetCssClasses = memoizeOne(getCssClasses, _isEqual);
 const memoizedCriticalPathsBySpanID = memoizeOne(buildCriticalPathIndex);
+const emptyCriticalPathIndex: ReturnType<typeof buildCriticalPathIndex> = {};
+const emptyPrunedPaths = new Map<string, CriticalPathSection[]>();
 
 /**
  * Precompute bubbled critical path sections for all parents with pruned children.
  * Returns a map from parent spanID → merged critical path sections from pruned subtrees.
- * Memoized so it runs once per render cycle (when criticalPath/prunedServices/spans change).
+ * Memoized so it runs once per render cycle (when pathBySpanID/prunedServices/spans change).
  */
 const memoizedPrunedCriticalPaths = memoizeOne(buildPrunedCriticalPaths);
 
@@ -377,17 +379,32 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
       const hasPrunedChildren =
         prunedServices.size > 0 &&
         span.childSpans.some(child => prunedServices.has(child.resource.serviceName));
-      const pathBySpanID = memoizedCriticalPathsBySpanID(criticalPath);
-      const prunedPaths = memoizedPrunedCriticalPaths(criticalPath, prunedServices, trace.spans);
-      const criticalPathSections = getVisibleCriticalPathSections(
-        isCollapsed,
-        hasPrunedChildren,
-        trace,
-        span,
-        criticalPath,
-        pathBySpanID,
-        prunedPaths
-      );
+      let criticalPathSections: CriticalPathSection[];
+      if (isCollapsed) {
+        criticalPathSections = getVisibleCriticalPathSections(
+          isCollapsed,
+          hasPrunedChildren,
+          trace,
+          span,
+          criticalPath,
+          emptyCriticalPathIndex,
+          emptyPrunedPaths
+        );
+      } else {
+        const pathBySpanID = memoizedCriticalPathsBySpanID(criticalPath);
+        const prunedPaths = hasPrunedChildren
+          ? memoizedPrunedCriticalPaths(pathBySpanID, prunedServices, trace.spans)
+          : emptyPrunedPaths;
+        criticalPathSections = getVisibleCriticalPathSections(
+          isCollapsed,
+          hasPrunedChildren,
+          trace,
+          span,
+          criticalPath,
+          pathBySpanID,
+          prunedPaths
+        );
+      }
       // Check for direct child "server" span if the span is a "client" span.
       let rpc = null;
       if (isCollapsed) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import cx from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import _isEqual from 'lodash/isEqual';
@@ -10,11 +10,7 @@ import _isEqual from 'lodash/isEqual';
 import memoizeOne from 'memoize-one';
 import type { Location, NavigateFunction } from 'react-router-dom';
 import { actions } from './duck';
-import {
-  buildCriticalPathIndex,
-  buildPrunedCriticalPaths,
-  getVisibleCriticalPathSections,
-} from './criticalPath';
+import { makeCriticalPathContext } from './criticalPath';
 import generateRowStates, { RowState } from './generateRowStates';
 import ListView from './ListView';
 import PrunedSpanRow from './PrunedSpanRow';
@@ -121,16 +117,6 @@ function getCssClasses(currentViewRange: [number, number]) {
 const memoizedGenerateRowStates = memoizeOne(generateRowStatesFromTrace);
 const memoizedViewBoundsFunc = memoizeOne(createViewedBoundsFunc, _isEqual);
 const memoizedGetCssClasses = memoizeOne(getCssClasses, _isEqual);
-const memoizedCriticalPathsBySpanID = memoizeOne(buildCriticalPathIndex);
-const emptyCriticalPathIndex: ReturnType<typeof buildCriticalPathIndex> = {};
-const emptyPrunedPaths = new Map<string, CriticalPathSection[]>();
-
-/**
- * Precompute bubbled critical path sections for all parents with pruned children.
- * Returns a map from parent spanID → merged critical path sections from pruned subtrees.
- * Memoized so it runs once per render cycle (when pathBySpanID/prunedServices/spans change).
- */
-const memoizedPrunedCriticalPaths = memoizeOne(buildPrunedCriticalPaths);
 
 // export for tests
 export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceViewImpl(
@@ -140,6 +126,11 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
 
   const propsRef = useRef(props);
   propsRef.current = props;
+
+  const criticalPathContext = useMemo(
+    () => makeCriticalPathContext(props.trace, props.criticalPath, props.prunedServices),
+    [props.trace, props.criticalPath, props.prunedServices]
+  );
 
   const getRowStates = useCallback((): RowState[] => {
     const { trace, childrenHiddenIDs, detailStates, detailPanelMode, prunedServices } = propsRef.current;
@@ -359,7 +350,6 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
         selectedSpanID,
         timelineBarsVisible,
         trace,
-        criticalPath,
         useOtelTerms,
       } = propsRef.current;
       // to avert flow error
@@ -379,32 +369,7 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
       const hasPrunedChildren =
         prunedServices.size > 0 &&
         span.childSpans.some(child => prunedServices.has(child.resource.serviceName));
-      let criticalPathSections: CriticalPathSection[];
-      if (isCollapsed) {
-        criticalPathSections = getVisibleCriticalPathSections(
-          isCollapsed,
-          hasPrunedChildren,
-          trace,
-          span,
-          criticalPath,
-          emptyCriticalPathIndex,
-          emptyPrunedPaths
-        );
-      } else {
-        const pathBySpanID = memoizedCriticalPathsBySpanID(criticalPath);
-        const prunedPaths = hasPrunedChildren
-          ? memoizedPrunedCriticalPaths(pathBySpanID, prunedServices, trace.spans)
-          : emptyPrunedPaths;
-        criticalPathSections = getVisibleCriticalPathSections(
-          isCollapsed,
-          hasPrunedChildren,
-          trace,
-          span,
-          criticalPath,
-          pathBySpanID,
-          prunedPaths
-        );
-      }
+      const criticalPathSections = criticalPathContext.sectionsFor(span, isCollapsed, hasPrunedChildren);
       // Check for direct child "server" span if the span is a "client" span.
       let rpc = null;
       if (isCollapsed) {
@@ -460,7 +425,7 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
         </div>
       );
     },
-    [getClippingCssClasses, getViewedBounds, focusSpan]
+    [getClippingCssClasses, getViewedBounds, focusSpan, criticalPathContext]
   );
 
   const renderSpanDetailRow = useCallback(

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import _groupBy from 'lodash/groupBy';
-
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan, IOtelTrace } from '../../../types/otel';
 
@@ -51,11 +49,23 @@ function mergeChildrenCriticalPath(
   return criticalPathSections;
 }
 
-export function buildCriticalPathIndex(criticalPath: CriticalPathSection[]) {
-  return _groupBy(criticalPath, x => x.spanID);
+function buildCriticalPathIndex(criticalPath: CriticalPathSection[]) {
+  const result = new Map<string, CriticalPathSection[]>();
+  if (!criticalPath) return result;
+
+  for (const section of criticalPath) {
+    const sections = result.get(section.spanID);
+    if (sections) {
+      sections.push(section);
+    } else {
+      result.set(section.spanID, [section]);
+    }
+  }
+
+  return result;
 }
 
-export function buildPrunedCriticalPaths(
+function buildPrunedCriticalPaths(
   pathBySpanID: ReturnType<typeof buildCriticalPathIndex>,
   prunedServices: Set<string>,
   spans: ReadonlyArray<IOtelSpan>
@@ -64,7 +74,7 @@ export function buildPrunedCriticalPaths(
   const result = new Map<string, CriticalPathSection[]>();
 
   const collectFromSubtree = (s: IOtelSpan, sections: CriticalPathSection[]) => {
-    const spanSections = pathBySpanID[s.spanID];
+    const spanSections = pathBySpanID.get(s.spanID);
     if (spanSections) {
       for (const section of spanSections) {
         sections.push({ ...section });
@@ -100,7 +110,7 @@ export function buildPrunedCriticalPaths(
  *   the service filter prunes entire subtrees, so the direct parent is always the nearest
  *   visible ancestor of a pruned span.
  */
-export function getVisibleCriticalPathSections(
+function getVisibleCriticalPathSections(
   isCollapsed: boolean,
   hasPrunedChildren: boolean,
   trace: IOtelTrace,
@@ -113,7 +123,7 @@ export function getVisibleCriticalPathSections(
     return mergeChildrenCriticalPath(trace, span.spanID, criticalPath);
   }
 
-  const ownSections = span.spanID in pathBySpanID ? pathBySpanID[span.spanID] : [];
+  const ownSections = pathBySpanID.get(span.spanID) ?? [];
 
   if (hasPrunedChildren) {
     // Precomputed map of parent spanID → critical path sections from pruned subtrees.
@@ -124,4 +134,31 @@ export function getVisibleCriticalPathSections(
   }
 
   return ownSections;
+}
+
+export type CriticalPathContext = {
+  sectionsFor(span: IOtelSpan, isCollapsed: boolean, hasPrunedChildren: boolean): CriticalPathSection[];
+};
+
+export function makeCriticalPathContext(
+  trace: IOtelTrace,
+  criticalPath: CriticalPathSection[],
+  prunedServices: Set<string>
+): CriticalPathContext {
+  const index = buildCriticalPathIndex(criticalPath);
+  const pruned = buildPrunedCriticalPaths(index, prunedServices, trace.spans);
+
+  return {
+    sectionsFor(span, isCollapsed, hasPrunedChildren) {
+      return getVisibleCriticalPathSections(
+        isCollapsed,
+        hasPrunedChildren,
+        trace,
+        span,
+        criticalPath,
+        index,
+        pruned
+      );
+    },
+  };
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import _groupBy from 'lodash/groupBy';
+
+import { CriticalPathSection } from '../../../types/critical_path';
+import { IOtelSpan, IOtelTrace } from '../../../types/otel';
+
+function mergeChildrenCriticalPath(
+  trace: IOtelTrace,
+  spanID: string,
+  criticalPath: CriticalPathSection[]
+): CriticalPathSection[] {
+  if (!criticalPath) {
+    return [];
+  }
+  // Define an array to store the IDs of the span and its descendants (if the span is collapsed)
+  const allRequiredSpanIds = new Set<string>([spanID]);
+
+  // Use pre-built spanMap
+  const spanMap = trace.spanMap;
+
+  // If the span is collapsed, recursively find all of its descendants.
+  const findAllDescendants = (span: IOtelSpan) => {
+    if (span.hasChildren && span.childSpans.length > 0) {
+      span.childSpans.forEach(child => {
+        allRequiredSpanIds.add(child.spanID);
+        findAllDescendants(child);
+      });
+    }
+  };
+
+  // Start from the initially selected span
+  const startingSpan = spanMap.get(spanID);
+  if (startingSpan) {
+    findAllDescendants(startingSpan);
+  }
+
+  const criticalPathSections: CriticalPathSection[] = [];
+  criticalPath.forEach(each => {
+    if (allRequiredSpanIds.has(each.spanID)) {
+      if (criticalPathSections.length !== 0 && each.sectionEnd === criticalPathSections[0].sectionStart) {
+        // Merge Critical Paths if they are consecutive
+        criticalPathSections[0].sectionStart = each.sectionStart;
+      } else {
+        criticalPathSections.unshift({ ...each });
+      }
+    }
+  });
+
+  return criticalPathSections;
+}
+
+export function buildCriticalPathIndex(criticalPath: CriticalPathSection[]) {
+  return _groupBy(criticalPath, x => x.spanID);
+}
+
+export function buildPrunedCriticalPaths(
+  criticalPath: CriticalPathSection[],
+  prunedServices: Set<string>,
+  spans: ReadonlyArray<IOtelSpan>
+): Map<string, CriticalPathSection[]> {
+  if (prunedServices.size === 0) return new Map();
+  const pathBySpanID = buildCriticalPathIndex(criticalPath);
+  const result = new Map<string, CriticalPathSection[]>();
+
+  const collectFromSubtree = (s: IOtelSpan, sections: CriticalPathSection[]) => {
+    const spanSections = pathBySpanID[s.spanID];
+    if (spanSections) {
+      for (const section of spanSections) {
+        sections.push({ ...section });
+      }
+    }
+    for (const child of s.childSpans) {
+      collectFromSubtree(child, sections);
+    }
+  };
+
+  for (const span of spans) {
+    if (!span.hasChildren) continue;
+    const prunedSections: CriticalPathSection[] = [];
+    for (const child of span.childSpans) {
+      if (prunedServices.has(child.resource.serviceName)) {
+        collectFromSubtree(child, prunedSections);
+      }
+    }
+    if (prunedSections.length > 0) {
+      result.set(span.spanID, prunedSections);
+    }
+  }
+  return result;
+}
+
+/**
+ * Critical path display invariant: a span's bar shows the critical path sections of
+ * itself and all spans hidden beneath it, whether hidden by collapse or service filter.
+ * - Collapsed: mergeChildrenCriticalPath collects the full subtree (pruning-unaware,
+ *   which is correct — a collapsed subtree is entirely hidden regardless of filter).
+ * - Expanded with pruned direct children: own sections + pruned subtree sections bubbled
+ *   up via memoizedPrunedCriticalPaths. Only direct-child pruning needs handling because
+ *   the service filter prunes entire subtrees, so the direct parent is always the nearest
+ *   visible ancestor of a pruned span.
+ */
+export function getVisibleCriticalPathSections(
+  isCollapsed: boolean,
+  hasPrunedChildren: boolean,
+  trace: IOtelTrace,
+  span: IOtelSpan,
+  criticalPath: CriticalPathSection[],
+  pathBySpanID: ReturnType<typeof buildCriticalPathIndex>,
+  prunedPaths: Map<string, CriticalPathSection[]>
+) {
+  if (isCollapsed) {
+    return mergeChildrenCriticalPath(trace, span.spanID, criticalPath);
+  }
+
+  const ownSections = span.spanID in pathBySpanID ? pathBySpanID[span.spanID] : [];
+
+  if (hasPrunedChildren) {
+    // Precomputed map of parent spanID → critical path sections from pruned subtrees.
+    const prunedSections = prunedPaths.get(span.spanID);
+    if (prunedSections && prunedSections.length > 0) {
+      return [...ownSections, ...prunedSections];
+    }
+  }
+
+  return ownSections;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
@@ -56,12 +56,11 @@ export function buildCriticalPathIndex(criticalPath: CriticalPathSection[]) {
 }
 
 export function buildPrunedCriticalPaths(
-  criticalPath: CriticalPathSection[],
+  pathBySpanID: ReturnType<typeof buildCriticalPathIndex>,
   prunedServices: Set<string>,
   spans: ReadonlyArray<IOtelSpan>
 ): Map<string, CriticalPathSection[]> {
   if (prunedServices.size === 0) return new Map();
-  const pathBySpanID = buildCriticalPathIndex(criticalPath);
   const result = new Map<string, CriticalPathSection[]>();
 
   const collectFromSubtree = (s: IOtelSpan, sections: CriticalPathSection[]) => {


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #3771

## Description of the changes
-Added `criticalPath.ts` to hold critical path related helper functions.
-Extracted `buildCriticalPathIndex()` from `VirtualizedTraceView.tsx`.
-Extracted `buildPrunedCriticalPaths()` from `VirtualizedTraceView.tsx`.
-Extracted `getVisibleCriticalPathSections()` from `VirtualizedTraceView.tsx`.
-Kept memoizeOne wrappers in `VirtualizedTraceView.tsx` and delegated logic to the extracted helpers.
-Updated tests to use the extracted helper functions.

## How was this change tested?
-Ran `npm test`
-Ran `npm run lint`
-Ran `npm run tsc-lint`
-Ran `npm run build`
-Verified there are no user-visible behavior changes and all existing tests continue to pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
