### PR TITLE
fix(filter-spans): use JSON.stringify for object/array attribute values in span search

### DIFF
--- a/packages/jaeger-ui/src/utils/filter-spans.test.js
+++ b/packages/jaeger-ui/src/utils/filter-spans.test.js
@@ -235,4 +235,42 @@ describe('filterSpans', () => {
   it('should return an empty set if no spans match the filter', () => {
     expect(filterSpans('-processTagKey1', spans)).toEqual(new Set());
   });
+  it('should return spans whose tags have an object value containing the filter text', () => {
+    const spanWithObjectTag = {
+      spanID: 'span-id-object',
+      operationName: 'operationNameObject',
+      process: {
+        serviceName: 'serviceNameObject',
+        tags: [],
+      },
+      tags: [
+        {
+          key: 'gen_ai.input.messages',
+          value: { role: 'user', content: 'hello world' },
+        },
+      ],
+      logs: [],
+    };
+    expect(filterSpans('hello', [spanWithObjectTag])).toEqual(new Set(['span-id-object']));
+    expect(filterSpans('user', [spanWithObjectTag])).toEqual(new Set(['span-id-object']));
+  });
+
+  it('should return spans whose tags have an array value containing the filter text', () => {
+    const spanWithArrayTag = {
+      spanID: 'span-id-array',
+      operationName: 'operationNameArray',
+      process: {
+        serviceName: 'serviceNameArray',
+        tags: [],
+      },
+      tags: [
+        {
+          key: 'http.response.headers',
+          value: ['application/json', 'gzip'],
+        },
+      ],
+      logs: [],
+    };
+    expect(filterSpans('application/json', [spanWithArrayTag])).toEqual(new Set(['span-id-array']));
+  });
 });

--- a/packages/jaeger-ui/src/utils/filter-spans.ts
+++ b/packages/jaeger-ui/src/utils/filter-spans.ts
@@ -39,7 +39,7 @@ export default function filterSpans(textFilter: string, spans: ReadonlyArray<Spa
           if (isTextInFilters(excludeKeys, kv.key)) return false;
           const value = (kv as any).value; // handle legacy KeyValuePair and IAttribute
           if (value === null || value === undefined) return false;
-          const valueString = String(value);
+          const valueString = typeof value === 'object' ? JSON.stringify(value) : String(value);
           // match if key, value or key=value string matches an item in includeFilters
           return (
             isTextInFilters(includeFilters, kv.key) ||


### PR DESCRIPTION
## Description

Fixes span search silently failing when the search term appears inside an object or array attribute value.

`String(value)` on a JavaScript object always returns `"[object Object]"`, and on an array returns a comma-joined string that loses keys and nested structure. So any span attribute whose value is a JSON object (e.g. `gen_ai.input.messages`, HTTP headers) could never be found by value search.

## Fix

Use `JSON.stringify(value)` for object/array attribute values so the full structure is searchable — matching the existing logic already used in `AttributesTable.tsx`'s `getFilterValue()` helper.

## Testing

Added 2 new test cases in `filter-spans.test.js` covering search inside object and array attribute values. All 22 tests pass.

Fixes #4165