### PR TITLE
Enhance accessibility for trace page search controls

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.test.jsx
@@ -88,6 +88,12 @@ describe('<TracePageSearchBar>', () => {
       expect(defaultProps.nextResult).toHaveBeenCalled();
     });
 
+    it('renders navigation buttons with accessible names', () => {
+      expect(screen.getByRole('button', { name: /locate current match/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /previous match/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /next match/i })).toBeInTheDocument();
+    });
+
     it('hides navigation buttons when not navigable', () => {
       cleanup();
       render(<TracePageSearchBar {...defaultProps} navigable={false} />);

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.tsx
@@ -81,7 +81,11 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
           arrow={{ pointAtCenter: true }}
           placement="bottomLeft"
           trigger="hover"
-          overlayStyle={{ maxWidth: '600px' }} // This is a large tooltip and the default is too narrow.
+          styles={{
+            root: {
+              maxWidth: '600px',
+            },
+          }} // This is a large tooltip and the default is too narrow.
           title={renderTooltip()}
         >
           <div className="help-btn-container">
@@ -94,6 +98,8 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
               className={cx(btnClass, 'TracePageSearchBar--locateBtn')}
               disabled={!textFilter}
               htmlType="button"
+              title="Locate current match"
+              aria-label="Locate current match"
               onClick={focusUiFindMatches}
             >
               <IoLocate />
@@ -102,6 +108,8 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
               className={cx(btnClass, 'TracePageSearchBar--ButtonUp')}
               disabled={!textFilter}
               htmlType="button"
+              title="Previous match"
+              aria-label="Previous match"
               data-testid="UpOutlined"
               onClick={prevResult}
             >
@@ -111,6 +119,8 @@ export function TracePageSearchBarFn(props: TracePageSearchBarProps & { forwarde
               className={cx(btnClass, 'TracePageSearchBar--ButtonDown')}
               disabled={!textFilter}
               htmlType="button"
+              title="Next match"
+              aria-label="Next match"
               data-testid="DownOutlined"
               onClick={nextResult}
             >


### PR DESCRIPTION
## Which problem is this PR solving?



This PR improves accessibility for the trace page search controls and updates deprecated Ant Design Tooltip usage.



## Description of the changes



* Replaced deprecated `overlayStyle` with `styles.root` in the Ant Design `Tooltip`.

* Added `title` and `aria-label` attributes to the trace page search navigation buttons

  * Locate current match
  * Previous match
  * Next match
* Improved accessibility for screen reader users and provided descriptive labels for icon-only controls.

## How was this change tested?

* Verified the changes locally using the development server.
* Confirmed that the search navigation buttons expose the expected labels.
* Verified that the Tooltip deprecation warning is resolved.

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [ ] I have signed all commits
* [ ] I have added unit tests for the new functionality
* [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

* [ ] **Moderate**: AI helped with code generation or debugging specific parts
* [x] **None**: No AI tools were used in creating this PR
* [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
* [ ] **Heavy**: AI generated most or all of the code changes