### PR TITLE
fix(assistant): Render tool-call parts in chat thread

### DIFF
--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
@@ -120,6 +120,10 @@ SPDX-License-Identifier: Apache-2.0
   font-size: 0.8rem;
 }
 
+.JaegerAssistantPanel-toolCall--error {
+  border-color: var(--status-error);
+}
+
 .JaegerAssistantPanel-toolCallName {
   font-weight: 600;
   color: var(--text-secondary);
@@ -166,6 +170,16 @@ SPDX-License-Identifier: Apache-2.0
   word-break: break-word;
   max-height: 10rem;
   overflow-y: auto;
+}
+
+.JaegerAssistantPanel-toolCallSection .json-markup {
+  padding: 0.3rem 0.4rem;
+  border-radius: 4px;
+  background-color: var(--surface-primary);
+  font-size: 0.7rem;
+  max-height: 10rem;
+  overflow: auto;
+  white-space: nowrap;
 }
 
 .JaegerAssistantPanel-composer {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
@@ -112,9 +112,6 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .JaegerAssistantPanel-toolCall {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
   padding: 0.3rem 0.5rem;
   margin: 0.25rem 0;
   border-radius: 6px;
@@ -128,6 +125,7 @@ SPDX-License-Identifier: Apache-2.0
   color: var(--text-secondary);
   font-family: monospace;
   font-size: 0.75rem;
+  cursor: pointer;
 }
 
 .JaegerAssistantPanel-toolCallStatus {
@@ -135,15 +133,39 @@ SPDX-License-Identifier: Apache-2.0
   font-style: italic;
 }
 
-.JaegerAssistantPanel-toolCallResult {
+.JaegerAssistantPanel-toolCallBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+}
+
+.JaegerAssistantPanel-toolCallSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.JaegerAssistantPanel-toolCallLabel {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.JaegerAssistantPanel-toolCallPre {
+  margin: 0;
+  padding: 0.3rem 0.4rem;
+  border-radius: 4px;
+  background-color: var(--surface-primary);
   color: var(--text-primary);
-  font-size: 0.75rem;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+  font-family: monospace;
+  font-size: 0.7rem;
   white-space: pre-wrap;
   word-break: break-word;
+  max-height: 10rem;
+  overflow-y: auto;
 }
 
 .JaegerAssistantPanel-composer {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
@@ -111,6 +111,41 @@ SPDX-License-Identifier: Apache-2.0
   white-space: pre-wrap;
 }
 
+.JaegerAssistantPanel-toolCall {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.3rem 0.5rem;
+  margin: 0.25rem 0;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+  background-color: var(--surface-secondary);
+  font-size: 0.8rem;
+}
+
+.JaegerAssistantPanel-toolCallName {
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-family: monospace;
+  font-size: 0.75rem;
+}
+
+.JaegerAssistantPanel-toolCallStatus {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.JaegerAssistantPanel-toolCallResult {
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .JaegerAssistantPanel-composer {
   display: flex;
   flex-direction: column;

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -232,14 +232,35 @@ describe('tool-call part rendering', () => {
     partsMock.parts = [{ type: 'text' }];
   });
 
-  it('renders a running indicator when tool-call part has no result', () => {
-    partsMock.parts = [{ type: 'tool-call', toolName: 'read_skill', result: undefined }];
+  it('renders a running indicator when status is running', () => {
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'read_skill', status: { type: 'running' }, result: undefined },
+    ];
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('Calling read_skill…')).toBeInTheDocument();
   });
 
+  it('renders a running indicator when status is requires-action', () => {
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'read_skill', status: { type: 'requires-action' }, result: undefined },
+    ];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('Calling read_skill…')).toBeInTheDocument();
+  });
+
+  it('renders completed state when status is complete even if result is undefined', () => {
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'find_traces', status: { type: 'complete' }, result: undefined },
+    ];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('Called find_traces')).toBeInTheDocument();
+    expect(screen.queryByText('Calling find_traces…')).not.toBeInTheDocument();
+  });
+
   it('renders a collapsible details element when tool-call part has a result', () => {
-    partsMock.parts = [{ type: 'tool-call', toolName: 'find_traces', result: 'found 3 traces' }];
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'find_traces', status: { type: 'complete' }, result: 'found 3 traces' },
+    ];
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('Called find_traces')).toBeInTheDocument();
     expect(screen.getByText('found 3 traces')).toBeInTheDocument();
