### PR TITLE
refactor(stats): Extract computeSpanSelfTime to shared utility

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/tableValues.ts
@@ -1,80 +1,14 @@
 // Copyright (c) 2020 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import memoizeOne from 'memoize-one';
 import { IOtelTrace, IOtelSpan } from '../../../types/otel';
 import { ITableSpan } from './types';
 import colorGenerator from '../../../utils/color-generator';
+import computeSpanSelfTime from '../../../utils/compute-span-self-time';
 
 export const getServiceName = () => 'Service Name';
 export const getOperationName = (useOtelTerms: boolean) => (useOtelTerms ? 'Span Name' : 'Operation Name');
 const getAttributeName = (useOtelTerms: boolean) => (useOtelTerms ? 'Attribute' : 'Tag');
-
-function parentChildOfMap(allSpans: ReadonlyArray<IOtelSpan>): Record<string, IOtelSpan[]> {
-  const parentChildOfMap: Record<string, IOtelSpan[]> = {};
-  allSpans.forEach(s => {
-    if (s.parentSpanID) {
-      parentChildOfMap[s.parentSpanID] = parentChildOfMap[s.parentSpanID] || [];
-      parentChildOfMap[s.parentSpanID].push(s);
-    }
-  });
-  return parentChildOfMap;
-}
-
-const memoizedParentChildOfMap = memoizeOne(parentChildOfMap);
-
-function getChildOfSpans(parentID: string, allSpans: ReadonlyArray<IOtelSpan>): IOtelSpan[] {
-  return memoizedParentChildOfMap(allSpans)[parentID] || [];
-}
-
-function computeSelfTime(parentSpan: IOtelSpan, allSpans: ReadonlyArray<IOtelSpan>): IOtelSpan['duration'] {
-  if (!parentSpan.hasChildren) return parentSpan.duration;
-
-  let parentSpanSelfTime = parentSpan.duration;
-  let previousChildEndTime = parentSpan.startTime;
-
-  const children = getChildOfSpans(parentSpan.spanID, allSpans).sort((a, b) => a.startTime - b.startTime);
-
-  const parentSpanEndTime = parentSpan.endTime;
-
-  for (let index = 0; index < children.length; index++) {
-    const child = children[index];
-
-    const childEndTime = child.endTime;
-    const childStartsAfterParentEnded = child.startTime > parentSpanEndTime;
-    const childEndsBeforePreviousChild = childEndTime < previousChildEndTime;
-
-    // parent |..................|
-    // child    |.......|                     - previousChild
-    // child     |.....|                      - childEndsBeforePreviousChild is true, skipped
-    // child                         |......| - childStartsAfterParentEnded is true, skipped
-    if (childStartsAfterParentEnded || childEndsBeforePreviousChild) {
-      continue;
-    }
-
-    // parent |.....................|
-    // child    |.......|                    - previousChild
-    // child        |.....|                  - nonOverlappingStartTime is previousChildEndTime
-    // child                |.....|          - nonOverlappingStartTime is child.startTime
-    const nonOverlappingStartTime = Math.max(previousChildEndTime, child.startTime);
-    const childEndTimeOrParentEndTime = Math.min(parentSpanEndTime, childEndTime);
-
-    const nonOverlappingDuration = childEndTimeOrParentEndTime - nonOverlappingStartTime;
-    parentSpanSelfTime = (parentSpanSelfTime - nonOverlappingDuration) as IOtelSpan['duration'];
-
-    // last span which can be included in self time calculation, because it ends after parent span ends
-    // parent |.......................|
-    // child                      |.....|        - last span included in self time calculation
-    // child                       |.........|   - skipped
-    if (childEndTimeOrParentEndTime === parentSpanEndTime) {
-      break;
-    }
-
-    previousChildEndTime = childEndTime as IOtelSpan['duration'];
-  }
-
-  return parentSpanSelfTime;
-}
 
 function computeColumnValues(
   trace: IOtelTrace,
@@ -92,7 +26,7 @@ function computeColumnValues(
     resultValueChange.max = span.duration;
   }
 
-  const tempSelf = computeSelfTime(span, allSpans);
+  const tempSelf = computeSpanSelfTime(span) as IOtelSpan['duration'];
   if (resultValueChange.selfMin > tempSelf) {
     resultValueChange.selfMin = tempSelf;
   }

--- a/packages/jaeger-ui/src/types/otel.ts
+++ b/packages/jaeger-ui/src/types/otel.ts
@@ -88,6 +88,7 @@ export interface IOtelSpan {
   // Derived properties
   depth: number;
   hasChildren: boolean;
+  // Sorted by startTime (ascending).
   childSpans: ReadonlyArray<IOtelSpan>;
   relativeStartTime: Microseconds; // microseconds since trace start
 

--- a/packages/jaeger-ui/src/utils/compute-span-self-time.test.ts
+++ b/packages/jaeger-ui/src/utils/compute-span-self-time.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import computeSpanSelfTime from './compute-span-self-time';
+import { IOtelSpan } from '../types/otel';
+import { Microseconds } from '../types/units';
+
+function us(n: number): Microseconds {
+  return n as Microseconds;
+}
+
+function makeSpan(startTime: number, duration: number, children: Partial<IOtelSpan>[] = []): IOtelSpan {
+  return {
+    startTime: us(startTime),
+    duration: us(duration),
+    endTime: us(startTime + duration),
+    hasChildren: children.length > 0,
+    childSpans: children as IOtelSpan[],
+  } as unknown as IOtelSpan;
+}
+
+function makeChild(startTime: number, duration: number): Partial<IOtelSpan> {
+  return { startTime: us(startTime), duration: us(duration), endTime: us(startTime + duration) };
+}
+
+describe('computeSpanSelfTime', () => {
+  it('returns full duration for a leaf span', () => {
+    const span = makeSpan(0, 100);
+    expect(computeSpanSelfTime(span)).toBe(100);
+  });
+
+  it('subtracts a single child that fits within parent', () => {
+    // parent: [0..100], child: [10..50]
+    const span = makeSpan(0, 100, [makeChild(10, 40)]);
+    expect(computeSpanSelfTime(span)).toBe(60);
+  });
+
+  it('handles two non-overlapping children', () => {
+    // parent: [0..100], child1: [10..30], child2: [50..70]
+    const span = makeSpan(0, 100, [makeChild(10, 20), makeChild(50, 20)]);
+    expect(computeSpanSelfTime(span)).toBe(60);
+  });
+
+  it('handles overlapping children (parallel RPCs)', () => {
+    // parent: [0..100], child1: [10..60], child2: [30..80]
+    // covered range: [10..80] = 70, self = 30
+    const span = makeSpan(0, 100, [makeChild(10, 50), makeChild(30, 50)]);
+    expect(computeSpanSelfTime(span)).toBe(30);
+  });
+
+  it('clamps child that extends past parent end', () => {
+    // parent: [0..100], child: [50..150]
+    // covered range: [50..100] = 50, self = 50
+    const span = makeSpan(0, 100, [makeChild(50, 100)]);
+    expect(computeSpanSelfTime(span)).toBe(50);
+  });
+
+  it('skips child that starts after parent ends', () => {
+    // parent: [0..100], child: [120..150]
+    const span = makeSpan(0, 100, [makeChild(120, 30)]);
+    expect(computeSpanSelfTime(span)).toBe(100);
+  });
+
+  it('skips child fully covered by previous child', () => {
+    // parent: [0..100], child1: [10..70], child2: [20..50] (fully within child1)
+    // covered range: [10..70] = 60, self = 40
+    const span = makeSpan(0, 100, [makeChild(10, 60), makeChild(20, 30)]);
+    expect(computeSpanSelfTime(span)).toBe(40);
+  });
+
+  it('handles child starting at parent start', () => {
+    // parent: [0..100], child: [0..100]
+    const span = makeSpan(0, 100, [makeChild(0, 100)]);
+    expect(computeSpanSelfTime(span)).toBe(0);
+  });
+
+  it('handles two children starting at parent start, one extending past', () => {
+    // parent: [0..100], child1: [0..60], child2: [0..120]
+    // covered range: [0..100] (clamped), self = 0
+    const span = makeSpan(0, 100, [makeChild(0, 60), makeChild(0, 120)]);
+    expect(computeSpanSelfTime(span)).toBe(0);
+  });
+
+  it('handles three short children with partial overlaps', () => {
+    // parent: [0..100], child1: [10..40], child2: [30..60], child3: [70..90]
+    // covered: [10..60] + [70..90] = 50 + 20 = 70, self = 30
+    const span = makeSpan(0, 100, [makeChild(10, 30), makeChild(30, 30), makeChild(70, 20)]);
+    expect(computeSpanSelfTime(span)).toBe(30);
+  });
+
+  it('returns zero (not negative) when children fully cover parent', () => {
+    // parent: [10..50], child: [0..100] (extends both sides)
+    const span = makeSpan(10, 40, [makeChild(0, 100)]);
+    expect(computeSpanSelfTime(span)).toBe(0);
+  });
+});

--- a/packages/jaeger-ui/src/utils/compute-span-self-time.ts
+++ b/packages/jaeger-ui/src/utils/compute-span-self-time.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IOtelSpan } from '../types/otel';
+
+/**
+ * Computes self-time for a span using a sweep-line over its children.
+ * Subtracts non-overlapping child durations from the parent's duration,
+ * handling overlapping children (parallel RPCs) and children extending
+ * past the parent's bounds.
+ *
+ * Relies on IOtelSpan.childSpans being sorted by startTime (ascending).
+ */
+export default function computeSpanSelfTime(span: IOtelSpan): number {
+  if (!span.hasChildren) return span.duration;
+
+  let selfTime: number = span.duration;
+  let previousChildEndTime = span.startTime;
+
+  const children = span.childSpans;
+  const parentEndTime = span.endTime;
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const childEndTime = child.endTime;
+
+    // parent |..................|
+    // child    |.......|                     - previousChild
+    // child     |.....|                      - childEndsBeforePreviousChild → skip
+    // child                         |......| - childStartsAfterParentEnded → skip
+    if (child.startTime > parentEndTime || childEndTime < previousChildEndTime) {
+      continue;
+    }
+
+    // parent |.....................|
+    // child    |.......|                    - previousChild
+    // child        |.....|                  - nonOverlappingStart is previousChildEndTime
+    // child                |.....|          - nonOverlappingStart is child.startTime
+    const nonOverlappingStart = Math.max(previousChildEndTime, child.startTime);
+    const clampedEnd = Math.min(parentEndTime, childEndTime);
+    selfTime -= clampedEnd - nonOverlappingStart;
+
+    // parent |.......................|
+    // child                      |.....|    - last span included; rest are past parent end
+    if (clampedEnd === parentEndTime) break;
+    previousChildEndTime = childEndTime;
+  }
+
+  return Math.max(0, selfTime);
+}


### PR DESCRIPTION
## Summary
- Extract the self-time sweep-line algorithm from `TraceStatistics/tableValues.ts` into `src/utils/compute-span-self-time.ts` for reuse across components (e.g., the upcoming flamegraph table)
- Uses `span.childSpans` directly (sorted by startTime invariant documented on IOtelSpan), eliminating `parentChildOfMap`, `getChildOfSpans`, and `memoize-one` dependency
- Add focused unit tests covering all algorithm edge cases (leaf span, overlapping children, children past parent bounds, etc.)

## Test plan
- [x] All existing TraceStatistics tests pass unchanged (selfTotal values match)
- [x] New `compute-span-self-time.test.ts` covers 11 edge cases
- [x] `npm run tsc-lint` passes
- [x] `npm run fmt && npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)