### PR TITLE
refactor(TracePage): Decouple search logic

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
@@ -7,7 +7,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LayoutManager } from '@jaegertracing/plexus';
 import transformTraceData from '../../../model/transform-trace-data';
-import calculateTraceDagEV from './calculateTraceDagEV';
 import TraceGraph, { setOnEdgePath } from './TraceGraph';
 import { MODE_SERVICE, MODE_TIME, MODE_SELFTIME } from './OpNode';
 import testTrace from './testTrace.json';
@@ -66,7 +65,6 @@ vi.mock('@jaegertracing/plexus', () => {
 });
 
 const transformedTrace = transformTraceData(testTrace);
-const ev = calculateTraceDagEV(transformedTrace.asOtelTrace());
 
 describe('<TraceGraph>', () => {
   let props;

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.test.jsx
@@ -74,7 +74,7 @@ describe('<TraceGraph>', () => {
   beforeEach(() => {
     props = {
       headerHeight: 60,
-      ev,
+      trace: transformedTrace.asOtelTrace(),
     };
   });
 
@@ -181,12 +181,17 @@ describe('<TraceGraph>', () => {
   it('handles uiFind mode correctly', () => {
     const propsWithUiFind = {
       ...props,
-      uiFind: 'test-service',
-      uiFindVertexKeys: new Set(['key1', 'key2']),
+      uiFind: 'service1',
     };
     render(<TraceGraph {...propsWithUiFind} />);
     const wrapper = screen.getByTestId('mock-digraph').parentElement;
     expect(wrapper).toHaveClass('is-uiFind-mode');
+  });
+
+  it('fires onSearchResults callback when trace and uiFind are provided', () => {
+    const onSearchResults = jest.fn();
+    render(<TraceGraph {...props} uiFind="service1" onSearchResults={onSearchResults} />);
+    expect(onSearchResults).toHaveBeenCalledWith(expect.objectContaining({ count: expect.any(Number) }));
   });
 
   it('initializes with correct default mode', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/TraceGraph.tsx
@@ -16,21 +16,25 @@ import {
   MODE_SELFTIME,
   getHelpTable,
 } from './OpNode';
-import { TEv, TSumSpan } from './types';
+import { TSumSpan } from './types';
 import { TDenseSpanMembers } from '../../../model/trace-dag/types';
 import TDagPlexusVertex from '../../../model/trace-dag/types/TDagPlexusVertex';
 import { TNil } from '../../../types';
 import { TraceGraphConfig } from '../../../types/config';
+import { IOtelTrace } from '../../../types/otel';
+import { OnSearchResultsCallback } from '../types';
+import calculateTraceDagEV from './calculateTraceDagEV';
+import { getUiFindVertexKeys } from '../../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
 
 import './TraceGraph.css';
 
 type Props = {
   headerHeight: number;
-  ev?: TEv | TNil;
+  trace?: IOtelTrace | TNil;
   uiFind: string | TNil;
-  uiFindVertexKeys: Set<string> | TNil;
   traceGraphConfig?: TraceGraphConfig;
   useOtelTerms: boolean;
+  onSearchResults?: OnSearchResultsCallback;
 };
 
 const { classNameIsSmall, scaleOpacity, scaleStrokeOpacity } = Digraph.propsFactories;
@@ -96,14 +100,28 @@ const getHelpContent = (useOtelTerms: boolean) => (
 
 function TraceGraph({
   headerHeight,
-  ev = null,
+  trace = null,
   uiFind,
-  uiFindVertexKeys,
   traceGraphConfig,
   useOtelTerms,
+  onSearchResults,
 }: Props) {
   const [showHelp, setShowHelp] = React.useState(false);
   const [mode, setMode] = React.useState(MODE_SERVICE);
+
+  const ev = React.useMemo(() => {
+    if (!trace) return null;
+    return calculateTraceDagEV(trace);
+  }, [trace]);
+
+  const uiFindVertexKeys = React.useMemo(() => {
+    if (!uiFind || !ev) return undefined;
+    return getUiFindVertexKeys(uiFind, ev.vertices || []);
+  }, [uiFind, ev]);
+
+  React.useEffect(() => {
+    onSearchResults?.({ count: uiFindVertexKeys?.size ?? 0 });
+  }, [uiFindVertexKeys, onSearchResults]);
 
   const layoutManagerRef = React.useRef<LayoutManager | null>(null);
   if (layoutManagerRef.current === null) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
@@ -44,7 +44,6 @@ describe('<TraceSpanView>', () => {
     defaultProps = {
       trace,
       uiFind: undefined,
-      uiFindVertexKeys: undefined,
     };
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -6,7 +6,6 @@ import { Table, Button, Select, Form, Tooltip } from 'antd';
 import dayjs from 'dayjs';
 import { ColumnProps } from 'antd/es/table';
 import './index.css';
-import { TNil } from '../../../types';
 import { IOtelSpan, IOtelTrace } from '../../../types/otel';
 import RelativeBar from '../../common/RelativeBar';
 import { formatDuration, formatDurationCompact } from '../../../utils/date';
@@ -18,7 +17,6 @@ type FilterType = 'serviceName' | 'operationName';
 
 type Props = {
   trace: IOtelTrace;
-  uiFindVertexKeys: Set<string> | TNil;
   uiFind: string | null | undefined;
   useOtelTerms: boolean;
 };

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -100,7 +100,7 @@ describe('<TraceTimelineViewer>', () => {
   const trace = legacyTrace.asOtelTrace();
   const props = {
     trace,
-    textFilter: null,
+    uiFind: null,
     viewRange: {
       time: {
         current: [0, 1],
@@ -163,6 +163,12 @@ describe('<TraceTimelineViewer>', () => {
     const initialCount = screen.getAllByTestId('virtualized-trace-view-mock').length;
     renderWithRedux(<TraceTimelineViewer {...props} />);
     expect(screen.getAllByTestId('virtualized-trace-view-mock')).toHaveLength(initialCount + 1);
+  });
+
+  it('fires onSearchResults callback when trace and uiFind are provided', () => {
+    const onSearchResults = jest.fn();
+    render(<TraceTimelineViewerImpl {...props} uiFind="service1" onSearchResults={onSearchResults} />);
+    expect(onSearchResults).toHaveBeenCalledWith(expect.objectContaining({ count: expect.any(Number) }));
   });
 
   it('derives selectedSpanID from Zustand detailStates', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -24,10 +24,17 @@ import VirtualizedTraceView from './VirtualizedTraceView';
 import VerticalResizer from '../../common/VerticalResizer';
 import { merge as mergeShortcuts } from '../keyboard-shortcuts';
 import { Accessors } from '../ScrollManager';
-import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../types';
+import {
+  TUpdateViewRangeTimeFunction,
+  IViewRange,
+  ViewRangeTimeUpdate,
+  OnSearchResultsCallback,
+} from '../types';
 import { TNil, ReduxState } from '../../../types';
 import { IOtelSpan, IOtelTrace } from '../../../types/otel';
 import { CriticalPathSection } from '../../../types/critical_path';
+import filterSpans from '../../../utils/filter-spans';
+import { filterPrunedSpanIDs } from './generateRowStates';
 
 import './index.css';
 
@@ -43,7 +50,8 @@ type TDispatchProps = {
 
 type TProps = TDispatchProps & {
   registerAccessors: (accessors: Accessors) => void;
-  findMatchesIDs: Set<string> | TNil;
+  uiFind: string | TNil;
+  onSearchResults?: OnSearchResultsCallback;
   scrollToFirstVisibleSpan: () => void;
   trace: IOtelTrace;
   criticalPath: CriticalPathSection[];
@@ -75,6 +83,8 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
     viewRange,
     trace,
     useOtelTerms,
+    uiFind,
+    onSearchResults,
     ...rest
   } = props;
 
@@ -92,6 +102,19 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   const zustandCollapseOne = useTraceTimelineStore(s => s.collapseOne);
   const zustandExpandAll = useTraceTimelineStore(s => s.expandAll);
   const zustandExpandOne = useTraceTimelineStore(s => s.expandOne);
+  const prunedServices = useTraceTimelineStore(s => s.prunedServices);
+
+  const matches = useMemo(() => {
+    if (!uiFind) return null;
+    const allMatches = filterSpans(uiFind, trace.spans);
+    return prunedServices.size > 0
+      ? filterPrunedSpanIDs(allMatches, trace.spanMap, prunedServices)
+      : allMatches;
+  }, [uiFind, trace.spans, trace.spanMap, prunedServices]);
+
+  useEffect(() => {
+    onSearchResults?.({ count: matches?.size ?? 0 });
+  }, [matches, onSearchResults]);
 
   const setSpanNameColumnWidth = useCallback(
     (width: number) => {
@@ -238,6 +261,7 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
   const virtualizedView = (
     <VirtualizedTraceView
       {...rest}
+      findMatchesIDs={matches}
       trace={trace}
       useOtelTerms={useOtelTerms}
       currentViewRangeTime={viewRange.time.current}

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -19,9 +19,7 @@ import * as track from './index.track';
 import * as keyboardShortcutsMod from './keyboard-shortcuts';
 import { merge as mergeShortcuts } from './keyboard-shortcuts';
 import * as scrollPageMod from './scroll-page';
-import * as calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
-import * as getUiFindVertexKeys from '../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
 import traceGenerator from '../../demo/trace-generators';
 import transformTraceData from '../../model/transform-trace-data';
 import filterSpansSpy from '../../utils/filter-spans';
@@ -31,15 +29,19 @@ import ScrollManager from './ScrollManager';
 
 let capturedHeaderProps = {};
 let capturedArchiveNotifierProps = {};
+let capturedTimelineProps = {};
+let capturedGraphProps = {};
 
 vi.mock('./TraceTimelineViewer', async () => {
-  return mockDefault(function MockTraceTimelineViewer() {
+  return mockDefault(function MockTraceTimelineViewer(props) {
+    capturedTimelineProps = props;
     return <div data-testid="mock-timeline-viewer">TraceTimelineViewer</div>;
   });
 });
 
 vi.mock('./TraceGraph/TraceGraph', async () => {
-  return mockDefault(function MockTraceGraph() {
+  return mockDefault(function MockTraceGraph(props) {
+    capturedGraphProps = props;
     return <div data-testid="mock-trace-graph">TraceGraph</div>;
   });
 });
@@ -239,8 +241,17 @@ describe('<TracePage>', () => {
     ScrollManager.mockClear();
     capturedHeaderProps = {};
     capturedArchiveNotifierProps = {};
+    capturedTimelineProps = {};
+    capturedGraphProps = {};
     defaultProps.focusUiFindMatches.mockClear();
     mockTraceTimelineStore.focusUiFindMatches.mockClear();
+    // Ensure headerHeight is non-zero so view components (TraceTimelineViewer, TraceGraph)
+    // are rendered. They are gated on `headerHeight` in TracePage.
+    jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('clearSearch', () => {
@@ -344,7 +355,7 @@ describe('<TracePage>', () => {
     });
   });
 
-  it('uses uiFind and params.id to compute memo cache key for filterSpans', () => {
+  it('uses uiFind and params.id to compute memo cache key for filterSpans (Statistics/SpanView only)', () => {
     const uiFind = 'uiFind';
     const localTrace = transformTraceData(traceGenerator.trace({})).asOtelTrace();
     useTraceMock.mockReturnValue({ data: localTrace, isPending: false, isError: false, error: null });
@@ -352,10 +363,14 @@ describe('<TracePage>', () => {
     filterSpansSpy.mockClear();
     filterSpansSpy.mockImplementation(() => new Set());
 
+    // Switch to TraceStatistics — filterSpans only runs for Statistics/SpanView views
     const { rerender } = render(<TracePage {...defaultProps} uiFind={undefined} />);
+    act(() => {
+      capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceStatistics);
+    });
     expect(filterSpansSpy).not.toHaveBeenCalled();
 
-    // Adding uiFind triggers filterSpans
+    // Adding uiFind while in Statistics view triggers filterSpans
     rerender(<TracePage {...defaultProps} uiFind={uiFind} />);
     expect(filterSpansSpy).toHaveBeenCalledTimes(1);
     expect(filterSpansSpy).toHaveBeenLastCalledWith(uiFind, localTrace.spans);
@@ -516,25 +531,48 @@ describe('<TracePage>', () => {
     expect(track.trackRange).toHaveBeenCalledWith('kbd', expect.any(Array), [0, 1]);
   });
 
-  it('computes graphFindMatches and sets findCount based on traceDagEV when viewType is TraceGraph', () => {
-    const mockVertices = [{ key: 'v1' }, { key: 'v2' }];
-    const mockMatches = new Set(['v1']);
-
-    calculateTraceDagEV.default.mockReturnValue({ vertices: mockVertices });
-    const getUiFindVertexKeysSpy = jest
-      .spyOn(getUiFindVertexKeys, 'getUiFindVertexKeys')
-      .mockReturnValue(mockMatches);
-
+  it('updates resultCount when TraceGraph fires onSearchResults callback', () => {
     render(<TracePage {...defaultProps} uiFind="some-search" />);
 
     act(() => {
       capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
     });
 
-    expect(getUiFindVertexKeysSpy).toHaveBeenCalledWith('some-search', mockVertices);
-    expect(capturedHeaderProps.resultCount).toBe(1);
+    expect(capturedHeaderProps.resultCount).toBe(0);
 
-    getUiFindVertexKeysSpy.mockRestore();
+    act(() => {
+      capturedGraphProps.onSearchResults?.({ count: 5 });
+    });
+
+    expect(capturedHeaderProps.resultCount).toBe(5);
+  });
+
+  it('updates resultCount when TraceTimelineViewer fires onSearchResults callback', () => {
+    render(<TracePage {...defaultProps} uiFind="some-search" />);
+
+    expect(capturedHeaderProps.resultCount).toBe(0);
+
+    act(() => {
+      capturedTimelineProps.onSearchResults?.({ count: 12 });
+    });
+
+    expect(capturedHeaderProps.resultCount).toBe(12);
+  });
+
+  it('resets resultCount to 0 when viewType changes', () => {
+    render(<TracePage {...defaultProps} uiFind="some-search" />);
+
+    act(() => {
+      capturedTimelineProps.onSearchResults?.({ count: 10 });
+    });
+
+    expect(capturedHeaderProps.resultCount).toBe(10);
+
+    act(() => {
+      capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
+    });
+
+    expect(capturedHeaderProps.resultCount).toBe(0);
   });
 
   describe('TracePageHeader props', () => {
@@ -668,83 +706,44 @@ describe('<TracePage>', () => {
       });
     });
 
-    describe('resultCount', () => {
-      let getUiFindVertexKeysSpy;
-
-      beforeAll(() => {
-        getUiFindVertexKeysSpy = jest.spyOn(getUiFindVertexKeys, 'getUiFindVertexKeys');
+    describe('resultCount via onSearchResults callback', () => {
+      it('is 0 by default before any view reports results', () => {
+        render(<TracePage {...defaultProps} uiFind="test-find" />);
+        expect(capturedHeaderProps.resultCount).toBe(0);
       });
 
-      beforeEach(() => {
-        getUiFindVertexKeysSpy.mockReset();
-        filterSpansSpy.mockReset();
+      it('reflects the count reported by TraceTimelineViewer', () => {
+        render(<TracePage {...defaultProps} uiFind="test-find" />);
+
+        act(() => {
+          capturedTimelineProps.onSearchResults?.({ count: 20 });
+        });
+
+        expect(capturedHeaderProps.resultCount).toBe(20);
       });
 
-      it('is the size of spanFindMatches when available', () => {
-        const size = 20;
-        const mockSet = new Set();
-        for (let i = 0; i < size; i++) {
-          mockSet.add(`span-${i}`);
-        }
+      it('reflects the count reported by TraceGraph', () => {
+        render(<TracePage {...defaultProps} uiFind="test-find" />);
 
-        filterSpansSpy.mockReset();
-        filterSpansSpy.mockReturnValue(mockSet);
+        act(() => {
+          capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
+        });
 
-        const props = {
-          ...defaultProps,
-          uiFind: 'test-find',
-        };
+        act(() => {
+          capturedGraphProps.onSearchResults?.({ count: 30 });
+        });
 
-        let resultCount;
-        if (props.uiFind) {
-          const spanFindMatches = filterSpansSpy(props.uiFind, trace.spans);
-          resultCount = spanFindMatches ? spanFindMatches.size : 0;
-        }
-
-        expect(resultCount).toBe(size);
+        expect(capturedHeaderProps.resultCount).toBe(30);
       });
 
-      it('is the size of graphFindMatches when available', () => {
-        const size = 30;
-        const mockSet = new Set();
-        for (let i = 0; i < size; i++) {
-          mockSet.add(`vertex-${i}`);
-        }
+      it('is 0 when view reports zero results', () => {
+        render(<TracePage {...defaultProps} uiFind="no-matches" />);
 
-        getUiFindVertexKeysSpy.mockReturnValue(mockSet);
+        act(() => {
+          capturedTimelineProps.onSearchResults?.({ count: 0 });
+        });
 
-        const props = {
-          ...defaultProps,
-          uiFind: 'test-find',
-        };
-
-        const viewType = ETraceViewType.TraceGraph;
-        let resultCount;
-
-        if (viewType === ETraceViewType.TraceGraph && props.uiFind) {
-          const vertices = [];
-          const graphFindMatches = getUiFindVertexKeysSpy(props.uiFind, vertices);
-          resultCount = graphFindMatches ? graphFindMatches.size : 0;
-        }
-
-        expect(resultCount).toBe(size);
-      });
-
-      it('defaults to 0 when no matches found', () => {
-        filterSpansSpy.mockReturnValue(null);
-
-        const props = {
-          ...defaultProps,
-          uiFind: 'no-matches',
-        };
-
-        let resultCount = null;
-        if (props.uiFind) {
-          const spanFindMatches = filterSpansSpy(props.uiFind, trace.spans);
-          resultCount = spanFindMatches ? spanFindMatches.size : 0;
-        }
-
-        expect(resultCount).toBe(0);
+        expect(capturedHeaderProps.resultCount).toBe(0);
       });
     });
 
@@ -887,19 +886,12 @@ describe('<TracePage>', () => {
   });
 
   describe('manages various UI state', () => {
-    beforeAll(() => {
-      calculateTraceDagEV.default.mockClear();
-    });
-
     it('propagates headerHeight changes', () => {
-      jest.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
       render(<TracePage {...defaultProps} />);
 
       const section = document.querySelector('section');
       expect(section).toBeInTheDocument();
       expect(section.style.paddingTop).toBe('100px');
-
-      jest.restoreAllMocks();
     });
 
     it('initializes slimView correctly', () => {
@@ -932,15 +924,12 @@ describe('<TracePage>', () => {
     });
 
     it('propagates traceView changes', () => {
-      calculateTraceDagEV.default.mockClear();
-
       render(<TracePage {...defaultProps} />);
 
       act(() => {
         capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
       });
       expect(capturedHeaderProps.viewType).toBe(ETraceViewType.TraceGraph);
-      expect(calculateTraceDagEV.default).toHaveBeenCalledWith(trace);
 
       act(() => {
         capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceSpansView);

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -559,7 +559,7 @@ describe('<TracePage>', () => {
     expect(capturedHeaderProps.resultCount).toBe(12);
   });
 
-  it('resets resultCount to 0 when viewType changes', () => {
+  it('shows 0 for a freshly switched view until that view reports its own count', () => {
     render(<TracePage {...defaultProps} uiFind="some-search" />);
 
     act(() => {
@@ -572,7 +572,41 @@ describe('<TracePage>', () => {
       capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
     });
 
+    // Stale result belonged to the timeline view, not the graph view now showing.
     expect(capturedHeaderProps.resultCount).toBe(0);
+  });
+
+  it('does not get stuck at 0 after the new view reports its count (regression, PR #4143 review)', () => {
+    render(<TracePage {...defaultProps} uiFind="some-search" />);
+
+    // Active search while on Trace Timeline.
+    act(() => {
+      capturedTimelineProps.onSearchResults?.({ count: 1 });
+    });
+    expect(capturedHeaderProps.resultCount).toBe(1);
+
+    // Switch to Trace Graph.
+    act(() => {
+      capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceGraph);
+    });
+    expect(capturedHeaderProps.resultCount).toBe(0);
+
+    // Trace Graph reports its own match count for the same search term.
+    act(() => {
+      capturedGraphProps.onSearchResults?.({ count: 1 });
+    });
+    expect(capturedHeaderProps.resultCount).toBe(1);
+
+    // Switch back to Trace Timeline without retyping the search.
+    act(() => {
+      capturedHeaderProps.onTraceViewChange(ETraceViewType.TraceTimelineViewer);
+    });
+    expect(capturedHeaderProps.resultCount).toBe(0);
+
+    act(() => {
+      capturedTimelineProps.onSearchResults?.({ count: 1 });
+    });
+    expect(capturedHeaderProps.resultCount).toBe(1);
   });
 
   describe('TracePageHeader props', () => {

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -31,7 +31,7 @@ import {
 } from './keyboard-shortcuts';
 import { cancel as cancelScroll, scrollBy, scrollTo } from './scroll-page';
 import ScrollManager from './ScrollManager';
-import calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
+
 import TraceGraph from './TraceGraph/TraceGraph';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
 import { useConfig } from '../../hooks/useConfig';
@@ -45,12 +45,13 @@ import {
   ViewRangeTimeUpdate,
   ETraceViewType,
   viewTypeShowsMinimap,
+  ISearchResults,
 } from './types';
 import { getUrl } from './url';
 import ErrorMessage from '../common/ErrorMessage';
 import LoadingIndicator from '../common/LoadingIndicator';
 import { parseUiFind } from '../common/UiFindInput';
-import { getUiFindVertexKeys } from '../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
+
 import { LocationState, ReduxState, TNil } from '../../types';
 import { useTrace } from '../../hooks/useTraceLoading';
 import { IOtelTrace } from '../../types/otel';
@@ -201,10 +202,15 @@ export function TracePageImpl(props: TProps) {
   const [slimView, setSlimView] = useState(() => Boolean(embedded?.timeline?.collapseTitle));
   const [viewType, setViewType] = useState<ETraceViewType>(ETraceViewType.TraceTimelineViewer);
   const [viewRange, setViewRange] = useState<IViewRange>({ time: { current: [0, 1] } });
-  const traceDagEV = useMemo(
-    () => (viewType === ETraceViewType.TraceGraph && traceData ? calculateTraceDagEV(traceData) : null),
-    [traceData, viewType]
-  );
+  const [findCount, setFindCount] = useState(0);
+
+  const handleSearchResults = useCallback(({ count }: ISearchResults) => {
+    setFindCount(count);
+  }, []);
+
+  useEffect(() => {
+    setFindCount(0);
+  }, [viewType]);
 
   const traceIsGenAI = useMemo(
     () =>
@@ -225,6 +231,26 @@ export function TracePageImpl(props: TProps) {
   const filterSpansMemo = useRef(
     _memoize(filterSpans, (textFilter: string) => `${textFilter} ${idRef.current}`)
   ).current;
+
+  const spanFindMatches = useMemo(() => {
+    if (
+      !uiFind ||
+      (viewType !== ETraceViewType.TraceStatistics && viewType !== ETraceViewType.TraceSpansView)
+    ) {
+      return undefined;
+    }
+    const allMatches = filterSpansMemo(uiFind, _get(traceData, 'spans'));
+    const otelTrace = traceData;
+    return otelTrace && prunedServices.size > 0
+      ? filterPrunedSpanIDs(allMatches, otelTrace.spanMap, prunedServices)
+      : allMatches;
+  }, [uiFind, traceData, prunedServices, viewType, filterSpansMemo]);
+
+  useEffect(() => {
+    if (viewType === ETraceViewType.TraceStatistics || viewType === ETraceViewType.TraceSpansView) {
+      setFindCount(spanFindMatches?.size ?? 0);
+    }
+  }, [spanFindMatches, viewType]);
 
   const scrollManagerRef = useRef<ScrollManager>(new ScrollManager(traceData, { scrollBy, scrollTo }));
 
@@ -384,24 +410,6 @@ export function TracePageImpl(props: TProps) {
     return <LoadingIndicator className="u-mt-vast" centered />;
   }
 
-  let findCount = 0;
-  let graphFindMatches: Set<string> | null | undefined;
-  let spanFindMatches: Set<string> | null | undefined;
-  if (uiFind) {
-    if (viewType === ETraceViewType.TraceGraph) {
-      graphFindMatches = getUiFindVertexKeys(uiFind, _get(traceDagEV, 'vertices', []));
-      findCount = graphFindMatches ? graphFindMatches.size : 0;
-    } else {
-      const allMatches = filterSpansMemo(uiFind, _get(traceData, 'spans'));
-      const otelTrace = traceData;
-      spanFindMatches =
-        otelTrace && prunedServices.size > 0
-          ? filterPrunedSpanIDs(allMatches, otelTrace.spanMap, prunedServices)
-          : allMatches;
-      findCount = spanFindMatches ? spanFindMatches.size : 0;
-    }
-  }
-
   const locationState = location.state;
   const isEmbedded = Boolean(embedded);
   const hasArchiveStorage = Boolean(backendCapabilities?.archiveStorage);
@@ -447,7 +455,8 @@ export function TracePageImpl(props: TProps) {
       <TraceTimelineViewer
         registerAccessors={sm.setAccessors}
         scrollToFirstVisibleSpan={sm.scrollToFirstVisibleSpan}
-        findMatchesIDs={spanFindMatches}
+        uiFind={uiFind}
+        onSearchResults={handleSearchResults}
         trace={traceData}
         criticalPath={criticalPath}
         updateNextViewRangeTime={updateNextViewRangeTime}
@@ -461,7 +470,8 @@ export function TracePageImpl(props: TProps) {
       <TraceTimelineViewer
         registerAccessors={sm.setAccessors}
         scrollToFirstVisibleSpan={sm.scrollToFirstVisibleSpan}
-        findMatchesIDs={spanFindMatches}
+        uiFind={uiFind}
+        onSearchResults={handleSearchResults}
         trace={traceData}
         criticalPath={criticalPath}
         updateNextViewRangeTime={updateNextViewRangeTime}
@@ -474,11 +484,11 @@ export function TracePageImpl(props: TProps) {
     view = (
       <TraceGraph
         headerHeight={headerHeight}
-        ev={traceDagEV}
+        trace={traceData}
         uiFind={uiFind}
-        uiFindVertexKeys={graphFindMatches}
         traceGraphConfig={traceGraphConfig}
         useOtelTerms={useOtelTerms}
+        onSearchResults={handleSearchResults}
       />
     );
   } else if (ETraceViewType.TraceStatistics === viewType && headerHeight) {
@@ -492,13 +502,7 @@ export function TracePageImpl(props: TProps) {
     );
   } else if (ETraceViewType.TraceSpansView === viewType && headerHeight) {
     view = (
-      <TraceSpanView
-        key={traceData.traceID}
-        trace={traceData}
-        uiFindVertexKeys={spanFindMatches}
-        uiFind={uiFind}
-        useOtelTerms={useOtelTerms}
-      />
+      <TraceSpanView key={traceData.traceID} trace={traceData} uiFind={uiFind} useOtelTerms={useOtelTerms} />
     );
   } else if (ETraceViewType.TraceFlamegraph === viewType && headerHeight) {
     view = <TraceFlamegraph trace={traceData} />;

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -202,15 +202,21 @@ export function TracePageImpl(props: TProps) {
   const [slimView, setSlimView] = useState(() => Boolean(embedded?.timeline?.collapseTitle));
   const [viewType, setViewType] = useState<ETraceViewType>(ETraceViewType.TraceTimelineViewer);
   const [viewRange, setViewRange] = useState<IViewRange>({ time: { current: [0, 1] } });
-  const [findCount, setFindCount] = useState(0);
+  // Tagged with the viewType that produced it so a stale report from a previous view can never be
+  // mistaken for the current one, instead of resetting the count via a competing effect (which races
+  // with the child view's own effect on view switches — see #4143 review).
+  const [findResult, setFindResult] = useState<{ viewType: ETraceViewType; count: number }>(() => ({
+    viewType,
+    count: 0,
+  }));
+  const findCount = findResult.viewType === viewType ? findResult.count : 0;
 
-  const handleSearchResults = useCallback(({ count }: ISearchResults) => {
-    setFindCount(count);
-  }, []);
-
-  useEffect(() => {
-    setFindCount(0);
-  }, [viewType]);
+  const handleSearchResults = useCallback(
+    ({ count }: ISearchResults) => {
+      setFindResult({ viewType, count });
+    },
+    [viewType]
+  );
 
   const traceIsGenAI = useMemo(
     () =>
@@ -248,7 +254,7 @@ export function TracePageImpl(props: TProps) {
 
   useEffect(() => {
     if (viewType === ETraceViewType.TraceStatistics || viewType === ETraceViewType.TraceSpansView) {
-      setFindCount(spanFindMatches?.size ?? 0);
+      setFindResult({ viewType, count: spanFindMatches?.size ?? 0 });
     }
   }, [spanFindMatches, viewType]);
 

--- a/packages/jaeger-ui/src/components/TracePage/types.ts
+++ b/packages/jaeger-ui/src/components/TracePage/types.ts
@@ -45,6 +45,12 @@ export interface IViewRange {
   time: IViewRangeTime;
 }
 
+export interface ISearchResults {
+  count: number;
+}
+
+export type OnSearchResultsCallback = (results: ISearchResults) => void;
+
 export enum ETraceViewType {
   TraceTimelineViewer = 'TraceTimelineViewer',
   TraceGraph = 'TraceGraph',


### PR DESCRIPTION
Move search computation ownership from `TracePage` into `TraceGraph` and `TraceTimelineViewer`. Each view now computes its own search matches and reports the result count via an `onSearchResults` callback.

`TraceGraph` now owns DAG creation and graph-specific search logic, while `TraceTimelineViewer` owns span filtering and pruned-span search logic. `TracePage` is reduced to coordinating the search query and displaying the result count.

`TraceStatistics` search behavior is intentionally preserved unchanged to avoid behavioral regressions and keep the scope of this refactor focused.

Closes #4134

## Which problem is this PR solving?

* Resolves #4134
* Removes view-specific search logic from `TracePage`
* Reduces coupling between `TracePage` and individual trace views
* Makes it easier for future views to implement search without requiring changes to `TracePage`

## Description of the changes

* Added a shared `onSearchResults` callback contract for reporting search result counts
* Moved `calculateTraceDagEV()` and `getUiFindVertexKeys()` into `TraceGraph`
* Moved `filterSpans()` and `filterPrunedSpanIDs()` into `TraceTimelineViewer`
* Updated `TracePage` to manage only the search count state and callback handling
* Removed graph-specific search branching from `TracePage`
* Reset search count when switching between trace views
* Removed unused props and imports introduced by the previous architecture
* Preserved existing search highlighting and navigation behavior
* Left `TraceStatistics` search implementation unchanged to avoid regressions

## How was this change tested?

* Ran formatting and lint checks successfully
* Ran TypeScript validation successfully
* Verified production build succeeds
* Verified graph search highlighting and result counts
* Verified timeline search highlighting, result counts, and next/previous navigation
* Verified search counts update correctly when switching views
* All 3205 unit tests passed

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [ ] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test`



## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
