### PR TITLE
Cancel pending event reflow timers

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -140,93 +140,96 @@ describe('<AccordionEvents>', () => {
 
   it('dispatches events and handles show more/less functionality', () => {
     jest.useFakeTimers();
-    const originalDispatchEvent = window.dispatchEvent;
-    const mockDispatchEvent = jest.fn();
-    window.dispatchEvent = mockDispatchEvent;
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
 
-    const manyLogs = Array.from({ length: 5 }, (_, i) => ({
-      timestamp: 10 + i,
-      name: 'event',
-      attributes: [{ key: 'message', value: `event ${i}` }],
-    }));
+    try {
+      const manyLogs = Array.from({ length: 5 }, (_, i) => ({
+        timestamp: 10 + i,
+        name: 'event',
+        attributes: [{ key: 'message', value: `event ${i}` }],
+      }));
 
-    const propsWithManyLogs = {
-      ...defaultProps,
-      events: manyLogs,
-      currentViewRangeTime: [0.0, 1.0],
-      initialVisibleCount: 3,
-      spanID: 'test-span-123',
-    };
+      const propsWithManyLogs = {
+        ...defaultProps,
+        events: manyLogs,
+        currentViewRangeTime: [0.0, 1.0],
+        initialVisibleCount: 3,
+        spanID: 'test-span-123',
+      };
 
-    const { unmount } = render(<AccordionEvents {...propsWithManyLogs} isOpen />);
-    const showMoreButton = screen.getByRole('button', { name: /show more.../i });
-    fireEvent.click(showMoreButton);
-    jest.runAllTimers();
+      const { unmount } = render(<AccordionEvents {...propsWithManyLogs} isOpen />);
+      const showMoreButton = screen.getByRole('button', { name: /show more\.\.\./i });
+      fireEvent.click(showMoreButton);
+      jest.runAllTimers();
 
-    expect(mockDispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'jaeger:detail-measure',
-        detail: { spanID: 'test-span-123' },
-      })
-    );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'jaeger:detail-measure',
+          detail: { spanID: 'test-span-123' },
+        })
+      );
 
-    const showLessButton = screen.getByRole('button', { name: /show less/i });
-    fireEvent.click(showLessButton);
+      const showLessButton = screen.getByRole('button', { name: /show less/i });
+      fireEvent.click(showLessButton);
 
-    unmount();
+      unmount();
 
-    mockDispatchEvent.mockClear();
-    const propsWithoutSpanID = { ...propsWithManyLogs, spanID: undefined };
-    render(<AccordionEvents {...propsWithoutSpanID} isOpen />);
-    const showMoreButton2 = screen.getByRole('button', { name: /show more.../i });
-    fireEvent.click(showMoreButton2);
+      dispatchSpy.mockClear();
+      const propsWithoutSpanID = { ...propsWithManyLogs, spanID: undefined };
+      render(<AccordionEvents {...propsWithoutSpanID} isOpen />);
+      const showMoreButton2 = screen.getByRole('button', { name: /show more\.\.\./i });
+      fireEvent.click(showMoreButton2);
 
-    jest.runAllTimers();
+      jest.runAllTimers();
 
