### PR TITLE
feat(monitor): Support service/spanKind/timeframe URL params

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -10,6 +10,7 @@ import { MonitorATMServicesViewImpl as MonitorATMServicesView, mapStateToProps, 
 import { getLoopbackInterval, timeFrameOptions, yAxisTickFormat } from './timeFrameUtils';
 import { useServices } from '../../../hooks/useTraceDiscovery';
 import { ONE_HOUR_MS, TIME_RANGE_OPTIONS } from '../../../utils/time-range-options';
+import store from '../../../utils/storage';
 import {
   originInitialState,
   serviceMetrics,
@@ -736,6 +737,81 @@ describe('<MonitorATMServicesView>', () => {
       expect(fetchAll).toHaveBeenCalled();
       expect(fetchAgg).toHaveBeenCalled();
     });
+  });
+});
+
+describe('<MonitorATMServicesView> URL query params', () => {
+  const mockFetchAllServiceMetrics = jest.fn();
+  const mockFetchAggregatedServiceMetrics = jest.fn();
+
+  const baseProps = {
+    ...props,
+    fetchAllServiceMetrics: mockFetchAllServiceMetrics,
+    fetchAggregatedServiceMetrics: mockFetchAggregatedServiceMetrics,
+  };
+
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+    useServices.mockReturnValue({ data: ['service1', 'service2'], isLoading: false });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    useServices.mockReset();
+    useServices.mockImplementation(defaultUseServicesImpl);
+    cleanup();
+  });
+
+  it('seeds filters from URL query params', () => {
+    renderWithRouter(
+      <MonitorATMServicesView {...baseProps} search="?service=service2&spanKind=client&timeframe=3600000" />
+    );
+
+    expect(screen.getByTestId('select-a-service-input').value).toBe('service2');
+    expect(screen.getByTestId('span-kind-selector').value).toBe('client');
+    expect(screen.getByTestId('select-a-timeframe-input').value).toBe('3600000');
+  });
+
+  it('does not persist URL-sourced filters to localStorage', () => {
+    renderWithRouter(
+      <MonitorATMServicesView {...baseProps} search="?service=service2&spanKind=client&timeframe=3600000" />
+    );
+
+    expect(store.set).not.toHaveBeenCalledWith('lastAtmSearchService', expect.anything());
+    expect(store.set).not.toHaveBeenCalledWith('lastAtmSearchSpanKind', expect.anything());
+    expect(store.set).not.toHaveBeenCalledWith('lastAtmSearchTimeframe', expect.anything());
+  });
+
+  it('falls back to defaults and persists them when no URL params are present', () => {
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="" />);
+
+    expect(store.set).toHaveBeenCalledWith('lastAtmSearchService', 'service1');
+    expect(store.set).toHaveBeenCalledWith('lastAtmSearchSpanKind', 'server');
+  });
+
+  it('ignores invalid URL params and falls back to defaults', () => {
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="?spanKind=bogus&timeframe=notanumber" />);
+
+    expect(screen.getByTestId('span-kind-selector').value).toBe('server');
+    expect(store.set).toHaveBeenCalledWith('lastAtmSearchSpanKind', 'server');
+  });
+
+  it('persists a URL-seeded filter once the user changes it', async () => {
+    const trackSpy = jest.spyOn(track, 'trackSelectSpanKind').mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="?spanKind=client" />);
+
+    expect(store.set).not.toHaveBeenCalledWith('lastAtmSearchSpanKind', expect.anything());
+
+    await user.selectOptions(screen.getByTestId('span-kind-selector'), 'server');
+
+    await waitFor(() => {
+      expect(store.set).toHaveBeenCalledWith('lastAtmSearchSpanKind', 'server');
+    });
+
+    trackSpy.mockRestore();
   });
 });
 

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -813,6 +813,14 @@ describe('<MonitorATMServicesView> URL query params', () => {
 
     trackSpy.mockRestore();
   });
