### PR TITLE
fix: Increase critical path bar contrast in dark mode

### DIFF
--- a/packages/jaeger-ui/src/components/common/vars.css
+++ b/packages/jaeger-ui/src/components/common/vars.css
@@ -260,8 +260,8 @@ SPDX-License-Identifier: Apache-2.0
   --trace-emphasis-highlight: #3d3520;
 
   /* Critical Path */
-  --critical-path-color: #000;
-  --critical-path-outline: #fff;
+  --critical-path-color: #fff;
+  --critical-path-outline: #000;
 
   /* ============================================
     TRACE TIMELINE TOKENS - Dark Mode


### PR DESCRIPTION
Closes #4162

The critical path bar was invisible in dark mode because --critical-path-color and --critical-path-outline had the same values in both the :root block and the [data-theme='dark'] block in vars.css, so dark mode still rendered a black bar on a dark navy surface.

Root cause: lines 263-264 of vars.css duplicated the light-mode values instead of inverting them.

Fix: swap the two token values in the [data-theme='dark'] block so the bar is white with a black outline in dark mode.

The three screenshots below show the same trace. The critical path bars are the horizontal markers running through the span bars (thick black in light mode, invisible/white in dark mode).

light mode — critical path bars clearly visible as black stripes through the spans (this is the intended behaviour):

![light mode](https://raw.githubusercontent.com/bhavyamsharmaa/jaeger-ui/pr-assets/cp-light-mode.png)

dark mode before fix — same bars are invisible (black on dark navy background):

![dark mode before](https://raw.githubusercontent.com/bhavyamsharmaa/jaeger-ui/pr-assets/cp-before-dark.png)

dark mode after fix — bars visible again as white stripes:
![dark mode after](https://raw.githubusercontent.com/bhavyamsharmaa/jaeger-ui/pr-assets/cp-after-dark.png)