### PR TITLE
ci(renovate): Group @opentelemetry/* updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,12 @@
       "description": "@assistant-ui/* and @ag-ui/* share peer types (AssistantRuntime, HttpAgent); bumping them independently produces duplicate copies in node_modules and tsc errors. Pin exact versions (no ^) so npm dedupes a single copy."
     },
     {
+      "groupName": "opentelemetry",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@opentelemetry//"],
+      "description": "@opentelemetry/* packages share internal type contracts and version-locked peer deps; bump them together to avoid mismatches"
+    },
+    {
       "groupName": "do not apply patch upgrades to dependencies",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch", "digest"],


### PR DESCRIPTION
## Summary
- Adds a Renovate `packageRules` entry that groups all `@opentelemetry/*` packages into a single PR
- These packages share internal type contracts and version-locked peer deps, so bumping them together avoids mismatches

## Test plan
- [ ] Verify Renovate validates the config (Renovate Config Validator or dry-run)
- [ ] Next scheduled run should produce one grouped PR for any pending OTel updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)