### PR TITLE
Add trace graph accessibility labels

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
@@ -95,9 +95,9 @@ describe('<TraceGraph>', () => {
 
     // Initial mode should be service
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_SERVICE);
-    const timeButton = screen.getByRole('button', { name: 'T' });
-    const selftimeButton = screen.getByRole('button', { name: 'ST' });
-    const serviceButton = screen.getByRole('button', { name: 'S' });
+    const timeButton = screen.getByRole('button', { name: 'Switch trace graph coloring to time' });
+    const selftimeButton = screen.getByRole('button', { name: 'Switch trace graph coloring to self time' });
+    const serviceButton = screen.getByRole('button', { name: 'Switch trace graph coloring to service' });
 
     // Switch to time
     await userEvent.click(timeButton);

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -192,8 +192,10 @@ function TraceGraph({
               <Button
                 className={cx('TraceGraph--btn-service', { active: mode === MODE_SERVICE })}
                 htmlType="button"
+                aria-label="Switch trace graph coloring to service"
                 shape="circle"
                 size="small"
+                title="Service"
                 onClick={() => setMode(MODE_SERVICE)}
               >
                 S
@@ -205,8 +207,10 @@ function TraceGraph({
               <Button
                 className={cx('TraceGraph--btn-time', { active: mode === MODE_TIME })}
                 htmlType="button"
+                aria-label="Switch trace graph coloring to time"
                 shape="circle"
                 size="small"
+                title="Time"
                 onClick={() => setMode(MODE_TIME)}
               >
                 T
@@ -218,8 +222,10 @@ function TraceGraph({
               <Button
                 className={cx('TraceGraph--btn-selftime', { active: mode === MODE_SELFTIME })}
                 htmlType="button"
+                aria-label="Switch trace graph coloring to self time"
                 shape="circle"
                 size="small"
+                title="Selftime"
                 onClick={() => setMode(MODE_SELFTIME)}
               >
                 ST


### PR DESCRIPTION
Addresses #4099 by adding accessible names to the trace graph mode buttons and updating the test to assert the new accessible labels.