### PR TITLE
feat(search): Add absolute/relative toggle for table start time

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -6,7 +6,6 @@ import { Col, Divider, Row, Tag, Tooltip } from 'antd';
 import { Link } from 'react-router-dom';
 
 import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
 
 import { IoWarning } from 'react-icons/io5';
 
@@ -14,15 +13,13 @@ import { trackConversions, EAltViewActions } from './index.track';
 import * as markers from './ResultItem.markers';
 import ResultItemTitle from './ResultItemTitle';
 import ServicePills from './ServicePills';
-import { formatRelativeDate } from '../../../utils/date';
+import { formatRelativeDate, formatRelativeTime } from '../../../utils/date';
 import { getIncompleteTraceTooltip } from '../../../model/trace-viewer';
 
 import type { TraceSummary } from '../../../types/trace-summary';
 import type { TracePageLink } from '../../TracePage/url';
 
 import './ResultItem.css';
-
-dayjs.extend(relativeTime);
 
 type Props = {
   durationPercent: number;
@@ -56,9 +53,8 @@ export default function ResultItem({
     orphanSpanCount,
   } = traceSummary;
 
-  const startTimeDayjs = dayjs(startTime / 1000);
-  const timeStr = startTimeDayjs.format('h:mm:ss a');
-  const fromNow = startTimeDayjs.fromNow();
+  const timeStr = dayjs(startTime / 1000).format('h:mm:ss a');
+  const fromNow = formatRelativeTime(startTime);
 
   return (
     <div className="ResultItem" onClick={trackTraceConversions} role="button">

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.test.tsx
@@ -10,6 +10,8 @@ import * as orderBy from '../../../model/order-by';
 import type { OrderBy } from '../../../model/order-by';
 import { toOrderBy, fromOrderBy } from '../../../model/search';
 import type { Microseconds } from '../../../types/units';
+import { useSearchResultsStore } from '../store.search-results';
+import { formatDatetime } from '../../../utils/date';
 
 const FIXED_START_TIME = 1700000000000000 as Microseconds;
 
@@ -42,6 +44,8 @@ const defaultProps = {
 describe('TraceTable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    useSearchResultsStore.setState({ startTimeDisplay: 'absolute' });
   });
 
   it('renders correct row count for a 5-trace fixture', () => {
@@ -134,6 +138,55 @@ describe('TraceTable', () => {
       </MemoryRouter>
     );
     expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});
+
+describe('Start Time display toggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSearchResultsStore.setState({ startTimeDisplay: 'absolute' });
+  });
+
+  it('renders absolute formatted time by default', () => {
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} />
+      </MemoryRouter>
+    );
+    expect(screen.getAllByText(formatDatetime(FIXED_START_TIME))).toHaveLength(mockTraces.length);
+  });
+
+  it('switches to relative time when the header toggle is clicked', () => {
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle start time format' }));
+    expect(screen.queryByText(formatDatetime(FIXED_START_TIME))).not.toBeInTheDocument();
+    expect(useSearchResultsStore.getState().startTimeDisplay).toBe('relative');
+  });
+
+  it('clicking the toggle does not trigger column sorting', () => {
+    const handleSortChange = vi.fn();
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} handleSortChange={handleSortChange} />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle start time format' }));
+    expect(handleSortChange).not.toHaveBeenCalled();
+  });
+
+  it('persists the preference to localStorage', () => {
+    render(
+      <MemoryRouter>
+        <TraceTable {...defaultProps} />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle start time format' }));
+    const stored = JSON.parse(localStorage.getItem('jaeger.search-results.mode') ?? '{}');
+    expect(stored.state.startTimeDisplay).toBe('relative');
   });
 });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/TraceTable.tsx
@@ -4,19 +4,26 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Checkbox, Table, Tag, Tooltip } from 'antd';
+import { Button, Checkbox, Table, Tag, Tooltip } from 'antd';
 import type { ColumnsType, TableProps } from 'antd/es/table';
 import type { SorterResult, SortOrder } from 'antd/es/table/interface';
 import Overflow from '@rc-component/overflow';
 import _sortBy from 'lodash/sortBy';
+import { IoSwapHorizontalOutline } from 'react-icons/io5';
 import { TraceSummary } from '../../../types/trace-summary';
