### PR TITLE
fix(DependencyGraph): include lookback in View traces URL to prevent 400 error.

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
@@ -466,15 +466,15 @@ describe('handleViewTraces', () => {
 
     handleViewTraces(hoveredNode);
 
-    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: 'test-service' });
+    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: 'test-service', lookback: '1h' });
     expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
   });
 
   it('should handle null node gracefully', () => {
     handleViewTraces(null);
 
-    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: undefined });
-    expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
+    expect(getSearchUrlSpy).not.toHaveBeenCalled();
+    expect(windowOpenSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -12,6 +12,7 @@ import { getUrl as getSearchUrl } from '../SearchTracePage/url';
 
 import './dag.css';
 import { DAG_MAX_NUM_SERVICES } from '../../constants';
+import { DEFAULT_LOOKBACK } from '../../constants/search-form';
 
 type TProps = {
   data: {
@@ -59,7 +60,7 @@ export const renderNode = (
 
 export const handleViewTraces = (hoveredNode: TVertex | null) => {
   if (!hoveredNode?.key) return;
-  window.open(getSearchUrl({ service: hoveredNode.key, lookback: '1h' }), '_blank');
+  window.open(getSearchUrl({ service: hoveredNode.key, lookback: DEFAULT_LOOKBACK }), '_blank');
 };
 
 export const createHandleNodeClick =

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -58,7 +58,8 @@ export const renderNode = (
 };
 
 export const handleViewTraces = (hoveredNode: TVertex | null) => {
-  window.open(getSearchUrl({ service: hoveredNode?.key }), '_blank');
+  if (!hoveredNode?.key) return;
+  window.open(getSearchUrl({ service: hoveredNode.key, lookback: '1h' }), '_blank');
 };
 
 export const createHandleNodeClick =


### PR DESCRIPTION

## Which problem is this PR solving?

- #4148 

`handleViewTraces` in the System Architecture DAG view (`DAG.tsx`) builds the 
"View traces" URL with only the `service` param:

```js
window.open(getSearchUrl({ service: hoveredNode?.key }), '_blank');
```

Since no `lookback`, `start`, or `end` is included, `SearchTracePage`'s existing 
logic to derive `start`/`end` from `lookback` (added for legacy/HotROD-style links) 
never runs, and the search request fails with a 400 Bad Request.

## Description of the changes
-  Adds a default `lookback: '1h'` to the generated URL, so the existing 
  start/end-derivation logic in `searchQueryFromUrl` kicks in correctly.
- Adds a guard so `handleViewTraces` does nothing if `hoveredNode` is null 
  (previously it would still call `window.open` with an invalid URL).
- Updates the two existing `handleViewTraces` tests in `DAG.test.jsx` to match 
  the new expected behavior.

## How was this change tested?
- -Ran the app locally with the Jaeger backend + HotROD demo data.
- Reproduced the 400 error before the fix (screenshots in linked issue).
- Applied the fix, confirmed the generated URL now includes `lookback=1h`, and 
  the Search page successfully loads results instead of erroring.
- Ran the full `DAG.test.jsx` suite - all 30 tests pass, including the two 
  updated `handleViewTraces` tests.

## Checklist
- [-] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [-] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [-] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes

https://github.com/user-attachments/assets/4e4648d5-cb62-4198-9b20-30e45e5e67c3

