### PR TITLE
fix(a11y): keyboard focus management and ARIA attributes for expanded span details (#4166)

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -270,4 +270,33 @@ describe('<SpanBarRow>', () => {
       undefined
     );
   });
+
+  describe('ARIA attributes on toggle button', () => {
+    it('sets aria-expanded=false when isDetailExpanded is false', () => {
+      render(<SpanBarRow {...defaultProps} isDetailExpanded={false} />);
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('sets aria-expanded=true when isDetailExpanded is true', () => {
+      render(<SpanBarRow {...defaultProps} isDetailExpanded={true} />);
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('sets aria-controls pointing to the detail panel id', () => {
+      render(<SpanBarRow {...defaultProps} />);
+      const toggle = screen.getByRole('switch');
+      expect(toggle).toHaveAttribute('aria-controls', `span-detail-${spanID}`);
+    });
+  });
+
+  describe('toggleRef prop', () => {
+    it('calls toggleRef with the toggle anchor element when mounted', () => {
+      const toggleRef = jest.fn();
+      render(<SpanBarRow {...defaultProps} toggleRef={toggleRef} />);
+      expect(toggleRef).toHaveBeenCalledTimes(1);
+      expect(toggleRef).toHaveBeenCalledWith(expect.any(HTMLElement));
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -28,6 +28,8 @@ type SpanBarRowProps = {
   timelineBarsVisible: boolean;
   onDetailToggled: (spanID: string) => void;
   onChildrenToggled: (spanID: string) => void;
+  /** Ref callback so the parent can restore focus to this row after collapse. */
+  toggleRef?: (el: HTMLAnchorElement | null) => void;
   numTicks: number;
   rpc?:
     | {
@@ -84,6 +86,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   traceDuration,
   onDetailToggled,
   onChildrenToggled,
+  toggleRef,
   useOtelTerms,
 }) => {
   const _detailToggle = useCallback(() => {
@@ -151,11 +154,14 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
           <a
             className={`span-name ${isDetailExpanded ? 'is-detail-expanded' : ''}`}
             aria-checked={isDetailExpanded}
+            aria-controls={`span-detail-${span.spanID}`}
+            aria-expanded={isDetailExpanded}
             onClick={_detailToggle}
             onKeyDown={_detailToggleKeyDown}
             role="switch"
             style={{ borderColor: color }}
             tabIndex={0}
+            ref={toggleRef}
           >
             <span
               className={`span-svc-name ${isParent && !isChildrenExpanded ? 'is-children-collapsed' : ''}`}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
@@ -148,4 +148,24 @@ describe('<SpanDetailRow>', () => {
     // linksGetter is passed directly to SpanDetail (no adapter needed since props already have OTEL signature)
     expect(props.linksGetter).toHaveBeenCalledWith(attributes, 0);
   });
+
+  describe('Focus management & ARIA linking', () => {
+    it('sets the correct ID on the detail wrapper', () => {
+      const { container } = render(<SpanDetailRow {...props} />);
+      const wrapper = container.querySelector('.detail-info-wrapper');
+      expect(wrapper).toHaveAttribute('id', `span-detail-${span.spanID}`);
+    });
+
+    it('sets tabIndex={-1} to allow programmatic focus', () => {
+      const { container } = render(<SpanDetailRow {...props} />);
+      const wrapper = container.querySelector('.detail-info-wrapper');
+      expect(wrapper).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('auto-focuses the detail wrapper on mount', () => {
+      const { container } = render(<SpanDetailRow {...props} />);
+      const wrapper = container.querySelector('.detail-info-wrapper');
+      expect(document.activeElement).toBe(wrapper);
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import SpanDetail from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
@@ -39,6 +39,15 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
     props.onDetailToggled(props.span.spanID);
   };
 
+  // Auto-focus the detail panel when it mounts so keyboard users land
+  // directly inside the expanded content (WCAG 2.1 SC 2.4.3).
+  const detailPanelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (detailPanelRef.current) {
+      detailPanelRef.current.focus();
+    }
+  }, []);
+
   const {
     color,
     nameColumnWidth,
@@ -75,7 +84,15 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
         </TimelineRow.Cell>
       )}
       <TimelineRow.Cell width={timelineBarsVisible ? 1 - nameColumnWidth : 1}>
-        <div className="detail-info-wrapper" style={{ borderTopColor: color }}>
+        <div
+          id={`span-detail-${span.spanID}`}
+          className="detail-info-wrapper"
+          style={{ borderTopColor: color }}
+          // tabIndex={-1} makes the div programmatically focusable without
+          // adding it to the natural tab order.
+          tabIndex={-1}
+          ref={detailPanelRef}
+        >
           <SpanDetail
             detailState={detailState}
             linksGetter={linksGetter}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
@@ -887,4 +887,40 @@ describe('<VirtualizedTraceViewImpl>', () => {
       expect(result).toBeTruthy();
     });
   });
+
+  describe('Focus restoration on detail collapse', () => {
+    it('restores focus to the triggering toggle button when a detail row is collapsed', () => {
+      // Mock requestAnimationFrame to run immediately
+      const origRaf = window.requestAnimationFrame;
+      window.requestAnimationFrame = cb => {
+        cb();
+        return 0;
+      };
+
+      try {
+        const { props } = expandRow(0);
+        const { listViewProps } = renderAndCapture(props);
+
+        // Get the SpanBarRow wrapper result from itemRenderer
+        const rowResult = listViewProps.itemRenderer('key-0', {}, 0, {});
+        const spanBarRow = rowResult.props.children;
+
+        // Register a fake toggle anchor element via toggleRef
+        const mockFocus = jest.fn();
+        const mockAnchor = { focus: mockFocus };
+        spanBarRow.props.toggleRef(mockAnchor);
+
+        // Verify that triggering collapse onDetailToggled calls detailToggle and restores focus
+        spanBarRow.props.onDetailToggled(trace.spans[0].spanID);
+
+        expect(mockProps.detailToggle).toHaveBeenCalledWith(trace.spans[0].spanID);
+        expect(mockFocus).toHaveBeenCalledTimes(1);
+
+        // Clean up mockAnchor from map by calling toggleRef(null)
+        spanBarRow.props.toggleRef(null);
+      } finally {
+        window.requestAnimationFrame = origRaf;
+      }
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -127,6 +127,10 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
   const propsRef = useRef(props);
   propsRef.current = props;
 
+  // Stores a ref to each span row's toggle <a> element so we can
+  // restore focus back to the triggering row when the detail is collapsed.
+  const spanToggleRefs = useRef<Map<string, HTMLAnchorElement>>(new Map());
+
   const criticalPathContext = useMemo(
     () => makeCriticalPathContext(props.trace, props.criticalPath, props.prunedServices),
     [props.trace, props.criticalPath, props.prunedServices]
@@ -150,6 +154,24 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
       viewStart: zoomStart,
       viewEnd: zoomEnd,
     });
+  }, []);
+
+  // When a span detail is collapsed, restore focus to the toggle button that
+  // triggered the expand so keyboard users do not lose their position in the list.
+  const handleDetailToggle = useCallback((spanID: string) => {
+    const { detailStates, detailToggle } = propsRef.current;
+    const isCurrentlyExpanded = detailStates.has(spanID);
+    detailToggle(spanID);
+    if (isCurrentlyExpanded) {
+      // Use rAF so the DOM has settled (the detail row is removed) before we
+      // move focus — avoids the browser jumping back up to the document root.
+      requestAnimationFrame(() => {
+        const toggleEl = spanToggleRefs.current.get(spanID);
+        if (toggleEl) {
+          toggleEl.focus();
+        }
+      });
+    }
   }, []);
 
   const focusSpan = useCallback((uiFind: string) => {
@@ -343,7 +365,6 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
         childrenHiddenIDs,
         childrenToggle,
         detailStates,
-        detailToggle,
         findMatchesIDs,
         nameColumnWidth,
         prunedServices,
@@ -396,6 +417,16 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
         };
       }
 
+      // Ref callback: store (or remove) the toggle element for this spanID
+      // so we can restore focus when the detail row collapses.
+      const handleToggleRef = (el: HTMLAnchorElement | null) => {
+        if (el) {
+          spanToggleRefs.current.set(spanID, el);
+        } else {
+          spanToggleRefs.current.delete(spanID);
+        }
+      };
+
       return (
         <div className="VirtualizedTraceView--row" key={key} style={style} {...attrs}>
           <SpanBarRow
@@ -409,8 +440,9 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
             isSelected={isSelected}
             timelineBarsVisible={timelineBarsVisible}
             numTicks={NUM_TICKS}
-            onDetailToggled={detailToggle}
+            onDetailToggled={handleDetailToggle}
             onChildrenToggled={childrenToggle}
+            toggleRef={handleToggleRef}
             rpc={rpc}
             noInstrumentedServer={noInstrumentedServer}
             hasOwnError={hasOwnError}
@@ -425,7 +457,7 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
         </div>
       );
     },
-    [getClippingCssClasses, getViewedBounds, focusSpan, criticalPathContext]
+    [getClippingCssClasses, getViewedBounds, focusSpan, criticalPathContext, handleDetailToggle]
   );
 
   const renderSpanDetailRow = useCallback(
@@ -440,7 +472,6 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
         detailWarningsToggle,
         detailStates,
         detailTagsToggle,
-        detailToggle,
         nameColumnWidth,
         timelineBarsVisible,
         trace,
@@ -459,7 +490,7 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
             color={color}
             nameColumnWidth={nameColumnWidth}
             timelineBarsVisible={timelineBarsVisible}
-            onDetailToggled={detailToggle}
+            onDetailToggled={handleDetailToggle}
             detailState={detailState}
             linksGetter={linksGetterFromAttributes(span)}
             eventItemToggle={eventItemToggleAdapter(detailLogItemToggle)}
@@ -478,7 +509,7 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
         </div>
       );
     },
-    [linksGetterFromAttributes, eventItemToggleAdapter, focusSpan]
+    [linksGetterFromAttributes, eventItemToggleAdapter, focusSpan, handleDetailToggle]
   );
 
   const renderRow = useCallback(


### PR DESCRIPTION
Resolves: #4166

## Context & Motivation

While testing the timeline view with a screen reader and keyboard-only navigation, I noticed that expanding a span detail panel caused serious focus management issues. When pressing `Enter` or `Space` on a span row to expand its detail drawer, the DOM focus remained stuck on the row or jumped outside the timeline entirely. Pressing `Tab` afterwards moved focus all the way up to the top header navigation bar, forcing keyboard users to tab through dozens of elements to reach tags, logs, or metadata inside the newly revealed panel.

Additionally, there was no ARIA connection between the expand toggle button and the detail panel it controls, meaning screen readers could not announce the relationship or guide users into the content.

This PR fixes these focus management and ARIA gaps to make the timeline view fully usable for keyboard and screen reader users.

## Implementation Details

Three files were changed to implement the three requirements from the issue:

### 1. `SpanBarRow.tsx` — ARIA linking on the toggle button

Added `aria-expanded` and `aria-controls` to the span name toggle `<a>` element, and a `ref` callback (`toggleRef`) so the parent can store a reference to the DOM node for focus restoration:

```tsx
<a
  role="switch"
  aria-checked={isDetailExpanded}
  aria-expanded={isDetailExpanded}          // screen reader announces state
  aria-controls={`span-detail-${spanID}`}  // points to the panel below
  ref={toggleRef}                            // parent tracks this node
>
```

### 2. `SpanDetailRow.tsx` — Auto-focus and panel ID

Added `id`, `tabIndex={-1}`, and a `useEffect` to programmatically focus the detail panel the moment it mounts:

```tsx
const detailPanelRef = useRef<HTMLDivElement>(null);
useEffect(() => { detailPanelRef.current?.focus(); }, []);

<div
  id={`span-detail-${span.spanID}`}  // matches aria-controls above
  tabIndex={-1}                         // focusable by code, not Tab key
  ref={detailPanelRef}                  // auto-focused on mount
>
```

### 3. `VirtualizedTraceView.tsx` — Focus restoration on collapse

Added a `spanToggleRefs` map to store toggle button DOM nodes per span, and a `handleDetailToggle` wrapper that restores focus via `requestAnimationFrame` after the panel is collapsed:

```tsx
const spanToggleRefs = useRef<Map<string, HTMLAnchorElement>>(new Map());

const handleDetailToggle = useCallback((spanID: string) => {
  const { detailStates, detailToggle } = propsRef.current;
  const isCurrentlyExpanded = detailStates.has(spanID);
  detailToggle(spanID);
  if (isCurrentlyExpanded) {
    requestAnimationFrame(() => {
      spanToggleRefs.current.get(spanID)?.focus(); // restore focus on collapse
    });
  }
}, []);
```

`requestAnimationFrame` is used to wait for the DOM to settle after the detail row is removed before moving focus, which avoids the browser jumping to `<body>`.

## Impact

- **Accessibility:** Fixes WCAG 2.1 SC 2.4.3 (Focus Order) and SC 4.1.2 (Name, Role, Value) for the timeline span detail expand/collapse interaction.
- **No functional regressions:** The toggle logic is unchanged; only focus management and ARIA attributes are added.
- **No new dependencies.**

## Verification & Testing

- **Type Check:** `npm run type-check` passes with zero errors.
- **Lint:** `npm run lint` passes with zero warnings or errors.
- **Format:** `npm run fmt` reports no changes needed.
- **Unit Tests:** `npm test` passes — no functional logic was changed.