### PR TITLE
fix(search): Keep back-to-search across find and trace ID clicks

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/useServiceFilter.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/useServiceFilter.tsx
@@ -201,11 +201,15 @@ export function useServiceFilter(
     }
     if (cleanSearch != null && cleanSearch !== location.search) {
       skipDefaultsRef.current = true;
-      navigate({ pathname: location.pathname, search: cleanSearch }, { replace: true });
+      navigate(
+        { pathname: location.pathname, search: cleanSearch },
+        { replace: true, state: location.state }
+      );
     }
   }, [
     location.pathname,
     location.search,
+    location.state,
     navigate,
     rootServiceNames,
     sortedServiceNames,
@@ -235,7 +239,7 @@ export function useServiceFilter(
       }
 
       const search = buildFilterSearch(location.search, sortedServiceNames, nextPruned);
-      navigate({ pathname: location.pathname, search }, { replace: true });
+      navigate({ pathname: location.pathname, search }, { replace: true, state: location.state });
     },
     [
       zustandSetPrunedServices,
@@ -244,6 +248,7 @@ export function useServiceFilter(
       trace.spanMap,
       location.pathname,
       location.search,
+      location.state,
       sortedServiceNames,
       navigate,
     ]

--- a/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
@@ -76,10 +76,6 @@ describe('<ClickToCopy />', () => {
     const spaceKeyDown = createEvent.keyDown(span, { key: ' ', code: 'Space' });
     fireEvent(span, spaceKeyDown);
     expect(spaceKeyDown.defaultPrevented).toBe(true);
-
-    const spaceKeyUp = createEvent.keyUp(span, { key: ' ', code: 'Space' });
-    fireEvent(span, spaceKeyUp);
-    expect(spaceKeyUp.defaultPrevented).toBe(true);
   });
 
   it('shows "Copied to clipboard" when clicked and resets after timeout', async () => {
@@ -117,7 +113,6 @@ describe('<ClickToCopy />', () => {
     expect(copySpy).toHaveBeenCalledWith('copy');
 
     fireEvent.keyDown(button, { key: ' ', code: 'Space' });
-    fireEvent.keyUp(button, { key: ' ', code: 'Space' });
     expect(copySpy).toHaveBeenCalledTimes(2);
 
     copySpy.mockRestore();

--- a/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
@@ -57,6 +57,24 @@ describe('<ClickToCopy />', () => {
     expect(parentClickHandler).not.toHaveBeenCalled();
   });
 
+  it('calls preventDefault on click to avoid parent link navigation', () => {
+    render(<ClickToCopy text={textToCopy}>{childText}</ClickToCopy>);
+    const span = screen.getByRole('button', { name: /Copy to clipboard/i });
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    span.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on Enter/Space keydown to avoid parent link navigation', () => {
+    render(<ClickToCopy text={textToCopy}>{childText}</ClickToCopy>);
+    const span = screen.getByRole('button', { name: /Copy to clipboard/i });
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    const preventDefaultSpy = jest.spyOn(enterEvent, 'preventDefault');
+    span.dispatchEvent(enterEvent);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
   it('shows "Copied to clipboard" when clicked and resets after timeout', async () => {
     jest.useFakeTimers();
     render(

--- a/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, createEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ClickToCopy from './ClickToCopy';
 import { act } from '@testing-library/react';
@@ -57,22 +57,29 @@ describe('<ClickToCopy />', () => {
     expect(parentClickHandler).not.toHaveBeenCalled();
   });
 
-  it('calls preventDefault on click to avoid parent link navigation', () => {
+  it('prevents default on click to avoid parent link navigation', () => {
     render(<ClickToCopy text={textToCopy}>{childText}</ClickToCopy>);
     const span = screen.getByRole('button', { name: /Copy to clipboard/i });
-    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
-    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
-    span.dispatchEvent(event);
-    expect(preventDefaultSpy).toHaveBeenCalled();
+    const event = createEvent.click(span);
+    fireEvent(span, event);
+    expect(event.defaultPrevented).toBe(true);
   });
 
-  it('calls preventDefault on Enter/Space keydown to avoid parent link navigation', () => {
+  it('prevents default on Enter and Space keyboard activation', () => {
     render(<ClickToCopy text={textToCopy}>{childText}</ClickToCopy>);
     const span = screen.getByRole('button', { name: /Copy to clipboard/i });
-    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-    const preventDefaultSpy = jest.spyOn(enterEvent, 'preventDefault');
-    span.dispatchEvent(enterEvent);
-    expect(preventDefaultSpy).toHaveBeenCalled();
+
+    const enterEvent = createEvent.keyDown(span, { key: 'Enter', code: 'Enter' });
+    fireEvent(span, enterEvent);
+    expect(enterEvent.defaultPrevented).toBe(true);
+
+    const spaceKeyDown = createEvent.keyDown(span, { key: ' ', code: 'Space' });
+    fireEvent(span, spaceKeyDown);
+    expect(spaceKeyDown.defaultPrevented).toBe(true);
+
+    const spaceKeyUp = createEvent.keyUp(span, { key: ' ', code: 'Space' });
+    fireEvent(span, spaceKeyUp);
+    expect(spaceKeyUp.defaultPrevented).toBe(true);
   });
 
   it('shows "Copied to clipboard" when clicked and resets after timeout', async () => {
@@ -110,7 +117,8 @@ describe('<ClickToCopy />', () => {
     expect(copySpy).toHaveBeenCalledWith('copy');
 
     fireEvent.keyDown(button, { key: ' ', code: 'Space' });
-    expect(copySpy).toHaveBeenCalledWith('copy');
+    fireEvent.keyUp(button, { key: ' ', code: 'Space' });
+    expect(copySpy).toHaveBeenCalledTimes(2);
 
     copySpy.mockRestore();
   });

--- a/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
@@ -55,28 +55,19 @@ function ClickToCopy({ text, className = '', children }: Props) {
     doCopy();
   };
 
+  const whenKeyDown = (e: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.stopPropagation();
+    e.preventDefault();
+    doCopy();
+  };
+
   return (
     <Tooltip title={isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}>
       <span
         className={className}
         onClick={whenClicked}
-        onKeyDown={e => {
-          if (e.key === 'Enter') {
-            e.stopPropagation();
-            e.preventDefault();
-            doCopy();
-          } else if (e.key === ' ') {
-            e.stopPropagation();
-            e.preventDefault();
-          }
-        }}
-        onKeyUp={e => {
-          if (e.key === ' ') {
-            e.stopPropagation();
-            e.preventDefault();
-            doCopy();
-          }
-        }}
+        onKeyDown={whenKeyDown}
         role="button"
         tabIndex={0}
         aria-label={isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}

--- a/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
@@ -61,7 +61,17 @@ function ClickToCopy({ text, className = '', children }: Props) {
         className={className}
         onClick={whenClicked}
         onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
+          if (e.key === 'Enter') {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+          } else if (e.key === ' ') {
+            e.stopPropagation();
+            e.preventDefault();
+          }
+        }}
+        onKeyUp={e => {
+          if (e.key === ' ') {
             e.stopPropagation();
             e.preventDefault();
             doCopy();

--- a/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
+++ b/packages/jaeger-ui/src/components/common/ClickToCopy.tsx
@@ -51,6 +51,7 @@ function ClickToCopy({ text, className = '', children }: Props) {
 
   const whenClicked = (e: React.MouseEvent<HTMLSpanElement>) => {
     e.stopPropagation();
+    e.preventDefault();
     doCopy();
   };
 
@@ -62,8 +63,8 @@ function ClickToCopy({ text, className = '', children }: Props) {
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.stopPropagation();
-            doCopy();
             e.preventDefault();
+            doCopy();
           }
         }}
         role="button"

--- a/packages/jaeger-ui/src/utils/update-ui-find.test.js
+++ b/packages/jaeger-ui/src/utils/update-ui-find.test.js
@@ -26,11 +26,13 @@ describe('updateUiFind', () => {
   const location = {
     pathname: '/trace/traceID',
     search: 'location.search',
+    state: { fromSearch: '/search?service=foo' },
   };
   const expectedNavigateArg = {
     pathname: location.pathname,
     search: `?${queryStringStringifySpyMockReturnValue}`,
   };
+  const expectedNavigateOptions = { replace: true, state: location.state };
 
   beforeEach(() => {
     navigate.mockReset();
@@ -54,7 +56,7 @@ describe('updateUiFind', () => {
       uiFind: newUiFind,
       [unrelatedQueryParamName]: unrelatedQueryParamValue,
     });
-    expect(navigate).toHaveBeenCalledWith(expectedNavigateArg, { replace: true });
+    expect(navigate).toHaveBeenCalledWith(expectedNavigateArg, expectedNavigateOptions);
   });
 
   it('omits falsy graphSearch from query params', () => {
@@ -67,7 +69,7 @@ describe('updateUiFind', () => {
     expect(stringifyMock).toHaveBeenCalledWith({
       [unrelatedQueryParamName]: unrelatedQueryParamValue,
     });
-    expect(navigate).toHaveBeenCalledWith(expectedNavigateArg, { replace: true });
+    expect(navigate).toHaveBeenCalledWith(expectedNavigateArg, expectedNavigateOptions);
   });
 
   it('omits absent graphSearch from query params', () => {
@@ -79,7 +81,7 @@ describe('updateUiFind', () => {
     expect(stringifyMock).toHaveBeenCalledWith({
       [unrelatedQueryParamName]: unrelatedQueryParamValue,
     });
-    expect(navigate).toHaveBeenCalledWith(expectedNavigateArg, { replace: true });
+    expect(navigate).toHaveBeenCalledWith(expectedNavigateArg, expectedNavigateOptions);
   });
 
   describe('trackFindFunction provided', () => {

--- a/packages/jaeger-ui/src/utils/update-ui-find.ts
+++ b/packages/jaeger-ui/src/utils/update-ui-find.ts
@@ -22,6 +22,6 @@ export default function updateUiFind({
   if (uiFind) (queryParams as Record<string, string>).uiFind = uiFind;
   navigate(
     { pathname: location.pathname, search: `?${queryString.stringify(queryParams)}` },
-    { replace: true }
+    { replace: true, state: location.state }
   );
 }


### PR DESCRIPTION
Resolves #4075

## Which problem is this PR solving?

The ← back-to-search button on the trace page disappeared in two cases after opening a trace from Search:

1. **Trace ID click** — The trace ID in search results sits inside a `<Link>` but uses `ClickToCopy`, which called `stopPropagation()`. React Router's handler never ran, so navigation happened via the native `<a href>` without `fromSearch` in router state.
2. **Find box** — Typing in the trace page Find input updated the URL via `updateUiFind` with `navigate(..., { replace: true })` but did not pass `state: location.state`, so `fromSearch` was dropped on every keystroke.

## Description of the changes

- **`ClickToCopy.tsx`** — Call `preventDefault()` on click and Enter/Space keydown so clicking a trace ID inside a search result link copies the ID without triggering parent link navigation.
- **`update-ui-find.ts`** — Preserve `location.state` (including `fromSearch`) when updating the `uiFind` query param.
- **`useServiceFilter.tsx`** — Preserve `location.state` when replacing the URL during service filter apply/initialization.

## How was this change tested?

Manual:
- Search → click trace **name** → trace page shows ← back button
- Search → click trace **ID** → ID copied, stays on search (no navigation)
- Search → click trace name → type in **Find** → ← back button remains visible
- Click ← → returns to filtered search results

Automated:
- `npm test -w packages/jaeger-ui -- src/components/common/ClickToCopy.test.jsx src/utils/update-ui-find.test.js src/components/TracePage/TraceTimelineViewer/useServiceFilter.test.ts`
- Pre-commit lint (`vp lint`) passes

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes