### PR TITLE
fix(plexus): Use currentColor for DDG edge weight labels in dark mode

### DIFF
--- a/packages/plexus/src/Digraph/SvgEdge.tsx
+++ b/packages/plexus/src/Digraph/SvgEdge.tsx
@@ -76,7 +76,7 @@ function SvgEdge<U = {}>(props: TProps<U>) {
       />
 
       {label && (
-        <text x={labelX} y={labelY} fill="#000" fontSize="1rem" fontWeight="bold">
+        <text x={labelX} y={labelY} fill="currentColor" fontSize="1rem" fontWeight="bold">
           {label}
         </text>
       )}

--- a/packages/plexus/src/Digraph/SvgEdgesLayer.test.jsx
+++ b/packages/plexus/src/Digraph/SvgEdgesLayer.test.jsx
@@ -103,9 +103,9 @@ describe('SvgEdgesLayer', () => {
       expect(SvgLayer.lastProps.classNamePart).toBe('SvgEdgesLayer');
     });
 
-    it('passes extraWrapper with black stroke to SvgLayer', () => {
+    it('passes extraWrapper with currentColor stroke to SvgLayer', () => {
       render(<SvgEdgesLayer {...defaultProps} />);
-      expect(SvgLayer.lastProps.extraWrapper).toEqual({ stroke: '#000' });
+      expect(SvgLayer.lastProps.extraWrapper).toEqual({ stroke: 'currentColor' });
     });
 
     it('passes getClassName to SvgLayer', () => {

--- a/packages/plexus/src/Digraph/SvgEdgesLayer.tsx
+++ b/packages/plexus/src/Digraph/SvgEdgesLayer.tsx
@@ -13,10 +13,12 @@ type TProps<T = {}, U = {}> = Omit<TStandaloneEdgesLayer<T, U>, 'edges' | 'layer
   standalone?: boolean;
 };
 
-// Add the default black stroke on an outer <g> so CSS classes or styles
-// on the inner <g> can override it
-// TODO: A more configurable approach to setting a default stroke color
-const INHERIT_STROKE = { stroke: '#000' };
+// Apply the default stroke on the outer <g> so that CSS classes or styles on the
+// inner <g> can still override it per-edge. We use `currentColor` here instead of
+// a hardcoded color — it inherits the CSS `color` property from the nearest ancestor
+// that sets it, which Ant Design's theme engine handles correctly for both light and
+// dark modes (avoiding the invisible-black-on-dark-background bug).
+const DEFAULT_STROKE_STYLE = { stroke: 'currentColor' };
 
 const SvgEdgesLayer = <T = {}, U = {}>(props: TProps<T, U>) => {
   const { getClassName, graphState, markerEndId, markerStartId, setOnEdge } = props;
@@ -27,7 +29,7 @@ const SvgEdgesLayer = <T = {}, U = {}>(props: TProps<T, U>) => {
   }
 
   return (
-    <SvgLayer {...props} classNamePart="SvgEdgesLayer" extraWrapper={INHERIT_STROKE}>
+    <SvgLayer {...props} classNamePart="SvgEdgesLayer" extraWrapper={DEFAULT_STROKE_STYLE}>
       <SvgEdges
         getClassName={getClassName}
         layoutEdges={layoutEdges}


### PR DESCRIPTION
Resolves: #4070

## Context & Motivation

I was testing the System Architecture graph in Dark Mode and noticed the numbers
on the arrows connecting services were completely invisible. After digging into the
code, I found that the edge weight labels in `SvgEdge.tsx` had a hardcoded
`fill="#000"` — solid black text on a dark background. Similarly, `SvgEdgesLayer.tsx`
had `stroke: '#000'` hardcoded as the default edge stroke, with a pre-existing TODO
comment acknowledging it needed to be fixed.

Yurishkuro confirmed this is a bug — fallout from the dark theme migration.

## Screenshots

**Before (broken — labels invisible in dark mode):**
<img width="1280" height="822" alt="image" src="https://github.com/user-attachments/assets/71b5ced6-9b45-4b0a-a08d-1d174afe412d" />


**After (fixed — labels readable in dark mode):**
<img width="1918" height="1151" alt="Screenshot 2026-06-15 092044" src="https://github.com/user-attachments/assets/c7c34310-cf5b-40fd-8bbf-b53e35bc818b" />


## Implementation Details

The fix replaces hardcoded `#000` with `currentColor`, which is the SVG standard
way to inherit color from the CSS `color` property. Since Ant Design's theme engine
already sets `color` correctly for both light and dark modes, this just works.

- **`SvgEdge.tsx`** — changed `fill="#000"` to `fill="currentColor"` on the label text
- **`SvgEdgesLayer.tsx`** — changed `stroke: '#000'` to `stroke: 'currentColor'` and
  cleaned up the stale TODO comment
- **`SvgEdgesLayer.test.jsx`** — updated the existing assertion to match the new value

I went with `currentColor` instead of `var(--text-secondary)` because CSS variables
don't work as inline SVG attributes — they only work in CSS property context.
`currentColor` is the right tool here and is already used elsewhere for icon colors.

## Impact

- Edge weight labels are now readable in dark mode
- Light mode looks exactly the same — the DDG's CSS (`stroke: #444` on `.Ddg--Edges`)
  still overrides the stroke for arrow lines
- Removed a hardcoded magic value and a stale TODO from the plexus library

## Testing

- ✅ `npm run tsc-lint` — no type errors
- ✅ `npm test` — all 2,980 tests pass
- ✅ `npm run fmt` — no formatting changes needed
- ✅ `npm run build` — builds successfully