-import { formatDuration, formatDurationCompact, formatDatetime } from '../../../utils/date';
+import {
+  formatDuration,
+  formatDurationCompact,
+  formatDatetime,
+  formatRelativeTime,
+} from '../../../utils/date';
 import RelativeBar from '../../common/RelativeBar';
 import { toOrderBy, fromOrderBy } from '../../../model/search';
 import type { SortableColumnKey, SortDirection } from '../../../model/search';
 import type { OrderBy } from '../../../model/order-by';
 import type { TracePageLink } from '../../TracePage/url';
 import { ServicePill, type ServiceEntry } from './ServicePills';
+import { useSearchResultsStore } from '../store.search-results';
 
 const BOTH_DIRECTIONS: SortOrder[] = ['ascend', 'descend'];
 
@@ -71,6 +78,8 @@ export default function TraceTable({
 }: TraceTableProps) {
   const navigate = useNavigate();
   const { key: sortKey, order: sortOrder } = fromOrderBy(sortBy);
+  const startTimeDisplay = useSearchResultsStore(s => s.startTimeDisplay);
+  const setStartTimeDisplay = useSearchResultsStore(s => s.setStartTimeDisplay);
 
   // Hide columns when no summary in the result set supports them.
   // A backend that omits errorSpanCount/spanCount leaves those fields undefined;
@@ -180,11 +189,28 @@ export default function TraceTable({
         sortDirections: BOTH_DIRECTIONS,
       },
       {
-        title: 'Start Time',
+        title: (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            Start Time
+            <Tooltip title={startTimeDisplay === 'absolute' ? 'Show relative time' : 'Show absolute time'}>
+              <Button
+                type="text"
+                size="small"
+                icon={<IoSwapHorizontalOutline />}
+                aria-label="Toggle start time format"
+                onClick={e => {
+                  e.stopPropagation();
+                  setStartTimeDisplay(startTimeDisplay === 'absolute' ? 'relative' : 'absolute');
+                }}
+              />
+            </Tooltip>
+          </span>
+        ),
         key: 'startTime',
         onCell: () => ({ style: { overflow: 'hidden' } }),
         render: (_: unknown, trace: TraceSummary) => {
           const formatted = formatDatetime(trace.startTime);
+          const displayed = startTimeDisplay === 'relative' ? formatRelativeTime(trace.startTime) : formatted;
           return (
             <Tooltip title={formatted}>
               <span
@@ -197,13 +223,12 @@ export default function TraceTable({
                   display: 'block',
                 }}
               >
-                {formatted}
+                {displayed}
               </span>
             </Tooltip>
           );
         },
         sorter: true,
-
         sortOrder: sortKey === 'startTime' ? sortOrder : undefined,
         sortDirections: BOTH_DIRECTIONS,
       },
@@ -243,6 +268,8 @@ export default function TraceTable({
     toggleComparison,
     showServicesColumn,
     showErrorsColumn,
+    startTimeDisplay,
+    setStartTimeDisplay,
   ]);
 
   const onChange: TableProps<TraceSummary>['onChange'] = (_pagination, _filters, sorter) => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.test.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.test.ts
@@ -1,17 +1,28 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useSearchResultsStore } from './store.search-results';
+
+// Exercises the store's real initial state via a fresh module import, rather than
+// asserting against a value the test itself set up — the singleton store created at
+// module load time is shared (and mutated) across the other tests in this file.
+describe('useSearchResultsStore — default state', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('defaults startTimeDisplay to absolute on a fresh store', async () => {
+    const { useSearchResultsStore: freshStore } = await import('./store.search-results');
+    expect(freshStore.getState().startTimeDisplay).toBe('absolute');
+  });
+});
 
 describe('useSearchResultsStore', () => {
   beforeEach(() => {
     localStorage.clear();
     useSearchResultsStore.setState({ viewMode: 'table', startTimeDisplay: 'absolute' });
-  });
-
-  it('defaults startTimeDisplay to absolute', () => {
-    expect(useSearchResultsStore.getState().startTimeDisplay).toBe('absolute');
   });
 
   it('setStartTimeDisplay updates startTimeDisplay', () => {

--- a/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.test.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSearchResultsStore } from './store.search-results';
+
+describe('useSearchResultsStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSearchResultsStore.setState({ viewMode: 'table', startTimeDisplay: 'absolute' });
+  });
+
+  it('defaults startTimeDisplay to absolute', () => {
+    expect(useSearchResultsStore.getState().startTimeDisplay).toBe('absolute');
+  });
+
+  it('setStartTimeDisplay updates startTimeDisplay', () => {
+    useSearchResultsStore.getState().setStartTimeDisplay('relative');
+    expect(useSearchResultsStore.getState().startTimeDisplay).toBe('relative');
+  });
+
+  it('setStartTimeDisplay persists to localStorage', () => {
+    useSearchResultsStore.getState().setStartTimeDisplay('relative');
+    const stored = JSON.parse(localStorage.getItem('jaeger.search-results.mode') ?? '{}');
+    expect(stored.state.startTimeDisplay).toBe('relative');
+  });
+
+  it('persists startTimeDisplay independently of viewMode', () => {
+    useSearchResultsStore.getState().setViewMode('list');
+    useSearchResultsStore.getState().setStartTimeDisplay('relative');
+    const stored = JSON.parse(localStorage.getItem('jaeger.search-results.mode') ?? '{}');
+    expect(stored.state.viewMode).toBe('list');
+    expect(stored.state.startTimeDisplay).toBe('relative');
+  });
+});

