### PR TITLE
fix(bug): clear trace ID input field on navigation/reload (#4135)

### DIFF
--- a/packages/jaeger-ui/src/components/App/JaegerAskSearchInput.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAskSearchInput.test.jsx
@@ -50,7 +50,7 @@ describe('<JaegerAskSearchInput /> trace lookup (assistant disabled)', () => {
     expect(screen.getByPlaceholderText('Lookup by Trace ID...')).toBeInTheDocument();
   });
 
-  it('navigates to trace page on form submit', () => {
+  it('navigates to trace page on form submit and clears the input', () => {
     render(
       <MemoryRouter>
         <JaegerAskSearchInput />
@@ -62,6 +62,7 @@ describe('<JaegerAskSearchInput /> trace lookup (assistant disabled)', () => {
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(`/trace/${traceId}`);
+    expect(screen.getByTestId('idInput')).toHaveValue('');
   });
 
   it('does not navigate when input is empty', () => {
@@ -123,6 +124,7 @@ describe('<JaegerAskSearchInput /> assistant mode', () => {
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('');
   });
 
   it('still navigates for 16–32 hex trace ids (preserves original form)', () => {
@@ -140,6 +142,7 @@ describe('<JaegerAskSearchInput /> assistant mode', () => {
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
     expect(mockNavigate).toHaveBeenCalledWith(`/trace/${traceId}`);
+    expect(textarea).toHaveValue('');
   });
 
   it('navigates for base64-encoded trace ids', () => {
@@ -157,6 +160,7 @@ describe('<JaegerAskSearchInput /> assistant mode', () => {
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
     expect(mockNavigate).toHaveBeenCalledWith('/trace/%2FlhpXXcq1Bdw%2B4twt863jg%3D%3D');
+    expect(textarea).toHaveValue('');
   });
 
   it('Shift+Enter does not submit', () => {

--- a/packages/jaeger-ui/src/components/App/JaegerAskSearchInput.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAskSearchInput.tsx
@@ -18,13 +18,17 @@ const ASK_JAEGER_PLACEHOLDER = 'Ask Jaeger or lookup trace';
 
 function TraceLookupSearchInput() {
   const navigate = useNavigate();
+  const [value, setValue] = React.useState('');
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
   const goToTrace = React.useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      const form = event.currentTarget;
-      const value = (form.elements.namedItem('idInput') as HTMLInputElement)?.value;
-      if (value) {
-        navigate(getUrl(value));
+      const val = valueRef.current;
+      if (val) {
+        navigate(getUrl(val));
+        setValue('');
       }
     },
     [navigate]
@@ -41,6 +45,8 @@ function TraceLookupSearchInput() {
         className="TraceIDSearchInput--input"
         data-testid="idInput"
         name="idInput"
+        value={value}
+        onChange={e => setValue(e.target.value)}
         placeholder={TRACE_LOOKUP_PLACEHOLDER}
         prefix={<IoSearch />}
         allowClear


### PR DESCRIPTION
Resolves: #4135

Context & Motivation
I noticed that when looking up a trace by pasting its ID into the "Lookup by Trace ID..." search box, the UI correctly navigates to the trace page but the input box does not clear. Since the top navigation menu persists across page loads, the ID remains stuck in the search box even if you click around the app or try to look up another trace. 

Historically, this box cleared automatically after a search. The issue started when the new combined AI Assistant textarea logic was added. While it makes sense for the assistant to retain context, the trace ID lookup should be cleared once the navigation starts.

Video:
https://drive.google.com/file/d/12TZER0_Ilp2w-0nHOPWL5GdUw3Jzp4Ii/view?usp=sharing

Implementation Details
The problem was that the `TraceLookupSearchInput` was rendered as an uncontrolled Ant Design `<Input />` component. Because the navigation is handled via client-side routing (`useNavigate`) and the header doesn't remount, the input element kept its DOM value.

- Converted `TraceLookupSearchInput` in `JaegerAskSearchInput.tsx` to a controlled component using a React state variable (`value`).
- Updated the submit handler to reset the state (`setValue('')`) after a successful navigation.
- Added assertions (`expect().toHaveValue('')`) to the unit tests in `JaegerAskSearchInput.test.jsx` to verify that both the default lookup input and the assistant textarea are cleared on form submit.

Impact
- Looking up a trace ID now clears the text field immediately upon navigation.
- The input is clean and ready for the next query without requiring the user to manually clear it.

Testing
✅ npm test — all unit tests pass (including the updated `JaegerAskSearchInput.test.jsx` test cases)
✅ npm run lint — no lint or type-check errors
✅ npm run build — builds successfully
