### PR TITLE
Refactor: Standardize KeyValuePair typing across the DDG Model

### DIFF
--- a/packages/jaeger-ui/src/model/ddg/transformDdgData.ts
+++ b/packages/jaeger-ui/src/model/ddg/transformDdgData.ts
@@ -4,7 +4,7 @@
 import memoizeOne from 'memoize-one';
 import objectHash from 'object-hash';
 
-import { KeyValuePair } from '../../types/trace';
+import type { KeyValuePair } from '../../types/trace';
 
 import {
   PathElem,
@@ -18,7 +18,7 @@ import {
 
 const stringifyEntry = ({ service, operation }: TDdgPayloadEntry) => `${service}\v${operation}`;
 
-function group(arg: KeyValuePair<any>[]): Record<string, any[]> {
+function group(arg: KeyValuePair[]): Record<string, any[]> {
   const result: Record<string, any[]> = {};
   arg.forEach(({ key, value }) => {
     if (!result[key]) result[key] = [];

--- a/packages/jaeger-ui/src/model/ddg/transformDdgData.ts
+++ b/packages/jaeger-ui/src/model/ddg/transformDdgData.ts
@@ -4,6 +4,8 @@
 import memoizeOne from 'memoize-one';
 import objectHash from 'object-hash';
 
+import { KeyValuePair } from '../../types/trace';
+
 import {
   PathElem,
   TDdgModel,
@@ -16,8 +18,7 @@ import {
 
 const stringifyEntry = ({ service, operation }: TDdgPayloadEntry) => `${service}\v${operation}`;
 
-// TODO: Everett Tech Debt: Fix KeyValuePair types
-function group(arg: { key: string; value: any }[]): Record<string, any[]> {
+function group(arg: KeyValuePair<any>[]): Record<string, any[]> {
   const result: Record<string, any[]> = {};
   arg.forEach(({ key, value }) => {
     if (!result[key]) result[key] = [];

--- a/packages/jaeger-ui/src/model/ddg/types.ts
+++ b/packages/jaeger-ui/src/model/ddg/types.ts
@@ -7,6 +7,8 @@ import PathElem from './PathElem';
 
 export { default as PathElem } from './PathElem';
 
+import { KeyValuePair } from '../../types/trace';
+
 export enum EViewModifier {
   None,
   Hovered,
@@ -41,11 +43,7 @@ export type TDdgPayloadEntry = {
 
 export type TDdgPayloadPath = {
   path: TDdgPayloadEntry[];
-  // TODO: Everett Tech Debt: Fix KeyValuePair types
-  attributes: {
-    key: 'exemplar_trace_id';
-    value: string;
-  }[];
+  attributes: KeyValuePair[];
 };
 
 export type TDdgPayload = {

--- a/packages/jaeger-ui/src/model/ddg/types.ts
+++ b/packages/jaeger-ui/src/model/ddg/types.ts
@@ -7,7 +7,7 @@ import PathElem from './PathElem';
 
 export { default as PathElem } from './PathElem';
 
-import { KeyValuePair } from '../../types/trace';
+import type { KeyValuePair } from '../../types/trace';
 
 export enum EViewModifier {
   None,
@@ -43,7 +43,7 @@ export type TDdgPayloadEntry = {
 
 export type TDdgPayloadPath = {
   path: TDdgPayloadEntry[];
-  attributes: KeyValuePair[];
+  attributes: (KeyValuePair & { key: 'exemplar_trace_id'; value: string })[];
 };
 
 export type TDdgPayload = {


### PR DESCRIPTION
**Resolves:** #4050
#### Context & Motivation
While reviewing the DDG (Data-Driven Dependency Graph) model, I noticed scattered technical debt related to type definitions. Specifically, key-value pair structures were being defined using inline, hardcoded object arrays (e.g., `{ key: string; value: any }[]`). 
Not only did this bypass Jaeger's globally established `KeyValuePair` type, but it also left behind legacy `TODO` comments indicating the need for a unified type strategy. This PR resolves that debt, making the DDG domain more robust and DRY.
#### Implementation Details
This PR strips out the redundant inline types and enforces the use of the global `KeyValuePair` interface:
*   **`src/model/ddg/types.ts`**: Imported `KeyValuePair` from `src/types/trace.ts` and refactored the `TDdgPayloadPath` interface to leverage it for the `attributes` property.
*   **`src/model/ddg/transformDdgData.ts`**: Updated the `group` function's parameter signature to strictly accept `KeyValuePair<any>[]`, ensuring type safety maps correctly to the incoming DDG payloads.
*   **Cleanup**: Safely removed all legacy `// TODO: Everett Tech Debt` comments associated with this issue.
#### Impact
*   **Maintainability**: Centralizing the type definition ensures that any future changes to Jaeger's core key-value structures will automatically propagate to the DDG model.
*   **Type Safety**: Eliminates unchecked inline type declarations. 
#### Verification & Testing
To ensure these typing changes introduce no regressions, the following checks were successfully run:
- [x] **Type Check**: `npm run type-check` compiles flawlessly.
- [x] **Unit Tests**: `npm test` passes, verifying no functional logic was disrupted by the type enforcement.
- [x] **Code Quality**: `npm run fmt` and `npm run lint` report no new warnings. 
