### PR TITLE
feat(flamegraph): Resizable 50/50 table/chart split with scroll affordance

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/FlamegraphTable.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/FlamegraphTable.test.tsx
@@ -42,13 +42,14 @@ describe('<FlamegraphTable />', () => {
 
   it('shows "Service & Operation" column header by default', () => {
     render(<FlamegraphTable {...defaultProps} />);
-    expect(screen.getByText('Service & Operation')).toBeInTheDocument();
+    // The first column is fixed, so antd clones its header into the fixed-column layer.
+    expect(screen.getAllByText('Service & Operation')[0]).toBeInTheDocument();
   });
 
   it('shows "Service & Span Name" when useOpenTelemetryTerms is true', () => {
     mockUseConfig.mockReturnValue({ useOpenTelemetryTerms: true });
     render(<FlamegraphTable {...defaultProps} />);
-    expect(screen.getByText('Service & Span Name')).toBeInTheDocument();
+    expect(screen.getAllByText('Service & Span Name')[0]).toBeInTheDocument();
   });
 
   it('displays service name and operation name separately', () => {
@@ -99,7 +100,7 @@ describe('<FlamegraphTable />', () => {
 
   it('clicking column header toggles sort direction', () => {
     render(<FlamegraphTable {...defaultProps} />);
-    const countHeader = screen.getByText('Count');
+    const countHeader = screen.getAllByText('Count')[0];
     fireEvent.click(countHeader);
     // After clicking Count, rows should be sorted by count
     const rows = screen.getAllByRole('row');
@@ -110,7 +111,7 @@ describe('<FlamegraphTable />', () => {
   it('sort does not allow a third "cancel" state', () => {
     render(<FlamegraphTable {...defaultProps} />);
     // Default sort: self descend. Click Self header twice — should toggle to ascend then back to descend, never cancel
-    const selfHeader = screen.getByText('Self');
+    const selfHeader = screen.getAllByText('Self')[0];
     fireEvent.click(selfHeader); // ascend
     fireEvent.click(selfHeader); // descend
     // All rows should still be visible (sorted, not unsorted/cancelled)

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/FlamegraphTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/FlamegraphTable.tsx
@@ -60,6 +60,7 @@ const FlamegraphTable = ({ data, searchQuery, selectedItem, onRowClick, maxSelf,
       title: `Service & ${useOpenTelemetryTerms ? 'Span Name' : 'Operation'}`,
       dataIndex: 'name',
       key: 'name',
+      fixed: 'left',
       sortOrder: sortState.field === 'name' ? sortState.order : undefined,
       sorter: (a, b) => a.name.localeCompare(b.name),
       render: (_name: string, row: IFlamegraphTableRow) => {
@@ -135,6 +136,7 @@ const FlamegraphTable = ({ data, searchQuery, selectedItem, onRowClick, maxSelf,
       onRow={record => ({
         onClick: () => onRowClick(record.name),
       })}
+      scroll={{ x: 'max-content' }}
       data-testid="flamegraph-table"
     />
   );

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.css
@@ -26,6 +26,8 @@ SPDX-License-Identifier: Apache-2.0
   flex-direction: row;
   gap: 16px;
   min-height: 300px;
+  /* positioning context for the absolutely-positioned VerticalResizer in "both" mode */
+  position: relative;
 }
 
 .Flamegraph-content[data-view-mode='table'],
@@ -76,12 +78,7 @@ SPDX-License-Identifier: Apache-2.0
   min-width: 0;
 }
 
-/* "Both" mode: table 40%, chart fills rest */
-.Flamegraph-content[data-view-mode='both'] .Flamegraph-content--table {
-  flex: 0 0 40%;
-  max-width: 40%;
-}
-
+/* "Both" mode: table width is set inline (default 50%, drag-resizable); chart fills the rest */
 .Flamegraph-content[data-view-mode='both'] .Flamegraph-content--chart-wrapper {
   flex: 1;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.jsx
@@ -191,6 +191,25 @@ describe('<TraceFlamegraph />', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
+  it('renders a resizer in "both" mode with the table at the default 50% split', () => {
+    render(<TraceFlamegraph trace={otelTrace} />);
+    expect(screen.getByTestId('vertical-resizer')).toBeInTheDocument();
+    const tablePanel = screen.getByRole('table').closest('.Flamegraph-content--table');
+    expect(tablePanel).toHaveStyle({ maxWidth: '50%' });
+  });
+
+  it('does not render the resizer in table-only mode', () => {
+    render(<TraceFlamegraph trace={otelTrace} />);
+    fireEvent.click(screen.getByText('Table'));
+    expect(screen.queryByTestId('vertical-resizer')).not.toBeInTheDocument();
+  });
+
+  it('does not render the resizer in flamegraph-only mode', () => {
+    render(<TraceFlamegraph trace={otelTrace} />);
+    fireEvent.click(screen.getByText('Flamegraph'));
+    expect(screen.queryByTestId('vertical-resizer')).not.toBeInTheDocument();
+  });
+
   it('reset calls chart.resetZoom and chart.clear', () => {
     render(<TraceFlamegraph trace={otelTrace} />);
     const searchInput = screen.getByTestId('flamegraph-search');

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Tooltip } from 'antd';
 import flamegraph from 'd3-flame-graph';
 import { select } from 'd3-selection';
@@ -17,6 +17,7 @@ import FlamegraphToolbar, { ViewMode } from './FlamegraphToolbar';
 import FlamegraphTable from './FlamegraphTable';
 import FlamegraphContextMenu from './FlamegraphContextMenu';
 import FlamegraphTooltip from './FlamegraphTooltip';
+import VerticalResizer from '../../common/VerticalResizer';
 
 import 'd3-flame-graph/dist/d3-flamegraph.css';
 import './index.css';
@@ -37,14 +38,24 @@ interface TooltipState {
 
 const HIGHLIGHT_COLOR = '#E600E6';
 
+// Smallest gap (px) to leave to the right of the fixed first column when the table is at its
+// minimum width, so a sliver of the scrollable columns stays visible.
+const TABLE_MIN_GUTTER_PX = 16;
+
 const TraceFlamegraph = ({ trace }: any) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ReturnType<typeof flamegraph> | null>(null);
   const searchActiveRef = useRef(false);
   const zoomedNodeRef = useRef<any>(null);
   const hoveredFrameRef = useRef<Element | null>(null);
 
   const [viewMode, setViewMode] = useState<ViewMode>('both');
+  // Fraction of the content width allotted to the table in "both" mode (rest goes to the chart).
+  const [tableWidth, setTableWidth] = useState(0.5);
+  // Lower bound for the table fraction, derived from the (fixed) first column's width so the
+  // resizer can't shrink the table narrower than the Service & Operation column.
+  const [tableMinFraction, setTableMinFraction] = useState(0.2);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
   const [chartZoomed, setChartZoomed] = useState(false);
@@ -180,6 +191,38 @@ const TraceFlamegraph = ({ trace }: any) => {
     }
   }, [searchQuery, selectedItem, viewMode]);
 
+  // Re-fit the chart to its new width after the split is dragged (onChange fires once, on drag end).
+  useEffect(() => {
+    if (!showChart || !chartRef.current || !containerRef.current || !flameData) return;
+    chartRef.current.width(containerRef.current.clientWidth || 800);
+    select(containerRef.current).datum(flameData).call(chartRef.current);
+  }, [tableWidth, showChart, flameData]);
+
+  // Keep the resizer's minimum tied to the fixed first column's width, recomputing on layout
+  // changes (mode switch, data change, window resize). Without this the table could be dragged
+  // narrower than the pinned column, making the horizontal scroll behave erratically.
+  useLayoutEffect(() => {
+    if (viewMode !== 'both') return undefined;
+    const measure = () => {
+      const content = contentRef.current;
+      if (!content) return;
+      const contentW = content.clientWidth;
+      const firstCol = content.querySelector<HTMLElement>('.Flamegraph-content--table thead th');
+      const colW = firstCol ? firstCol.getBoundingClientRect().width : 0;
+      if (contentW > 0 && colW > 0) {
+        setTableMinFraction(Math.min(0.6, (colW + TABLE_MIN_GUTTER_PX) / contentW));
+      }
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [viewMode, tableData]);
+
+  // Clamp the current split into the allowed range whenever the minimum changes.
+  useEffect(() => {
+    setTableWidth(w => Math.min(0.8, Math.max(tableMinFraction, w)));
+  }, [tableMinFraction]);
+
   const handleReset = useCallback(() => {
     setSearchQuery('');
     setSelectedItem(null);
@@ -251,9 +294,16 @@ const TraceFlamegraph = ({ trace }: any) => {
         onCollapseAbove={handleCollapseAbove}
         showChart={showChart}
       />
-      <div className="Flamegraph-content" data-view-mode={viewMode}>
+      <div className="Flamegraph-content" data-view-mode={viewMode} ref={contentRef}>
         {showTable && (
-          <div className="Flamegraph-content--table">
+          <div
+            className="Flamegraph-content--table"
+            style={
+              viewMode === 'both'
+                ? { flex: `0 0 ${tableWidth * 100}%`, maxWidth: `${tableWidth * 100}%` }
+                : undefined
+            }
+          >
             <FlamegraphTable
               data={tableData}
               searchQuery={searchQuery}
@@ -263,6 +313,9 @@ const TraceFlamegraph = ({ trace }: any) => {
               maxTotal={maxTotal}
             />
           </div>
+        )}
+        {viewMode === 'both' && (
+          <VerticalResizer min={tableMinFraction} max={0.8} position={tableWidth} onChange={setTableWidth} />
         )}
         {showChart && (
           <div className="Flamegraph-content--chart-wrapper">


### PR DESCRIPTION
## Which problem is this PR solving?

- In the Flamegraph "both" view the table was fixed at 40% of the width, which clipped the `Self`/`Total` columns, and the overflow used a plain `overflow: auto` scrollbar that stays hidden (overlay scrollbars on macOS) until you actually scroll — so there was no hint that more columns existed off-screen.
- There was no way to rebalance how much space the table vs. the flamegraph chart gets.

## Description of the changes

- **Pin the first column** (`Service & Operation` / `Service & Span Name`) and enable antd's native horizontal scroll (`scroll={{ x: 'max-content' }}`), so an overflowing table shows a scrollbar plus a right-edge shadow and keeps the row label anchored while scrolling.
- **Default the table/chart split to 50/50** (was 40/60) so `Self` fits without scrolling in common cases.
- **Add the standard `VerticalResizer`** to drag the table/chart boundary; the d3 chart re-fits to its new width on drag end.
- **Bound the resizer minimum** to the fixed first column's width, so the table can never be dragged narrower than the Service & Operation column (which would make the pinned-column scroll behave erratically). The minimum is recomputed on mode/data/window-size changes.

## How was this change tested?

- Manually verified in the running UI (Flamegraph "both" mode): default 50/50 split, draggable resizer with the chart re-fitting, the drag clamping so the table never shrinks below the first column, and the pinned column + edge shadow when the table still overflows.
- Added/updated unit tests: resizer presence per view mode and default split in `index.test.jsx`; header lookups in `FlamegraphTable.test.tsx` adjusted for the cloned fixed-column header.
- `npm run fmt`, `npm run lint`, `npm test` (3174 passing), and `npm run build` all pass.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] All commits are signed with DCO (`git commit -s`)
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR

Used Claude Code (Opus 4.8) to investigate the layout, implement the changes, and verify them live with the Playwright browser plugin against a local Jaeger instance (including measuring column widths and exercising the resizer drag). All changes were reviewed by the author.