### PR TITLE
refactor: Migrate store.layout.ts to Zustand persist middleware

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
@@ -141,15 +141,26 @@ function normalizeLayoutPrefs(stored: Partial<LayoutPrefs>): LayoutPrefs {
 // Storage adapter that reads/writes the namespaced JSON key and, on first load (before that key exists),
 // transparently falls back to the legacy unprefixed keys. The legacy keys are intentionally left in place:
 // the not-yet-removed Redux `duck.ts` still reads them in `newInitialState()`.
+//
+// Normalization (config defaults + clamping) happens here, exactly once per load, so the returned `state`
+// is always a complete, consistent LayoutPrefs. This intentionally bypasses persist's version/migrate
+// machinery — `normalizeLayoutPrefs` is the single reconciliation step — so callers must not normalize
+// again in `merge` (double-normalization is not idempotent for the width-budget reset).
 const layoutPrefsStorage: PersistStorage<LayoutPrefs> = {
   getItem: name => {
     const raw = localStorage.getItem(name);
     if (raw) {
-      return JSON.parse(raw) as StorageValue<LayoutPrefs>;
+      try {
+        const parsed = JSON.parse(raw) as StorageValue<Partial<LayoutPrefs>>;
+        return { state: normalizeLayoutPrefs(parsed.state ?? {}), version: STORAGE_VERSION };
+      } catch {
+        // Corrupted / partially-written value: drop it and fall back to legacy keys so the page still loads.
+        localStorage.removeItem(name);
+      }
     }
     const legacy = readLegacyLayoutPrefs();
     if (legacy) {
-      return { state: legacy as LayoutPrefs, version: STORAGE_VERSION };
+      return { state: normalizeLayoutPrefs(legacy), version: STORAGE_VERSION };
     }
     return null;
   },
@@ -213,11 +224,8 @@ export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()(
         detailPanelMode: state.detailPanelMode,
         timelineBarsVisible: state.timelineBarsVisible,
       }),
-      // Re-apply config defaults + clamping over whatever was rehydrated (or migrated from legacy keys).
-      merge: (persistedState, currentState) => ({
-        ...currentState,
-        ...normalizeLayoutPrefs((persistedState ?? {}) as Partial<LayoutPrefs>),
-      }),
+      // No custom `merge`: the storage adapter already returns a fully-normalized state, so persist's
+      // default shallow merge ({ ...current, ...persisted }) correctly overlays the four prefs.
     }
   )
 );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
