### PR TITLE
refactor(TracePage): Decouple view specific search logic from TracePage

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.jsx
@@ -54,6 +54,9 @@ vi.mock('d3-flame-graph', () => ({
   default: () => mockChart,
 }));
 
+const mockFilterSpans = vi.hoisted(() => vi.fn(() => new Set()));
+vi.mock('../../../utils/filter-spans', () => ({ default: mockFilterSpans }));
+
 vi.mock('d3-selection', () => ({
   select: vi.fn(container => {
     // Create a fake SVG element in the container so event listeners can attach
@@ -83,6 +86,22 @@ describe('<TraceFlamegraph />', () => {
   it('renders the flamegraph wrapper', () => {
     render(<TraceFlamegraph trace={otelTrace} />);
     expect(screen.getByTestId('flamegraph-wrapper')).toBeInTheDocument();
+  });
+
+  it('reports uiFind match count via onSearchResults', () => {
+    const onSearchResults = vi.fn();
+    mockFilterSpans.mockReturnValue(new Set());
+    const { rerender } = render(
+      <TraceFlamegraph trace={otelTrace} uiFind={undefined} onSearchResults={onSearchResults} />
+    );
+    // No query → reports 0.
+    expect(onSearchResults).toHaveBeenLastCalledWith({ count: 0, matches: new Set() });
+
+    const matches = new Set(['x', 'y']);
+    mockFilterSpans.mockReturnValue(matches);
+    onSearchResults.mockClear();
+    rerender(<TraceFlamegraph trace={otelTrace} uiFind="q" onSearchResults={onSearchResults} />);
+    expect(onSearchResults).toHaveBeenLastCalledWith({ count: 2, matches });
   });
 
   it('renders empty state when trace is null', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
@@ -18,6 +18,8 @@ import FlamegraphTable from './FlamegraphTable';
 import FlamegraphContextMenu from './FlamegraphContextMenu';
 import FlamegraphTooltip from './FlamegraphTooltip';
 import VerticalResizer from '../../common/VerticalResizer';
+import filterSpans from '../../../utils/filter-spans';
+import { TOnSearchResults } from '../types';
 
 import 'd3-flame-graph/dist/d3-flamegraph.css';
 import './index.css';
@@ -42,7 +44,15 @@ const HIGHLIGHT_COLOR = '#E600E6';
 // minimum width, so a sliver of the scrollable columns stays visible.
 const TABLE_MIN_GUTTER_PX = 16;
 
-const TraceFlamegraph = ({ trace }: any) => {
+const TraceFlamegraph = ({
+  trace,
+  uiFind,
+  onSearchResults = () => {},
+}: {
+  trace: any;
+  uiFind?: string | null;
+  onSearchResults?: TOnSearchResults;
+}) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<ReturnType<typeof flamegraph> | null>(null);
@@ -69,6 +79,17 @@ const TraceFlamegraph = ({ trace }: any) => {
     () => (otelTrace ? convertOtelTraceToFlameData(otelTrace) : null),
     [otelTrace]
   );
+  // Adopt the shared search pattern: compute matches for the global `uiFind` query and report the
+  // count up. This is the in-page find (distinct from the flamegraph's own `searchQuery` box).
+  const uiFindMatches = useMemo(
+    () =>
+      uiFind && otelTrace ? (filterSpans(uiFind, otelTrace.spans) ?? new Set<string>()) : new Set<string>(),
+    [uiFind, otelTrace]
+  );
+  useEffect(() => {
+    onSearchResults({ count: uiFindMatches.size, matches: uiFindMatches });
+  }, [uiFindMatches, onSearchResults]);
+
   const flameData = collapsedRoot || fullFlameData;
   const tableData = useMemo(() => (otelTrace ? generateTableData(otelTrace) : []), [otelTrace]);
   const maxSelf = useMemo(() => Math.max(...tableData.map(r => r.self), 1), [tableData]);

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
@@ -7,7 +7,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LayoutManager } from '@jaegertracing/plexus';
 import transformTraceData from '../../../model/transform-trace-data';
-import calculateTraceDagEV from './calculateTraceDagEV';
 import TraceGraph, { setOnEdgePath } from './TraceGraph';
 import { MODE_SERVICE, MODE_TIME, MODE_SELFTIME } from './OpNode';
 import testTrace from './testTrace.json';
@@ -66,7 +65,7 @@ vi.mock('@jaegertracing/plexus', () => {
 });
 
 const transformedTrace = transformTraceData(testTrace);
-const ev = calculateTraceDagEV(transformedTrace.asOtelTrace());
+const otelTrace = transformedTrace.asOtelTrace();
 
 describe('<TraceGraph>', () => {
   let props;
@@ -74,7 +73,8 @@ describe('<TraceGraph>', () => {
   beforeEach(() => {
     props = {
       headerHeight: 60,
-      ev,
+      trace: otelTrace,
+      onSearchResults: jest.fn(),
     };
   });
 
@@ -86,8 +86,22 @@ describe('<TraceGraph>', () => {
   });
 
   it('may show no traces', () => {
-    render(<TraceGraph />);
+    render(<TraceGraph onSearchResults={jest.fn()} />);
     expect(screen.getByText('No trace found')).toBeInTheDocument();
+  });
+
+  it('derives the DAG from the trace and reports the match count for uiFind', () => {
+    const onSearchResults = jest.fn();
+    render(<TraceGraph {...props} uiFind="" onSearchResults={onSearchResults} />);
+    // No query → no matches reported.
+    expect(onSearchResults).toHaveBeenLastCalledWith({ count: 0, matches: new Set() });
+
+    onSearchResults.mockClear();
+    // A query that matches at least one service in the test trace reports a positive count.
+    render(<TraceGraph {...props} uiFind="service" onSearchResults={onSearchResults} />);
+    const reported = onSearchResults.mock.calls.at(-1)[0];
+    expect(reported.count).toBeGreaterThan(0);
+    expect(reported.matches.size).toBe(reported.count);
   });
 
   it('switches node mode when clicking mode buttons', async () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -16,19 +16,23 @@ import {
   MODE_SELFTIME,
   getHelpTable,
 } from './OpNode';
-import { TEv, TSumSpan } from './types';
+import { TSumSpan } from './types';
+import calculateTraceDagEV from './calculateTraceDagEV';
 import { TDenseSpanMembers } from '../../../model/trace-dag/types';
 import TDagPlexusVertex from '../../../model/trace-dag/types/TDagPlexusVertex';
 import { TNil } from '../../../types';
+import { IOtelTrace } from '../../../types/otel';
 import { TraceGraphConfig } from '../../../types/config';
+import { getUiFindVertexKeys } from '../../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
+import { TOnSearchResults } from '../types';
 
 import './TraceGraph.css';
 
 type Props = {
   headerHeight: number;
-  ev?: TEv | TNil;
+  trace?: IOtelTrace | TNil;
   uiFind: string | TNil;
-  uiFindVertexKeys: Set<string> | TNil;
+  onSearchResults: TOnSearchResults;
   traceGraphConfig?: TraceGraphConfig;
   useOtelTerms: boolean;
 };
@@ -100,16 +104,22 @@ const getHelpContent = (useOtelTerms: boolean) => (
   </div>
 );
 
-function TraceGraph({
-  headerHeight,
-  ev = null,
-  uiFind,
-  uiFindVertexKeys,
-  traceGraphConfig,
-  useOtelTerms,
-}: Props) {
+function TraceGraph({ headerHeight, trace, uiFind, onSearchResults, traceGraphConfig, useOtelTerms }: Props) {
   const [showHelp, setShowHelp] = React.useState(false);
   const [mode, setMode] = React.useState(MODE_SERVICE);
+
+  // The graph owns its own search: it derives the DAG from the trace and computes the set of
+  // matching vertices from `uiFind`, then reports the match count to the parent.
+  const ev = React.useMemo(() => (trace ? calculateTraceDagEV(trace) : null), [trace]);
+  const uiFindVertexKeys = React.useMemo(
+    () => (uiFind && ev ? getUiFindVertexKeys(uiFind, ev.vertices) : undefined),
+    [uiFind, ev]
+  );
+
+  React.useEffect(() => {
+    const matches = uiFindVertexKeys ?? new Set<string>();
+    onSearchResults({ count: matches.size, matches });
+  }, [uiFindVertexKeys, onSearchResults]);
 
   const layoutManagerRef = React.useRef<LayoutManager | null>(null);
   if (layoutManagerRef.current === null) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
@@ -44,8 +44,23 @@ describe('<TraceSpanView>', () => {
     defaultProps = {
       trace,
       uiFind: undefined,
-      uiFindVertexKeys: undefined,
+      onSearchResults: jest.fn(),
     };
+  });
+
+  it('reports search match count via onSearchResults', () => {
+    const onSearchResults = jest.fn();
+    const { rerender } = render(
+      <TraceSpanView {...defaultProps} onSearchResults={onSearchResults} uiFind={undefined} />
+    );
+    // No query → reports 0.
+    expect(onSearchResults).toHaveBeenLastCalledWith({ count: 0, matches: new Set() });
+
+    onSearchResults.mockClear();
+    rerender(<TraceSpanView {...defaultProps} onSearchResults={onSearchResults} uiFind="service1" />);
+    const reported = onSearchResults.mock.calls.at(-1)[0];
+    expect(reported.count).toBeGreaterThan(0);
+    expect(reported.matches.size).toBe(reported.count);
   });
 
   it('does not explode', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Table, Button, Select, Form, Tooltip } from 'antd';
 import dayjs from 'dayjs';
 import { ColumnProps } from 'antd/es/table';
@@ -13,21 +13,35 @@ import { formatDuration, formatDurationCompact } from '../../../utils/date';
 import prefixUrl from '../../../utils/prefix-url';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 import SearchableSelect from '../../common/SearchableSelect';
+import filterSpans from '../../../utils/filter-spans';
+import { TOnSearchResults } from '../types';
 
 type FilterType = 'serviceName' | 'operationName';
 
 type Props = {
   trace: IOtelTrace;
-  uiFindVertexKeys: Set<string> | TNil;
-  uiFind: string | null | undefined;
+  uiFind: string | TNil;
+  onSearchResults: TOnSearchResults;
   useOtelTerms: boolean;
 };
 
 export default function TraceSpanView(props: Props) {
+  const { uiFind, onSearchResults } = props;
   const [filters, setFilters] = useState<Record<FilterType, string[]>>({
     serviceName: [],
     operationName: [],
   });
+
+  // The spans table owns its own search: it computes matching span IDs from `uiFind` and reports
+  // the count up so the parent can display it without knowing how this view searches.
+  const matches = useMemo(
+    () => (uiFind ? (filterSpans(uiFind, props.trace.spans) ?? new Set<string>()) : new Set<string>()),
+    [uiFind, props.trace.spans]
+  );
+
+  useEffect(() => {
+    onSearchResults({ count: matches.size, matches });
+  }, [matches, onSearchResults]);
 
   const { serviceNamesList, operationNamesList, serviceToOperationsMap, maxDuration } = useMemo(() => {
     const serviceNamesSet = new Set<string>();

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
@@ -110,6 +110,29 @@ describe('<TraceTagOverview>', () => {
     });
   });
 
+  it('re-reports search results when the trace changes with the same query', async () => {
+    const onSearchResults = jest.fn();
+    const { rerender } = render(
+      <TraceStatistics {...defaultProps} onSearchResults={onSearchResults} uiFind="service1" />
+    );
+    await waitFor(() => expect(onSearchResults).toHaveBeenCalled());
+
+    onSearchResults.mockClear();
+    // Same query, different trace instance → should recompute and report again.
+    const otherTrace = transformTraceData(testTrace).asOtelTrace();
+    await act(async () => {
+      rerender(
+        <TraceStatistics
+          {...defaultProps}
+          trace={otherTrace}
+          onSearchResults={onSearchResults}
+          uiFind="service1"
+        />
+      );
+    });
+    await waitFor(() => expect(onSearchResults).toHaveBeenCalled());
+  });
+
   it('check handler', async () => {
     async function timedAct(fn, label) {
       const startTime = performance.now();

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
@@ -16,7 +16,7 @@ describe('<TraceTagOverview>', () => {
   const defaultProps = {
     trace: transformedTrace,
     uiFind: undefined,
-    uiFindVertexKeys: undefined,
+    onSearchResults: jest.fn(),
     useOtelTerms: false,
   };
 
@@ -36,9 +36,6 @@ describe('<TraceTagOverview>', () => {
   });
 
   it('check search', async () => {
-    const searchSet = new Set();
-    searchSet.add('service1	op1	__LEAF__');
-
     let componentInstance;
     const TestWrapper = () => {
       return (
@@ -66,7 +63,6 @@ describe('<TraceTagOverview>', () => {
           }}
           {...defaultProps}
           uiFind="service1"
-          uiFindVertexKeys={searchSet}
         />
       );
     });
@@ -87,7 +83,6 @@ describe('<TraceTagOverview>', () => {
           }}
           {...defaultProps}
           uiFind={undefined}
-          uiFindVertexKeys={undefined}
         />
       );
     });
@@ -95,6 +90,23 @@ describe('<TraceTagOverview>', () => {
     await waitFor(() => {
       const tableCells = screen.getAllByRole('cell');
       expect(tableCells.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('reports the search match count via onSearchResults', async () => {
+    const onSearchResults = jest.fn();
+    const { rerender } = render(
+      <TraceStatistics {...defaultProps} onSearchResults={onSearchResults} uiFind={undefined} />
+    );
+    // No query → reports 0 on mount.
+    expect(onSearchResults).toHaveBeenLastCalledWith({ count: 0, matches: new Set() });
+
+    await act(async () => {
+      rerender(<TraceStatistics {...defaultProps} onSearchResults={onSearchResults} uiFind="service1" />);
+    });
+    // A query that matches spans reports a positive count.
+    await waitFor(() => {
+      expect(onSearchResults.mock.calls.at(-1)[0].count).toBeGreaterThan(0);
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
@@ -133,11 +133,12 @@ export default class TraceStatistics extends Component<Props, State> {
   }
 
   /**
-   * If the search query changes the search function is called and the match count is reported up.
-   * @param props all props
+   * Re-run the search and report the count when either the query or the trace changes (e.g.
+   * navigating to a different trace while staying on the Statistics view).
+   * @param prevProps previous props
    */
-  componentDidUpdate(props: Props) {
-    if (this.props.uiFind !== props.uiFind) {
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.uiFind !== prevProps.uiFind || this.props.trace !== prevProps.trace) {
       this.changeTableValueSearch();
       this.reportSearchResults();
     }

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
@@ -8,14 +8,15 @@ import { ColumnProps } from 'antd/es/table';
 import { IOtelTrace } from '../../../types/otel';
 import TraceStatisticsHeader from './TraceStatisticsHeader';
 import { ITableSpan } from './types';
-import { TNil } from '../../../types';
 import PopupSQL from './PopupSql';
 import { getServiceName } from './tableValues';
+import filterSpans from '../../../utils/filter-spans';
+import { TOnSearchResults } from '../types';
 
 type Props = {
   trace: IOtelTrace;
-  uiFindVertexKeys: Set<string> | TNil;
   uiFind: string | null | undefined;
+  onSearchResults: TOnSearchResults;
   useOtelTerms: boolean;
 };
 
@@ -124,21 +125,40 @@ export default class TraceStatistics extends Component<Props, State> {
     this.handler = this.handler.bind(this);
     this.togglePopup = this.togglePopup.bind(this);
 
-    this.searchInTable(this.props.uiFindVertexKeys!, this.state.tableValue, this.props.uiFind);
+    this.searchInTable(this.getSearchMatches(), this.state.tableValue, this.props.uiFind);
+  }
+
+  componentDidMount() {
+    this.reportSearchResults();
   }
 
   /**
-   * If the search props change the search function is called.
+   * If the search query changes the search function is called and the match count is reported up.
    * @param props all props
    */
   componentDidUpdate(props: Props) {
-    if (this.props.uiFindVertexKeys !== props.uiFindVertexKeys) {
+    if (this.props.uiFind !== props.uiFind) {
       this.changeTableValueSearch();
+      this.reportSearchResults();
     }
   }
 
+  /**
+   * Compute the set of matching span IDs for the current query. The view owns this so the parent
+   * does not need to know how statistics search works.
+   */
+  getSearchMatches(): Set<string> {
+    const { uiFind, trace } = this.props;
+    return uiFind ? filterSpans(uiFind, trace.spans) || new Set<string>() : new Set<string>();
+  }
+
+  reportSearchResults() {
+    const matches = this.getSearchMatches();
+    this.props.onSearchResults({ count: matches.size, matches });
+  }
+
   changeTableValueSearch() {
-    this.searchInTable(this.props.uiFindVertexKeys!, this.state.tableValue, this.props.uiFind);
+    this.searchInTable(this.getSearchMatches(), this.state.tableValue, this.props.uiFind);
     // reload the componente
     const tableValueState = this.state.tableValue;
     this.setState(prevState => ({
@@ -160,7 +180,7 @@ export default class TraceStatistics extends Component<Props, State> {
     this.setState(prevState => {
       return {
         ...prevState,
-        tableValue: this.searchInTable(this.props.uiFindVertexKeys!, tableValue, this.props.uiFind),
+        tableValue: this.searchInTable(this.getSearchMatches(), tableValue, this.props.uiFind),
         sortIndex: 1,
         sortAsc: false,
         valueNameSelector1,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -62,7 +62,16 @@ const mockUseServiceFilter = vi.hoisted(() => ({
 vi.mock('./useServiceFilter', () => ({
   useServiceFilter: vi.fn(() => mockUseServiceFilter),
 }));
-vi.mock('./VirtualizedTraceView', () => mockDefault(() => <div data-testid="virtualized-trace-view-mock" />));
+let capturedVirtualizedProps = {};
+vi.mock('./VirtualizedTraceView', () =>
+  mockDefault(props => {
+    capturedVirtualizedProps = props;
+    return <div data-testid="virtualized-trace-view-mock" />;
+  })
+);
+
+const mockFilterSpans = vi.hoisted(() => vi.fn());
+vi.mock('../../../utils/filter-spans', () => ({ default: mockFilterSpans }));
 vi.mock('./SpanDetailSidePanel', () => mockDefault(() => <div data-testid="span-detail-side-panel-mock" />));
 vi.mock('../../common/VerticalResizer', () => ({
   default: ({ onChange }) => (
@@ -97,6 +106,8 @@ describe('<TraceTimelineViewer>', () => {
   const props = {
     trace,
     textFilter: null,
+    uiFind: undefined,
+    onSearchResults: jest.fn(),
     viewRange: {
       time: {
         current: [0, 1],
@@ -130,6 +141,7 @@ describe('<TraceTimelineViewer>', () => {
     props.collapseOne.mockClear();
     props.setSpanNameColumnWidth.mockClear();
     props.setSidePanelWidth.mockClear();
+    props.onSearchResults.mockClear();
     mockLayoutPrefsStore.setSpanNameColumnWidth.mockClear();
     mockLayoutPrefsStore.setSidePanelWidth.mockClear();
     mockTraceTimelineStore.collapseAll.mockClear();
@@ -144,6 +156,9 @@ describe('<TraceTimelineViewer>', () => {
     mockUseTraceTimelineStore.setState.mockClear();
     mockUseServiceFilter.prunedServices = new Set();
     mockUseServiceFilter.serviceFilterNode = null;
+    mockTraceTimelineStore.prunedServices = new Set();
+    mockFilterSpans.mockReset();
+    capturedVirtualizedProps = {};
     jest.spyOn(KeyboardShortcuts, 'merge').mockClear();
   });
 
@@ -158,6 +173,37 @@ describe('<TraceTimelineViewer>', () => {
     const initialCount = screen.getAllByTestId('virtualized-trace-view-mock').length;
     renderWithRedux(<TraceTimelineViewer {...props} />);
     expect(screen.getAllByTestId('virtualized-trace-view-mock')).toHaveLength(initialCount + 1);
+  });
+
+  describe('search', () => {
+    it('reports 0 matches and passes no findMatchesIDs when there is no uiFind', () => {
+      render(<TraceTimelineViewerImpl {...props} uiFind={undefined} />);
+      expect(mockFilterSpans).not.toHaveBeenCalled();
+      expect(props.onSearchResults).toHaveBeenLastCalledWith({ count: 0, matches: new Set() });
+      expect(capturedVirtualizedProps.findMatchesIDs).toBeNull();
+    });
+
+    it('computes matches from uiFind, passes them to VirtualizedTraceView, and reports the count', () => {
+      const matches = new Set(['a', 'b', 'c']);
+      mockFilterSpans.mockReturnValue(matches);
+      render(<TraceTimelineViewerImpl {...props} uiFind="query" />);
+      expect(mockFilterSpans).toHaveBeenCalledWith('query', trace.spans);
+      expect(capturedVirtualizedProps.findMatchesIDs).toBe(matches);
+      expect(props.onSearchResults).toHaveBeenLastCalledWith({ count: 3, matches });
+    });
+
+    it('applies service pruning to the matches when services are pruned', () => {
+      // Match every span, then prune one service so the survivor set is strictly smaller.
+      const matches = new Set(trace.spans.map(s => s.spanID));
+      mockFilterSpans.mockReturnValue(matches);
+      mockTraceTimelineStore.prunedServices = new Set([trace.spans[0].resource.serviceName]);
+      render(<TraceTimelineViewerImpl {...props} uiFind="query" />);
+
+      const ids = capturedVirtualizedProps.findMatchesIDs;
+      const reported = props.onSearchResults.mock.calls.at(-1)[0];
+      expect(reported.count).toBe(ids ? ids.size : 0);
+      expect(reported.count).toBeLessThan(matches.size);
+    });
   });
 
   it('derives selectedSpanID from Zustand detailStates', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
 import { actions } from './duck';
+import { filterPrunedSpanIDs } from './generateRowStates';
 import {
   getSelectedSpanID,
   MIN_TIMELINE_COLUMN_WIDTH,
@@ -22,10 +23,11 @@ import VirtualizedTraceView from './VirtualizedTraceView';
 import VerticalResizer from '../../common/VerticalResizer';
 import { merge as mergeShortcuts } from '../keyboard-shortcuts';
 import { Accessors } from '../ScrollManager';
-import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../types';
+import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate, TOnSearchResults } from '../types';
 import { TNil, ReduxState } from '../../../types';
 import { IOtelSpan, IOtelTrace } from '../../../types/otel';
 import { CriticalPathSection } from '../../../types/critical_path';
+import filterSpans from '../../../utils/filter-spans';
 
 import './index.css';
 
@@ -41,7 +43,8 @@ type TDispatchProps = {
 
 type TProps = TDispatchProps & {
   registerAccessors: (accessors: Accessors) => void;
-  findMatchesIDs: Set<string> | TNil;
+  uiFind: string | TNil;
+  onSearchResults: TOnSearchResults;
   scrollToFirstVisibleSpan: () => void;
   trace: IOtelTrace;
   criticalPath: CriticalPathSection[];
@@ -72,12 +75,30 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
     updateViewRangeTime,
     viewRange,
     trace,
+    uiFind,
+    onSearchResults,
     useOtelTerms,
     ...rest
   } = props;
 
   // Layout preferences are owned by Zustand; Redux setters are also called for the tracking middleware.
   const detailPanelMode = useLayoutPrefsStore(s => s.detailPanelMode);
+  const prunedServices = useTraceTimelineStore(s => s.prunedServices);
+
+  // The timeline owns its own search: it computes the set of matching span IDs from `uiFind`,
+  // applying the same service-pruning that hides rows, then reports the match count to the parent.
+  const findMatchesIDs = useMemo<Set<string> | TNil>(() => {
+    if (!uiFind) return null;
+    const allMatches = filterSpans(uiFind, trace.spans);
+    return prunedServices.size > 0 && allMatches
+      ? filterPrunedSpanIDs(allMatches, trace.spanMap, prunedServices)
+      : allMatches;
+  }, [uiFind, trace, prunedServices]);
+
+  useEffect(() => {
+    const matches = findMatchesIDs ?? new Set<string>();
+    onSearchResults({ count: matches.size, matches });
+  }, [findMatchesIDs, onSearchResults]);
   const sidePanelWidth = useLayoutPrefsStore(s => s.sidePanelWidth);
   const spanNameColumnWidth = useLayoutPrefsStore(s => s.spanNameColumnWidth);
   const timelineBarsVisible = useLayoutPrefsStore(s => s.timelineBarsVisible);
@@ -226,6 +247,7 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   const virtualizedView = (
     <VirtualizedTraceView
       {...rest}
+      findMatchesIDs={findMatchesIDs}
       trace={trace}
       useOtelTerms={useOtelTerms}
       currentViewRangeTime={viewRange.time.current}

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -20,34 +20,37 @@ import * as keyboardShortcutsMod from './keyboard-shortcuts';
 import { reset as resetShortcuts, merge as mergeShortcuts } from './keyboard-shortcuts';
 import * as scrollPageMod from './scroll-page';
 import { cancel as cancelScroll } from './scroll-page';
-import * as calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
-import * as getUiFindVertexKeys from '../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
 import { fetchedState } from '../../constants';
 import traceGenerator from '../../demo/trace-generators';
 import transformTraceData from '../../model/transform-trace-data';
-import filterSpansSpy from '../../utils/filter-spans';
 import updateUiFindSpy from '../../utils/update-ui-find';
 import { ETraceViewType } from './types';
 import ScrollManager from './ScrollManager';
 
 let capturedHeaderProps = {};
 let capturedArchiveNotifierProps = {};
+let capturedTimelineProps = {};
+let capturedGraphProps = {};
+let capturedStatisticsProps = {};
 
 vi.mock('./TraceTimelineViewer', async () => {
-  return mockDefault(function MockTraceTimelineViewer() {
+  return mockDefault(function MockTraceTimelineViewer(props) {
+    capturedTimelineProps = props;
     return <div data-testid="mock-timeline-viewer">TraceTimelineViewer</div>;
   });
 });
 
 vi.mock('./TraceGraph/TraceGraph', async () => {
-  return mockDefault(function MockTraceGraph() {
+  return mockDefault(function MockTraceGraph(props) {
+    capturedGraphProps = props;
     return <div data-testid="mock-trace-graph">TraceGraph</div>;
   });
 });
 
 vi.mock('./TraceStatistics/index', async () => {
-  return mockDefault(function MockTraceStatistics() {
+  return mockDefault(function MockTraceStatistics(props) {
+    capturedStatisticsProps = props;
     return <div data-testid="mock-trace-statistics">TraceStatistics</div>;
   });
 });
@@ -88,7 +91,6 @@ vi.mock('./ScrollManager', async () => {
 vi.mock('./index.track');
 vi.mock('./keyboard-shortcuts');
 vi.mock('./scroll-page');
-vi.mock('../../utils/filter-spans');
 vi.mock('../../utils/update-ui-find');
 vi.mock('./TracePageHeader/SpanGraph', async () =>
   mockDefault(() => <div data-testid="span-graph">SpanGraph</div>)
@@ -98,9 +100,6 @@ vi.mock('./TracePageHeader/TracePageSearchBar', async () =>
   mockDefault(() => <div data-testid="search-bar">SearchBar</div>)
 );
 vi.mock('./CriticalPath/index');
-vi.mock('./TraceGraph/calculateTraceDagEV', async () => ({
-  default: jest.fn(() => ({})),
-}));
 vi.mock('../common/ErrorMessage', async () =>
   mockDefault(() => <div data-testid="error-message">Error</div>)
 );
@@ -230,10 +229,6 @@ describe('<TracePage>', () => {
   };
   const notDefaultPropsId = `not ${defaultProps.params.id}`;
 
-  beforeAll(() => {
-    filterSpansSpy.mockReturnValue(new Set());
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
     useEmbeddedStateMock.mockReturnValue(null);
@@ -241,6 +236,9 @@ describe('<TracePage>', () => {
     ScrollManager.mockClear();
     capturedHeaderProps = {};
     capturedArchiveNotifierProps = {};
+    capturedTimelineProps = {};
+    capturedGraphProps = {};
+    capturedStatisticsProps = {};
     defaultProps.focusUiFindMatches.mockClear();
     mockTraceTimelineStore.focusUiFindMatches.mockClear();
   });
@@ -346,28 +344,41 @@ describe('<TracePage>', () => {
     });
   });
 
-  it('uses uiFind and params.id to compute memo cache key for filterSpans', () => {
+  it('passes uiFind and an onSearchResults callback down to the active view', () => {
+    jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
     const uiFind = 'uiFind';
-    const localTrace = transformTraceData(traceGenerator.trace({})).asOtelTrace();
-    useTraceMock.mockReturnValue({ data: localTrace, isPending: false, isError: false, error: null });
+    render(<TracePage {...defaultProps} uiFind={uiFind} />);
 
-    filterSpansSpy.mockClear();
-    filterSpansSpy.mockImplementation(() => new Set());
+    expect(capturedTimelineProps.uiFind).toBe(uiFind);
+    expect(typeof capturedTimelineProps.onSearchResults).toBe('function');
+    jest.restoreAllMocks();
+  });
 
-    const { rerender } = render(<TracePage {...defaultProps} uiFind={undefined} />);
-    expect(filterSpansSpy).not.toHaveBeenCalled();
+  it('updates the header resultCount when a view reports its search results', () => {
+    jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
+    render(<TracePage {...defaultProps} uiFind="uiFind" />);
 
-    // Adding uiFind triggers filterSpans
-    rerender(<TracePage {...defaultProps} uiFind={uiFind} />);
-    expect(filterSpansSpy).toHaveBeenCalledTimes(1);
-    expect(filterSpansSpy).toHaveBeenLastCalledWith(uiFind, localTrace.spans);
+    act(() => {
+      capturedTimelineProps.onSearchResults({ count: 7, matches: new Set() });
+    });
+    expect(capturedHeaderProps.resultCount).toBe(7);
+    jest.restoreAllMocks();
+  });
 
-    // Changing the trace id invalidates the cache
-    const otherTrace = transformTraceData(traceGenerator.trace({})).asOtelTrace();
-    useTraceMock.mockReturnValue({ data: otherTrace, isPending: false, isError: false, error: null });
-    rerender(<TracePage {...defaultProps} params={{ id: 'different-trace-id' }} uiFind={uiFind} />);
-    expect(filterSpansSpy).toHaveBeenCalledTimes(2);
-    expect(filterSpansSpy).toHaveBeenLastCalledWith(uiFind, otherTrace.spans);
+  it('resets resultCount to 0 when the view type changes', () => {
+    jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
+    render(<TracePage {...defaultProps} uiFind="uiFind" />);
+
+    act(() => {
+      capturedTimelineProps.onSearchResults({ count: 7, matches: new Set() });
+    });
+    expect(capturedHeaderProps.resultCount).toBe(7);
+
+    act(() => {
+      capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
+    });
+    expect(capturedHeaderProps.resultCount).toBe(0);
+    jest.restoreAllMocks();
   });
 
   it('renders a loading indicator when trace is not loaded', () => {
@@ -518,25 +529,23 @@ describe('<TracePage>', () => {
     expect(track.trackRange).toHaveBeenCalledWith('kbd', expect.any(Array), [0, 1]);
   });
 
-  it('computes graphFindMatches and sets findCount based on traceDagEV when viewType is TraceGraph', () => {
-    const mockVertices = [{ key: 'v1' }, { key: 'v2' }];
-    const mockMatches = new Set(['v1']);
-
-    calculateTraceDagEV.default.mockReturnValue({ vertices: mockVertices });
-    const getUiFindVertexKeysSpy = jest
-      .spyOn(getUiFindVertexKeys, 'getUiFindVertexKeys')
-      .mockReturnValue(mockMatches);
-
+  it('passes trace, uiFind and onSearchResults to TraceGraph and reflects its reported count', () => {
+    jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
     render(<TracePage {...defaultProps} uiFind="some-search" />);
 
     act(() => {
       capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
     });
 
-    expect(getUiFindVertexKeysSpy).toHaveBeenCalledWith('some-search', mockVertices);
-    expect(capturedHeaderProps.resultCount).toBe(1);
+    expect(capturedGraphProps.trace).toBe(trace);
+    expect(capturedGraphProps.uiFind).toBe('some-search');
+    expect(typeof capturedGraphProps.onSearchResults).toBe('function');
 
-    getUiFindVertexKeysSpy.mockRestore();
+    act(() => {
+      capturedGraphProps.onSearchResults({ count: 1, matches: new Set() });
+    });
+    expect(capturedHeaderProps.resultCount).toBe(1);
+    jest.restoreAllMocks();
   });
 
   describe('TracePageHeader props', () => {
@@ -667,86 +676,6 @@ describe('<TracePage>', () => {
         expect(results[1].showArchiveButton).toBe(false);
         expect(results[2].showArchiveButton).toBe(false);
         expect(results[3].showArchiveButton).toBe(false);
-      });
-    });
-
-    describe('resultCount', () => {
-      let getUiFindVertexKeysSpy;
-
-      beforeAll(() => {
-        getUiFindVertexKeysSpy = jest.spyOn(getUiFindVertexKeys, 'getUiFindVertexKeys');
-      });
-
-      beforeEach(() => {
-        getUiFindVertexKeysSpy.mockReset();
-        filterSpansSpy.mockReset();
-      });
-
-      it('is the size of spanFindMatches when available', () => {
-        const size = 20;
-        const mockSet = new Set();
-        for (let i = 0; i < size; i++) {
-          mockSet.add(`span-${i}`);
-        }
-
-        filterSpansSpy.mockReset();
-        filterSpansSpy.mockReturnValue(mockSet);
-
-        const props = {
-          ...defaultProps,
-          uiFind: 'test-find',
-        };
-
-        let resultCount;
-        if (props.uiFind) {
-          const spanFindMatches = filterSpansSpy(props.uiFind, trace.spans);
-          resultCount = spanFindMatches ? spanFindMatches.size : 0;
-        }
-
-        expect(resultCount).toBe(size);
-      });
-
-      it('is the size of graphFindMatches when available', () => {
-        const size = 30;
-        const mockSet = new Set();
-        for (let i = 0; i < size; i++) {
-          mockSet.add(`vertex-${i}`);
-        }
-
-        getUiFindVertexKeysSpy.mockReturnValue(mockSet);
-
-        const props = {
-          ...defaultProps,
-          uiFind: 'test-find',
-        };
-
-        const viewType = ETraceViewType.TraceGraph;
-        let resultCount;
-
-        if (viewType === ETraceViewType.TraceGraph && props.uiFind) {
-          const vertices = [];
-          const graphFindMatches = getUiFindVertexKeysSpy(props.uiFind, vertices);
-          resultCount = graphFindMatches ? graphFindMatches.size : 0;
-        }
-
-        expect(resultCount).toBe(size);
-      });
-
-      it('defaults to 0 when no matches found', () => {
-        filterSpansSpy.mockReturnValue(null);
-
-        const props = {
-          ...defaultProps,
-          uiFind: 'no-matches',
-        };
-
-        let resultCount = null;
-        if (props.uiFind) {
-          const spanFindMatches = filterSpansSpy(props.uiFind, trace.spans);
-          resultCount = spanFindMatches ? spanFindMatches.size : 0;
-        }
-
-        expect(resultCount).toBe(0);
       });
     });
 
@@ -889,10 +818,6 @@ describe('<TracePage>', () => {
   });
 
   describe('manages various UI state', () => {
-    beforeAll(() => {
-      calculateTraceDagEV.default.mockClear();
-    });
-
     it('propagates headerHeight changes', () => {
       jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
       render(<TracePage {...defaultProps} />);
@@ -934,15 +859,12 @@ describe('<TracePage>', () => {
     });
 
     it('propagates traceView changes', () => {
-      calculateTraceDagEV.default.mockClear();
-
       render(<TracePage {...defaultProps} />);
 
       act(() => {
         capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
       });
       expect(capturedHeaderProps.viewType).toBe(ETraceViewType.TraceGraph);
-      expect(calculateTraceDagEV.default).toHaveBeenCalledWith(trace);
 
       act(() => {
         capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceSpansView);

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -8,9 +8,7 @@ import { useNormalizeTraceId } from './useNormalizeTraceId';
 import { useNavigate } from 'react-router-dom';
 import type { Location } from 'react-router-dom';
 import _clamp from 'lodash/clamp';
-import _get from 'lodash/get';
 import _mapValues from 'lodash/mapValues';
-import _memoize from 'lodash/memoize';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -31,13 +29,11 @@ import {
 } from './keyboard-shortcuts';
 import { cancel as cancelScroll, scrollBy, scrollTo } from './scroll-page';
 import ScrollManager from './ScrollManager';
-import calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import TraceGraph from './TraceGraph/TraceGraph';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
 import { useConfig } from '../../hooks/useConfig';
 import TracePageHeader from './TracePageHeader';
 import TraceTimelineViewer from './TraceTimelineViewer';
-import { filterPrunedSpanIDs } from './TraceTimelineViewer/generateRowStates';
 import { actions as timelineActions } from './TraceTimelineViewer/duck';
 import {
   TUpdateViewRangeTimeFunction,
@@ -45,16 +41,15 @@ import {
   ViewRangeTimeUpdate,
   ETraceViewType,
   viewTypeShowsMinimap,
+  TSearchResults,
 } from './types';
 import { getUrl } from './url';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
 import { parseUiFind } from '../common/UiFindInput';
-import { getUiFindVertexKeys } from '../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
 import { LocationState, ReduxState, TNil } from '../../types';
 import { useTrace } from '../../hooks/useTraceLoading';
 import { IOtelTrace } from '../../types/otel';
-import filterSpans from '../../utils/filter-spans';
 import updateUiFind from '../../utils/update-ui-find';
 import TraceStatistics from './TraceStatistics/index';
 import TraceSpanView from './TraceSpanView/index';
@@ -173,7 +168,6 @@ export function TracePageImpl(props: TProps) {
   const timelineBarsVisible = useLayoutPrefsStore(s => s.timelineBarsVisible);
   const zustandSetTimelineBarsVisible = useLayoutPrefsStore(s => s.setTimelineBarsVisible);
   const zustandFocusUiFindMatches = useTraceTimelineStore(s => s.focusUiFindMatches);
-  const prunedServices = useTraceTimelineStore(s => s.prunedServices);
 
   const setDetailPanelMode = useCallback(
     (mode: SpanDetailPanelMode) => {
@@ -201,10 +195,18 @@ export function TracePageImpl(props: TProps) {
   const [slimView, setSlimView] = useState(() => Boolean(embedded?.timeline?.collapseTitle));
   const [viewType, setViewType] = useState<ETraceViewType>(ETraceViewType.TraceTimelineViewer);
   const [viewRange, setViewRange] = useState<IViewRange>({ time: { current: [0, 1] } });
-  const traceDagEV = useMemo(
-    () => (viewType === ETraceViewType.TraceGraph && traceData ? calculateTraceDagEV(traceData) : null),
-    [traceData, viewType]
-  );
+
+  // Each searchable view computes its own matches and reports the count up via onSearchResults.
+  // The parent only tracks the count for display in the header; it has no knowledge of how any
+  // particular view searches. Reset to 0 on view change so a stale count from the previous view
+  // is never shown before the new view reports its results.
+  const [findCount, setFindCount] = useState(0);
+  const handleSearchResults = useCallback((results: TSearchResults) => setFindCount(results.count), []);
+  const prevViewTypeRef = useRef(viewType);
+  if (prevViewTypeRef.current !== viewType) {
+    prevViewTypeRef.current = viewType;
+    setFindCount(0);
+  }
 
   const traceIsGenAI = useMemo(
     () =>
@@ -219,12 +221,6 @@ export function TracePageImpl(props: TProps) {
   const viewRangeRef = useRef(viewRange);
   viewRangeRef.current = viewRange;
   const prevIdRef = useRef(id);
-  const idRef = useRef(id);
-  idRef.current = id;
-
-  const filterSpansMemo = useRef(
-    _memoize(filterSpans, (textFilter: string) => `${textFilter} ${idRef.current}`)
-  ).current;
 
   const scrollManagerRef = useRef<ScrollManager>(new ScrollManager(traceData, { scrollBy, scrollTo }));
 
@@ -384,24 +380,6 @@ export function TracePageImpl(props: TProps) {
     return <LoadingIndicator className="u-mt-vast" centered />;
   }
 
-  let findCount = 0;
-  let graphFindMatches: Set<string> | null | undefined;
-  let spanFindMatches: Set<string> | null | undefined;
-  if (uiFind) {
-    if (viewType === ETraceViewType.TraceGraph) {
-      graphFindMatches = getUiFindVertexKeys(uiFind, _get(traceDagEV, 'vertices', []));
-      findCount = graphFindMatches ? graphFindMatches.size : 0;
-    } else {
-      const allMatches = filterSpansMemo(uiFind, _get(traceData, 'spans'));
-      const otelTrace = traceData;
-      spanFindMatches =
-        otelTrace && prunedServices.size > 0
-          ? filterPrunedSpanIDs(allMatches, otelTrace.spanMap, prunedServices)
-          : allMatches;
-      findCount = spanFindMatches ? spanFindMatches.size : 0;
-    }
-  }
-
   const locationState = location.state;
   const isEmbedded = Boolean(embedded);
   const hasArchiveStorage = Boolean(backendCapabilities?.archiveStorage);
@@ -447,7 +425,8 @@ export function TracePageImpl(props: TProps) {
       <TraceTimelineViewer
         registerAccessors={sm.setAccessors}
         scrollToFirstVisibleSpan={sm.scrollToFirstVisibleSpan}
-        findMatchesIDs={spanFindMatches}
+        uiFind={uiFind}
+        onSearchResults={handleSearchResults}
         trace={traceData}
         criticalPath={criticalPath}
         updateNextViewRangeTime={updateNextViewRangeTime}
@@ -461,7 +440,8 @@ export function TracePageImpl(props: TProps) {
       <TraceTimelineViewer
         registerAccessors={sm.setAccessors}
         scrollToFirstVisibleSpan={sm.scrollToFirstVisibleSpan}
-        findMatchesIDs={spanFindMatches}
+        uiFind={uiFind}
+        onSearchResults={handleSearchResults}
         trace={traceData}
         criticalPath={criticalPath}
         updateNextViewRangeTime={updateNextViewRangeTime}
@@ -474,9 +454,9 @@ export function TracePageImpl(props: TProps) {
     view = (
       <TraceGraph
         headerHeight={headerHeight}
-        ev={traceDagEV}
+        trace={traceData}
         uiFind={uiFind}
-        uiFindVertexKeys={graphFindMatches}
+        onSearchResults={handleSearchResults}
         traceGraphConfig={traceGraphConfig}
         useOtelTerms={useOtelTerms}
       />
@@ -485,8 +465,8 @@ export function TracePageImpl(props: TProps) {
     view = (
       <TraceStatistics
         trace={traceData}
-        uiFindVertexKeys={spanFindMatches}
         uiFind={uiFind}
+        onSearchResults={handleSearchResults}
         useOtelTerms={useOtelTerms}
       />
     );
@@ -495,13 +475,13 @@ export function TracePageImpl(props: TProps) {
       <TraceSpanView
         key={traceData.traceID}
         trace={traceData}
-        uiFindVertexKeys={spanFindMatches}
         uiFind={uiFind}
+        onSearchResults={handleSearchResults}
         useOtelTerms={useOtelTerms}
       />
     );
   } else if (ETraceViewType.TraceFlamegraph === viewType && headerHeight) {
-    view = <TraceFlamegraph trace={traceData} />;
+    view = <TraceFlamegraph trace={traceData} uiFind={uiFind} onSearchResults={handleSearchResults} />;
   } else if (ETraceViewType.TraceLogs === viewType && headerHeight) {
     view = <TraceLogsView trace={traceData} useOtelTerms={useOtelTerms} />;
   }

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -198,15 +198,20 @@ export function TracePageImpl(props: TProps) {
 
   // Each searchable view computes its own matches and reports the count up via onSearchResults.
   // The parent only tracks the count for display in the header; it has no knowledge of how any
-  // particular view searches. Reset to 0 on view change so a stale count from the previous view
-  // is never shown before the new view reports its results.
-  const [findCount, setFindCount] = useState(0);
-  const handleSearchResults = useCallback((results: TSearchResults) => setFindCount(results.count), []);
-  const prevViewTypeRef = useRef(viewType);
-  if (prevViewTypeRef.current !== viewType) {
-    prevViewTypeRef.current = viewType;
-    setFindCount(0);
-  }
+  // particular view searches. The reported result is tagged with the view type that produced it, so
+  // a count from a previous view reads as 0 until the current view reports — this resets the count
+  // on view change without mutating state during render.
+  const viewTypeRef = useRef(viewType);
+  viewTypeRef.current = viewType;
+  const [findResult, setFindResult] = useState<{ viewType: ETraceViewType; count: number }>({
+    viewType,
+    count: 0,
+  });
+  const handleSearchResults = useCallback(
+    (results: TSearchResults) => setFindResult({ viewType: viewTypeRef.current, count: results.count }),
+    []
+  );
+  const findCount = findResult.viewType === viewType ? findResult.count : 0;
 
   const traceIsGenAI = useMemo(
     () =>

--- a/packages/jaeger-ui/src/components/TracePage/types.ts
+++ b/packages/jaeger-ui/src/components/TracePage/types.ts
@@ -45,6 +45,16 @@ export interface IViewRange {
   time: IViewRangeTime;
 }
 
+// Common contract for "inversion of control on search": a searchable view computes its own matches
+// from the `uiFind` query and reports them up. The parent displays the count without knowing how the
+// view searches. `matches` carries the matching IDs so a parent can use them (e.g. navigation) too.
+export type TSearchResults = {
+  count: number;
+  matches: Set<string>;
+};
+
+export type TOnSearchResults = (results: TSearchResults) => void;
+
 export enum ETraceViewType {
   TraceTimelineViewer = 'TraceTimelineViewer',
   TraceGraph = 'TraceGraph',


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4134 

## Description of the changes
Inverts control on search: the parent now only knows a view *is* searchable, not *how* it searches (mirroring helpers like `viewTypeShowsMinimap()`).

- Added a common callback contract in `TracePage/types.ts`: `TOnSearchResults = (results: { count: number; matches: Set<string> }) => void`.
- `TracePage` now passes `uiFind` + `onSearchResults` to each searchable view and only stores the reported `count` for the header. It resets the count on view change so a stale count is never shown.
- Each view computes its own matches and reports up:
  - `TraceGraph` now derives the DAG (`calculateTraceDagEV`) and vertex matches (`getUiFindVertexKeys`) internally from `trace`.
  - `TraceTimelineViewer` computes span matches via `filterSpans` (+ existing service pruning) internally.
  - `TraceStatistics`, `TraceSpanView`, and `TraceFlamegraph` adopt the same pattern.
- Removed the now-dead search props and the parent's branching/`filterSpans` memoization, along with the imports that are no longer needed there. 

## How was this change tested?
- Updated/added unit tests for each view to cover the `onSearchResults` contract (count reported on mount, recomputed on `uiFind` change, pruning applied in the timeline) and updated `TracePage` tests to assert it passes `uiFind` + `onSearchResults` down and reflects the reported count.
- `tsc`, eslint/oxlint, and prettier all pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
