### PR TITLE
fix(dag): Add default lookback to View Traces URL

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
@@ -466,14 +466,14 @@ describe('handleViewTraces', () => {
 
     handleViewTraces(hoveredNode);
 
-    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: 'test-service' });
+    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: 'test-service', lookback: '1h' });
     expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
   });
 
   it('should handle null node gracefully', () => {
     handleViewTraces(null);
 
-    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: undefined });
+    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: undefined, lookback: '1h' });
     expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
   });
 });

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -12,6 +12,7 @@ import { getUrl as getSearchUrl } from '../SearchTracePage/url';
 
 import './dag.css';
 import { DAG_MAX_NUM_SERVICES } from '../../constants';
+import { DEFAULT_LOOKBACK } from '../../constants/search-form';
 
 type TProps = {
   data: {
@@ -58,7 +59,7 @@ export const renderNode = (
 };
 
 export const handleViewTraces = (hoveredNode: TVertex | null) => {
-  window.open(getSearchUrl({ service: hoveredNode?.key }), '_blank');
+  window.open(getSearchUrl({ service: hoveredNode?.key, lookback: DEFAULT_LOOKBACK }), '_blank');
 };
 
 export const createHandleNodeClick =


### PR DESCRIPTION
## Summary

Fixes #4148

When clicking **View traces** on a node in the System Architecture DAG, `handleViewTraces` built the search URL with only the `service` param:

```ts
window.open(getSearchUrl({ service: hoveredNode?.key }), '_blank');
```

`SearchTracePage` can derive `start`/`end` from a `lookback` param, but with neither `lookback` nor `start`/`end` present, the derivation never runs and the backend returns a **400 Bad Request**.

## Fix

Pass `lookback: DEFAULT_LOOKBACK` (`'1h'`) to `getSearchUrl` so a valid time range is always included:

```ts
window.open(getSearchUrl({ service: hoveredNode?.key, lookback: DEFAULT_LOOKBACK }), '_blank');
```

`DEFAULT_LOOKBACK` is already used throughout the search form constants — this change reuses the same value for consistency.

## Changes

- `packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx` — add `lookback` to `getSearchUrl` call
- `packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx` — update two assertions to expect `lookback: '1h'`

## Test plan

- [x] Existing DAG tests pass (`npm test -w packages/jaeger-ui -- src/components/DependencyGraph/DAG.test.jsx` → 30/30 passing)
- [x] Manually verified: clicking "View traces" on a DAG node now opens `/search?service=<name>&lookback=1h` which resolves without a 400