### PR TITLE
Adjust self-loop edge labels

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
@@ -95,9 +95,9 @@ describe('<TraceGraph>', () => {
 
     // Initial mode should be service
     expect(screen.getByTestId('mock-digraph')).toHaveAttribute('data-mode', MODE_SERVICE);
-    const timeButton = screen.getByRole('button', { name: 'T' });
-    const selftimeButton = screen.getByRole('button', { name: 'ST' });
-    const serviceButton = screen.getByRole('button', { name: 'S' });
+    const timeButton = screen.getByRole('button', { name: 'Switch trace graph coloring to time' });
+    const selftimeButton = screen.getByRole('button', { name: 'Switch trace graph coloring to self time' });
+    const serviceButton = screen.getByRole('button', { name: 'Switch trace graph coloring to service' });
 
     // Switch to time
     await userEvent.click(timeButton);

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -192,8 +192,10 @@ function TraceGraph({
               <Button
                 className={cx('TraceGraph--btn-service', { active: mode === MODE_SERVICE })}
                 htmlType="button"
+                aria-label="Switch trace graph coloring to service"
                 shape="circle"
                 size="small"
+                title="Service"
                 onClick={() => setMode(MODE_SERVICE)}
               >
                 S
@@ -205,8 +207,10 @@ function TraceGraph({
               <Button
                 className={cx('TraceGraph--btn-time', { active: mode === MODE_TIME })}
                 htmlType="button"
+                aria-label="Switch trace graph coloring to time"
                 shape="circle"
                 size="small"
+                title="Time"
                 onClick={() => setMode(MODE_TIME)}
               >
                 T
@@ -218,8 +222,10 @@ function TraceGraph({
               <Button
                 className={cx('TraceGraph--btn-selftime', { active: mode === MODE_SELFTIME })}
                 htmlType="button"
+                aria-label="Switch trace graph coloring to self time"
                 shape="circle"
                 size="small"
+                title="Selftime"
                 onClick={() => setMode(MODE_SELFTIME)}
               >
                 ST

--- a/packages/plexus/src/Digraph/SvgEdge.test.jsx
+++ b/packages/plexus/src/Digraph/SvgEdge.test.jsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import SvgEdge from './SvgEdge';
+
+const baseProps = {
+  getClassName: name => `test-${name}`,
+  renderUtils: {
+    getGlobalId: id => `global-${id}`,
+  },
+  layoutEdge: {
+    edge: { from: 'a', to: 'b' },
+    pathPoints: [
+      [0, 100],
+      [50, 120],
+    ],
+  },
+};
+
+describe('SvgEdge', () => {
+  it('renders the label text at the midpoint for normal edges', () => {
+    const { container, getByText } = render(
+      <svg>
+        <SvgEdge {...baseProps} label="Hello" />
+      </svg>
+    );
+
+    const text = getByText('Hello');
+    expect(text).toBeTruthy();
+    expect(container.querySelector('text').getAttribute('dominant-baseline')).toBe('middle');
+    expect(text.getAttribute('y')).toBe('110');
+  });
+
+  it('lifts the label above self-loops', () => {
+    const selfLoopProps = {
+      ...baseProps,
+      layoutEdge: {
+        edge: { from: 'a', to: 'a' },
+        pathPoints: [
+          [0, 140],
+          [40, 116],
+          [80, 132],
+        ],
+      },
+    };
+
+    const { getByText } = render(
+      <svg>
+        <SvgEdge {...selfLoopProps} label="Loop" />
+      </svg>
+    );
+
+    expect(getByText('Loop').getAttribute('y')).toBe('108');
+  });
+});

--- a/packages/plexus/src/Digraph/SvgEdge.tsx
+++ b/packages/plexus/src/Digraph/SvgEdge.tsx
@@ -36,13 +36,13 @@ function makePathD(points: [number, number][]) {
   return dArr.join(' ');
 }
 
-function computeLabelCoord(pathPoints: [number, number][], label?: string | undefined) {
+function computeLabelCoord(pathPoints: [number, number][], label?: string | undefined, selfLoop = false) {
   const [startX, startY] = pathPoints[0];
   const [endX, endY] = pathPoints[pathPoints.length - 1];
 
   const xOffset = (label?.length ?? 0) * 5;
   const labelX = (startX + endX) / 2 - xOffset;
-  const labelY = (startY + endY) / 2;
+  const labelY = selfLoop ? Math.min(...pathPoints.map(([, y]) => y)) - 8 : (startY + endY) / 2;
 
   return { labelX, labelY };
 }
@@ -62,7 +62,8 @@ function SvgEdge<U = {}>(props: TProps<U>) {
     getProps(setOnEdge, layoutEdge, renderUtils)
   );
 
-  const { labelX, labelY } = computeLabelCoord(pathPoints, label);
+  const selfLoop = layoutEdge.edge.from === layoutEdge.edge.to;
+  const { labelX, labelY } = computeLabelCoord(pathPoints, label, selfLoop);
 
   return (
     <g>
@@ -76,7 +77,7 @@ function SvgEdge<U = {}>(props: TProps<U>) {
       />
 
       {label && (
-        <text x={labelX} y={labelY} fill="currentColor" fontSize="1rem" fontWeight="bold">
+        <text x={labelX} y={labelY} fill="currentColor" fontSize="1rem" fontWeight="bold" dominantBaseline="middle">
           {label}
         </text>
       )}


### PR DESCRIPTION
Fixes the system architecture graph label placement for self-referencing edges so the label sits above the loop instead of being clipped into the curve.\n\nAdds a focused test for the normal-edge midpoint and self-loop offset behavior.