@@ -77,8 +77,10 @@ function readLegacyLayoutPrefs(): Partial<LayoutPrefs> | null {
 
 // Applies config-driven defaults and clamps the stored prefs into a consistent layout.
 // Mirrors the bootstrapping logic that previously lived in `getInitialLayoutState()`/duck `newInitialState()`,
-// but operates on already-typed values instead of reading localStorage directly. Runs on every rehydrate
-// (via persist `merge`) and for the initial state, so a stale/oversized stored width can never break layout.
+// but operates on already-typed values instead of reading localStorage directly. It is invoked exactly once
+// per load inside `layoutPrefsStorage.getItem` (and for the store's initial state); persist then applies its
+// default shallow merge. Do not also normalize in a custom `merge`: the width-budget reset is not idempotent,
+// so a stale/oversized stored width must be reconciled exactly once.
 function normalizeLayoutPrefs(stored: Partial<LayoutPrefs>): LayoutPrefs {
   const { traceTimeline } = getConfig();
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.layout.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { create } from 'zustand';
+import { persist, type PersistStorage, type StorageValue } from 'zustand/middleware';
 import type { SpanDetailPanelMode } from '../../../types/config';
 import getConfig from '../../../utils/config/get-config';
 import {
@@ -12,11 +13,15 @@ import {
   SPAN_NAME_COLUMN_WIDTH_MIN,
 } from './store.constants';
 
-type TraceTimelineLayoutPrefsStore = {
+// The persisted slice of the store: the four user layout preferences (no actions).
+type LayoutPrefs = {
   spanNameColumnWidth: number;
   sidePanelWidth: number;
   detailPanelMode: SpanDetailPanelMode;
   timelineBarsVisible: boolean;
+};
+
+type TraceTimelineLayoutPrefsStore = LayoutPrefs & {
   setSpanNameColumnWidth: (width: number) => void;
   setSidePanelWidth: (width: number) => void;
   // Updates layout fields only; use `setDetailPanelMode` from `./store` to also sync detail panel state.
@@ -24,36 +29,80 @@ type TraceTimelineLayoutPrefsStore = {
   setTimelineBarsVisible: (visible: boolean) => void;
 };
 
-// Reads user layout preferences from localStorage and merges them with config-driven defaults.
-// Mirrors the logic that was previously in TraceTimelineViewer/duck.ts `newInitialState()`.
-export function getInitialLayoutState(): Pick<
-  TraceTimelineLayoutPrefsStore,
-  'spanNameColumnWidth' | 'sidePanelWidth' | 'detailPanelMode' | 'timelineBarsVisible'
-> {
+// Single namespaced localStorage key holding the JSON-serialized prefs (replaces the four raw keys).
+const STORAGE_KEY = 'jaeger.layout';
+const STORAGE_VERSION = 1;
+
+// Legacy unprefixed keys written by the pre-Zustand-persist implementation (and still by duck.ts).
+// localStorage key 'timelineVisible' is kept as-is for backward compatibility with stored preferences.
+const LEGACY_SPAN_NAME_COLUMN_WIDTH = 'spanNameColumnWidth';
+const LEGACY_SIDE_PANEL_WIDTH = 'sidePanelWidth';
+const LEGACY_DETAIL_PANEL_MODE = 'detailPanelMode';
+const LEGACY_TIMELINE_VISIBLE = 'timelineVisible';
+
+// Reads the legacy unprefixed keys into a partial LayoutPrefs, or returns null when none are present.
+// Used as a one-time fallback on first load before the namespaced key exists.
+function readLegacyLayoutPrefs(): Partial<LayoutPrefs> | null {
+  const rawSpanNameColumnWidth = localStorage.getItem(LEGACY_SPAN_NAME_COLUMN_WIDTH);
+  const rawSidePanelWidth = localStorage.getItem(LEGACY_SIDE_PANEL_WIDTH);
+  const rawDetailPanelMode = localStorage.getItem(LEGACY_DETAIL_PANEL_MODE);
+  const rawTimelineVisible = localStorage.getItem(LEGACY_TIMELINE_VISIBLE);
+
+  if (
+    rawSpanNameColumnWidth === null &&
+    rawSidePanelWidth === null &&
+    rawDetailPanelMode === null &&
+    rawTimelineVisible === null
+  ) {
+    return null;
+  }
+
+  const prefs: Partial<LayoutPrefs> = {};
+  const parsedSpanNameColumnWidth = parseFloat(rawSpanNameColumnWidth ?? '');
+  if (!Number.isNaN(parsedSpanNameColumnWidth)) {
+    prefs.spanNameColumnWidth = parsedSpanNameColumnWidth;
+  }
+  const parsedSidePanelWidth = parseFloat(rawSidePanelWidth ?? '');
+  if (!Number.isNaN(parsedSidePanelWidth)) {
+    prefs.sidePanelWidth = parsedSidePanelWidth;
+  }
+  if (rawDetailPanelMode === 'sidepanel' || rawDetailPanelMode === 'inline') {
+    prefs.detailPanelMode = rawDetailPanelMode;
+  }
+  if (rawTimelineVisible !== null) {
+    prefs.timelineBarsVisible = rawTimelineVisible !== 'false';
+  }
+  return prefs;
+}
+
+// Applies config-driven defaults and clamps the stored prefs into a consistent layout.
+// Mirrors the bootstrapping logic that previously lived in `getInitialLayoutState()`/duck `newInitialState()`,
+// but operates on already-typed values instead of reading localStorage directly. Runs on every rehydrate
+// (via persist `merge`) and for the initial state, so a stale/oversized stored width can never break layout.
+function normalizeLayoutPrefs(stored: Partial<LayoutPrefs>): LayoutPrefs {
   const { traceTimeline } = getConfig();
 
   let detailPanelMode: SpanDetailPanelMode = 'inline';
   if (traceTimeline?.enableSidePanel) {
-    const stored = localStorage.getItem('detailPanelMode');
-    if (stored === 'sidepanel') {
+    if (stored.detailPanelMode === 'sidepanel') {
       detailPanelMode = 'sidepanel';
-    } else if (traceTimeline.defaultDetailPanelMode === 'sidepanel' && stored === null) {
+    } else if (traceTimeline.defaultDetailPanelMode === 'sidepanel' && stored.detailPanelMode === undefined) {
       detailPanelMode = 'sidepanel';
     }
   }
 
-  // localStorage key kept as 'timelineVisible' for backward compatibility with stored user preferences.
-  const storedTimelineVisible = localStorage.getItem('timelineVisible');
-  const timelineBarsVisible = storedTimelineVisible === null ? true : storedTimelineVisible !== 'false';
+  const timelineBarsVisible = stored.timelineBarsVisible ?? true;
 
-  const parsedSpanNameColumnWidth = parseFloat(localStorage.getItem('spanNameColumnWidth') ?? '');
-  let spanNameColumnWidth = Number.isNaN(parsedSpanNameColumnWidth)
-    ? 0.25
-    : Math.min(Math.max(parsedSpanNameColumnWidth, SPAN_NAME_COLUMN_WIDTH_MIN), SPAN_NAME_COLUMN_WIDTH_MAX);
+  let spanNameColumnWidth =
+    stored.spanNameColumnWidth === undefined
+      ? 0.25
+      : Math.min(
+          Math.max(stored.spanNameColumnWidth, SPAN_NAME_COLUMN_WIDTH_MIN),
+          SPAN_NAME_COLUMN_WIDTH_MAX
+        );
 
-  const parsedSidePanelWidth = parseFloat(localStorage.getItem('sidePanelWidth') ?? '');
-  const sidePanelWidthExplicit = !Number.isNaN(parsedSidePanelWidth);
-  const rawSidePanelWidth = sidePanelWidthExplicit ? parsedSidePanelWidth : (1 - spanNameColumnWidth) / 2;
+  const sidePanelWidthExplicit = stored.sidePanelWidth !== undefined;
+  const rawSidePanelWidth = sidePanelWidthExplicit ? stored.sidePanelWidth! : (1 - spanNameColumnWidth) / 2;
   let sidePanelWidth = Math.min(Math.max(rawSidePanelWidth, SIDE_PANEL_WIDTH_MIN), SIDE_PANEL_WIDTH_MAX);
 
   // The two stored widths must leave room for the timeline column.
@@ -89,43 +138,88 @@ export function getInitialLayoutState(): Pick<
   return { spanNameColumnWidth, sidePanelWidth, detailPanelMode, timelineBarsVisible };
 }
 
-export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()((set, get) => ({
-  ...getInitialLayoutState(),
-
-  setSpanNameColumnWidth: (width: number) => {
-    const { detailPanelMode, sidePanelWidth } = get();
-    const maxWidth =
-      detailPanelMode === 'sidepanel'
-        ? Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH)
-        : SPAN_NAME_COLUMN_WIDTH_MAX;
-    const spanNameColumnWidth = Math.min(Math.max(width, SPAN_NAME_COLUMN_WIDTH_MIN), maxWidth);
-    localStorage.setItem('spanNameColumnWidth', spanNameColumnWidth.toString());
-    set({ spanNameColumnWidth });
-  },
-
-  setSidePanelWidth: (width: number) => {
-    const { timelineBarsVisible, spanNameColumnWidth } = get();
-    const availableWidth = timelineBarsVisible
-      ? 1 - spanNameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH
-      : 1 - spanNameColumnWidth;
-    const maxWidth = Math.max(SIDE_PANEL_WIDTH_MIN, Math.min(SIDE_PANEL_WIDTH_MAX, availableWidth));
-    const sidePanelWidth = Math.min(Math.max(width, SIDE_PANEL_WIDTH_MIN), maxWidth);
-    localStorage.setItem('sidePanelWidth', sidePanelWidth.toString());
-    set({ sidePanelWidth });
-  },
-
-  applyDetailPanelModeToLayout: (mode: SpanDetailPanelMode) => {
-    localStorage.setItem('detailPanelMode', mode);
-    let { spanNameColumnWidth, sidePanelWidth } = get();
-    if (mode === 'sidepanel') {
-      const maxWidth = Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH);
-      spanNameColumnWidth = Math.min(spanNameColumnWidth, maxWidth);
+// Storage adapter that reads/writes the namespaced JSON key and, on first load (before that key exists),
+// transparently falls back to the legacy unprefixed keys. The legacy keys are intentionally left in place:
+// the not-yet-removed Redux `duck.ts` still reads them in `newInitialState()`.
+const layoutPrefsStorage: PersistStorage<LayoutPrefs> = {
+  getItem: name => {
+    const raw = localStorage.getItem(name);
+    if (raw) {
+      return JSON.parse(raw) as StorageValue<LayoutPrefs>;
     }
-    set({ detailPanelMode: mode, spanNameColumnWidth });
+    const legacy = readLegacyLayoutPrefs();
+    if (legacy) {
+      return { state: legacy as LayoutPrefs, version: STORAGE_VERSION };
+    }
+    return null;
   },
+  setItem: (name, value) => {
+    localStorage.setItem(name, JSON.stringify(value));
+  },
+  removeItem: name => {
+    localStorage.removeItem(name);
+  },
+};
 
-  setTimelineBarsVisible: (visible: boolean) => {
-    localStorage.setItem('timelineVisible', String(visible));
-    set({ timelineBarsVisible: visible });
-  },
-}));
+export const useLayoutPrefsStore = create<TraceTimelineLayoutPrefsStore>()(
+  persist(
+    (set, get) => ({
+      ...normalizeLayoutPrefs({}),
+
+      setSpanNameColumnWidth: (width: number) => {
+        const { detailPanelMode, sidePanelWidth } = get();
+        const maxWidth =
+          detailPanelMode === 'sidepanel'
+            ? Math.min(SPAN_NAME_COLUMN_WIDTH_MAX, 1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH)
+            : SPAN_NAME_COLUMN_WIDTH_MAX;
+        const spanNameColumnWidth = Math.min(Math.max(width, SPAN_NAME_COLUMN_WIDTH_MIN), maxWidth);
+        set({ spanNameColumnWidth });
+      },
+
+      setSidePanelWidth: (width: number) => {
+        const { timelineBarsVisible, spanNameColumnWidth } = get();
+        const availableWidth = timelineBarsVisible
+          ? 1 - spanNameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH
+          : 1 - spanNameColumnWidth;
+        const maxWidth = Math.max(SIDE_PANEL_WIDTH_MIN, Math.min(SIDE_PANEL_WIDTH_MAX, availableWidth));
+        const sidePanelWidth = Math.min(Math.max(width, SIDE_PANEL_WIDTH_MIN), maxWidth);
+        set({ sidePanelWidth });
+      },
+
+      applyDetailPanelModeToLayout: (mode: SpanDetailPanelMode) => {
+        let { spanNameColumnWidth, sidePanelWidth } = get();
+        if (mode === 'sidepanel') {
+          const maxWidth = Math.min(
+            SPAN_NAME_COLUMN_WIDTH_MAX,
+            1 - sidePanelWidth - MIN_TIMELINE_COLUMN_WIDTH
+          );
+          spanNameColumnWidth = Math.min(spanNameColumnWidth, maxWidth);
+        }
+        set({ detailPanelMode: mode, spanNameColumnWidth });
+      },
+
+      setTimelineBarsVisible: (visible: boolean) => {
+        set({ timelineBarsVisible: visible });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      version: STORAGE_VERSION,
+      storage: layoutPrefsStorage,
+      // Persist only the data fields, never the action functions.
+      partialize: state => ({
+        spanNameColumnWidth: state.spanNameColumnWidth,
+        sidePanelWidth: state.sidePanelWidth,
+        detailPanelMode: state.detailPanelMode,
+        timelineBarsVisible: state.timelineBarsVisible,
+      }),
+      // Re-apply config defaults + clamping over whatever was rehydrated (or migrated from legacy keys).
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...normalizeLayoutPrefs((persistedState ?? {}) as Partial<LayoutPrefs>),
+      }),
+    }
+  )
+);
+
+export { normalizeLayoutPrefs };

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.test.ts
@@ -6,8 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DetailState from './SpanDetail/DetailState';
 import {
   calculateFocusedFindRowStates,
-  getInitialLayoutState,
   getSelectedSpanID,
+  normalizeLayoutPrefs,
   setDetailPanelMode,
   SIDE_PANEL_WIDTH_MAX,
   SIDE_PANEL_WIDTH_MIN,
@@ -27,101 +27,196 @@ import getConfig from '../../../utils/config/get-config';
 import filterSpans from '../../../utils/filter-spans';
 import spanAncestorIds from '../../../utils/span-ancestor-ids';
 
-describe('getInitialLayoutState()', () => {
+describe('normalizeLayoutPrefs()', () => {
   beforeEach(() => {
-    localStorage.clear();
     vi.mocked(getConfig).mockReturnValue({} as ReturnType<typeof getConfig>);
   });
 
-  it('returns default values when localStorage is empty and config has no traceTimeline', () => {
-    const state = getInitialLayoutState();
+  it('returns default values when no prefs are stored and config has no traceTimeline', () => {
+    const state = normalizeLayoutPrefs({});
     expect(state.spanNameColumnWidth).toBe(0.25);
     expect(state.timelineBarsVisible).toBe(true);
     expect(state.detailPanelMode).toBe('inline');
     expect(state.sidePanelWidth).toBeCloseTo(0.375);
   });
 
-  it('reads spanNameColumnWidth from localStorage', () => {
-    localStorage.setItem('spanNameColumnWidth', '0.4');
-    const state = getInitialLayoutState();
+  it('passes through a stored spanNameColumnWidth', () => {
+    const state = normalizeLayoutPrefs({ spanNameColumnWidth: 0.4 });
     expect(state.spanNameColumnWidth).toBeCloseTo(0.4);
   });
 
   it('clamps spanNameColumnWidth to [MIN, MAX]', () => {
-    localStorage.setItem('spanNameColumnWidth', '0.01');
-    expect(getInitialLayoutState().spanNameColumnWidth).toBe(SPAN_NAME_COLUMN_WIDTH_MIN);
-
-    localStorage.setItem('spanNameColumnWidth', '0.99');
-    expect(getInitialLayoutState().spanNameColumnWidth).toBe(SPAN_NAME_COLUMN_WIDTH_MAX);
+    expect(normalizeLayoutPrefs({ spanNameColumnWidth: 0.01 }).spanNameColumnWidth).toBe(
+      SPAN_NAME_COLUMN_WIDTH_MIN
+    );
+    expect(normalizeLayoutPrefs({ spanNameColumnWidth: 0.99 }).spanNameColumnWidth).toBe(
+      SPAN_NAME_COLUMN_WIDTH_MAX
+    );
   });
 
-  it('reads sidePanelWidth from localStorage', () => {
-    localStorage.setItem('spanNameColumnWidth', '0.25');
-    localStorage.setItem('sidePanelWidth', '0.3');
-    const state = getInitialLayoutState();
+  it('passes through a stored sidePanelWidth', () => {
+    const state = normalizeLayoutPrefs({ spanNameColumnWidth: 0.25, sidePanelWidth: 0.3 });
     expect(state.sidePanelWidth).toBeCloseTo(0.3);
   });
 
   it('clamps sidePanelWidth to [MIN, MAX]', () => {
-    localStorage.setItem('sidePanelWidth', '0.01');
-    expect(getInitialLayoutState().sidePanelWidth).toBe(SIDE_PANEL_WIDTH_MIN);
-
-    localStorage.setItem('sidePanelWidth', '0.99');
-    expect(getInitialLayoutState().sidePanelWidth).toBe(SIDE_PANEL_WIDTH_MAX);
+    expect(normalizeLayoutPrefs({ sidePanelWidth: 0.01 }).sidePanelWidth).toBe(SIDE_PANEL_WIDTH_MIN);
+    expect(normalizeLayoutPrefs({ sidePanelWidth: 0.99 }).sidePanelWidth).toBe(SIDE_PANEL_WIDTH_MAX);
   });
 
   it('resets sidePanelWidth when sum with spanNameColumnWidth >= 1', () => {
-    localStorage.setItem('spanNameColumnWidth', '0.6');
-    localStorage.setItem('sidePanelWidth', '0.6');
-    const state = getInitialLayoutState();
+    const state = normalizeLayoutPrefs({ spanNameColumnWidth: 0.6, sidePanelWidth: 0.6 });
     expect(state.spanNameColumnWidth + state.sidePanelWidth).toBeLessThan(1);
   });
 
   it('resets both widths when no combination leaves room', () => {
-    localStorage.setItem('spanNameColumnWidth', '0.85');
-    localStorage.setItem('sidePanelWidth', '0.7');
-    const state = getInitialLayoutState();
+    const state = normalizeLayoutPrefs({ spanNameColumnWidth: 0.85, sidePanelWidth: 0.7 });
     expect(state.spanNameColumnWidth + state.sidePanelWidth).toBeLessThan(1);
   });
 
-  it('reads timelineBarsVisible=false from localStorage', () => {
-    localStorage.setItem('timelineVisible', 'false');
-    expect(getInitialLayoutState().timelineBarsVisible).toBe(false);
+  it('passes through timelineBarsVisible=false', () => {
+    expect(normalizeLayoutPrefs({ timelineBarsVisible: false }).timelineBarsVisible).toBe(false);
   });
 
-  it('reads timelineBarsVisible=true from localStorage when value is not "false"', () => {
-    localStorage.setItem('timelineVisible', 'true');
-    expect(getInitialLayoutState().timelineBarsVisible).toBe(true);
+  it('defaults timelineBarsVisible to true when not stored', () => {
+    expect(normalizeLayoutPrefs({}).timelineBarsVisible).toBe(true);
   });
 
   it('defaults detailPanelMode to inline when enableSidePanel is false', () => {
     vi.mocked(getConfig).mockReturnValue({
       traceTimeline: { enableSidePanel: false },
     } as ReturnType<typeof getConfig>);
-    expect(getInitialLayoutState().detailPanelMode).toBe('inline');
+    expect(normalizeLayoutPrefs({}).detailPanelMode).toBe('inline');
   });
 
-  it('reads detailPanelMode=sidepanel from localStorage when enableSidePanel is true', () => {
+  it('honors a stored detailPanelMode=sidepanel when enableSidePanel is true', () => {
     vi.mocked(getConfig).mockReturnValue({
       traceTimeline: { enableSidePanel: true },
     } as ReturnType<typeof getConfig>);
-    localStorage.setItem('detailPanelMode', 'sidepanel');
-    expect(getInitialLayoutState().detailPanelMode).toBe('sidepanel');
+    expect(normalizeLayoutPrefs({ detailPanelMode: 'sidepanel' }).detailPanelMode).toBe('sidepanel');
   });
 
-  it('uses defaultDetailPanelMode from config when localStorage is empty and enableSidePanel is true', () => {
+  it('uses defaultDetailPanelMode from config when none is stored and enableSidePanel is true', () => {
     vi.mocked(getConfig).mockReturnValue({
       traceTimeline: { enableSidePanel: true, defaultDetailPanelMode: 'sidepanel' },
     } as ReturnType<typeof getConfig>);
-    expect(getInitialLayoutState().detailPanelMode).toBe('sidepanel');
+    expect(normalizeLayoutPrefs({}).detailPanelMode).toBe('sidepanel');
   });
 
   it('keeps detailPanelMode=inline when stored value is not sidepanel', () => {
     vi.mocked(getConfig).mockReturnValue({
       traceTimeline: { enableSidePanel: true },
     } as ReturnType<typeof getConfig>);
+    expect(normalizeLayoutPrefs({ detailPanelMode: 'inline' }).detailPanelMode).toBe('inline');
+  });
+
+  it('reserves the timeline column in sidepanel mode by resetting both widths when needed', () => {
+    vi.mocked(getConfig).mockReturnValue({
+      traceTimeline: { enableSidePanel: true },
+    } as ReturnType<typeof getConfig>);
+    // Wide name column with a derived (non-explicit) side panel: the first budget check is skipped,
+    // so the sidepanel-specific reset must kick in and reset both widths to defaults.
+    const state = normalizeLayoutPrefs({ spanNameColumnWidth: 0.85, detailPanelMode: 'sidepanel' });
+    expect(state.detailPanelMode).toBe('sidepanel');
+    expect(state.spanNameColumnWidth).toBe(0.25);
+    expect(state.sidePanelWidth).toBeCloseTo(0.35);
+  });
+
+  it('shrinks only the side panel in sidepanel mode when that alone leaves room for the timeline', () => {
+    vi.mocked(getConfig).mockReturnValue({
+      traceTimeline: { enableSidePanel: true },
+    } as ReturnType<typeof getConfig>);
+    // Sum (0.99) is under 1 (first budget check skipped) but over the sidepanel limit (0.95);
+    // shrinking the side panel alone restores the timeline column without resetting the name column.
+    const state = normalizeLayoutPrefs({
+      spanNameColumnWidth: 0.7,
+      sidePanelWidth: 0.29,
+      detailPanelMode: 'sidepanel',
+    });
+    expect(state.spanNameColumnWidth).toBeCloseTo(0.7);
+    expect(state.sidePanelWidth).toBeCloseTo(0.25);
+  });
+});
+
+describe('useLayoutPrefsStore persistence (legacy migration + corrupted value)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(getConfig).mockReturnValue({} as ReturnType<typeof getConfig>);
+  });
+
+  it('migrates legacy unprefixed keys on rehydrate', async () => {
+    localStorage.setItem('spanNameColumnWidth', '0.4');
+    localStorage.setItem('sidePanelWidth', '0.3');
+    localStorage.setItem('timelineVisible', 'false');
+    await useLayoutPrefsStore.persist.rehydrate();
+    const state = useLayoutPrefsStore.getState();
+    expect(state.spanNameColumnWidth).toBeCloseTo(0.4);
+    expect(state.sidePanelWidth).toBeCloseTo(0.3);
+    expect(state.timelineBarsVisible).toBe(false);
+  });
+
+  it('reads detailPanelMode=sidepanel from the legacy key when enableSidePanel is true', async () => {
+    vi.mocked(getConfig).mockReturnValue({
+      traceTimeline: { enableSidePanel: true },
+    } as ReturnType<typeof getConfig>);
+    localStorage.setItem('detailPanelMode', 'sidepanel');
+    await useLayoutPrefsStore.persist.rehydrate();
+    expect(useLayoutPrefsStore.getState().detailPanelMode).toBe('sidepanel');
+  });
+
+  it('honors a legacy detailPanelMode=inline over the config default and reads timelineVisible=true', async () => {
+    vi.mocked(getConfig).mockReturnValue({
+      traceTimeline: { enableSidePanel: true, defaultDetailPanelMode: 'sidepanel' },
+    } as ReturnType<typeof getConfig>);
     localStorage.setItem('detailPanelMode', 'inline');
-    expect(getInitialLayoutState().detailPanelMode).toBe('inline');
+    localStorage.setItem('timelineVisible', 'true');
+    await useLayoutPrefsStore.persist.rehydrate();
+    const state = useLayoutPrefsStore.getState();
+    expect(state.detailPanelMode).toBe('inline');
+    expect(state.timelineBarsVisible).toBe(true);
+  });
+
+  it('ignores unparseable legacy width values and falls back to defaults', async () => {
+    localStorage.setItem('spanNameColumnWidth', 'not-a-number');
+    await useLayoutPrefsStore.persist.rehydrate();
+    expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBe(0.25);
+  });
+
+  it('prefers the namespaced jaeger.layout key over legacy keys', async () => {
+    localStorage.setItem('spanNameColumnWidth', '0.4');
+    localStorage.setItem(
+      'jaeger.layout',
+      JSON.stringify({ state: { spanNameColumnWidth: 0.5 }, version: 1 })
+    );
+    await useLayoutPrefsStore.persist.rehydrate();
+    expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(0.5);
+  });
+
+  it('drops a corrupted namespaced value and falls back to legacy keys', async () => {
+    localStorage.setItem('jaeger.layout', '{ not valid json');
+    localStorage.setItem('spanNameColumnWidth', '0.4');
+    await useLayoutPrefsStore.persist.rehydrate();
+    expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(0.4);
+    expect(localStorage.getItem('jaeger.layout')).toBeNull();
+  });
+
+  it('keeps current state when storage is empty on rehydrate', async () => {
+    useLayoutPrefsStore.setState({ spanNameColumnWidth: 0.33 });
+    localStorage.clear();
+    await useLayoutPrefsStore.persist.rehydrate();
+    expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(0.33);
+  });
+
+  it('treats a namespaced value without a state property as empty and uses defaults', async () => {
+    localStorage.setItem('jaeger.layout', JSON.stringify({ version: 1 }));
+    await useLayoutPrefsStore.persist.rehydrate();
+    expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBe(0.25);
+  });
+
+  it('clearStorage removes the namespaced key', () => {
+    localStorage.setItem('jaeger.layout', JSON.stringify({ state: {}, version: 1 }));
+    useLayoutPrefsStore.persist.clearStorage();
+    expect(localStorage.getItem('jaeger.layout')).toBeNull();
   });
 });
 
@@ -160,7 +255,7 @@ describe('trace timeline zustand stores', () => {
       it('updates spanNameColumnWidth and persists to localStorage', () => {
         useLayoutPrefsStore.getState().setSpanNameColumnWidth(0.4);
         expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(0.4);
-        expect(localStorage.getItem('spanNameColumnWidth')).toBe('0.4');
+        expect(JSON.parse(localStorage.getItem('jaeger.layout')!).state.spanNameColumnWidth).toBeCloseTo(0.4);
       });
 
       it('clamps to SPAN_NAME_COLUMN_WIDTH_MIN', () => {
@@ -184,7 +279,7 @@ describe('trace timeline zustand stores', () => {
       it('updates sidePanelWidth and persists to localStorage', () => {
         useLayoutPrefsStore.getState().setSidePanelWidth(0.4);
         expect(useLayoutPrefsStore.getState().sidePanelWidth).toBeCloseTo(0.4);
-        expect(localStorage.getItem('sidePanelWidth')).toBe('0.4');
+        expect(JSON.parse(localStorage.getItem('jaeger.layout')!).state.sidePanelWidth).toBeCloseTo(0.4);
       });
 
       it('clamps to SIDE_PANEL_WIDTH_MIN', () => {
@@ -214,13 +309,13 @@ describe('trace timeline zustand stores', () => {
       it('updates timelineBarsVisible and persists to localStorage', () => {
         useLayoutPrefsStore.getState().setTimelineBarsVisible(false);
         expect(useLayoutPrefsStore.getState().timelineBarsVisible).toBe(false);
-        expect(localStorage.getItem('timelineVisible')).toBe('false');
+        expect(JSON.parse(localStorage.getItem('jaeger.layout')!).state.timelineBarsVisible).toBe(false);
       });
 
-      it('persists true as "true"', () => {
+      it('persists true', () => {
         useLayoutPrefsStore.getState().setTimelineBarsVisible(false);
         useLayoutPrefsStore.getState().setTimelineBarsVisible(true);
-        expect(localStorage.getItem('timelineVisible')).toBe('true');
+        expect(JSON.parse(localStorage.getItem('jaeger.layout')!).state.timelineBarsVisible).toBe(true);
       });
     });
   });
@@ -229,7 +324,7 @@ describe('trace timeline zustand stores', () => {
     it('updates detailPanelMode and persists to localStorage', () => {
       setDetailPanelMode('sidepanel');
       expect(useLayoutPrefsStore.getState().detailPanelMode).toBe('sidepanel');
-      expect(localStorage.getItem('detailPanelMode')).toBe('sidepanel');
+      expect(JSON.parse(localStorage.getItem('jaeger.layout')!).state.detailPanelMode).toBe('sidepanel');
     });
 
     it('clamps spanNameColumnWidth when switching to sidepanel', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.ts
@@ -14,7 +14,7 @@ export {
   SPAN_NAME_COLUMN_WIDTH_MIN,
 } from './store.constants';
 
-export { getInitialLayoutState, useLayoutPrefsStore } from './store.layout';
+export { normalizeLayoutPrefs, useLayoutPrefsStore } from './store.layout';
 
 export { useTraceTimelineStore } from './store.timeline';
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #3981 (part of #3926 )

## Description of the changes
- **Migrated `useLayoutPrefsStore` to the `persist` middleware** (same pattern as `components/SearchTracePage/store.search-results.ts`), replacing manual `localStorage` management.
- **Removed `getInitialLayoutState()` bootstrapping** and the four inline `localStorage.setItem` calls from the setters — persistence is now handled automatically by `persist`.
- **Single namespaced key**: prefs are stored under one `jaeger.layout` JSON blob via `partialize` (data fields only, never the action functions), instead of four raw unprefixed keys.
- **Preserved the non-trivial clamping/consistency logic** (width-budget checks, config-driven `detailPanelMode` default) by extracting it into a pure `normalizeLayoutPrefs()` helper that runs on the initial state and on every rehydrate via the persist `merge` callback.
- **Legacy preferences are not lost**: a custom storage `getItem` reads the legacy keys (`spanNameColumnWidth`, `sidePanelWidth`, `detailPanelMode`, `timelineVisible`) as a one-time fallback before the namespaced key exists. The legacy keys are intentionally left in place because the not-yet-removed Redux `duck.ts` still reads them in `newInitialState()`.

> Note on `migrate`: the issue suggested reading the legacy keys via a `migrate` step. zustand's `persist` only invokes `migrate` when its own key already exists with an older `version`, so it cannot reach foreign keys on first load. A custom storage `getItem` fallback is used instead.

## How was this change tested?
- Verified the package type-checks with `npm run tsc-lint`, and that the changed files pass `npm run oxlint` and `npm run fmt`. Note that `store.test.ts` still imports the removed `getInitialLayoutState` and needs updating to target `normalizeLayoutPrefs` and the new `jaeger.layout` key before the suite is green.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
