### PR TITLE
fix(tracepage): handle root span navigation at index 0

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/ScrollManager.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/ScrollManager.test.js
@@ -185,6 +185,35 @@ describe('ScrollManager', () => {
       expect(scrollPastMock).toHaveBeenLastCalledWith(parentOfLastRowWithHiddenChildrenIndex, 1);
     });
 
+    it('scrolls to index 0 when scrolling down and index 0 is the only match', () => {
+      accessors.getTopRowIndexVisible.mockReturnValue(5);
+      accessors.getBottomRowIndexVisible.mockReturnValue(5);
+      accessors.getSearchedSpanIDs = () => new Set([trace.spans[0].spanID]);
+
+      manager._scrollToVisibleSpan(1, 0);
+      expect(scrollPastMock).toHaveBeenLastCalledWith(0, 1);
+    });
+
+    it('scrolls to correct span when startRow is provided and mapping is not 1:1', () => {
+      // Mock non-1:1 mapping: row 2 maps to span 4, and span 4 maps to row 2
+      accessors.mapRowIndexToSpanIndex.mockImplementation(r => (r === 2 ? 4 : r));
+      accessors.mapSpanIndexToRowIndex.mockImplementation(s => (s === 4 ? 2 : s));
+      accessors.getSearchedSpanIDs = () => new Set([trace.spans[4].spanID]);
+
+      manager._scrollToVisibleSpan(1, 2);
+      expect(accessors.mapRowIndexToSpanIndex).toHaveBeenCalledWith(2);
+      expect(scrollPastMock).toHaveBeenLastCalledWith(2, 1);
+    });
+
+    it('scrolls to index 0 when scrolling up and index 0 is the only match', () => {
+      accessors.getTopRowIndexVisible.mockReturnValue(1);
+      accessors.getBottomRowIndexVisible.mockReturnValue(1);
+      accessors.getSearchedSpanIDs = () => new Set([trace.spans[0].spanID]);
+
+      manager._scrollToVisibleSpan(-1);
+      expect(scrollPastMock).toHaveBeenLastCalledWith(0, -1);
+    });
+
     describe('scrollToNextVisibleSpan() and scrollToPrevVisibleSpan()', () => {
       beforeEach(() => {
         // change spans so 0 and 4 are top-level and their children are collapsed

--- a/packages/jaeger-ui/src/components/TracePage/ScrollManager.ts
+++ b/packages/jaeger-ui/src/components/TracePage/ScrollManager.ts
@@ -118,7 +118,9 @@ export default class ScrollManager {
     }
     // fullViewSpanIndex is one row inside the view window unless already at the top or bottom
     let fullViewSpanIndex = spanIndex;
-    if (spanIndex !== 0 && spanIndex !== spans.length - 1) {
+    if (startRow != null) {
+      fullViewSpanIndex = spanIndex - direction;
+    } else if (spanIndex !== 0 && spanIndex !== spans.length - 1) {
       fullViewSpanIndex -= direction;
     }
     const [viewStart, viewEnd] = xrs.getViewRange();
@@ -155,7 +157,7 @@ export default class ScrollManager {
       nextSpanIndex = i;
       break;
     }
-    if (!nextSpanIndex || nextSpanIndex === boundary) {
+    if (nextSpanIndex === undefined || nextSpanIndex === boundary) {
       // might as well scroll to the top or bottom
       nextSpanIndex = boundary - direction;
 


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #4131

## Description of the changes
Fix the navigation logic in ScrollManager so a valid span index of 0 is no longer treated as a missing result.
Ensure searches starting from startRow include index 0, preventing navigation from incorrectly jumping to the last span.
Add regression tests covering navigation to the root span for both upward and downward navigation.

## How was this change tested?
Added regression tests in ScrollManager.test.js covering navigation to the root span.
Ran the ScrollManager test suite locally and verified all tests pass.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
