### PR TITLE
fix(lint): Strengthen linting for JS/JSX files

### DIFF
--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -74,5 +74,3 @@ function UIConfig() {
     // backendCapabilities: { archiveStorage: true, aiAssistant: true }
   };
 }
-
-module.exports = UIConfig;

--- a/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
+++ b/packages/jaeger-ui/jaeger-ui.config.console-analytics.js
@@ -74,3 +74,5 @@ function UIConfig() {
     // backendCapabilities: { archiveStorage: true, aiAssistant: true }
   };
 }
+
+module.exports = UIConfig;

--- a/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Header/HopsSelector/index.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 

--- a/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
+++ b/packages/jaeger-ui/src/components/DeepDependencies/index.test.jsx
@@ -888,24 +888,6 @@ describe('DeepDependencyGraphPage', () => {
         operation,
       },
     };
-    const services = [service];
-    const serverOpsForService = {
-      [service]: ['some operation'],
-    };
-    const state = {
-      otherState: 'otherState',
-      router: {
-        location: {
-          search: 'search',
-        },
-      },
-      services: {
-        serverOpsForService,
-        otherState: 'otherState',
-        services,
-      },
-    };
-    const ownProps = { location: { search } };
     const mockGraph = { getVisible: () => ({}) };
     const hash = 'testHash';
     const doneGraphState = {
@@ -1026,19 +1008,6 @@ describe('DeepDependencyGraphPage', () => {
     const serviceTwo = 'svc-bridge-two';
     const keyOne = getStateEntryKey({ service: serviceOne, operation: '*', start: 0, end: 0 });
     const keyTwo = getStateEntryKey({ service: serviceTwo, operation: '*', start: 0, end: 0 });
-
-    function makeDoneEntry(hash) {
-      return {
-        state: fetchedState.DONE,
-        model: {
-          hash,
-          distanceToPathElems: new Map(),
-          paths: [],
-          services: new Map(),
-          visIdxToPathElem: [],
-        },
-      };
-    }
 
     function renderBridgeHook(initialOptions) {
       return renderHook(({ options }) => useDdgViewModifierBridgeProps(options), {

--- a/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
+++ b/packages/jaeger-ui/src/components/DeepDependencies/url.test.js
@@ -117,18 +117,18 @@ describe('DeepDependencyGraph/url', () => {
 
     it('handles absent values', () => {
       ['end', 'hash', 'operation', 'service', 'start', 'visEncoding'].forEach(param => {
-        const { [param]: unused, ...rest } = expectedParams;
+        const { [param]: _unused, ...rest } = expectedParams;
 
-        const { [param]: alsoUnused, ...rv } = acceptableParams;
+        const { [param]: _alsoUnused, ...rv } = acceptableParams;
         parseSpy.mockReturnValue(rv);
         expect(getUrlState(getSearch())).toEqual(rest);
       });
     });
 
     it("defaults `density` to 'ppe'", () => {
-      const { density: unused, ...rest } = expectedParams;
+      const { density: _unused, ...rest } = expectedParams;
 
-      const { density: alsoUnused, ...rv } = acceptableParams;
+      const { density: _alsoUnused, ...rv } = acceptableParams;
       parseSpy.mockReturnValue(rv);
       expect(getUrlState(getSearch())).toEqual({ ...rest, density: 'ppe' });
     });

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -152,7 +152,6 @@ const renderWithRouter = component => {
 };
 
 describe('<MonitorATMServicesView>', () => {
-  let wrapper;
   const mockFetchServices = jest.fn();
   const mockFetchAllServiceMetrics = jest.fn();
   const mockFetchAggregatedServiceMetrics = jest.fn();
@@ -169,11 +168,10 @@ describe('<MonitorATMServicesView>', () => {
       fetchAllServiceMetrics: mockFetchAllServiceMetrics,
       fetchAggregatedServiceMetrics: mockFetchAggregatedServiceMetrics,
     };
-    wrapper = renderWithRouter(<MonitorATMServicesView {...defaultProps} />);
+    renderWithRouter(<MonitorATMServicesView {...defaultProps} />);
   });
 
   afterEach(() => {
-    wrapper = null;
     jest.clearAllMocks();
     // Reset useServices mock to default implementation to avoid test order-dependence
     useServices.mockReset();
@@ -865,7 +863,6 @@ describe('<MonitorATMServicesView> URL query params', () => {
 });
 
 describe('<MonitorATMServicesView> on page switch', () => {
-  let wrapper;
   const stateOnPageSwitch = {
     services: {
       services: [],
@@ -875,14 +872,13 @@ describe('<MonitorATMServicesView> on page switch', () => {
   };
 
   const propsOnPageSwitch = mapStateToProps(stateOnPageSwitch);
-  const mockFetchServices = jest.fn();
   const mockFetchAllServiceMetrics = jest.fn();
   const mockFetchAggregatedServiceMetrics = jest.fn();
 
   beforeEach(() => {
     cleanup();
     useServices.mockReturnValue({ data: ['apple'], isLoading: false });
-    wrapper = renderWithRouter(
+    renderWithRouter(
       <MonitorATMServicesView
         {...propsOnPageSwitch}
         fetchAllServiceMetrics={mockFetchAllServiceMetrics}

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/operationDetailsTable/index.test.jsx
@@ -62,10 +62,7 @@ describe('<OperationTableDetails>', () => {
 });
 
 describe('<OperationTableDetails> with data', () => {
-  let originalProps;
-
   beforeEach(() => {
-    originalProps = { ...props };
     jest.clearAllMocks();
   });
 

--- a/packages/jaeger-ui/src/components/QualityMetrics/MetricCard.test.jsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/MetricCard.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MetricCard from './MetricCard';
 

--- a/packages/jaeger-ui/src/components/QualityMetrics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/QualityMetrics/index.test.jsx
@@ -221,7 +221,7 @@ describe('QualityMetrics', () => {
           rej(error);
           try {
             await promise;
-          } catch (e) {
+          } catch {
             // intentionally left blank
           }
         });
@@ -380,7 +380,7 @@ describe('QualityMetrics', () => {
           rej({ message });
           try {
             await promise;
-          } catch (e) {
+          } catch {
             // intentionally left blank
           }
         });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -6,7 +6,7 @@ const { mockUseIsSearchFetching } = vi.hoisted(() => ({
 }));
 
 vi.mock('../common/SearchableSelect', () => {
-  const MockSearchableSelect = ({ onChange, 'data-testid': testId, disabled, value, ...props }) => {
+  const MockSearchableSelect = ({ onChange, 'data-testid': testId, disabled, value }) => {
     if (onChange && testId) {
       MockSearchableSelect.onChangeFns[testId] = onChange;
     }
@@ -74,7 +74,6 @@ import {
   validateDurationFields,
 } from './SearchForm';
 import * as markers from './SearchForm.markers';
-import { CHANGE_SERVICE_ACTION_TYPE } from '../../constants/search-form';
 import { useServices, useSpanNames } from '../../hooks/useTraceDiscovery';
 import { AppQueryClientProvider } from '../../query/app-query-client';
 import getConfig from '../../utils/config/get-config';

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/AltViewOptions.test.jsx
@@ -14,7 +14,6 @@ describe('AltViewOptions', () => {
   let getConfigValueSpy;
   let getUrlSpy;
   let getUrlStateSpy;
-  let trackConversionsSpy;
 
   const props = {
     traceResultsView: true,
@@ -25,7 +24,7 @@ describe('AltViewOptions', () => {
     getUrlSpy = jest.spyOn(url, 'getUrl');
     getUrlStateSpy = jest.spyOn(url, 'getUrlState');
     getConfigValueSpy = jest.spyOn(getConfig, 'default');
-    trackConversionsSpy = jest.spyOn(trackingModule, 'trackConversions');
+    jest.spyOn(trackingModule, 'trackConversions');
   });
 
   beforeEach(() => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -154,7 +154,7 @@ describe('<SearchResults>', () => {
   });
 
   it('uses default skipMessage value when not provided', () => {
-    const { skipMessage: _skipMessage, ...propsWithoutSkipMessage } = baseProps;
+    const { skipMessage: _unused, ...propsWithoutSkipMessage } = baseProps;
     renderWithRouter(<SearchResults {...propsWithoutSkipMessage} traceSummaries={[]} />);
     expect(screen.getByText(/No trace results\. Try another query\./i)).toBeInTheDocument();
   });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/index.test.jsx
@@ -154,7 +154,7 @@ describe('<SearchResults>', () => {
   });
 
   it('uses default skipMessage value when not provided', () => {
-    const { skipMessage, ...propsWithoutSkipMessage } = baseProps;
+    const { skipMessage: _skipMessage, ...propsWithoutSkipMessage } = baseProps;
     renderWithRouter(<SearchResults {...propsWithoutSkipMessage} traceSummaries={[]} />);
     expect(screen.getByText(/No trace results\. Try another query\./i)).toBeInTheDocument();
   });

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.test.jsx
@@ -84,29 +84,6 @@ const AllProvider = ({ children, initialEntries = ['/search'] }) => (
   </QueryClientProvider>
 );
 
-// Helper that exposes the MemoryRouter's navigate function via a callback ref.
-function NavigateSpy({ onNavigate }) {
-  const { useNavigate: useNav } = require('react-router-dom');
-  const navigate = useNav();
-  React.useEffect(() => {
-    onNavigate(navigate);
-  }, [navigate, onNavigate]);
-  return null;
-}
-
-function AllProviderWithNav({ children, initialEntries = ['/search'], onNavigate }) {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={initialEntries}>
-        <Provider store={globalStore}>
-          {children}
-          <NavigateSpy onNavigate={onNavigate} />
-        </Provider>
-      </MemoryRouter>
-    </QueryClientProvider>
-  );
-}
-
 describe('<SearchTracePage>', () => {
   beforeEach(() => {
     useEmbeddedStateMock.mockReturnValue(null);

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/renderNode.test.jsx
@@ -11,8 +11,6 @@ import EmphasizedNode from '../../common/EmphasizedNode';
 describe('drawNode', () => {
   const operation = 'operationName';
   const service = 'serviceName';
-  const defaultCount = 100;
-
   afterEach(cleanup);
 
   describe('diffNode', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/OpNode.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import OpNode, {

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.test.jsx
@@ -157,7 +157,7 @@ describe('<TracePageHeader>', () => {
   });
 
   it('renders the header items', () => {
-    HEADER_ITEMS.forEach((item, i) => {
+    HEADER_ITEMS.forEach(item => {
       const renderedValue = item.renderer(defaultProps.trace);
       if (renderedValue === null) return;
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageSearchBar.test.jsx
@@ -50,10 +50,8 @@ describe('<TracePageSearchBar>', () => {
   });
 
   describe('truthy textFilter', () => {
-    let wrapper;
-
     beforeEach(() => {
-      wrapper = render(<TracePageSearchBar {...defaultProps} />);
+      render(<TracePageSearchBar {...defaultProps} />);
     });
 
     it('renders UiFindInput with correct props', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/ReferencesButton.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import ReferencesButton from './ReferencesButton';

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -122,7 +122,7 @@ describe('<AccordionEvents>', () => {
   });
 
   it('is interactive by default', () => {
-    const { interactive: _interactive, ...propsWithoutInteractive } = defaultProps;
+    const { interactive: _unused, ...propsWithoutInteractive } = defaultProps;
     render(<AccordionEvents {...propsWithoutInteractive} isOpen />);
 
     const header = screen.getByRole('switch');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionEvents.test.jsx
@@ -122,7 +122,7 @@ describe('<AccordionEvents>', () => {
   });
 
   it('is interactive by default', () => {
-    const { interactive, ...propsWithoutInteractive } = defaultProps;
+    const { interactive: _interactive, ...propsWithoutInteractive } = defaultProps;
     render(<AccordionEvents {...propsWithoutInteractive} isOpen />);
 
     const header = screen.getByRole('switch');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/index.test.jsx
@@ -12,7 +12,6 @@ import SpanDetail from './index';
 import { formatDuration } from '../utils';
 import traceGenerator from '../../../../demo/trace-generators';
 import transformTraceData from '../../../../model/transform-trace-data';
-import OtelSpanFacade from '../../../../model/OtelSpanFacade';
 
 vi.mock('./AccordionAttributes', () => {
   return mockDefault(function MockAccordionAttributes({ label, onToggle }) {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
@@ -8,7 +8,6 @@ import userEvent from '@testing-library/user-event';
 
 import SpanDetailRow from './SpanDetailRow';
 import DetailState from './SpanDetail/DetailState';
-import SpanTreeOffset from './SpanTreeOffset';
 
 const MockSpanDetail = jest.fn(() => <div data-testid="mocked-span-detail" />);
 vi.mock('./SpanDetail', () => ({

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
-import spanAncestorIds from '../../../utils/span-ancestor-ids';
-
 vi.mock('../../../utils/span-ancestor-ids');
 
 describe('SpanTreeOffset', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
@@ -10,7 +10,6 @@ import {
   isKindProducer,
 } from './utils';
 
-import traceGenerator from '../../../demo/trace-generators';
 import { SpanKind, StatusCode } from '../../../types/otel';
 
 describe('TraceTimelineViewer/utils', () => {

--- a/packages/jaeger-ui/src/components/TracePage/Tween.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/Tween.test.js
@@ -110,7 +110,7 @@ describe('Tween', () => {
       try {
         current.done = !current.done;
         // eslint-disable-next-line no-empty
-      } catch (_) {}
+      } catch {}
       expect(current).toEqual(copy);
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -17,13 +17,11 @@ import {
 } from './index';
 import * as track from './index.track';
 import * as keyboardShortcutsMod from './keyboard-shortcuts';
-import { reset as resetShortcuts, merge as mergeShortcuts } from './keyboard-shortcuts';
+import { merge as mergeShortcuts } from './keyboard-shortcuts';
 import * as scrollPageMod from './scroll-page';
-import { cancel as cancelScroll } from './scroll-page';
 import * as calculateTraceDagEV from './TraceGraph/calculateTraceDagEV';
 import { trackSlimHeaderToggle } from './TracePageHeader/TracePageHeader.track';
 import * as getUiFindVertexKeys from '../TraceDiff/TraceDiffGraph/traceDiffGraphUtils';
-import { fetchedState } from '../../constants';
 import traceGenerator from '../../demo/trace-generators';
 import transformTraceData from '../../model/transform-trace-data';
 import filterSpansSpy from '../../utils/filter-spans';

--- a/packages/jaeger-ui/src/model/search.test.js
+++ b/packages/jaeger-ui/src/model/search.test.js
@@ -5,7 +5,7 @@ import _maxBy from 'lodash/maxBy';
 import _minBy from 'lodash/minBy';
 
 import * as orderBy from './order-by';
-import { sortTraces, sortTraceSummaries, toOrderBy, fromOrderBy } from './search';
+import { sortTraces, sortTraceSummaries } from './search';
 import traceGenerator from '../demo/trace-generators';
 import transformTraceData from './transform-trace-data';
 

--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -381,17 +381,6 @@ describe('transformTraceData()', () => {
 
     it('should calculate depth and sort spans in DFS order', () => {
       // Create a linear trace: Root -> Child -> GrandChild
-      const grandChildSpan = {
-        traceID,
-        spanID: 'grandChild',
-        operationName: 'grandChildOp',
-        references: [{ refType: 'CHILD_OF', traceID, spanID: spans[0].spanID }],
-        startTime: startTime + 200,
-        duration: 10,
-        tags: [],
-        processID: 'p1',
-      };
-
       // spans[0] is 'someOperationName', referencing rootSpanID
       // rootSpanWithoutRefs is the root (start + 50)
       // spans[0] starts at startTime (0 relative to trace start? No, trace start is startTime).

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -46,7 +46,7 @@ describe('fileReader.readJsonFile', () => {
       const p = readJsonFile({ rando: true });
       // prevent the unhandled rejection warning
       p.catch(() => {});
-    } catch (_) {
+    } catch {
       threw = true;
     }
     return expect(threw).toBe(false);

--- a/packages/plexus/src/Digraph/SvgLayer.test.jsx
+++ b/packages/plexus/src/Digraph/SvgLayer.test.jsx
@@ -10,7 +10,7 @@ import SvgLayer from './SvgLayer';
 // Use React.createElement instead of JSX, because jest.mock factory functions cannot reference external variables
 vi.mock('./SvgDefEntry', () => {
   const React = require('react');
-  const MockSvgDefEntry = ({ localId, getClassName: _getClassName }) =>
+  const MockSvgDefEntry = ({ localId, getClassName: _unused }) =>
     React.createElement('marker', { id: localId, 'data-testid': `def-${localId}` });
   return { default: MockSvgDefEntry };
 });
@@ -42,7 +42,7 @@ describe('SvgLayer', () => {
   };
 
   // Helper to render inside SVG context
-  const renderSvgLayer = (props, _options = {}) => {
+  const renderSvgLayer = (props, _unused = {}) => {
     const mergedProps = { ...defaultProps, ...props };
     // If standalone or topLayer, component renders its own svg
     if (mergedProps.standalone || mergedProps.topLayer) {
@@ -76,7 +76,7 @@ describe('SvgLayer', () => {
 
   describe('container props', () => {
     it('merges custom props from setOnContainer', () => {
-      const setOnContainer = _graphState => ({
+      const setOnContainer = _unused => ({
         'data-custom': 'value',
       });
       const { container } = renderSvgLayer({ setOnContainer });

--- a/packages/plexus/src/Digraph/SvgLayer.test.jsx
+++ b/packages/plexus/src/Digraph/SvgLayer.test.jsx
@@ -10,7 +10,7 @@ import SvgLayer from './SvgLayer';
 // Use React.createElement instead of JSX, because jest.mock factory functions cannot reference external variables
 vi.mock('./SvgDefEntry', () => {
   const React = require('react');
-  const MockSvgDefEntry = ({ localId, getClassName }) =>
+  const MockSvgDefEntry = ({ localId, getClassName: _getClassName }) =>
     React.createElement('marker', { id: localId, 'data-testid': `def-${localId}` });
   return { default: MockSvgDefEntry };
 });
@@ -42,7 +42,7 @@ describe('SvgLayer', () => {
   };
 
   // Helper to render inside SVG context
-  const renderSvgLayer = (props, options = {}) => {
+  const renderSvgLayer = (props, _options = {}) => {
     const mergedProps = { ...defaultProps, ...props };
     // If standalone or topLayer, component renders its own svg
     if (mergedProps.standalone || mergedProps.topLayer) {
@@ -76,7 +76,7 @@ describe('SvgLayer', () => {
 
   describe('container props', () => {
     it('merges custom props from setOnContainer', () => {
-      const setOnContainer = graphState => ({
+      const setOnContainer = _graphState => ({
         'data-custom': 'value',
       });
       const { container } = renderSvgLayer({ setOnContainer });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,6 +166,9 @@ export default defineConfig({
       {
         files: ['**/*.{js,jsx}'],
         rules: {
+          // JS/JSX files are not checked by tsc, so lint rules are the only safety net here.
+          // Rules that cannot be enforced cleanly are listed below with an explanation.
+          //
           // no-shadow is off because vi.mock() factory functions must re-require('react')
           // inside the factory (factories cannot close over outer variables), which
           // unavoidably shadows the top-level React import.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,9 @@ export default defineConfig({
       '**/demo/**',
       'packages/jaeger-ui/src/api/v3/generated-client.ts',
       '**/*.cjs',
+      // Example config file: injected as a browser script or run in a vm sandbox,
+      // neither of which has CommonJS module; UIConfig is a global, not an export.
+      'packages/jaeger-ui/jaeger-ui.config.console-analytics.js',
     ],
     rules: {
       'constructor-super': 'error',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -168,10 +168,12 @@ export default defineConfig({
         rules: {
           // JavaScript/JSX files: disable rules that tsc enforces for .ts files.
           // no-unused-vars is enabled here because tsc does not check .js files.
-          'no-redeclare': 'off',
+          //
+          // no-shadow stays off: vi.mock() factory functions cannot close over outer
+          // variables, so tests legitimately re-require('react') inside the factory,
+          // which shadows the top-level import. There is no clean fix short of
+          // per-site eslint-disable comments.
           'no-shadow': 'off',
-          'no-use-before-define': 'off',
-          'no-useless-constructor': 'off',
         },
       },
     ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -163,9 +163,8 @@ export default defineConfig({
       {
         files: ['**/*.{js,jsx}'],
         rules: {
-          // JavaScript/JSX files: fully disable rules that TypeScript handles for .ts files.
-          // This override applies to all matched JS/JSX files in the repo, which tsc does not check.
-          'no-unused-vars': 'off',
+          // JavaScript/JSX files: disable rules that tsc enforces for .ts files.
+          // no-unused-vars is enabled here because tsc does not check .js files.
           'no-redeclare': 'off',
           'no-shadow': 'off',
           'no-use-before-define': 'off',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,13 +166,9 @@ export default defineConfig({
       {
         files: ['**/*.{js,jsx}'],
         rules: {
-          // JavaScript/JSX files: disable rules that tsc enforces for .ts files.
-          // no-unused-vars is enabled here because tsc does not check .js files.
-          //
-          // no-shadow stays off: vi.mock() factory functions cannot close over outer
-          // variables, so tests legitimately re-require('react') inside the factory,
-          // which shadows the top-level import. There is no clean fix short of
-          // per-site eslint-disable comments.
+          // no-shadow is off because vi.mock() factory functions must re-require('react')
+          // inside the factory (factories cannot close over outer variables), which
+          // unavoidably shadows the top-level React import.
           'no-shadow': 'off',
         },
       },


### PR DESCRIPTION
## Summary

JS/JSX files had five lint rules blanket-disabled since #3748 with the comment "tsc doesn't check .js files". That's true, but it meant unused imports, dead code, and other issues in test files went completely undetected. This PR re-enables all rules that can be enforced cleanly and clears the violations.

**Rules now enabled for `*.{js,jsx}`:**
- `no-unused-vars` — 46 violations cleared across 28 files
- `no-redeclare`, `no-use-before-define`, `no-useless-constructor` — zero violations, free to enable

**Rule kept off:**
- `no-shadow` — `vi.mock()` factory functions cannot close over outer variables, so tests must `require('react')` inside the factory, shadowing the top-level import. No clean fix without per-site eslint-disable comments.

**Violation cleanup buckets** (same as the TS cleanup in #3753):
- Removed unused imports (`screen`, `within`, `waitFor`, `traceGenerator`, `SpanTreeOffset`, `OtelSpanFacade`, `CHANGE_SERVICE_ACTION_TYPE`, and others)
- Removed unused local variables, dead functions, and unreferenced assignments
- Removed unused callback/function parameters; prefixed intentionally-discarded destructuring aliases with `_unused`
- Collapsed empty `catch (e) {}` bindings to bare `catch {}`
- Excluded `jaeger-ui.config.console-analytics.js` from the linter — it is injected as a browser script or run in a `vm` sandbox, neither of which has CommonJS `module`; `UIConfig` is accessed as a global, not via an export

## Test plan

- [x] `npm run fmt` — passes
- [x] `npm run lint` — 0 errors (only pre-existing `no-explicit-any` warnings)
- [x] `npm test` — 3281 tests pass (261 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)