### PR TITLE
fix(a11y): Add keyboard accessibility to interactive divs in TraceTimelineViewer

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -39,6 +39,13 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
     props.onDetailToggled(props.span.spanID);
   };
 
+  const _detailToggleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      props.onDetailToggled(props.span.spanID);
+    }
+  };
+
   const {
     color,
     nameColumnWidth,
@@ -68,8 +75,10 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
               className="detail-row-expanded-accent"
               aria-checked="true"
               onClick={_detailToggle}
+              onKeyDown={_detailToggleKeyDown}
               role="switch"
               style={{ borderColor: color }}
+              tabIndex={0}
             />
           </span>
         </TimelineRow.Cell>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineRow.tsx
@@ -20,7 +20,7 @@ function TimelineRowCell({
   className,
   width,
   style = {},
-  onClick = () => {},
+  onClick,
 }: {
   children: React.ReactNode;
   className?: string;
@@ -30,8 +30,23 @@ function TimelineRowCell({
 }) {
   const widthPercent = `${width * 100}%`;
   const mergedStyle = { ...style, flexBasis: widthPercent, maxWidth: widthPercent };
+  const handleKeyDown = onClick
+    ? (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick(e as unknown as React.MouseEvent<HTMLDivElement>);
+        }
+      }
+    : undefined;
   return (
-    <div className={`ub-relative ${className || ''}`} style={mergedStyle} onClick={onClick}>
+    <div
+      className={`ub-relative ${className || ''}`}
+      style={mergedStyle}
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={handleKeyDown}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
Resolves: #4065 
Context & Motivation
Interactive elements in TimelineRow.Cell and SpanDetailRow were using onClick handlers on div/span elements without the corresponding keyboard support, making them unreachable for keyboard-only users.

Implementation Details
This PR adds keyboard accessibility (tabIndex, role, and onKeyDown) to these interactive elements:

TimelineRow.Cell: when an onClick handler is provided, now adds role="button", tabIndex={0}, and an onKeyDown handler (Enter/Space) so the span-view column is focusable and activatable by keyboard. Also dropped the no-op default onClick so interactive-ness can be reliably detected without an extra prop.

SpanDetailRow: the .detail-row-expanded-accent span already had role="switch" and aria-checked but was missing tabIndex={0} and onKeyDown. Added both to match the pattern already in SpanBarRow.

Impact
Accessibility: Keyboard-only users can now navigate and interact with the trace timeline rows.

Verification & Testing
To ensure these accessibility changes introduce no regressions, the following checks were successfully run:

Unit Tests: All 2865 tests pass.

Code Quality: npm run fmt, npm run lint, and npm run build pass clean.