### PR TITLE
perf: make deduplicateTags linear using a Set instead of Array.some

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -13,14 +13,17 @@ import OtelTraceFacade from './OtelTraceFacade';
 // exported for tests
 export function deduplicateTags(spanTags: ReadonlyArray<KeyValuePair>) {
   const warningsHash: Map<string, string> = new Map<string, string>();
-  const tags: KeyValuePair[] = spanTags.reduce<KeyValuePair[]>((uniqueTags, tag) => {
-    if (!uniqueTags.some(t => t.key === tag.key && t.value === tag.value)) {
-      uniqueTags.push(tag);
+  const seen = new Set<string>();
+  const tags: KeyValuePair[] = [];
+  for (const tag of spanTags) {
+    const key = `${tag.key}:${tag.value}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      tags.push(tag);
     } else {
-      warningsHash.set(`${tag.key}:${tag.value}`, `Duplicate tag "${tag.key}:${tag.value}"`);
+      warningsHash.set(key, `Duplicate tag "${tag.key}:${tag.value}"`);
     }
-    return uniqueTags;
-  }, []);
+  }
   const warnings = Array.from(warningsHash.values());
   return { tags, warnings };
 }

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -16,7 +16,7 @@ export function deduplicateTags(spanTags: ReadonlyArray<KeyValuePair>) {
   const seen = new Set<string>();
   const tags: KeyValuePair[] = [];
   for (const tag of spanTags) {
-    const key = `${tag.key}:${tag.value}`;
+    const key = `${tag.key}\0${tag.type ?? ''}\0${tag.value}`;
     if (!seen.has(key)) {
       seen.add(key);
       tags.push(tag);


### PR DESCRIPTION
deduplicateTags was using Array.some inside reduce, scanning the whole accumulated array for each tag. Swapped to a Set keyed on tag key+value so deduplication is O(n) instead of O(n²). Matters for GenAI spans that can have large numbers of tags.

Closes #4109