### PR TITLE
fix(ci): Use full npm install and bump engines.npm to 11.13.0

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -30,7 +30,7 @@ jobs:
           npm install -g npm@$NPM_VERSION
 
       - name: Regenerate lockfile
-        run: npm install --package-lock-only --ignore-scripts
+        run: npm install --ignore-scripts
 
       - name: Commit if changed
         run: |

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": ">=24.6.0",
-    "npm": ">=11.6.0"
+    "npm": ">=11.13.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.6",


### PR DESCRIPTION
## Summary
- Fixes the Dependabot lockfile fixup workflow still producing diffs with missing `libc` fields
- Root cause: `--package-lock-only` doesn't fully resolve platform bindings, so npm skips writing `libc` metadata
- Fix: use `npm install --ignore-scripts` (full resolution) instead
- Also bumps `engines.npm` from `>=11.6.0` to `>=11.13.0` — the CI was installing 11.6.0 which predates consistent `libc` field writing. The lockfile on main was generated with 11.13.0

## Test plan
- [ ] After merge, re-run the workflow on PR #4059 (or wait for next Dependabot PR)
- [ ] Verify the lockfile diff no longer removes `libc` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)