### PR TITLE
fix: Add default lookback to 'View traces' DAG search URL

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -58,7 +58,7 @@ export const renderNode = (
 };
 
 export const handleViewTraces = (hoveredNode: TVertex | null) => {
-  window.open(getSearchUrl({ service: hoveredNode?.key }), '_blank');
+  window.open(getSearchUrl({ service: hoveredNode?.key, lookback: '1h' }), '_blank');
 };
 
 export const createHandleNodeClick =


### PR DESCRIPTION
**Problem:** The handleViewTraces function in DAG.tsx opened the search page with only the service parameter, missing a time range. Without lookback, start, or end, the search API call fails with a 400 Bad Request.

**Fix:** Add a default lookback of 1h so the search derives valid start/end timestamps from the lookback duration via lookbackFromUrlState.

Closes #4148