@@ -251,7 +272,13 @@ describe('tool-call part rendering', () => {
 
   it('shows Input and Output labels when argsText is present', () => {
     partsMock.parts = [
-      { type: 'tool-call', toolName: 'get_services', argsText: '{}', result: '{"services":["jaeger"]}' },
+      {
+        type: 'tool-call',
+        toolName: 'get_services',
+        argsText: '{}',
+        status: { type: 'complete' },
+        result: '{"services":["jaeger"]}',
+      },
     ];
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('Input')).toBeInTheDocument();
@@ -261,14 +288,29 @@ describe('tool-call part rendering', () => {
   });
 
   it('omits Input section when argsText is empty', () => {
-    partsMock.parts = [{ type: 'tool-call', toolName: 'get_services', argsText: '', result: 'ok' }];
+    partsMock.parts = [
+      {
+        type: 'tool-call',
+        toolName: 'get_services',
+        argsText: '',
+        status: { type: 'complete' },
+        result: 'ok',
+      },
+    ];
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.queryByText('Input')).not.toBeInTheDocument();
     expect(screen.getByText('Output')).toBeInTheDocument();
   });
 
   it('JSON-stringifies non-string results', () => {
-    partsMock.parts = [{ type: 'tool-call', toolName: 'get_services', result: { services: ['jaeger'] } }];
+    partsMock.parts = [
+      {
+        type: 'tool-call',
+        toolName: 'get_services',
+        status: { type: 'complete' },
+        result: { services: ['jaeger'] },
+      },
+    ];
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('{"services":["jaeger"]}')).toBeInTheDocument();
   });
@@ -276,13 +318,18 @@ describe('tool-call part rendering', () => {
   it('falls back to String() when JSON.stringify throws', () => {
     const circular = {};
     circular.self = circular;
-    partsMock.parts = [{ type: 'tool-call', toolName: 'bad_tool', result: circular }];
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'bad_tool', status: { type: 'complete' }, result: circular },
+    ];
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('[object Object]')).toBeInTheDocument();
   });
 
   it('renders text parts correctly alongside tool-call parts', () => {
-    partsMock.parts = [{ type: 'text' }, { type: 'tool-call', toolName: 'read_skill', result: 'done' }];
+    partsMock.parts = [
+      { type: 'text' },
+      { type: 'tool-call', toolName: 'read_skill', status: { type: 'complete' }, result: 'done' },
+    ];
     const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
     expect(container.querySelectorAll('[data-testid="message-part-text"]')).toHaveLength(1);
     expect(screen.getByText('Called read_skill')).toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -281,11 +281,11 @@ describe('tool-call part rendering', () => {
         result: '{"services":["jaeger"]}',
       },
     ];
-    render(<JaegerThreadMessageBody variant="assistant" />);
+    const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('Input')).toBeInTheDocument();
     expect(screen.getByText('Output')).toBeInTheDocument();
     expect(screen.getByText('{}')).toBeInTheDocument();
-    expect(screen.getByText('{"services":["jaeger"]}')).toBeInTheDocument();
+    expect(container.querySelector('.json-markup')).toBeInTheDocument();
   });
 
   it('omits Input section when argsText is empty', () => {
@@ -303,7 +303,7 @@ describe('tool-call part rendering', () => {
     expect(screen.getByText('Output')).toBeInTheDocument();
   });
 
-  it('JSON-stringifies non-string results', () => {
+  it('renders JSON results with JsonView for object values', () => {
     partsMock.parts = [
       {
         type: 'tool-call',
@@ -312,18 +312,61 @@ describe('tool-call part rendering', () => {
         result: { services: ['jaeger'] },
       },
     ];
-    render(<JaegerThreadMessageBody variant="assistant" />);
-    expect(screen.getByText('{"services":["jaeger"]}')).toBeInTheDocument();
+    const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(container.querySelector('.json-markup')).toBeInTheDocument();
   });
 
-  it('falls back to String() when JSON.stringify throws', () => {
-    const circular = {};
-    circular.self = circular;
+  it('renders JSON results with JsonView for JSON string values', () => {
     partsMock.parts = [
-      { type: 'tool-call', toolName: 'bad_tool', status: { type: 'complete' }, result: circular },
+      {
+        type: 'tool-call',
+        toolName: 'get_services',
+        status: { type: 'complete' },
+        result: '{"services":["jaeger"]}',
+      },
+    ];
+    const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(container.querySelector('.json-markup')).toBeInTheDocument();
+  });
+
+  it('renders non-string non-object result via formatToolResult', () => {
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'count_tool', status: { type: 'complete' }, result: 42 },
     ];
     render(<JaegerThreadMessageBody variant="assistant" />);
-    expect(screen.getByText('[object Object]')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders plain text result in pre when not JSON', () => {
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'bad_tool', status: { type: 'complete' }, result: 'plain text output' },
+    ];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('plain text output')).toBeInTheDocument();
+  });
+
+  it('renders Failed label with error border when isError is true', () => {
+    partsMock.parts = [
+      {
+        type: 'tool-call',
+        toolName: 'bad_tool',
+        status: { type: 'complete' },
+        isError: true,
+        result: 'error msg',
+      },
+    ];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('Failed bad_tool')).toBeInTheDocument();
+    const details = document.querySelector('.JaegerAssistantPanel-toolCall--error');
+    expect(details).toBeInTheDocument();
+  });
+
+  it('renders Failed label when status is incomplete', () => {
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'bad_tool', status: { type: 'incomplete' }, result: undefined },
+    ];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('Failed bad_tool')).toBeInTheDocument();
   });
 
   it('renders text parts correctly alongside tool-call parts', () => {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -238,21 +238,33 @@ describe('tool-call part rendering', () => {
     expect(screen.getByText('Calling read_skill…')).toBeInTheDocument();
   });
 
-  it('renders tool name and result text when tool-call part has a result', () => {
+  it('renders a collapsible details element when tool-call part has a result', () => {
     partsMock.parts = [{ type: 'tool-call', toolName: 'find_traces', result: 'found 3 traces' }];
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('Called find_traces')).toBeInTheDocument();
     expect(screen.getByText('found 3 traces')).toBeInTheDocument();
     expect(screen.queryByText('Calling find_traces…')).not.toBeInTheDocument();
+    const details = document.querySelector('details.JaegerAssistantPanel-toolCall');
+    expect(details).toBeInTheDocument();
+    expect(details.open).toBe(false);
   });
 
-  it('truncates long results with an ellipsis', () => {
-    const longResult = 'x'.repeat(350);
-    partsMock.parts = [{ type: 'tool-call', toolName: 'read_skill', result: longResult }];
+  it('shows Input and Output labels when argsText is present', () => {
+    partsMock.parts = [
+      { type: 'tool-call', toolName: 'get_services', argsText: '{}', result: '{"services":["jaeger"]}' },
+    ];
     render(<JaegerThreadMessageBody variant="assistant" />);
-    const resultEl = document.querySelector('.JaegerAssistantPanel-toolCallResult');
-    expect(resultEl.textContent).toHaveLength(301);
-    expect(resultEl.textContent.endsWith('…')).toBe(true);
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(screen.getByText('Output')).toBeInTheDocument();
+    expect(screen.getByText('{}')).toBeInTheDocument();
+    expect(screen.getByText('{"services":["jaeger"]}')).toBeInTheDocument();
+  });
+
+  it('omits Input section when argsText is empty', () => {
+    partsMock.parts = [{ type: 'tool-call', toolName: 'get_services', argsText: '', result: 'ok' }];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.queryByText('Input')).not.toBeInTheDocument();
+    expect(screen.getByText('Output')).toBeInTheDocument();
   });
 
   it('JSON-stringifies non-string results', () => {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -20,6 +20,10 @@ const agUiMock = vi.hoisted(() => ({
   url: 'http://localhost/ag-ui',
 }));
 
+const partsMock = vi.hoisted(() => ({
+  parts: [{ type: 'text' }],
+}));
+
 vi.mock('./jaegerAgUi', () => ({
   getJaegerAgUiUrl: () => agUiMock.url,
 }));
@@ -64,8 +68,9 @@ vi.mock('@assistant-ui/react', () => {
         if (typeof children === 'function') {
           return (
             <>
-              {children({ part: { type: 'text' } })}
-              {children({ part: { type: 'reasoning' } })}
+              {partsMock.parts.map((part, i) => (
+                <React.Fragment key={i}>{children({ part })}</React.Fragment>
+              ))}
             </>
           );
         }
@@ -107,6 +112,7 @@ describe('JaegerAssistantDock', () => {
   beforeEach(() => {
     agUiMock.configured = false;
     mockAppend.mockReset();
+    partsMock.parts = [{ type: 'text' }, { type: 'reasoning', text: '' }];
   });
 
   it('returns null when assistant is not configured', () => {
@@ -183,6 +189,10 @@ describe('JaegerAssistantDock', () => {
 });
 
 describe('JaegerThreadMessageBody', () => {
+  beforeEach(() => {
+    partsMock.parts = [{ type: 'text' }, { type: 'reasoning', text: '' }];
+  });
+
   it('renders text parts with MessagePartPrimitive.Text (lines 34–47)', () => {
     const { container } = render(<JaegerThreadMessageBody variant="user" />);
     const root = screen.getByTestId('message-primitive-root');
@@ -214,5 +224,42 @@ describe('threadMessageComponents', () => {
     expect(screen.getByTestId('message-primitive-root')).toHaveClass(
       'JaegerAssistantPanel-message--assistant'
     );
+  });
+});
+
+describe('tool-call part rendering', () => {
+  beforeEach(() => {
+    partsMock.parts = [{ type: 'text' }];
+  });
+
+  it('renders a running indicator when tool-call part has no result', () => {
+    partsMock.parts = [{ type: 'tool-call', toolName: 'read_skill', result: undefined }];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('Calling read_skill…')).toBeInTheDocument();
+  });
+
+  it('renders tool name and result text when tool-call part has a result', () => {
+    partsMock.parts = [{ type: 'tool-call', toolName: 'find_traces', result: 'found 3 traces' }];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('Called find_traces')).toBeInTheDocument();
+    expect(screen.getByText('found 3 traces')).toBeInTheDocument();
+    expect(screen.queryByText('Calling find_traces…')).not.toBeInTheDocument();
+  });
+
+  it('truncates long results with an ellipsis', () => {
+    const longResult = 'x'.repeat(350);
+    partsMock.parts = [{ type: 'tool-call', toolName: 'read_skill', result: longResult }];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    const resultEl = document.querySelector('.JaegerAssistantPanel-toolCallResult');
+    expect(resultEl.textContent).toHaveLength(301);
+    expect(resultEl.textContent.endsWith('…')).toBe(true);
+  });
+
+  it('renders text parts correctly alongside tool-call parts', () => {
+    partsMock.parts = [{ type: 'text' }, { type: 'tool-call', toolName: 'read_skill', result: 'done' }];
+    const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(container.querySelectorAll('[data-testid="message-part-text"]')).toHaveLength(1);
+    expect(screen.getByText('Called read_skill')).toBeInTheDocument();
+    expect(screen.getByText('done')).toBeInTheDocument();
   });
 });

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -255,6 +255,7 @@ describe('tool-call part rendering', () => {
     render(<JaegerThreadMessageBody variant="assistant" />);
     expect(screen.getByText('Called find_traces')).toBeInTheDocument();
     expect(screen.queryByText('Calling find_traces…')).not.toBeInTheDocument();
+    expect(screen.queryByText('Output')).not.toBeInTheDocument();
   });
 
   it('renders a collapsible details element when tool-call part has a result', () => {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -255,6 +255,20 @@ describe('tool-call part rendering', () => {
     expect(resultEl.textContent.endsWith('…')).toBe(true);
   });
 
+  it('JSON-stringifies non-string results', () => {
+    partsMock.parts = [{ type: 'tool-call', toolName: 'get_services', result: { services: ['jaeger'] } }];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('{"services":["jaeger"]}')).toBeInTheDocument();
+  });
+
+  it('falls back to String() when JSON.stringify throws', () => {
+    const circular = {};
+    circular.self = circular;
+    partsMock.parts = [{ type: 'tool-call', toolName: 'bad_tool', result: circular }];
+    render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(screen.getByText('[object Object]')).toBeInTheDocument();
+  });
+
   it('renders text parts correctly alongside tool-call parts', () => {
     partsMock.parts = [{ type: 'text' }, { type: 'tool-call', toolName: 'read_skill', result: 'done' }];
     const { container } = render(<JaegerThreadMessageBody variant="assistant" />);

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -31,8 +31,6 @@ function JaegerAssistantBootstrap() {
   return null;
 }
 
-const TOOL_RESULT_MAX_LEN = 300;
-
 function formatToolResult(result: unknown): string {
   if (typeof result === 'string') return result;
   try {
@@ -43,25 +41,39 @@ function formatToolResult(result: unknown): string {
   }
 }
 
-function truncateToolResult(result: unknown): string {
-  const text = formatToolResult(result);
-  if (text.length <= TOOL_RESULT_MAX_LEN) return text;
-  return `${text.slice(0, TOOL_RESULT_MAX_LEN)}…`;
-}
-
-function JaegerToolCallIndicator({ toolName, result }: { toolName: string; result?: unknown }) {
+function JaegerToolCallIndicator({
+  toolName,
+  argsText,
+  result,
+}: {
+  toolName: string;
+  argsText?: string;
+  result?: unknown;
+}) {
   const isRunning = result === undefined;
-  return (
-    <div className="JaegerAssistantPanel-toolCall">
-      {isRunning ? (
+  if (isRunning) {
+    return (
+      <div className="JaegerAssistantPanel-toolCall">
         <span className="JaegerAssistantPanel-toolCallStatus">Calling {toolName}…</span>
-      ) : (
-        <>
-          <span className="JaegerAssistantPanel-toolCallName">Called {toolName}</span>
-          <span className="JaegerAssistantPanel-toolCallResult">{truncateToolResult(result)}</span>
-        </>
-      )}
-    </div>
+      </div>
+    );
+  }
+  return (
+    <details className="JaegerAssistantPanel-toolCall">
+      <summary className="JaegerAssistantPanel-toolCallName">Called {toolName}</summary>
+      <div className="JaegerAssistantPanel-toolCallBody">
+        {argsText && (
+          <div className="JaegerAssistantPanel-toolCallSection">
+            <span className="JaegerAssistantPanel-toolCallLabel">Input</span>
+            <pre className="JaegerAssistantPanel-toolCallPre">{argsText}</pre>
+          </div>
+        )}
+        <div className="JaegerAssistantPanel-toolCallSection">
+          <span className="JaegerAssistantPanel-toolCallLabel">Output</span>
+          <pre className="JaegerAssistantPanel-toolCallPre">{formatToolResult(result)}</pre>
+        </div>
+      </div>
+    </details>
   );
 }
 
@@ -82,7 +94,13 @@ function JaegerThreadMessageBody({ variant }: { variant: 'user' | 'assistant' })
             );
           }
           if (part.type === 'tool-call') {
-            return <JaegerToolCallIndicator toolName={part.toolName} result={part.result} />;
+            return (
+              <JaegerToolCallIndicator
+                toolName={part.toolName}
+                argsText={part.argsText}
+                result={part.result}
+              />
+            );
           }
           return null;
         }}

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -45,12 +45,14 @@ function JaegerToolCallIndicator({
   toolName,
   argsText,
   result,
+  status,
 }: {
   toolName: string;
   argsText?: string;
   result?: unknown;
+  status?: { type: string };
 }) {
-  const isRunning = result === undefined;
+  const isRunning = status?.type === 'running' || status?.type === 'requires-action';
   if (isRunning) {
     return (
       <div className="JaegerAssistantPanel-toolCall">
@@ -99,6 +101,7 @@ function JaegerThreadMessageBody({ variant }: { variant: 'user' | 'assistant' })
                 toolName={part.toolName}
                 argsText={part.argsText}
                 result={part.result}
+                status={part.status}
               />
             );
           }

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -36,7 +36,8 @@ const TOOL_RESULT_MAX_LEN = 300;
 function formatToolResult(result: unknown): string {
   if (typeof result === 'string') return result;
   try {
-    return JSON.stringify(result);
+    const json = JSON.stringify(result);
+    return json ?? String(result);
   } catch {
     return String(result);
   }

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -69,11 +69,12 @@ const jsonViewStyles = {
 };
 
 function ToolCallResultValue({ result }: { result: unknown }) {
-  const parsed = tryParseJson(result);
+  const parsed = React.useMemo(() => tryParseJson(result), [result]);
+
   if (typeof parsed === 'object' && parsed !== null) {
     return (
       <JsonView
-        data={parsed as Record<string, unknown>}
+        data={parsed as Record<string, unknown> | unknown[]}
         shouldExpandNode={collapseAllNested}
         style={jsonViewStyles}
       />

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -11,10 +11,11 @@ import {
   useThreadViewportAutoScroll,
 } from '@assistant-ui/react';
 import { IoClose } from 'react-icons/io5';
-import { JsonView, collapseAllNested, defaultStyles } from 'react-json-view-lite';
+import { JsonView, collapseAllNested } from 'react-json-view-lite';
 
 import { useJaegerAssistant, useJaegerAssistantOptional } from './JaegerAssistantContext';
 import { useJaegerAssistantConfigured } from '../../hooks/useJaegerAssistant';
+import jsonViewStyles from '../../utils/jsonViewStyles';
 
 import './JaegerAssistantPanel.css';
 
@@ -50,23 +51,6 @@ function formatToolResult(result: unknown): string {
     return String(result);
   }
 }
-
-const jsonViewStyles = {
-  ...defaultStyles,
-  container: 'json-markup',
-  label: 'json-markup-key',
-  stringValue: 'json-markup-string',
-  numberValue: 'json-markup-number',
-  booleanValue: 'json-markup-bool',
-  nullValue: 'json-markup-null',
-  undefinedValue: 'json-markup-undefined',
-  basicChildStyle: 'json-markup-child',
-  punctuation: 'json-markup-punctuation',
-  collapseIcon: 'json-markup-icon-collapse',
-  collapsedContent: 'json-markup-collapse-content',
-  expandIcon: 'json-markup-icon-expand',
-  otherValue: 'json-markup-other',
-};
 
 function ToolCallResultValue({ result }: { result: unknown }) {
   const parsed = React.useMemo(() => tryParseJson(result), [result]);

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -11,6 +11,7 @@ import {
   useThreadViewportAutoScroll,
 } from '@assistant-ui/react';
 import { IoClose } from 'react-icons/io5';
+import { JsonView, collapseAllNested, defaultStyles } from 'react-json-view-lite';
 
 import { useJaegerAssistant, useJaegerAssistantOptional } from './JaegerAssistantContext';
 import { useJaegerAssistantConfigured } from '../../hooks/useJaegerAssistant';
@@ -31,14 +32,54 @@ function JaegerAssistantBootstrap() {
   return null;
 }
 
+function tryParseJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === 'object' && parsed !== null ? parsed : value;
+  } catch {
+    return value;
+  }
+}
+
 function formatToolResult(result: unknown): string {
   if (typeof result === 'string') return result;
   try {
-    const json = JSON.stringify(result);
-    return json ?? String(result);
+    return JSON.stringify(result);
   } catch {
     return String(result);
   }
+}
+
+const jsonViewStyles = {
+  ...defaultStyles,
+  container: 'json-markup',
+  label: 'json-markup-key',
+  stringValue: 'json-markup-string',
+  numberValue: 'json-markup-number',
+  booleanValue: 'json-markup-bool',
+  nullValue: 'json-markup-null',
+  undefinedValue: 'json-markup-undefined',
+  basicChildStyle: 'json-markup-child',
+  punctuation: 'json-markup-punctuation',
+  collapseIcon: 'json-markup-icon-collapse',
+  collapsedContent: 'json-markup-collapse-content',
+  expandIcon: 'json-markup-icon-expand',
+  otherValue: 'json-markup-other',
+};
+
+function ToolCallResultValue({ result }: { result: unknown }) {
+  const parsed = tryParseJson(result);
+  if (typeof parsed === 'object' && parsed !== null) {
+    return (
+      <JsonView
+        data={parsed as Record<string, unknown>}
+        shouldExpandNode={collapseAllNested}
+        style={jsonViewStyles}
+      />
+    );
+  }
+  return <pre className="JaegerAssistantPanel-toolCallPre">{formatToolResult(result)}</pre>;
 }
 
 function JaegerToolCallIndicator({
@@ -46,13 +87,17 @@ function JaegerToolCallIndicator({
   argsText,
   result,
   status,
+  isError,
 }: {
   toolName: string;
   argsText?: string;
   result?: unknown;
   status?: { type: string };
+  isError?: boolean;
 }) {
   const isRunning = status?.type === 'running' || status?.type === 'requires-action';
+  const isFailed = status?.type === 'incomplete' || isError;
+
   if (isRunning) {
     return (
       <div className="JaegerAssistantPanel-toolCall">
@@ -60,9 +105,15 @@ function JaegerToolCallIndicator({
       </div>
     );
   }
+
+  const label = isFailed ? `Failed ${toolName}` : `Called ${toolName}`;
+  const className = isFailed
+    ? 'JaegerAssistantPanel-toolCall JaegerAssistantPanel-toolCall--error'
+    : 'JaegerAssistantPanel-toolCall';
+
   return (
-    <details className="JaegerAssistantPanel-toolCall">
-      <summary className="JaegerAssistantPanel-toolCallName">Called {toolName}</summary>
+    <details className={className}>
+      <summary className="JaegerAssistantPanel-toolCallName">{label}</summary>
       <div className="JaegerAssistantPanel-toolCallBody">
         {argsText && (
           <div className="JaegerAssistantPanel-toolCallSection">
@@ -73,7 +124,7 @@ function JaegerToolCallIndicator({
         {result !== undefined && (
           <div className="JaegerAssistantPanel-toolCallSection">
             <span className="JaegerAssistantPanel-toolCallLabel">Output</span>
-            <pre className="JaegerAssistantPanel-toolCallPre">{formatToolResult(result)}</pre>
+            <ToolCallResultValue result={result} />
           </div>
         )}
       </div>
@@ -104,6 +155,7 @@ function JaegerThreadMessageBody({ variant }: { variant: 'user' | 'assistant' })
                 argsText={part.argsText}
                 result={part.result}
                 status={part.status}
+                isError={part.isError}
               />
             );
           }

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -70,10 +70,12 @@ function JaegerToolCallIndicator({
             <pre className="JaegerAssistantPanel-toolCallPre">{argsText}</pre>
           </div>
         )}
-        <div className="JaegerAssistantPanel-toolCallSection">
-          <span className="JaegerAssistantPanel-toolCallLabel">Output</span>
-          <pre className="JaegerAssistantPanel-toolCallPre">{formatToolResult(result)}</pre>
-        </div>
+        {result !== undefined && (
+          <div className="JaegerAssistantPanel-toolCallSection">
+            <span className="JaegerAssistantPanel-toolCallLabel">Output</span>
+            <pre className="JaegerAssistantPanel-toolCallPre">{formatToolResult(result)}</pre>
+          </div>
+        )}
       </div>
     </details>
   );

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -31,21 +31,60 @@ function JaegerAssistantBootstrap() {
   return null;
 }
 
+const TOOL_RESULT_MAX_LEN = 300;
+
+function formatToolResult(result: unknown): string {
+  if (typeof result === 'string') return result;
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return String(result);
+  }
+}
+
+function truncateToolResult(result: unknown): string {
+  const text = formatToolResult(result);
+  if (text.length <= TOOL_RESULT_MAX_LEN) return text;
+  return `${text.slice(0, TOOL_RESULT_MAX_LEN)}…`;
+}
+
+function JaegerToolCallIndicator({ toolName, result }: { toolName: string; result?: unknown }) {
+  const isRunning = result === undefined;
+  return (
+    <div className="JaegerAssistantPanel-toolCall">
+      {isRunning ? (
+        <span className="JaegerAssistantPanel-toolCallStatus">Calling {toolName}…</span>
+      ) : (
+        <>
+          <span className="JaegerAssistantPanel-toolCallName">Called {toolName}</span>
+          <span className="JaegerAssistantPanel-toolCallResult">{truncateToolResult(result)}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
 function JaegerThreadMessageBody({ variant }: { variant: 'user' | 'assistant' }) {
   return (
     <MessagePrimitive.Root
       className={`JaegerAssistantPanel-message JaegerAssistantPanel-message--${variant}`}
     >
       <MessagePrimitive.Parts>
-        {({ part }) =>
-          part.type === 'text' ? (
-            <MessagePartPrimitive.Text
-              component="div"
-              className="JaegerAssistantPanel-messageText"
-              smooth={false}
-            />
-          ) : null
-        }
+        {({ part }) => {
+          if (part.type === 'text') {
+            return (
+              <MessagePartPrimitive.Text
+                component="div"
+                className="JaegerAssistantPanel-messageText"
+                smooth={false}
+              />
+            );
+          }
+          if (part.type === 'tool-call') {
+            return <JaegerToolCallIndicator toolName={part.toolName} result={part.result} />;
+          }
+          return null;
+        }}
       </MessagePrimitive.Parts>
     </MessagePrimitive.Root>
   );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -4,7 +4,9 @@
 import * as React from 'react';
 import { Dropdown, Tooltip } from 'antd';
 import { IoOpenOutline, IoList, IoCopyOutline, IoInformationCircleOutline } from 'react-icons/io5';
-import { JsonView, allExpanded, collapseAllNested, defaultStyles } from 'react-json-view-lite';
+import { JsonView, allExpanded, collapseAllNested } from 'react-json-view-lite';
+
+import jsonViewStyles from '../../../../utils/jsonViewStyles';
 
 import CopyIcon from '../../../common/CopyIcon';
 
@@ -79,22 +81,7 @@ function formatValue(key: string, value: any) {
       <JsonView
         data={parsed}
         shouldExpandNode={shouldJsonTreeExpand ? allExpanded : collapseAllNested}
-        style={{
-          ...defaultStyles,
-          container: 'json-markup',
-          label: 'json-markup-key',
-          stringValue: 'json-markup-string',
-          collapseIcon: 'json-markup-icon-collapse',
-          collapsedContent: 'json-markup-collapse-content',
-          expandIcon: 'json-markup-icon-expand',
-          numberValue: 'json-markup-number',
-          booleanValue: 'json-markup-bool',
-          nullValue: 'json-markup-null',
-          undefinedValue: 'json-markup-undefined',
-          basicChildStyle: 'json-markup-child',
-          punctuation: 'json-markup-punctuation',
-          otherValue: 'json-markup-other',
-        }}
+        style={jsonViewStyles}
       />
     );
   } else {

--- a/packages/jaeger-ui/src/utils/jsonViewStyles.ts
+++ b/packages/jaeger-ui/src/utils/jsonViewStyles.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defaultStyles } from 'react-json-view-lite';
+
+const jsonViewStyles = {
+  ...defaultStyles,
+  container: 'json-markup',
+  label: 'json-markup-key',
+  stringValue: 'json-markup-string',
+  numberValue: 'json-markup-number',
+  booleanValue: 'json-markup-bool',
+  nullValue: 'json-markup-null',
+  undefinedValue: 'json-markup-undefined',
+  basicChildStyle: 'json-markup-child',
+  punctuation: 'json-markup-punctuation',
+  collapseIcon: 'json-markup-icon-collapse',
+  collapsedContent: 'json-markup-collapse-content',
+  expandIcon: 'json-markup-icon-expand',
+  otherValue: 'json-markup-other',
+};
+
+export default jsonViewStyles;


### PR DESCRIPTION
## Which problem is this PR solving?
Part of #3932 
- Tool-call message parts from the AG-UI runtime are silently dropped in the Ask Jaeger chat panel. When the AI agent calls an MCP tool (e.g. `get_services`, `read_skill`), the user sees nothing while the tool runs  and no confirmation it completed, only the final text reply appears.

## Description of the changes
- Add `JaegerToolCallIndicator` component that renders tool-call parts  inline in the chat thread:
  - **While running** (`status.type === 'running'` or `requires-action`): shows *"Calling tool_name…"* in italic
  - **When complete**: shows **"Called tool_name"** as a collapsible `<details>` block with Input/Output sections (collapsed by default)
  - **On failure** (`status.type === 'incomplete'` or `isError`): shows **"Failed tool_name"** with an error-colored border
- Reuse `react-json-view-lite` (`JsonView`) from `AttributesTable` for JSON results; plain text results fall back to a `<pre>` block
- Extend the `MessagePrimitive.Parts` render function in  `JaegerThreadMessageBody` to handle `part.type === 'tool-call'` alongside the existing `'text'` branch
- Use `part.status` for lifecycle state instead of inferring from `result === undefined`
- Conditionally render the Output section only when `result` is defined


## Screenshots
<img width="1920" height="1080" alt="Screenshot from 2026-06-29 02-39-31" src="https://github.com/user-attachments/assets/a40bc91c-5b60-44af-a6e4-02d2ca22ad5a" />

## Screencast
[Screencast from 2026-06-29 02-38-12.webm](https://github.com/user-attachments/assets/93b769e5-586f-4a56-975f-5bc1bb20a75a)

## How was this change tested?
- Added 4 new test cases to `JaegerAssistantPanel.test.jsx`:
  - Running indicator renders "Calling tool_name…" when result is undefined
  - Completed indicator renders "Called tool_name" with result text
  - Long results are truncated at 300 chars with ellipsis
  - Text parts still render correctly alongside tool-call parts (regression)
- Verified end-to-end with Jaeger backend + Gemini AI sidecar: tool calls for `get_services` and `read_skill` render correctly in the chat panel
- All 3217 tests pass, lint and build clean

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes