### PR TITLE
Default to table view for search results

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -339,6 +339,10 @@ describe('<SearchResults>', () => {
   });
 
   describe('search finished with results', () => {
+    beforeEach(() => {
+      useSearchResultsStore.setState({ viewMode: 'list' });
+    });
+
     it('shows a scatter plot', () => {
       renderWithRouter(<SearchResults {...baseProps} />);
       expect(screen.getByTestId('scatterplot')).toBeInTheDocument();
@@ -524,29 +528,29 @@ describe('<SearchResults>', () => {
 
   describe('view mode toggle', () => {
     beforeEach(() => {
-      useSearchResultsStore.setState({ viewMode: 'list' });
+      useSearchResultsStore.setState({ viewMode: 'table' });
       localStorage.clear();
     });
 
-    it('defaults to list view', () => {
+    it('defaults to table view', () => {
       renderWithRouter(<SearchResults {...baseProps} />);
-      expect(screen.getByTestId('result-a')).toBeInTheDocument();
-      expect(screen.queryByTestId('trace-table')).not.toBeInTheDocument();
-    });
-
-    it('switches to table view when Table button is clicked', () => {
-      renderWithRouter(<SearchResults {...baseProps} />);
-      fireEvent.click(screen.getByText('Table'));
       expect(screen.getByTestId('trace-table')).toBeInTheDocument();
       expect(screen.queryByTestId('result-a')).not.toBeInTheDocument();
     });
 
-    it('switches back to list view when List button is clicked', () => {
+    it('switches to list view when List button is clicked', () => {
       renderWithRouter(<SearchResults {...baseProps} />);
-      fireEvent.click(screen.getByText('Table'));
       fireEvent.click(screen.getByText('List'));
       expect(screen.getByTestId('result-a')).toBeInTheDocument();
       expect(screen.queryByTestId('trace-table')).not.toBeInTheDocument();
+    });
+
+    it('switches back to table view when Table button is clicked', () => {
+      renderWithRouter(<SearchResults {...baseProps} />);
+      fireEvent.click(screen.getByText('List'));
+      fireEvent.click(screen.getByText('Table'));
+      expect(screen.getByTestId('trace-table')).toBeInTheDocument();
+      expect(screen.queryByTestId('result-a')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -528,8 +528,8 @@ describe('<SearchResults>', () => {
 
   describe('view mode toggle', () => {
     beforeEach(() => {
-      useSearchResultsStore.setState({ viewMode: 'table' });
       localStorage.clear();
+      useSearchResultsStore.setState(useSearchResultsStore.getInitialState());
     });
 
     it('defaults to table view', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.ts
@@ -12,7 +12,7 @@ type SearchResultsStore = {
 export const useSearchResultsStore = create<SearchResultsStore>()(
   persist(
     set => ({
-      viewMode: 'list',
+      viewMode: 'table',
       setViewMode: mode => set({ viewMode: mode }),
     }),
     { name: 'jaeger.search-results.mode' }


### PR DESCRIPTION
## Summary
- Changes the default search results view mode from "List" to "Table"
- The table view provides a more compact and information-dense display of trace results
- Users can still toggle between views; preference is persisted in localStorage

## Test plan
- [x] All existing tests pass (updated to reflect new default)
- [x] Lint, type-check, and build all pass
- [ ] Manual verification: open Search page, confirm Table view is shown by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)