### PR TITLE
fix(ci): Add --ignore-scripts to Dependabot lockfile regeneration

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -30,7 +30,7 @@ jobs:
           npm install -g npm@$NPM_VERSION
 
       - name: Regenerate lockfile
-        run: npm install --package-lock-only
+        run: npm install --package-lock-only --ignore-scripts
 
       - name: Commit if changed
         run: |


### PR DESCRIPTION
## Summary
- Fixes the Dependabot lockfile fixup workflow failing with `husky: not found`
- `npm install --package-lock-only` still triggers the `prepare` lifecycle script, but `node_modules` aren't present — adding `--ignore-scripts` skips it

## Test plan
- [ ] Re-run the failed workflow on an existing Dependabot PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)