### PR TITLE
ci(renovate): Group @emnapi/* updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,12 @@
       "description": "@opentelemetry/* packages share internal type contracts and version-locked peer deps; bump them together to avoid mismatches"
     },
     {
+      "groupName": "emnapi",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@emnapi//"],
+      "description": "@emnapi/* packages are platform bindings that must stay in lockstep"
+    },
+    {
       "groupName": "do not apply patch upgrades to dependencies",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch", "digest"],


### PR DESCRIPTION
## Summary
- Adds a Renovate `packageRules` entry that groups all `@emnapi/*` packages into a single PR
- These are platform bindings that must stay in lockstep

## Test plan
- [ ] Verify Renovate validates the config (Renovate Config Validator or dry-run)
- [ ] Next scheduled run should produce one grouped PR for any pending @emnapi updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)