### PR TITLE
chore(model): Make deduplicateTags linear instead of O(n^2) in tag count

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -39,7 +39,7 @@ describe('deduplicateTags()', () => {
       { key: 'b.ip', value: '8.8.8.8' },
       { key: 'a.ip', value: '8.8.8.8' },
     ]);
-    expect(tagsInfo.warnings).toEqual(['Duplicate tag "b.ip:8.8.4.4"']);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag key="b.ip" value="8.8.4.4"']);
   });
 
   it('collapses repeated duplicates into a single warning and keeps the first', () => {
@@ -50,7 +50,7 @@ describe('deduplicateTags()', () => {
     ]);
 
     expect(tagsInfo.tags).toEqual([{ key: 'x', value: 'a' }]);
-    expect(tagsInfo.warnings).toEqual(['Duplicate tag "x:a"']);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag key="x" value="a"']);
   });
 
   it('does not collide when key or value contains a colon', () => {
@@ -76,7 +76,25 @@ describe('deduplicateTags()', () => {
       { key: 'a', value: 'b:c' },
     ]);
     // Both duplicated pairs are tracked separately; neither warning is dropped.
-    expect(tagsInfo.warnings).toEqual(['Duplicate tag "a:b:c"', 'Duplicate tag "a:b:c"']);
+    expect(tagsInfo.warnings).toEqual([
+      'Duplicate tag key="a:b" value="c"',
+      'Duplicate tag key="a" value="b:c"',
+    ]);
+  });
+
+  it('preserves distinct duplicate warnings when mixed-type values stringify the same', () => {
+    const tagsInfo = deduplicateTags([
+      { key: 'x', value: 1 },
+      { key: 'x', value: 1 },
+      { key: 'x', value: '1' },
+      { key: 'x', value: '1' },
+    ]);
+
+    expect(tagsInfo.tags).toEqual([
+      { key: 'x', value: 1 },
+      { key: 'x', value: '1' },
+    ]);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag key="x" value="1"', 'Duplicate tag key="x" value="1"']);
   });
 });
 

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -76,7 +76,7 @@ describe('deduplicateTags()', () => {
       { key: 'a', value: 'b:c' },
     ]);
     // Both duplicated pairs are tracked separately; neither warning is dropped.
-    expect(tagsInfo.warnings).toHaveLength(2);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag "a:b:c"', 'Duplicate tag "a:b:c"']);
   });
 });
 

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -41,6 +41,43 @@ describe('deduplicateTags()', () => {
     ]);
     expect(tagsInfo.warnings).toEqual(['Duplicate tag "b.ip:8.8.4.4"']);
   });