+
+  it('falls back to a loaded service when the URL service is not recognized', () => {
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="?service=evil%26foo=bar" />);
+
+    expect(mockFetchAllServiceMetrics).toHaveBeenCalledWith('service1', expect.anything());
+    expect(mockFetchAggregatedServiceMetrics).toHaveBeenCalledWith('service1', expect.anything());
+    expect(store.set).toHaveBeenCalledWith('lastAtmSearchService', 'service1');
+  });
 });
 
 describe('<MonitorATMServicesView> on page switch', () => {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -821,6 +821,15 @@ describe('<MonitorATMServicesView> URL query params', () => {
     expect(mockFetchAggregatedServiceMetrics).toHaveBeenCalledWith('service1', expect.anything());
     expect(store.set).toHaveBeenCalledWith('lastAtmSearchService', 'service1');
   });
+
+  it('does not surface an unrecognized URL service in the View all traces link', () => {
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="?service=evil%26foo=bar" />);
+
+    const link = screen.getByText('View all traces');
+    const href = link.getAttribute('href');
+    expect(href).toContain('service=service1');
+    expect(href).not.toContain('evil');
+  });
 });
 
 describe('<MonitorATMServicesView> on page switch', () => {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -753,6 +753,8 @@ describe('<MonitorATMServicesView> URL query params', () => {
   beforeEach(() => {
     cleanup();
     jest.clearAllMocks();
+    store.getString.mockReturnValue(undefined);
+    store.getNumber.mockReturnValue(undefined);
     useServices.mockReturnValue({ data: ['service1', 'service2'], isLoading: false });
   });
 
@@ -819,7 +821,37 @@ describe('<MonitorATMServicesView> URL query params', () => {
 
     expect(mockFetchAllServiceMetrics).toHaveBeenCalledWith('service1', expect.anything());
     expect(mockFetchAggregatedServiceMetrics).toHaveBeenCalledWith('service1', expect.anything());
-    expect(store.set).toHaveBeenCalledWith('lastAtmSearchService', 'service1');
+    expect(store.set).not.toHaveBeenCalledWith('lastAtmSearchService', expect.anything());
+  });
+
+  it('falls back to stored service when URL service is invalid', () => {
+    store.getString.mockImplementation(key => {
+      if (key === 'lastAtmSearchService') return 'service2';
+      return undefined;
+    });
+
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="?service=missing" />);
+
+    expect(screen.getByTestId('select-a-service-input').value).toBe('service2');
+    expect(mockFetchAllServiceMetrics).toHaveBeenCalledWith('service2', expect.anything());
+    expect(store.set).not.toHaveBeenCalledWith('lastAtmSearchService', expect.anything());
+  });
+
+  it('updates filters when search changes without remounting', () => {
+    const { rerender } = renderWithRouter(
+      <MonitorATMServicesView {...baseProps} search="?service=service1" />
+    );
+
+    expect(screen.getByTestId('select-a-service-input').value).toBe('service1');
+
+    rerender(
+      <MemoryRouter>
+        <MonitorATMServicesView {...baseProps} search="?service=service2&spanKind=client" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('select-a-service-input').value).toBe('service2');
+    expect(screen.getByTestId('span-kind-selector').value).toBe('client');
   });
 
   it('does not surface an unrecognized URL service in the View all traces link', () => {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -42,12 +42,17 @@ import withRouteProps from '../../../utils/withRouteProps';
 
 import SearchableSelect from '../../common/SearchableSelect';
 import { useServices } from '../../../hooks/useTraceDiscovery';
+import { getUrlState } from '../url';
 
 type TReduxProps = {
   metrics: MetricsReduxState;
 };
 
-type TProps = TReduxProps & TDispatchProps;
+type TOwnProps = {
+  search?: string;
+};
+
+type TProps = TReduxProps & TDispatchProps & TOwnProps;
 
 type TDispatchProps = {
   fetchAggregatedServiceMetrics: ActionFunctionAny<Action<Promise<FetchAggregatedServiceMetricsResponse>>>;
@@ -97,25 +102,35 @@ const convertServiceErrorRateToPercentages = (serviceErrorRate: null | ServiceMe
 };
 
 export function MonitorATMServicesViewImpl(props: TProps) {
-  const { fetchAllServiceMetrics, fetchAggregatedServiceMetrics, metrics } = props;
+  const { fetchAllServiceMetrics, fetchAggregatedServiceMetrics, metrics, search = '' } = props;
   const { data: services = [], isLoading: servicesLoading } = useServices();
   const docsLink = getConfig().monitor?.docsLink;
   const graphDivWrapper = useRef<HTMLDivElement>(null);
+
+  const urlState = getUrlState(search);
+
   const [endTime, setEndTime] = useState<number>(Date.now());
   const [graphWidth, setGraphWidth] = useState<number>(300);
   const [serviceOpsMetrics, setServiceOpsMetrics] = useState<ServiceOpsMetrics[] | undefined>(undefined);
   const [searchOps, setSearchOps] = useState<string>('');
   const [graphXDomain, setGraphXDomain] = useState<number[]>([]);
   const [selectedService, setSelectedService] = useState<string | undefined>(
-    store.getString('lastAtmSearchService')
+    urlState.service ?? store.getString('lastAtmSearchService')
   );
   const [selectedSpanKind, setSelectedSpanKind] = useState<spanKinds>(() => {
+    if (urlState.spanKind) return urlState.spanKind;
     const stored = store.getString('lastAtmSearchSpanKind');
     return spanKindOptions.some(opt => opt.value === stored) ? (stored as spanKinds) : 'server';
   });
   const [selectedTimeFrame, setSelectedTimeFrame] = useState<number>(
-    store.getNumber('lastAtmSearchTimeframe', ONE_HOUR_MS)
+    urlState.timeframe ?? store.getNumber('lastAtmSearchTimeframe', ONE_HOUR_MS)
   );
+
+  const urlOwned = useRef({
+    service: urlState.service != null,
+    spanKind: urlState.spanKind != null,
+    timeframe: urlState.timeframe != null,
+  });
 
   const calcGraphXDomain = useCallback(() => {
     const currentTime = Date.now();
@@ -133,17 +148,20 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   }, [services, selectedService]);
 
   const handleServiceChange = useCallback((value: string) => {
+    urlOwned.current.service = false;
     setSelectedService(value);
     trackSelectService(value);
   }, []);
 
   const handleSpanKindChange = useCallback((value: string) => {
+    urlOwned.current.spanKind = false;
     setSelectedSpanKind(value as spanKinds);
     const { label } = spanKindOptions.find(option => option.value === value)!;
     trackSelectSpanKind(label);
   }, []);
 
   const handleTimeFrameChange = useCallback((value: number) => {
+    urlOwned.current.timeframe = false;
     setSelectedTimeFrame(value);
     const { label } = timeFrameOptions.find(option => option.value === value)!;
     trackSelectTimeframe(label);
@@ -155,9 +173,9 @@ export function MonitorATMServicesViewImpl(props: TProps) {
     if (currentService) {
       const newEndTime = Date.now();
       setEndTime(newEndTime);
-      store.set('lastAtmSearchSpanKind', selectedSpanKind);
-      store.set('lastAtmSearchTimeframe', selectedTimeFrame);
-      store.set('lastAtmSearchService', currentService);
+      if (!urlOwned.current.spanKind) store.set('lastAtmSearchSpanKind', selectedSpanKind);
+      if (!urlOwned.current.timeframe) store.set('lastAtmSearchTimeframe', selectedTimeFrame);
+      if (!urlOwned.current.service) store.set('lastAtmSearchService', currentService);
 
       const metricQueryPayload = {
         quantile: 0.95,

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -72,6 +72,32 @@ const spanKindOptions = [
   { label: 'Consumer', value: 'consumer' },
 ];
 
+const getDefaultSpanKind = (): spanKinds => {
+  const stored = store.getString('lastAtmSearchSpanKind');
+  return spanKindOptions.some(opt => opt.value === stored) ? (stored as spanKinds) : 'server';
+};
+
+const resolveService = (candidate: string | undefined, services: string[]): string | undefined => {
+  if (candidate && services.includes(candidate)) return candidate;
+  const stored = store.getString('lastAtmSearchService');
+  if (stored && services.includes(stored)) return stored;
+  return services[0];
+};
+
+const getFiltersFromSearch = (search: string) => {
+  const urlState = getUrlState(search);
+  return {
+    selectedService: urlState.service ?? store.getString('lastAtmSearchService'),
+    selectedSpanKind: urlState.spanKind ?? getDefaultSpanKind(),
+    selectedTimeFrame: urlState.timeframe ?? store.getNumber('lastAtmSearchTimeframe', ONE_HOUR_MS),
+    urlOwned: {
+      service: urlState.service != null,
+      spanKind: urlState.spanKind != null,
+      timeframe: urlState.timeframe != null,
+    },
+  };
+};
+
 const calcDisplayTimeUnit = (serviceLatencies: ServiceMetricsObject | ServiceMetricsObject[] | null) => {
   let maxValue = 0;
 
@@ -107,30 +133,26 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   const docsLink = getConfig().monitor?.docsLink;
   const graphDivWrapper = useRef<HTMLDivElement>(null);
 
-  const urlState = getUrlState(search);
+  const initialFilters = getFiltersFromSearch(search);
 
   const [endTime, setEndTime] = useState<number>(Date.now());
   const [graphWidth, setGraphWidth] = useState<number>(300);
   const [serviceOpsMetrics, setServiceOpsMetrics] = useState<ServiceOpsMetrics[] | undefined>(undefined);
   const [searchOps, setSearchOps] = useState<string>('');
   const [graphXDomain, setGraphXDomain] = useState<number[]>([]);
-  const [selectedService, setSelectedService] = useState<string | undefined>(
-    urlState.service ?? store.getString('lastAtmSearchService')
-  );
-  const [selectedSpanKind, setSelectedSpanKind] = useState<spanKinds>(() => {
-    if (urlState.spanKind) return urlState.spanKind;
-    const stored = store.getString('lastAtmSearchSpanKind');
-    return spanKindOptions.some(opt => opt.value === stored) ? (stored as spanKinds) : 'server';
-  });
-  const [selectedTimeFrame, setSelectedTimeFrame] = useState<number>(
-    urlState.timeframe ?? store.getNumber('lastAtmSearchTimeframe', ONE_HOUR_MS)
-  );
+  const [selectedService, setSelectedService] = useState<string | undefined>(initialFilters.selectedService);
+  const [selectedSpanKind, setSelectedSpanKind] = useState<spanKinds>(initialFilters.selectedSpanKind);
+  const [selectedTimeFrame, setSelectedTimeFrame] = useState<number>(initialFilters.selectedTimeFrame);
 
-  const urlOwned = useRef({
-    service: urlState.service != null,
-    spanKind: urlState.spanKind != null,
-    timeframe: urlState.timeframe != null,
-  });
+  const urlOwned = useRef(initialFilters.urlOwned);
+
+  useEffect(() => {
+    const filters = getFiltersFromSearch(search);
+    urlOwned.current = filters.urlOwned;
+    setSelectedService(filters.selectedService);
+    setSelectedSpanKind(filters.selectedSpanKind);
+    setSelectedTimeFrame(filters.selectedTimeFrame);
+  }, [search]);
 
   const calcGraphXDomain = useCallback(() => {
     const currentTime = Date.now();
@@ -144,8 +166,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   }, []);
 
   const getSelectedService = useCallback(() => {
-    const candidate = selectedService || store.getString('lastAtmSearchService');
-    return candidate && services.includes(candidate) ? candidate : services[0];
+    return resolveService(selectedService, services);
   }, [services, selectedService]);
 
   const handleServiceChange = useCallback((value: string) => {
@@ -169,13 +190,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   }, []);
 
   const fetchMetrics = useCallback(() => {
-    const isValidSelected = selectedService != null && services.includes(selectedService);
-
-    if (!isValidSelected && urlOwned.current.service) {
-      urlOwned.current.service = false;
-    }
-
-    const currentService = isValidSelected ? selectedService : services[0];
+    const currentService = resolveService(selectedService, services);
 
     if (currentService) {
       const newEndTime = Date.now();
@@ -420,7 +435,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
             data={serviceOpsMetrics === undefined ? metrics.serviceOpsMetrics : serviceOpsMetrics}
             endTime={endTime}
             lookback={selectedTimeFrame}
-            serviceName={getSelectedService()}
+            serviceName={getSelectedService() ?? ''}
           />
         </Row>
       </div>

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -168,7 +168,13 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   }, []);
 
   const fetchMetrics = useCallback(() => {
-    const currentService = selectedService || services[0];
+    const isValidSelected = selectedService != null && services.includes(selectedService);
+
+    if (!isValidSelected && urlOwned.current.service) {
+      urlOwned.current.service = false;
+    }
+
+    const currentService = isValidSelected ? selectedService : services[0];
 
     if (currentService) {
       const newEndTime = Date.now();

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -144,7 +144,8 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   }, []);
 
   const getSelectedService = useCallback(() => {
-    return selectedService || store.getString('lastAtmSearchService') || services[0];
+    const candidate = selectedService || store.getString('lastAtmSearchService');
+    return candidate && services.includes(candidate) ? candidate : services[0];
   }, [services, selectedService]);
 
   const handleServiceChange = useCallback((value: string) => {

--- a/packages/jaeger-ui/src/components/Monitor/url.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/url.test.js
@@ -36,6 +36,10 @@ describe('Monitor/url', () => {
       expect(getUrlState('?timeframe=notanumber')).toEqual({});
     });
 
+    it('omits a timeframe with trailing non-numeric characters', () => {
+      expect(getUrlState('?timeframe=3600000junk')).toEqual({});
+    });
+
     it('ignores unrelated params such as uiEmbed', () => {
       expect(getUrlState('?service=myservice&uiEmbed=v0')).toEqual({ service: 'myservice' });
     });

--- a/packages/jaeger-ui/src/components/Monitor/url.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/url.test.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ROUTE_PATH, matches, getUrl } from './url';
+import { ROUTE_PATH, matches, getUrl, getUrlState } from './url';
 
 describe('Monitor/url', () => {
   it('matches', () => {
@@ -12,5 +12,36 @@ describe('Monitor/url', () => {
 
   it('getUrl', () => {
     expect(getUrl()).toBe(ROUTE_PATH);
+  });
+
+  describe('getUrlState', () => {
+    it('parses valid service, spanKind and timeframe', () => {
+      expect(getUrlState('?service=myservice&spanKind=client&timeframe=3600000')).toEqual({
+        service: 'myservice',
+        spanKind: 'client',
+        timeframe: 3600000,
+      });
+    });
+
+    it('returns an empty object when no params are present', () => {
+      expect(getUrlState('')).toEqual({});
+    });
+
+    it('omits an invalid spanKind', () => {
+      expect(getUrlState('?spanKind=bogus')).toEqual({});
+    });
+
+    it('omits a timeframe that is not a recognized option', () => {
+      expect(getUrlState('?timeframe=12345')).toEqual({});
+      expect(getUrlState('?timeframe=notanumber')).toEqual({});
+    });
+
+    it('ignores unrelated params such as uiEmbed', () => {
+      expect(getUrlState('?service=myservice&uiEmbed=v0')).toEqual({ service: 'myservice' });
+    });
+
+    it('uses the first value when a param is repeated', () => {
+      expect(getUrlState('?service=first&service=second')).toEqual({ service: 'first' });
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/Monitor/url.ts
+++ b/packages/jaeger-ui/src/components/Monitor/url.ts
@@ -1,11 +1,17 @@
 // Copyright (c) 2021 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import memoizeOne from 'memoize-one';
+import queryString from 'query-string';
 import { matchPath } from 'react-router-dom';
 
 import prefixUrl from '../../utils/prefix-url';
+import { spanKinds } from '../../types/metrics';
+import { timeFrameOptions } from './ServicesView/timeFrameUtils';
 
 export const ROUTE_PATH = prefixUrl('/monitor');
+
+const VALID_SPAN_KINDS: spanKinds[] = ['client', 'server', 'internal', 'producer', 'consumer'];
 
 export function matches(path: string) {
   return Boolean(matchPath(ROUTE_PATH, path));
@@ -14,3 +20,35 @@ export function matches(path: string) {
 export function getUrl() {
   return ROUTE_PATH;
 }
+
+export type TMonitorUrlState = {
+  service?: string;
+  spanKind?: spanKinds;
+  timeframe?: number;
+};
+
+const firstValue = (value: string | (string | null)[] | null): string | null =>
+  Array.isArray(value) ? value[0] : value;
+
+export const getUrlState = memoizeOne(function getUrlState(search: string): TMonitorUrlState {
+  const { service, spanKind, timeframe } = queryString.parse(search);
+  const rv: TMonitorUrlState = {};
+
+  const serviceValue = firstValue(service);
+  if (serviceValue) rv.service = serviceValue;
+
+  const spanKindValue = firstValue(spanKind);
+  if (spanKindValue && VALID_SPAN_KINDS.includes(spanKindValue as spanKinds)) {
+    rv.spanKind = spanKindValue as spanKinds;
+  }
+
+  const timeframeValue = firstValue(timeframe);
+  if (timeframeValue != null) {
+    const parsed = Number.parseInt(timeframeValue, 10);
+    if (Number.isFinite(parsed) && timeFrameOptions.some(option => option.value === parsed)) {
+      rv.timeframe = parsed;
+    }
+  }
+
+  return rv;
+});

--- a/packages/jaeger-ui/src/components/Monitor/url.ts
+++ b/packages/jaeger-ui/src/components/Monitor/url.ts
@@ -43,8 +43,8 @@ export const getUrlState = memoizeOne(function getUrlState(search: string): TMon
   }
 
   const timeframeValue = firstValue(timeframe);
-  if (timeframeValue != null) {
-    const parsed = Number.parseInt(timeframeValue, 10);
+  if (timeframeValue != null && /^\d+$/.test(timeframeValue)) {
+    const parsed = Number(timeframeValue);
     if (Number.isFinite(parsed) && timeFrameOptions.some(option => option.value === parsed)) {
       rv.timeframe = parsed;
     }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2482

## Description of the changes
- The Monitor tab now reads `service`, `spanKind`, and `timeframe` from the URL query params (e.g. `/monitor?service=myservice&spanKind=client&timeframe=3600000`), so the view can be deep-linked, bookmarked, and embedded.
- Filters resolve with priority **URL > localStorage > default**. Invalid or unrecognized params (bad `spanKind`, unknown `timeframe`) are ignored and fall back gracefully; unrelated params like `uiEmbed` are untouched.
- URL-sourced values are **not** persisted to localStorage — applying the `persist=false` concept from ADR-0010 (PR 2) — so opening a shared link never overwrites the recipient's saved Monitor defaults. Ownership transfers to the user (and the value becomes persistable) the moment they change a filter.
- Scope is read-only for now (no two-way URL sync / write-back on filter change).

Before:

https://github.com/user-attachments/assets/b786957b-6beb-46ad-8e35-9aa429f185ba

After:

https://github.com/user-attachments/assets/2bcd28b1-5857-4a82-b21c-7ddb97bacee5


## How was this change tested?
- Added unit tests for `getUrlState` in `Monitor/url.test.js` (valid parse, empty, invalid spanKind, invalid/unknown timeframe, ignores `uiEmbed`, repeated param).
- Added component tests in `Monitor/ServicesView/index.test.jsx`: URL seeding of all three filters, the no-persist guarantee (URL values not written to localStorage), fallback to defaults, invalid-param fallback, and persist-after-user-change.
- Ran `npm run fmt`, `npm run lint`, `npm test` (3214 + 115 passing), and `npm run build` — all pass.
- Manually verified against a local SPM backend (`docker-compose/monitor`) via the dev server.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes