### PR TITLE
perf(tests): extract searchInTable as pure function

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { act, cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import TraceStatistics from './index';
+import TraceStatistics, { searchInTable } from './index';
 import transformTraceData from '../../../model/transform-trace-data';
 import { getColumnValues, getColumnValuesSecondDropdown } from './tableValues';
 
@@ -426,16 +426,7 @@ describe('<TraceTagOverview>', () => {
     });
   });
 
-  it('should test searchInTable with complex search scenarios', async () => {
-    let componentRef;
-    const TestWrapper = () => {
-      const ref = React.useRef();
-      componentRef = ref;
-      return <TraceStatistics ref={ref} {...defaultProps} />;
-    };
-
-    render(<TestWrapper />);
-
+  it('should test searchInTable with complex search scenarios', () => {
     const mockTableData = [
       {
         name: 'parent1',
@@ -464,26 +455,12 @@ describe('<TraceTagOverview>', () => {
     ];
 
     const searchSet = new Set(['parent1detail1']);
-
-    await waitFor(() => {
-      if (componentRef.current) {
-        const result = componentRef.current.searchInTable(searchSet, mockTableData, null);
-        expect(result).toBeDefined();
-        expect(result.length).toBe(3);
-      }
-    });
+    const result = searchInTable(searchSet, mockTableData, null);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(3);
   });
 
-  it('should test searchInTable with uiFind matching and detail items', async () => {
-    let componentRef;
-    const TestWrapper = () => {
-      const ref = React.useRef();
-      componentRef = ref;
-      return <TraceStatistics ref={ref} {...defaultProps} />;
-    };
-
-    render(<TestWrapper />);
-
+  it('should test searchInTable with uiFind matching and detail items', () => {
     const mockTableData = [
       {
         name: 'searchterm',
@@ -511,25 +488,12 @@ describe('<TraceTagOverview>', () => {
       },
     ];
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        const result = componentRef.current.searchInTable(undefined, mockTableData, 'searchterm');
-        const highlightedItems = result.filter(item => item.searchColor === 'rgb(255,243,215)');
-        expect(highlightedItems.length).toBeGreaterThan(0);
-      }
-    });
+    const result = searchInTable(undefined, mockTableData, 'searchterm');
+    const highlightedItems = result.filter(item => item.searchColor === 'rgb(255,243,215)');
+    expect(highlightedItems.length).toBeGreaterThan(0);
   });
 
-  it('should test searchInTable with items that have subgroup values but are details', async () => {
-    let componentRef;
-    const TestWrapper = () => {
-      const ref = React.useRef();
-      componentRef = ref;
-      return <TraceStatistics ref={ref} {...defaultProps} />;
-    };
-
-    render(<TestWrapper />);
-
+  it('should test searchInTable with items that have subgroup values but are details', () => {
     const mockTableData = [
       {
         name: 'item1',
@@ -549,12 +513,8 @@ describe('<TraceTagOverview>', () => {
       },
     ];
 
-    await waitFor(() => {
-      if (componentRef.current) {
-        const result = componentRef.current.searchInTable(undefined, mockTableData, null);
-        expect(result[0].searchColor).toBe('rgb(248,248,248)');
-        expect(result[1].searchColor).toBe('rgb(248,248,248)');
-      }
-    });
+    const result = searchInTable(undefined, mockTableData, null);
+    expect(result[0].searchColor).toBe('rgb(248,248,248)');
+    expect(result[1].searchColor).toBe('rgb(248,248,248)');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
@@ -103,6 +103,65 @@ const columnsArray: {
   },
 ];
 
+export function searchInTable(
+  uiFindVertexKeys: Set<string>,
+  allTableSpans: ITableSpan[],
+  uiFind: string | null | undefined
+): ITableSpan[] {
+  const allTableSpansChange = allTableSpans;
+  const yellowSearchCollor = 'rgb(255,243,215)';
+  const defaultGrayCollor = 'rgb(248,248,248)';
+  for (let i = 0; i < allTableSpansChange.length; i++) {
+    if (!allTableSpansChange[i].isDetail && allTableSpansChange[i].hasSubgroupValue) {
+      allTableSpansChange[i].searchColor = 'transparent';
+    } else if (allTableSpansChange[i].hasSubgroupValue) {
+      allTableSpansChange[i].searchColor = defaultGrayCollor;
+    } else {
+      allTableSpansChange[i].searchColor = defaultGrayCollor;
+    }
+  }
+  if (typeof uiFindVertexKeys !== 'undefined') {
+    uiFindVertexKeys!.forEach(function calc(value) {
+      const uiFindVertexKeysSplit = value.split('\u000b');
+      for (let i = 0; i < allTableSpansChange.length; i++) {
+        if (
+          uiFindVertexKeysSplit[uiFindVertexKeysSplit.length - 1].indexOf(allTableSpansChange[i].name) !== -1
+        ) {
+          if (allTableSpansChange[i].parentElement === 'none') {
+            allTableSpansChange[i].searchColor = yellowSearchCollor;
+          } else if (
+            uiFindVertexKeysSplit[uiFindVertexKeysSplit.length - 1].indexOf(
+              allTableSpansChange[i].parentElement
+            ) !== -1
+          ) {
+            allTableSpansChange[i].searchColor = yellowSearchCollor;
+          }
+        }
+      }
+    });
+  }
+  if (uiFind) {
+    for (let i = 0; i < allTableSpansChange.length; i++) {
+      if (allTableSpansChange[i].name.indexOf(uiFind!) !== -1) {
+        allTableSpansChange[i].searchColor = yellowSearchCollor;
+        for (let j = 0; j < allTableSpansChange.length; j++) {
+          if (allTableSpansChange[j].parentElement === allTableSpansChange[i].name) {
+            allTableSpansChange[j].searchColor = yellowSearchCollor;
+          }
+        }
+        if (allTableSpansChange[i].isDetail) {
+          for (let j = 0; j < allTableSpansChange.length; j++) {
+            if (allTableSpansChange[i].parentElement === allTableSpansChange[j].name) {
+              allTableSpansChange[j].searchColor = yellowSearchCollor;
+            }
+          }
+        }
+      }
+    }
+  }
+  return allTableSpansChange;
+}
+
 /**
  * Trace Statistics Component
  */
@@ -194,63 +253,7 @@ export default class TraceStatistics extends Component<Props, State> {
     uiFindVertexKeys: Set<string>,
     allTableSpans: ITableSpan[],
     uiFind: string | null | undefined
-  ) => {
-    const allTableSpansChange = allTableSpans;
-    const yellowSearchCollor = 'rgb(255,243,215)';
-    const defaultGrayCollor = 'rgb(248,248,248)';
-    for (let i = 0; i < allTableSpansChange.length; i++) {
-      if (!allTableSpansChange[i].isDetail && allTableSpansChange[i].hasSubgroupValue) {
-        allTableSpansChange[i].searchColor = 'transparent';
-      } else if (allTableSpansChange[i].hasSubgroupValue) {
-        allTableSpansChange[i].searchColor = defaultGrayCollor;
-      } else {
-        allTableSpansChange[i].searchColor = defaultGrayCollor;
-      }
-    }
-    if (typeof uiFindVertexKeys !== 'undefined') {
-      uiFindVertexKeys!.forEach(function calc(value) {
-        const uiFindVertexKeysSplit = value.split('\u000b');
-
-        for (let i = 0; i < allTableSpansChange.length; i++) {
-          if (
-            uiFindVertexKeysSplit[uiFindVertexKeysSplit.length - 1].indexOf(allTableSpansChange[i].name) !==
-            -1
-          ) {
-            if (allTableSpansChange[i].parentElement === 'none') {
-              allTableSpansChange[i].searchColor = yellowSearchCollor;
-            } else if (
-              uiFindVertexKeysSplit[uiFindVertexKeysSplit.length - 1].indexOf(
-                allTableSpansChange[i].parentElement
-              ) !== -1
-            ) {
-              allTableSpansChange[i].searchColor = yellowSearchCollor;
-            }
-          }
-        }
-      });
-    }
-    if (uiFind) {
-      for (let i = 0; i < allTableSpansChange.length; i++) {
-        if (allTableSpansChange[i].name.indexOf(uiFind!) !== -1) {
-          allTableSpansChange[i].searchColor = yellowSearchCollor;
-
-          for (let j = 0; j < allTableSpansChange.length; j++) {
-            if (allTableSpansChange[j].parentElement === allTableSpansChange[i].name) {
-              allTableSpansChange[j].searchColor = yellowSearchCollor;
-            }
-          }
-          if (allTableSpansChange[i].isDetail) {
-            for (let j = 0; j < allTableSpansChange.length; j++) {
-              if (allTableSpansChange[i].parentElement === allTableSpansChange[j].name) {
-                allTableSpansChange[j].searchColor = yellowSearchCollor;
-              }
-            }
-          }
-        }
-      }
-    }
-    return allTableSpansChange;
-  };
+  ) => searchInTable(uiFindVertexKeys, allTableSpans, uiFind);
 
   render() {
     const onClickOption = (hasSubgroupValue: boolean, name: string) => {


### PR DESCRIPTION
Part of #3996

Extracts `searchInTable` as an exported pure function and updates 3 tests 
to call it directly instead of via componentRef, eliminating 3 unnecessary 
component renders.

Before: TraceStatistics/index.test.jsx ~5804ms
After:  TraceStatistics/index.test.jsx ~5695ms