-    expect(mockDispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'jaeger:list-resize' }));
-
-    window.dispatchEvent = originalDispatchEvent;
-    jest.useRealTimers();
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'jaeger:list-resize' })
+      );
+    } finally {
+      dispatchSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 
   it('cancels pending reflow timers when unmounted', () => {
     jest.useFakeTimers();
-    const originalDispatchEvent = window.dispatchEvent;
-    const originalRequestAnimationFrame = window.requestAnimationFrame;
-    const originalCancelAnimationFrame = window.cancelAnimationFrame;
-    const mockDispatchEvent = jest.fn();
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+    const requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => window.setTimeout(callback, 16));
+    const cancelAnimationFrameSpy = jest
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(id => window.clearTimeout(id));
 
-    window.dispatchEvent = mockDispatchEvent;
-    window.requestAnimationFrame = jest.fn(callback => window.setTimeout(callback, 16));
-    window.cancelAnimationFrame = jest.fn(id => window.clearTimeout(id));
+    try {
+      const manyLogs = Array.from({ length: 5 }, (_, i) => ({
+        timestamp: 10 + i,
+        name: 'event',
+        attributes: [{ key: 'message', value: `event ${i}` }],
+      }));
 
-    const manyLogs = Array.from({ length: 5 }, (_, i) => ({
-      timestamp: 10 + i,
-      name: 'event',
-      attributes: [{ key: 'message', value: `event ${i}` }],
-    }));
+      const propsWithManyLogs = {
+        ...defaultProps,
+        events: manyLogs,
+        currentViewRangeTime: [0.0, 1.0],
+        initialVisibleCount: 3,
+        spanID: 'test-span-123',
+      };
 
-    const propsWithManyLogs = {
-      ...defaultProps,
-      events: manyLogs,
-      currentViewRangeTime: [0.0, 1.0],
-      initialVisibleCount: 3,
-      spanID: 'test-span-123',
-    };
+      const { unmount } = render(<AccordionEvents {...propsWithManyLogs} isOpen />);
+      fireEvent.click(screen.getByRole('button', { name: /show more\.\.\./i }));
+      unmount();
 
-    const { unmount } = render(<AccordionEvents {...propsWithManyLogs} isOpen />);
-    fireEvent.click(screen.getByRole('button', { name: /show more.../i }));
-    unmount();
+      jest.runAllTimers();
 
-    jest.runAllTimers();
-
-    expect(mockDispatchEvent).not.toHaveBeenCalled();
-    expect(window.cancelAnimationFrame).toHaveBeenCalled();
-
-    window.dispatchEvent = originalDispatchEvent;
-    window.requestAnimationFrame = originalRequestAnimationFrame;
-    window.cancelAnimationFrame = originalCancelAnimationFrame;
-    jest.useRealTimers();
+      expect(dispatchSpy).not.toHaveBeenCalled();
+      expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+    } finally {
+      dispatchSpy.mockRestore();
+      requestAnimationFrameSpy.mockRestore();
+      cancelAnimationFrameSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 
   it('handles observer cleanup and errors', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -194,6 +194,14 @@ describe('<AccordionEvents>', () => {
   it('cancels pending reflow timers when unmounted', () => {
     jest.useFakeTimers();
     const dispatchSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    if (typeof window.requestAnimationFrame !== 'function') {
+      window.requestAnimationFrame = callback => window.setTimeout(callback, 16);
+    }
+    if (typeof window.cancelAnimationFrame !== 'function') {
+      window.cancelAnimationFrame = id => window.clearTimeout(id);
+    }
     const requestAnimationFrameSpy = jest
       .spyOn(window, 'requestAnimationFrame')
       .mockImplementation(callback => window.setTimeout(callback, 16));
@@ -228,6 +236,8 @@ describe('<AccordionEvents>', () => {
       dispatchSpy.mockRestore();
       requestAnimationFrameSpy.mockRestore();
       cancelAnimationFrameSpy.mockRestore();
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
       jest.useRealTimers();
     }
   });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -189,6 +189,46 @@ describe('<AccordionEvents>', () => {
     jest.useRealTimers();
   });
 
+  it('cancels pending reflow timers when unmounted', () => {
+    jest.useFakeTimers();
+    const originalDispatchEvent = window.dispatchEvent;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    const mockDispatchEvent = jest.fn();
+
+    window.dispatchEvent = mockDispatchEvent;
+    window.requestAnimationFrame = jest.fn(callback => window.setTimeout(callback, 16));
+    window.cancelAnimationFrame = jest.fn(id => window.clearTimeout(id));
+
+    const manyLogs = Array.from({ length: 5 }, (_, i) => ({
+      timestamp: 10 + i,
+      name: 'event',
+      attributes: [{ key: 'message', value: `event ${i}` }],
+    }));
+
+    const propsWithManyLogs = {
+      ...defaultProps,
+      events: manyLogs,
+      currentViewRangeTime: [0.0, 1.0],
+      initialVisibleCount: 3,
+      spanID: 'test-span-123',
+    };
+
+    const { unmount } = render(<AccordionEvents {...propsWithManyLogs} isOpen />);
+    fireEvent.click(screen.getByRole('button', { name: /show more.../i }));
+    unmount();
+
+    jest.runAllTimers();
+
+    expect(mockDispatchEvent).not.toHaveBeenCalled();
+    expect(window.cancelAnimationFrame).toHaveBeenCalled();
+
+    window.dispatchEvent = originalDispatchEvent;
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    jest.useRealTimers();
+  });
+
   it('handles observer cleanup and errors', () => {
     const originalResizeObserver = window.ResizeObserver;
     const originalMutationObserver = window.MutationObserver;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
@@ -52,6 +52,33 @@ export default function AccordionEvents({
   const [showOutOfRangeEvents, setShowOutOfRangeEvents] = React.useState(false);
   const [showAllEvents, setShowAllEvents] = React.useState(false);
   const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const pendingReflowTimers = React.useRef<{
+    timeoutId: number | null;
+    delayedTimeoutId: number | null;
+    animationFrameId: number | null;
+  }>({
+    timeoutId: null,
+    delayedTimeoutId: null,
+    animationFrameId: null,
+  });
+
+  const clearPendingReflowTimers = React.useCallback(() => {
+    const { timeoutId, delayedTimeoutId, animationFrameId } = pendingReflowTimers.current;
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+    }
+    if (delayedTimeoutId !== null) {
+      window.clearTimeout(delayedTimeoutId);
+    }
+    if (animationFrameId !== null && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(animationFrameId);
+    }
+    pendingReflowTimers.current = {
+      timeoutId: null,
+      delayedTimeoutId: null,
+      animationFrameId: null,
+    };
+  }, []);
 
   const notifyListReflow = React.useCallback(() => {
     const emit = () => {
@@ -66,12 +93,14 @@ export default function AccordionEvents({
       }
     };
 
-    setTimeout(emit);
+    clearPendingReflowTimers();
+
+    pendingReflowTimers.current.timeoutId = window.setTimeout(emit);
     if (typeof window !== 'undefined' && 'requestAnimationFrame' in window) {
-      window.requestAnimationFrame(emit);
+      pendingReflowTimers.current.animationFrameId = window.requestAnimationFrame(emit);
     }
-    setTimeout(emit, 50);
-  }, [spanID]);
+    pendingReflowTimers.current.delayedTimeoutId = window.setTimeout(emit, 50);
+  }, [clearPendingReflowTimers, spanID]);
 
   // Observe height changes in the content area to notify virtualized list to reflow
   React.useEffect(() => {
@@ -106,8 +135,9 @@ export default function AccordionEvents({
           void error;
         }
       }
+      clearPendingReflowTimers();
     };
-  }, [interactive, isOpen, notifyListReflow]);
+  }, [clearPendingReflowTimers, interactive, isOpen, notifyListReflow]);
 
   const inRangeEvents = React.useMemo(() => {
     const viewStartAbsolute = timestamp + currentViewRangeTime[0] * traceDuration;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
@@ -104,7 +104,7 @@ export default function AccordionEvents({
       return;
     }
     pendingReflowTimers.current.timeoutId = window.setTimeout(emit);
-    if ('requestAnimationFrame' in window) {
+    if (typeof window.requestAnimationFrame === 'function') {
       pendingReflowTimers.current.animationFrameId = window.requestAnimationFrame(emit);
     }
     pendingReflowTimers.current.delayedTimeoutId = window.setTimeout(emit, 50);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.tsx
@@ -64,14 +64,16 @@ export default function AccordionEvents({
 
   const clearPendingReflowTimers = React.useCallback(() => {
     const { timeoutId, delayedTimeoutId, animationFrameId } = pendingReflowTimers.current;
-    if (timeoutId !== null) {
-      window.clearTimeout(timeoutId);
-    }
-    if (delayedTimeoutId !== null) {
-      window.clearTimeout(delayedTimeoutId);
-    }
-    if (animationFrameId !== null && typeof window.cancelAnimationFrame === 'function') {
-      window.cancelAnimationFrame(animationFrameId);
+    if (typeof window !== 'undefined') {
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+      if (delayedTimeoutId !== null) {
+        window.clearTimeout(delayedTimeoutId);
+      }
+      if (animationFrameId !== null && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(animationFrameId);
+      }
     }
     pendingReflowTimers.current = {
       timeoutId: null,
@@ -83,6 +85,9 @@ export default function AccordionEvents({
   const notifyListReflow = React.useCallback(() => {
     const emit = () => {
       try {
+        if (typeof window === 'undefined') {
+          return;
+        }
         if (spanID) {
           window.dispatchEvent(new CustomEvent('jaeger:detail-measure', { detail: { spanID } }));
         } else {
@@ -95,8 +100,11 @@ export default function AccordionEvents({
 
     clearPendingReflowTimers();
 
+    if (typeof window === 'undefined') {
+      return;
+    }
     pendingReflowTimers.current.timeoutId = window.setTimeout(emit);
-    if (typeof window !== 'undefined' && 'requestAnimationFrame' in window) {
+    if ('requestAnimationFrame' in window) {
       pendingReflowTimers.current.animationFrameId = window.requestAnimationFrame(emit);
     }
     pendingReflowTimers.current.delayedTimeoutId = window.setTimeout(emit, 50);


### PR DESCRIPTION
Addresses #4061 by clearing pending timeout and animation frame callbacks when AccordionEvents unmounts, and adds a regression test that verifies the callbacks do not fire after unmount.