### PR TITLE
feat(genai): add GenAI tab shell to span detail panel

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import GenAITab from '.';
+import type { IOtelSpan } from '../../../../../types/otel';
+
+const span = { spanID: 'abc123' } as unknown as IOtelSpan;
+
+describe('GenAITab', () => {
+  it('renders the placeholder message', () => {
+    render(<GenAITab span={span} />);
+    expect(screen.getByText('GenAI details coming soon.')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import type { IOtelSpan } from '../../../../../types/otel';
+
+type Props = { span: IOtelSpan };
+
+export default function GenAITab({ span: _span }: Props): React.ReactElement {
+  return <div className="GenAITab">GenAI details coming soon.</div>;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -330,11 +330,12 @@ describe('<SpanDetail>', () => {
       expect(screen.getByTestId('genai-tab')).toBeInTheDocument();
     });
 
-    it('defaults to the Details tab for a non-GenAI span', () => {
+    it('renders no tab bar for a non-GenAI span — content is shown directly', () => {
       useJaegerAssistantEnabledMock.mockReturnValue(true);
       isGenAISpanMock.mockReturnValue(false);
       render(<SpanDetail {...props} />);
-      expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+      expect(screen.getByTestId('accordian-keyvalues-tags')).toBeInTheDocument();
     });
 
     it('defaults to the GenAI tab when span has gen_ai.* attributes and assistant is enabled', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -95,12 +95,8 @@ vi.mock('./GenAITab', () => {
   });
 });
 
-const { useJaegerAssistantEnabledMock, isGenAISpanMock } = vi.hoisted(() => ({
-  useJaegerAssistantEnabledMock: vi.fn(() => false),
+const { isGenAISpanMock } = vi.hoisted(() => ({
   isGenAISpanMock: vi.fn(() => false),
-}));
-vi.mock('../../../../hooks/useJaegerAssistant', () => ({
-  useJaegerAssistantEnabled: useJaegerAssistantEnabledMock,
 }));
 vi.mock('../../../../utils/genai', () => ({
   isGenAISpan: isGenAISpanMock,
@@ -305,41 +301,29 @@ describe('<SpanDetail>', () => {
 
   describe('GenAI tab', () => {
     beforeEach(() => {
-      useJaegerAssistantEnabledMock.mockReset();
       isGenAISpanMock.mockReset();
     });
 
-    it('does not show the GenAI tab when the AI assistant is disabled', () => {
-      useJaegerAssistantEnabledMock.mockReturnValue(false);
-      isGenAISpanMock.mockReturnValue(true);
-      render(<SpanDetail {...props} />);
-      expect(screen.queryByTestId('genai-tab')).not.toBeInTheDocument();
-    });
-
     it('does not show the GenAI tab when the span has no gen_ai.* attributes', () => {
-      useJaegerAssistantEnabledMock.mockReturnValue(true);
       isGenAISpanMock.mockReturnValue(false);
       render(<SpanDetail {...props} />);
-      expect(screen.queryByTestId('genai-tab')).not.toBeInTheDocument();
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument();
     });
 
-    it('shows the GenAI tab when AI assistant is enabled and span has gen_ai.* attributes', () => {
-      useJaegerAssistantEnabledMock.mockReturnValue(true);
+    it('shows the GenAI tab when the span has gen_ai.* attributes', () => {
       isGenAISpanMock.mockReturnValue(true);
       render(<SpanDetail {...props} />);
       expect(screen.getByRole('tab', { name: 'GenAI' })).toBeInTheDocument();
     });
 
     it('renders no tab bar for a non-GenAI span — content is shown directly', () => {
-      useJaegerAssistantEnabledMock.mockReturnValue(true);
       isGenAISpanMock.mockReturnValue(false);
       render(<SpanDetail {...props} />);
       expect(screen.queryByRole('tab')).not.toBeInTheDocument();
       expect(screen.getByTestId('accordian-keyvalues-tags')).toBeInTheDocument();
     });
 
-    it('defaults to the Details tab even when the span has gen_ai.* attributes', () => {
-      useJaegerAssistantEnabledMock.mockReturnValue(true);
+    it('defaults to the Details tab for a GenAI span', () => {
       isGenAISpanMock.mockReturnValue(true);
       render(<SpanDetail {...props} />);
       expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -89,6 +89,23 @@ vi.mock('../../../common/CopyIcon', () => {
   });
 });
 
+vi.mock('./GenAITab', () => {
+  return mockDefault(function MockGenAITab() {
+    return <div data-testid="genai-tab">GenAI Tab</div>;
+  });
+});
+
+const { useJaegerAssistantEnabledMock, isGenAISpanMock } = vi.hoisted(() => ({
+  useJaegerAssistantEnabledMock: vi.fn(() => false),
+  isGenAISpanMock: vi.fn(() => false),
+}));
+vi.mock('../../../../hooks/useJaegerAssistant', () => ({
+  useJaegerAssistantEnabled: useJaegerAssistantEnabledMock,
+}));
+vi.mock('../../../../utils/genai', () => ({
+  isGenAISpan: isGenAISpanMock,
+}));
+
 describe('<SpanDetail>', () => {
   let props;
   let spanData;
@@ -284,5 +301,47 @@ describe('<SpanDetail>', () => {
 
     expect(copyIcon).toBeInTheDocument();
     expect(copyText).toContain(`?uiFind=${props.span.spanID}`);
+  });
+
+  describe('GenAI tab', () => {
+    beforeEach(() => {
+      useJaegerAssistantEnabledMock.mockReset();
+      isGenAISpanMock.mockReset();
+    });
+
+    it('does not show the GenAI tab when the AI assistant is disabled', () => {
+      useJaegerAssistantEnabledMock.mockReturnValue(false);
+      isGenAISpanMock.mockReturnValue(true);
+      render(<SpanDetail {...props} />);
+      expect(screen.queryByTestId('genai-tab')).not.toBeInTheDocument();
+    });
+
+    it('does not show the GenAI tab when the span has no gen_ai.* attributes', () => {
+      useJaegerAssistantEnabledMock.mockReturnValue(true);
+      isGenAISpanMock.mockReturnValue(false);
+      render(<SpanDetail {...props} />);
+      expect(screen.queryByTestId('genai-tab')).not.toBeInTheDocument();
+    });
+
+    it('shows the GenAI tab when AI assistant is enabled and span has gen_ai.* attributes', () => {
+      useJaegerAssistantEnabledMock.mockReturnValue(true);
+      isGenAISpanMock.mockReturnValue(true);
+      render(<SpanDetail {...props} />);
+      expect(screen.getByTestId('genai-tab')).toBeInTheDocument();
+    });
+
+    it('defaults to the Details tab for a non-GenAI span', () => {
+      useJaegerAssistantEnabledMock.mockReturnValue(true);
+      isGenAISpanMock.mockReturnValue(false);
+      render(<SpanDetail {...props} />);
+      expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('defaults to the GenAI tab when span has gen_ai.* attributes and assistant is enabled', () => {
+      useJaegerAssistantEnabledMock.mockReturnValue(true);
+      isGenAISpanMock.mockReturnValue(true);
+      render(<SpanDetail {...props} />);
+      expect(screen.getByRole('tab', { name: 'GenAI' })).toHaveAttribute('aria-selected', 'true');
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -327,7 +327,7 @@ describe('<SpanDetail>', () => {
       useJaegerAssistantEnabledMock.mockReturnValue(true);
       isGenAISpanMock.mockReturnValue(true);
       render(<SpanDetail {...props} />);
-      expect(screen.getByTestId('genai-tab')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'GenAI' })).toBeInTheDocument();
     });
 
     it('renders no tab bar for a non-GenAI span — content is shown directly', () => {
@@ -338,11 +338,12 @@ describe('<SpanDetail>', () => {
       expect(screen.getByTestId('accordian-keyvalues-tags')).toBeInTheDocument();
     });
 
-    it('defaults to the GenAI tab when span has gen_ai.* attributes and assistant is enabled', () => {
+    it('defaults to the Details tab even when the span has gen_ai.* attributes', () => {
       useJaegerAssistantEnabledMock.mockReturnValue(true);
       isGenAISpanMock.mockReturnValue(true);
       render(<SpanDetail {...props} />);
-      expect(screen.getByRole('tab', { name: 'GenAI' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: 'GenAI' })).toHaveAttribute('aria-selected', 'false');
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { Divider } from 'antd';
+import { Divider, Tabs } from 'antd';
 
 import { IoLinkOutline } from 'react-icons/io5';
 import AccordionAttributes from './AccordionAttributes';
@@ -10,9 +10,12 @@ import AccordionEvents from './AccordionEvents';
 import AccordionLinks from './AccordionLinks';
 import AccordionText from './AccordionText';
 import DetailState from './DetailState';
+import GenAITab from './GenAITab';
 import { formatDuration, formatDurationCompact } from '../utils';
 import CopyIcon from '../../../common/CopyIcon';
 import LabeledList from '../../../common/LabeledList';
+import { useJaegerAssistantEnabled } from '../../../../hooks/useJaegerAssistant';
+import { isGenAISpan } from '../../../../utils/genai';
 
 import { TNil } from '../../../../types';
 import { Hyperlink } from '../../../../types/hyperlink';
@@ -86,6 +89,83 @@ export default function SpanDetail(props: SpanDetailProps) {
   ];
   const deepLinkCopyText = `${window.location.origin}${window.location.pathname}?uiFind=${span.spanID}`;
 
+  const aiEnabled = useJaegerAssistantEnabled();
+  const showGenAITab = aiEnabled && isGenAISpan(span);
+
+  const detailsContent = (
+    <div>
+      <div>
+        <AccordionAttributes
+          data={span.attributes}
+          label={attributesLabel}
+          linksGetter={linksGetter}
+          isOpen={isAttributesOpen}
+          onToggle={() => attributesToggle(span.spanID)}
+        />
+        {span.resource.attributes && span.resource.attributes.length > 0 && (
+          <AccordionAttributes
+            className="ub-mb1"
+            data={span.resource.attributes}
+            label={resourceLabel}
+            linksGetter={linksGetter}
+            isOpen={isResourceOpen}
+            onToggle={() => resourceToggle(span.spanID)}
+          />
+        )}
+      </div>
+      {span.events && span.events.length > 0 && (
+        <AccordionEvents
+          linksGetter={linksGetter}
+          events={span.events}
+          isOpen={eventsState.isOpen}
+          openedItems={eventsState.openedItems}
+          onToggle={() => eventsToggle(span.spanID)}
+          onItemToggle={eventItem => eventItemToggle(span.spanID, eventItem)}
+          timestamp={traceStartTime}
+          currentViewRangeTime={currentViewRangeTime}
+          traceDuration={traceDuration}
+          spanID={span.spanID}
+          useOtelTerms={useOtelTerms}
+          initialVisibleCount={eventsInitialVisibleCount}
+        />
+      )}
+      {warnings && warnings.length > 0 && (
+        <AccordionText
+          className="AccordianWarnings"
+          headerClassName="AccordianWarnings--header"
+          label={<span className="AccordianWarnings--label">Warnings</span>}
+          data={warnings}
+          isOpen={isWarningsOpen}
+          onToggle={() => warningsToggle(span.spanID)}
+        />
+      )}
+      {links && links.length > 0 && (
+        <AccordionLinks
+          data={links}
+          isOpen={isLinksOpen}
+          onToggle={() => linksToggle(span.spanID)}
+          focusSpan={focusSpan}
+          useOtelTerms={useOtelTerms}
+        />
+      )}
+      <small className="SpanDetail--debugInfo">
+        <span className="SpanDetail--debugLabel" data-label="SpanID:" /> {span.spanID}
+        <CopyIcon
+          copyText={deepLinkCopyText}
+          icon={<IoLinkOutline />}
+          placement="topRight"
+          tooltipTitle="Copy deep link to this span"
+          buttonText="Copy"
+        />
+      </small>
+    </div>
+  );
+
+  const tabItems = [
+    { key: 'details', label: 'Details', children: detailsContent },
+    ...(showGenAITab ? [{ key: 'genai', label: 'GenAI', children: <GenAITab span={span} /> }] : []),
+  ];
+
   return (
     <div>
       <div className="ub-flex ub-items-center">
@@ -97,72 +177,7 @@ export default function SpanDetail(props: SpanDetailProps) {
         />
       </div>
       <Divider className="SpanDetail--divider ub-my1" />
-      <div>
-        <div>
-          <AccordionAttributes
-            data={span.attributes}
-            label={attributesLabel}
-            linksGetter={linksGetter}
-            isOpen={isAttributesOpen}
-            onToggle={() => attributesToggle(span.spanID)}
-          />
-          {span.resource.attributes && span.resource.attributes.length > 0 && (
-            <AccordionAttributes
-              className="ub-mb1"
-              data={span.resource.attributes}
-              label={resourceLabel}
-              linksGetter={linksGetter}
-              isOpen={isResourceOpen}
-              onToggle={() => resourceToggle(span.spanID)}
-            />
-          )}
-        </div>
-        {span.events && span.events.length > 0 && (
-          <AccordionEvents
-            linksGetter={linksGetter}
-            events={span.events}
-            isOpen={eventsState.isOpen}
-            openedItems={eventsState.openedItems}
-            onToggle={() => eventsToggle(span.spanID)}
-            onItemToggle={eventItem => eventItemToggle(span.spanID, eventItem)}
-            timestamp={traceStartTime}
-            currentViewRangeTime={currentViewRangeTime}
-            traceDuration={traceDuration}
-            spanID={span.spanID}
-            useOtelTerms={useOtelTerms}
-            initialVisibleCount={eventsInitialVisibleCount}
-          />
-        )}
-        {warnings && warnings.length > 0 && (
-          <AccordionText
-            className="AccordianWarnings"
-            headerClassName="AccordianWarnings--header"
-            label={<span className="AccordianWarnings--label">Warnings</span>}
-            data={warnings}
-            isOpen={isWarningsOpen}
-            onToggle={() => warningsToggle(span.spanID)}
-          />
-        )}
-        {links && links.length > 0 && (
-          <AccordionLinks
-            data={links}
-            isOpen={isLinksOpen}
-            onToggle={() => linksToggle(span.spanID)}
-            focusSpan={focusSpan}
-            useOtelTerms={useOtelTerms}
-          />
-        )}
-        <small className="SpanDetail--debugInfo">
-          <span className="SpanDetail--debugLabel" data-label="SpanID:" /> {span.spanID}
-          <CopyIcon
-            copyText={deepLinkCopyText}
-            icon={<IoLinkOutline />}
-            placement="topRight"
-            tooltipTitle="Copy deep link to this span"
-            buttonText="Copy"
-          />
-        </small>
-      </div>
+      <Tabs defaultActiveKey={showGenAITab ? 'genai' : 'details'} items={tabItems} />
     </div>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -14,7 +14,6 @@ import GenAITab from './GenAITab';
 import { formatDuration, formatDurationCompact } from '../utils';
 import CopyIcon from '../../../common/CopyIcon';
 import LabeledList from '../../../common/LabeledList';
-import { useJaegerAssistantEnabled } from '../../../../hooks/useJaegerAssistant';
 import { isGenAISpan } from '../../../../utils/genai';
 
 import { TNil } from '../../../../types';
@@ -89,8 +88,7 @@ export default function SpanDetail(props: SpanDetailProps) {
   ];
   const deepLinkCopyText = `${window.location.origin}${window.location.pathname}?uiFind=${span.spanID}`;
 
-  const aiEnabled = useJaegerAssistantEnabled();
-  const showGenAITab = aiEnabled && isGenAISpan(span);
+  const showGenAITab = isGenAISpan(span);
 
   const detailsContent = (
     <div>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -161,11 +161,6 @@ export default function SpanDetail(props: SpanDetailProps) {
     </div>
   );
 
-  const tabItems = [
-    { key: 'details', label: 'Details', children: detailsContent },
-    ...(showGenAITab ? [{ key: 'genai', label: 'GenAI', children: <GenAITab span={span} /> }] : []),
-  ];
-
   return (
     <div>
       <div className="ub-flex ub-items-center">
@@ -177,7 +172,18 @@ export default function SpanDetail(props: SpanDetailProps) {
         />
       </div>
       <Divider className="SpanDetail--divider ub-my1" />
-      <Tabs defaultActiveKey={showGenAITab ? 'genai' : 'details'} items={tabItems} />
+      {showGenAITab ? (
+        <Tabs
+          key={span.spanID}
+          defaultActiveKey="genai"
+          items={[
+            { key: 'details', label: 'Details', children: detailsContent },
+            { key: 'genai', label: 'GenAI', children: <GenAITab span={span} /> },
+          ]}
+        />
+      ) : (
+        detailsContent
+      )}
     </div>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.tsx
@@ -175,7 +175,7 @@ export default function SpanDetail(props: SpanDetailProps) {
       {showGenAITab ? (
         <Tabs
           key={span.spanID}
-          defaultActiveKey="genai"
+          defaultActiveKey="details"
           items={[
             { key: 'details', label: 'Details', children: detailsContent },
             { key: 'genai', label: 'GenAI', children: <GenAITab span={span} /> },

--- a/packages/jaeger-ui/src/utils/genai/index.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/index.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { IAttribute, IOtelSpan } from '../../types/otel';
+import { isGenAISpan } from './index';
+
+function makeSpan(attrs: IAttribute[]): IOtelSpan {
+  return { attributes: attrs } as unknown as IOtelSpan;
+}
+
+describe('isGenAISpan', () => {
+  it('returns true when span has a gen_ai.* attribute', () => {
+    const span = makeSpan([{ key: 'gen_ai.system', value: 'openai' }]);
+    expect(isGenAISpan(span)).toBe(true);
+  });
+
+  it('returns true for any gen_ai.* key prefix', () => {
+    const span = makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }]);
+    expect(isGenAISpan(span)).toBe(true);
+  });
+
+  it('returns false when span has no gen_ai.* attributes', () => {
+    const span = makeSpan([{ key: 'http.method', value: 'GET' }]);
+    expect(isGenAISpan(span)).toBe(false);
+  });
+
+  it('returns false for an empty attribute list', () => {
+    expect(isGenAISpan(makeSpan([]))).toBe(false);
+  });
+
+  it('does not match keys that merely contain "gen_ai" in the middle', () => {
+    const span = makeSpan([{ key: 'custom.gen_ai.tag', value: 'x' }]);
+    expect(isGenAISpan(span)).toBe(false);
+  });
+});

--- a/packages/jaeger-ui/src/utils/genai/index.ts
+++ b/packages/jaeger-ui/src/utils/genai/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { IOtelSpan } from '../../types/otel';
+
+export function isGenAISpan(span: IOtelSpan): boolean {
+  return span.attributes.some(attr => attr.key.startsWith('gen_ai.'));
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #3820.

The span detail panel shows a flat accordion of raw attributes and events. For GenAI spans that carry dozens of `gen_ai.*` keys, token counts and prompt content, the raw list makes it hard to find what matters. This PR adds a tab layout so GenAI-specific information gets its own dedicated view instead of being buried in the generic attribute table.

## Description of the changes

Adds a two-tab layout to the span detail panel:

- **Details tab** — existing accordion content, unchanged for all spans; this is the default active tab
- **GenAI tab** — appears only when the span has at least one `gen_ai.*` attribute (checked via `isGenAISpan`)

For all other spans the layout is exactly as before — no tab bar, content rendered directly.

The GenAI tab body is a placeholder stub in this PR. Token counts, model info and prompt/tool-I/O rendering follow in the next PRs.

**New files:**
- `src/utils/genai/index.ts` — `isGenAISpan(span)` helper; checks `span.attributes` for any `gen_ai.*` key prefix. Note: #3856 adds `utils/genai/detect.ts` with a richer `classifySpan`; once that lands, `isGenAISpan` here will be re-expressed as `classifySpan(span) !== 'STANDARD'` and `index.ts` will become a thin re-export.
- `src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx` — placeholder stub for the GenAI tab content

**Modified:**
- `SpanDetail/index.tsx` — wraps existing detail content in antd `<Tabs>`, conditionally adds GenAI tab when `showGenAITab` is true

## How was this change tested?

- `npm test -w packages/jaeger-ui -- SpanDetail/index` — 13 tests pass (9 existing + 4 new for tab show/hide/default-key behavior)
- `npm test -w packages/jaeger-ui -- utils/genai` — 5 tests pass covering `isGenAISpan` edge cases
- CI lint-build and unit-tests checks pass

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes