### PR TITLE
Prevent ClickToCopy from triggering parent link navigation

### DIFF
--- a/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
@@ -57,6 +57,24 @@ describe('<ClickToCopy />', () => {
     expect(parentClickHandler).not.toHaveBeenCalled();
   });
 
+  it('calls preventDefault on click to avoid parent link navigation', () => {
+    render(<ClickToCopy text={textToCopy}>{childText}</ClickToCopy>);
+    const span = screen.getByRole('button', { name: /Copy to clipboard/i });
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    span.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on Enter/Space keydown to avoid parent link navigation', () => {
+    render(<ClickToCopy text={textToCopy}>{childText}</ClickToCopy>);
+    const span = screen.getByRole('button', { name: /Copy to clipboard/i });
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    const preventDefaultSpy = jest.spyOn(enterEvent, 'preventDefault');
+    span.dispatchEvent(enterEvent);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
   it('shows "Copied to clipboard" when clicked and resets after timeout', async () => {
     jest.useFakeTimers();
     render(

--- a/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
@@ -51,6 +51,7 @@ function ClickToCopy({ text, className = '', children }: Props) {
 
   const whenClicked = (e: React.MouseEvent<HTMLSpanElement>) => {
     e.stopPropagation();
+    e.preventDefault();
     doCopy();
   };
 
@@ -62,8 +63,8 @@ function ClickToCopy({ text, className = '', children }: Props) {
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.stopPropagation();
-            doCopy();
             e.preventDefault();
+            doCopy();
           }
         }}
         role="button"


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4075

## Description of the changes
- Added `e.preventDefault()` to `ClickToCopy`'s click and keydown handlers so that clicking the trace ID in search results only copies text and does not trigger the parent `<a>` tag's native navigation.

## How was this change tested?
Added and ran tests

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (writing the test)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes