### PR TITLE
fix(dev): Exclude react-icons/tb from Vite dep optimizer

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -30,6 +30,8 @@ jobs:
         run: npm run depcheck
       - run: npm run lint
       - run: npm run build
+      - name: Verify dev server starts without errors
+        run: npm run dev:check
       - name: Ensure PR is not on main branch
         uses: jaegertracing/jaeger/.github/actions/block-pr-from-main-branch@main
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test": "npm run --workspaces test --",
     "tsc-lint": "tsc -p packages/jaeger-ui/tsconfig.json && tsc -p packages/plexus/tsconfig.json",
     "tsc-lint-debug": "tsc -p packages/jaeger-ui/tsconfig.json --listFiles && tsc -p packages/plexus/tsconfig.json --listFiles",
+    "dev:check": "./scripts/check-dev-server.sh",
     "start": "cd packages/jaeger-ui && npm run start",
     "update-snapshots": "cd packages/jaeger-ui && npm test -- -u"
   },

--- a/packages/jaeger-ui/vite.config.mts
+++ b/packages/jaeger-ui/vite.config.mts
@@ -273,6 +273,12 @@ export default defineConfig({
       ],
     },
   },
+  optimizeDeps: {
+    // react-icons/tb is a 4400+ icon barrel. Vite 8 / Rolldown pre-bundles it
+    // into a single 4 MB file that Rolldown's import-analysis parser can't handle.
+    // Exclude it so Vite serves the ESM entry directly without pre-bundling.
+    exclude: ['react-icons/tb'],
+  },
   base: './',
   build: {
     outDir: 'build',

--- a/scripts/check-dev-server.sh
+++ b/scripts/check-dev-server.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Jaeger Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that the Vite dev server starts without errors.
+# Catches regressions (e.g. dep-optimizer failures) that survive `npm run build`.
+# Exits non-zero if the server emits a pre-transform or internal server error.
+set -euo pipefail
+
+PORT=15173
+LOG=$(mktemp)
+SERVER_PID=""
+
+cleanup() {
+  [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null || true
+  rm -f "$LOG"
+}
+trap cleanup EXIT INT TERM
+
+echo "Starting Vite dev server on port $PORT..."
+(cd packages/jaeger-ui && npm run start -- --port "$PORT") >"$LOG" 2>&1 &
+SERVER_PID=$!
+
+# Wait up to 30s for the "ready in" banner
+READY=0
+for _ in $(seq 1 30); do
+  if grep -q "ready in" "$LOG"; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "❌ Dev server process exited unexpectedly"
+    cat "$LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ $READY -eq 0 ]]; then
+  echo "❌ Dev server did not print 'ready in' within 30 seconds"
+  cat "$LOG"
+  exit 1
+fi
+
+# Give the server's warmup time to run (warmup.clientFiles triggers
+# dep-optimization eagerly, so errors surface within a few seconds of startup).
+sleep 8
+
+if grep -qE "Pre-transform error|Internal server error" "$LOG"; then
+  echo "❌ Dev server emitted errors after startup:"
+  grep -E "Pre-transform error|Internal server error" "$LOG"
+  exit 1
+fi
+
+echo "✅ Dev server started and warmed up without errors"


### PR DESCRIPTION
## Summary

- `react-icons/tb` contains 4400+ icons; Vite 8 / Rolldown 1.1.x pre-bundles the entire barrel into a single 4 MB file and then fails to run import analysis on it (`Pre-transform error: Failed to parse source for import analysis`). The `warmup.clientFiles` config triggers this immediately on startup since the TracePage imports two icons from that barrel (`TbArrowMerge`, `TbColumns2`).
- Fix: add `optimizeDeps.exclude: ['react-icons/tb']` so Vite skips pre-bundling the barrel and serves the ESM entry directly from `node_modules`. Only two icons are used, so there is no functional impact.
- Add `scripts/check-dev-server.sh` (exposed as `npm run dev:check`) and a corresponding CI step in `lint-build.yml`. The script starts the dev server, waits for the warmup to run, then exits non-zero if any `Pre-transform error` / `Internal server error` lines appear in the log — catching this class of regression without requiring a browser.

## Test plan

- [x] `npm start` starts cleanly with no pre-transform errors
- [x] `npm run dev:check` exits 0
- [x] `npm run build`, `npm run lint`, `npm test` all pass