### PR TITLE
Cancel pending event reflow timers

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -189,6 +189,46 @@ describe('<AccordionEvents>', () => {
     jest.useRealTimers();
   });
 
+  it('cancels pending reflow timers when unmounted', () => {
+    jest.useFakeTimers();
+    const originalDispatchEvent = window.dispatchEvent;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    const mockDispatchEvent = jest.fn();
+
+    window.dispatchEvent = mockDispatchEvent;
+    window.requestAnimationFrame = jest.fn(callback => window.setTimeout(callback, 16));
+    window.cancelAnimationFrame = jest.fn(id => window.clearTimeout(id));
+
+    const manyLogs = Array.from({ length: 5 }, (_, i) => ({
+      timestamp: 10 + i,
+      name: 'event',
+      attributes: [{ key: 'message', value: `event ${i}` }],
+    }));
+
+    const propsWithManyLogs = {
+      ...defaultProps,
+      events: manyLogs,
+      currentViewRangeTime: [0.0, 1.0],
+      initialVisibleCount: 3,
+      spanID: 'test-span-123',
+    };
+
+    const { unmount } = render(<AccordionEvents {...propsWithManyLogs} isOpen />);
+    fireEvent.click(screen.getByRole('button', { name: /show more.../i }));
+    unmount();
+
+    jest.runAllTimers();
+
+    expect(mockDispatchEvent).not.toHaveBeenCalled();
+    expect(window.cancelAnimationFrame).toHaveBeenCalled();
+
+    window.dispatchEvent = originalDispatchEvent;
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    jest.useRealTimers();
+  });
+
   it('handles observer cleanup and errors', () => {
     const originalResizeObserver = window.ResizeObserver;
     const originalMutationObserver = window.MutationObserver;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
@@ -52,6 +52,33 @@ export default function AccordionEvents({
   const [showOutOfRangeEvents, setShowOutOfRangeEvents] = React.useState(false);
   const [showAllEvents, setShowAllEvents] = React.useState(false);
   const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const pendingReflowTimers = React.useRef<{
+    timeoutId: number | null;
+    delayedTimeoutId: number | null;
+    animationFrameId: number | null;
+  }>({
+    timeoutId: null,
+    delayedTimeoutId: null,
+    animationFrameId: null,
+  });
+
+  const clearPendingReflowTimers = React.useCallback(() => {
+    const { timeoutId, delayedTimeoutId, animationFrameId } = pendingReflowTimers.current;
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+    }
+    if (delayedTimeoutId !== null) {
+      window.clearTimeout(delayedTimeoutId);
+    }
+    if (animationFrameId !== null && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(animationFrameId);
+    }
+    pendingReflowTimers.current = {
+      timeoutId: null,
+      delayedTimeoutId: null,
+      animationFrameId: null,
+    };
+  }, []);
 
   const notifyListReflow = React.useCallback(() => {
     const emit = () => {
@@ -66,12 +93,14 @@ export default function AccordionEvents({
       }
     };
 
-    setTimeout(emit);
+    clearPendingReflowTimers();
+
+    pendingReflowTimers.current.timeoutId = window.setTimeout(emit);
     if (typeof window !== 'undefined' && 'requestAnimationFrame' in window) {
-      window.requestAnimationFrame(emit);
+      pendingReflowTimers.current.animationFrameId = window.requestAnimationFrame(emit);
     }
-    setTimeout(emit, 50);
-  }, [spanID]);
+    pendingReflowTimers.current.delayedTimeoutId = window.setTimeout(emit, 50);
+  }, [clearPendingReflowTimers, spanID]);
 
   // Observe height changes in the content area to notify virtualized list to reflow
   React.useEffect(() => {
@@ -106,8 +135,9 @@ export default function AccordionEvents({
           void error;
         }
       }
+      clearPendingReflowTimers();
     };
-  }, [interactive, isOpen, notifyListReflow]);
+  }, [clearPendingReflowTimers, interactive, isOpen, notifyListReflow]);
 
   const inRangeEvents = React.useMemo(() => {
     const viewStartAbsolute = timestamp + currentViewRangeTime[0] * traceDuration;


### PR DESCRIPTION
Addresses #4061 by clearing pending timeout and animation frame callbacks when AccordionEvents unmounts, and adds a regression test that verifies the callbacks do not fire after unmount.