+
+  it('collapses repeated duplicates into a single warning and keeps the first', () => {
+    const tagsInfo = deduplicateTags([
+      { key: 'x', value: 'a' },
+      { key: 'x', value: 'a' },
+      { key: 'x', value: 'a' },
+    ]);
+
+    expect(tagsInfo.tags).toEqual([{ key: 'x', value: 'a' }]);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag "x:a"']);
+  });
+
+  it('does not collide when key or value contains a colon', () => {
+    const tagsInfo = deduplicateTags([
+      { key: 'a:b', value: 'c' },
+      { key: 'a', value: 'b:c' },
+    ]);
+
+    expect(tagsInfo.tags).toHaveLength(2);
+    expect(tagsInfo.warnings).toEqual([]);
+  });
+
+  it('reports both duplicates when colliding key/value pairs are each duplicated', () => {
+    const tagsInfo = deduplicateTags([
+      { key: 'a:b', value: 'c' },
+      { key: 'a:b', value: 'c' },
+      { key: 'a', value: 'b:c' },
+      { key: 'a', value: 'b:c' },
+    ]);
+
+    expect(tagsInfo.tags).toEqual([
+      { key: 'a:b', value: 'c' },
+      { key: 'a', value: 'b:c' },
+    ]);
+    // Both duplicated pairs are tracked separately; neither warning is dropped.
+    expect(tagsInfo.warnings).toHaveLength(2);
+  });
 });
 
 describe('transformTraceData()', () => {

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -25,7 +25,7 @@ export function deduplicateTags(spanTags: ReadonlyArray<KeyValuePair>) {
       seenValuesByKey.set(tag.key, seenValues);
     }
     if (seenValues.has(tag.value)) {
-      warningsHash.set(JSON.stringify([tag.key, tag.value]), `Duplicate tag "${tag.key}:${tag.value}"`);
+      warningsHash.set(`${tag.key}\0${String(tag.value)}`, `Duplicate tag "${tag.key}:${tag.value}"`);
     } else {
       seenValues.add(tag.value);
       tags.push(tag);

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -25,7 +25,10 @@ export function deduplicateTags(spanTags: ReadonlyArray<KeyValuePair>) {
       }
       tags.push(tag);
     } else {
-      warningsHash.set(`${tag.key}\0${String(tag.value)}`, `Duplicate tag "${tag.key}:${tag.value}"`);
+      warningsHash.set(
+        `${tag.key}\0${typeof tag.value}\0${String(tag.value)}`,
+        `Duplicate tag key="${tag.key}" value="${String(tag.value)}"`
+      );
     }
   }
   const warnings = Array.from(warningsHash.values());

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -13,14 +13,24 @@ import OtelTraceFacade from './OtelTraceFacade';
 // exported for tests
 export function deduplicateTags(spanTags: ReadonlyArray<KeyValuePair>) {
   const warningsHash: Map<string, string> = new Map<string, string>();
-  const tags: KeyValuePair[] = spanTags.reduce<KeyValuePair[]>((uniqueTags, tag) => {
-    if (!uniqueTags.some(t => t.key === tag.key && t.value === tag.value)) {
-      uniqueTags.push(tag);
-    } else {
-      warningsHash.set(`${tag.key}:${tag.value}`, `Duplicate tag "${tag.key}:${tag.value}"`);
+  const tags: KeyValuePair[] = [];
+  // Track seen values per key so duplicate detection is a single O(n) pass
+  // instead of rescanning the accumulated list for every tag. Keying by value
+  // (rather than a combined key+value string) avoids copying large tag values.
+  const seenValuesByKey = new Map<string, Set<KeyValuePair['value']>>();
+  for (const tag of spanTags) {
+    let seenValues = seenValuesByKey.get(tag.key);
+    if (!seenValues) {
+      seenValues = new Set();
+      seenValuesByKey.set(tag.key, seenValues);
     }
-    return uniqueTags;
-  }, []);
+    if (seenValues.has(tag.value)) {
+      warningsHash.set(JSON.stringify([tag.key, tag.value]), `Duplicate tag "${tag.key}:${tag.value}"`);
+    } else {
+      seenValues.add(tag.value);
+      tags.push(tag);
+    }
+  }
   const warnings = Array.from(warningsHash.values());
   return { tags, warnings };
 }

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -14,21 +14,18 @@ import OtelTraceFacade from './OtelTraceFacade';
 export function deduplicateTags(spanTags: ReadonlyArray<KeyValuePair>) {
   const warningsHash: Map<string, string> = new Map<string, string>();
   const tags: KeyValuePair[] = [];
-  // Track seen values per key so duplicate detection is a single O(n) pass
-  // instead of rescanning the accumulated list for every tag. Keying by value
-  // (rather than a combined key+value string) avoids copying large tag values.
-  const seenValuesByKey = new Map<string, Set<KeyValuePair['value']>>();
+  const seen = new Map<string, Set<KeyValuePair['value']>>();
   for (const tag of spanTags) {
-    let seenValues = seenValuesByKey.get(tag.key);
-    if (!seenValues) {
-      seenValues = new Set();
-      seenValuesByKey.set(tag.key, seenValues);
-    }
-    if (seenValues.has(tag.value)) {
-      warningsHash.set(`${tag.key}\0${String(tag.value)}`, `Duplicate tag "${tag.key}:${tag.value}"`);
-    } else {
-      seenValues.add(tag.value);
+    const values = seen.get(tag.key);
+    if (!values || !values.has(tag.value)) {
+      if (values) {
+        values.add(tag.value);
+      } else {
+        seen.set(tag.key, new Set([tag.value]));
+      }
       tags.push(tag);
+    } else {
+      warningsHash.set(`${tag.key}\0${String(tag.value)}`, `Duplicate tag "${tag.key}:${tag.value}"`);
     }
   }
   const warnings = Array.from(warningsHash.values());


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4109

## Description of the changes
- Rewrote the tag loop to use a Map of Sets instead of scanning an array
- This improves the time complexity from quadratic to linear
- Made the warning key collision safe by stringifying the key and value
- Fixed mixed-type collisions (e.g., 1 vs "1") in the warnings map
- Made the warning message text completely unambiguous

## How was this change tested?
- Wrote unit tests to verify the duplicate tracking logic
- Added a test to ensure keys with colons do not collide
- Added a test for mixed-type tag collisions
- Ran the local tests and linters

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)

