### PR TITLE
fix(trace): Prevent call-stack overflow on deeply nested traces

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -451,5 +451,39 @@ describe('transformTraceData()', () => {
       const ids = result.spans.map(s => s.spanID);
       expect(ids).toEqual(['root', 'child1', 'grandChild1', 'child2']);
     });
+
+    it('should handle deeply nested traces without overflowing the call stack', () => {
+      // A long parent -> child chain previously overflowed the stack because the
+      // traversal was recursive. The depth here exceeds the JS call-stack limit.
+      const depth = 20000;
+      const deepSpans = [];
+      for (let i = 0; i < depth; i++) {
+        deepSpans.push({
+          traceID,
+          spanID: `span-${i}`,
+          operationName: `op-${i}`,
+          references: i > 0 ? [{ refType: 'CHILD_OF', traceID, spanID: `span-${i - 1}` }] : [],
+          startTime: startTime + i,
+          duration,
+          tags: [],
+          logs: [],
+          processID: 'p1',
+        });
+      }
+
+      const traceData = { traceID, processes, spans: deepSpans };
+
+      let result;
+      expect(() => {
+        result = transformTraceData(traceData);
+      }).not.toThrow();
+
+      expect(result.spans.length).toBe(depth);
+      // Pre-order traversal keeps the chain in order, with depth matching position.
+      expect(result.spans[0].spanID).toBe('span-0');
+      expect(result.spans[0].depth).toBe(0);
+      expect(result.spans[depth - 1].spanID).toBe(`span-${depth - 1}`);
+      expect(result.spans[depth - 1].depth).toBe(depth - 1);
+    });
   });
 });

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -454,8 +454,9 @@ describe('transformTraceData()', () => {
 
     it('should handle deeply nested traces without overflowing the call stack', () => {
       // A long parent -> child chain previously overflowed the stack because the
-      // traversal was recursive. The depth here exceeds the JS call-stack limit.
-      const depth = 20000;
+      // traversal was recursive. This depth exceeds typical call-stack limits in
+      // our test runtime (V8), so the old recursive code reliably threw here.
+      const depth = 15000;
       const deepSpans = [];
       for (let i = 0; i < depth; i++) {
         deepSpans.push({

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -157,7 +157,9 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
   const spans: Span[] = [];
   const svcCounts: Record<string, number> = {};
 
-  // Depth-first traversal to order spans and populate flat array
+  // Pre-order depth-first traversal to order spans and populate flat array.
+  // Implemented iteratively with an explicit stack (rather than recursion) so
+  // that deeply nested traces do not overflow the call stack.
   const processSpan = (span: Span, depth: number) => {
     span.depth = depth;
     span.hasChildren = span.childSpans.length > 0;
@@ -185,13 +187,27 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
 
     spans.push(span);
 
-    // Sort children by startTime before processing them
+    // Sort children by startTime before processing them.
     (span.childSpans as Span[]).sort((a, b) => a.startTime - b.startTime);
-    span.childSpans.forEach(child => processSpan(child, depth + 1));
   };
 
   rootSpans.sort((a, b) => a.startTime - b.startTime);
-  rootSpans.forEach(root => processSpan(root, 0));
+
+  // Stack of spans pending traversal. Children are pushed in reverse order so
+  // they are popped (and thus visited) in ascending startTime order, matching
+  // the order a recursive pre-order traversal would produce.
+  const stack: { span: Span; depth: number }[] = [];
+  for (let i = rootSpans.length - 1; i >= 0; i--) {
+    stack.push({ span: rootSpans[i], depth: 0 });
+  }
+
+  while (stack.length > 0) {
+    const { span, depth } = stack.pop()!;
+    processSpan(span, depth);
+    for (let i = span.childSpans.length - 1; i >= 0; i--) {
+      stack.push({ span: span.childSpans[i], depth: depth + 1 });
+    }
+  }
 
   const traceName = getTraceName(spans);
   const tracePageTitle = getTracePageTitle(spans);


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4106 

## Description of the changes
- Replace the recursive `processSpan` traversal with an explicit stack-based iteration. Children are pushed in reverse order so they are visited in ascending `startTime` order, producing output identical to the previous pre-order recursion (same span order, depth, `hasChildren`, `subsidiarilyReferencedBy`).
- Add a regression test with a 15,000-deep chain that previously overflowed the stack.

## How was this change tested?
- New deep-trace test passes; it fails (throws `RangeError`) against the old recursive implementation.
- Existing `transform-trace-data` suite plus ordering-sensitive consumers (trace-DAG builder, timeline duck, TraceStatistics) — all green.
- `tsc --noEmit` and formatter/lint clean on the changed files.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