--- a/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/store.search-results.ts
@@ -4,9 +4,13 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+type StartTimeDisplay = 'absolute' | 'relative';
+
 type SearchResultsStore = {
   viewMode: 'list' | 'table';
   setViewMode: (mode: 'list' | 'table') => void;
+  startTimeDisplay: StartTimeDisplay;
+  setStartTimeDisplay: (display: StartTimeDisplay) => void;
 };
 
 export const useSearchResultsStore = create<SearchResultsStore>()(
@@ -14,6 +18,8 @@ export const useSearchResultsStore = create<SearchResultsStore>()(
     set => ({
       viewMode: 'table',
       setViewMode: mode => set({ viewMode: mode }),
+      startTimeDisplay: 'absolute',
+      setStartTimeDisplay: display => set({ startTimeDisplay: display }),
     }),
     { name: 'jaeger.search-results.mode' }
   )

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -5,11 +5,13 @@ import dayjs, { ConfigType } from 'dayjs';
 import _dropWhile from 'lodash/dropWhile';
 import _round from 'lodash/round';
 import _duration, { DurationUnitType } from 'dayjs/plugin/duration';
+import _relativeTime from 'dayjs/plugin/relativeTime';
 
 import { toFloatPrecision } from './number';
 import { Microseconds } from '../types/units';
 
 dayjs.extend(_duration);
+dayjs.extend(_relativeTime);
 
 const TODAY = 'Today';
 const YESTERDAY = 'Yesterday';
@@ -101,6 +103,19 @@ export function formatTime(duration: number): string {
  */
 export function formatDatetime(duration: number): string {
   return dayjs(duration / ONE_MILLISECOND).format(STANDARD_DATETIME_FORMAT);
+}
+
+/**
+ * @param {number} duration - Unix Time
+ * @return {string} relative, human-readable time string
+ *
+ * @example
+ * ```
+ * formatRelativeTime(Date.now() * 1000) // => 'a few seconds ago'
+ * ```
+ */
+export function formatRelativeTime(duration: number): string {
+  return dayjs(duration / ONE_MILLISECOND).fromNow();
 }
 
 /**

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -106,8 +106,8 @@ export function formatDatetime(duration: number): string {
 }
 
 /**
- * @param {number} duration - Unix Time
- * @return {string} relative, human-readable time string
+ * @param duration - Unix timestamp in microseconds
+ * @return relative, human-readable time string
  *
  * @example
  * ```

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -114,7 +114,7 @@ export function formatDatetime(duration: number): string {
  * formatRelativeTime(Date.now() * 1000) // => 'a few seconds ago'
  * ```
  */
-export function formatRelativeTime(duration: number): string {
+export function formatRelativeTime(duration: Microseconds): string {
   return dayjs(duration / ONE_MILLISECOND).fromNow();
 }
 


### PR DESCRIPTION
## Summary
- The table view's "Start Time" column always showed a dense absolute timestamp (e.g. "June 30 2026, 15:11:30.891"), unlike the list view's more scannable relative "x ago" display.
- Add a small swap-icon toggle in the "Start Time" column header to switch between absolute (default) and relative display. The icon has its own click handler with `stopPropagation`, so the rest of the header still triggers sorting as before.
- The preference is persisted via the existing `useSearchResultsStore` zustand store (same `jaeger.search-results.mode` localStorage key used for the list/table view-mode toggle), so it survives reloads.
- Absolute time stays the default since this is a debugging tool where timestamps usually need to be correlated against other absolute-time systems (logs, alerts); relative time remains opt-in for quick scans.

## Test plan
- [x] `npm run fmt`
- [x] `npm run lint`
- [x] `npm test` (3289+ tests, including new coverage for the toggle and its persistence)
- [x] `npm run build`