### PR TITLE
ci: Add workflow to fix Dependabot lockfile format

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -1,0 +1,42 @@
+name: 'Fix Dependabot lockfile'
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['package-lock.json']
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: 'package.json'
+
+      - name: Upgrade npm to match engines
+        run: |
+          NPM_VERSION=$(node -p "require('./package.json').engines.npm.replace(/[^0-9.]/g, '')")
+          npm install -g npm@$NPM_VERSION
+
+      - name: Regenerate lockfile
+        run: npm install --package-lock-only
+
+      - name: Commit if changed
+        run: |
+          git diff --quiet package-lock.json && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          git commit -s -m "fix(deps): Regenerate lockfile with npm $(npm --version)"
+          git push


### PR DESCRIPTION
## Summary
- Dependabot bundles an older npm that omits `libc` fields when regenerating `package-lock.json`, producing noisy diffs
- This workflow triggers on Dependabot PRs that touch the lockfile, re-runs `npm install --package-lock-only` with the project's pinned npm version, and pushes the normalized result back

## How it works
1. Triggers on `pull_request` when `package-lock.json` changes and actor is `dependabot[bot]`
2. Checks out the PR branch with write access
3. Installs the npm version from `engines.npm` in `package.json`
4. Runs `npm install --package-lock-only` to regenerate the lockfile
5. Commits and pushes if there are changes

## Test plan
- [ ] Merge this, then observe next Dependabot security PR — the workflow should auto-commit a lockfile fixup
- [ ] Verify the fixup commit restores `libc` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)