### PR TITLE
Feat/genai warning indicators

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -3,6 +3,15 @@
 
 import { JaegerClient, jaegerClient } from './client';
 import { ZodError } from 'zod';
+import getConfig from '../../utils/config/get-config';
+
+vi.mock('../../utils/config/get-config', () => ({
+  default: vi.fn(() => ({
+    api: {
+      requestTimeoutMs: 10000,
+    },
+  })),
+}));
 
 describe('JaegerClient', () => {
   let client: JaegerClient;
@@ -11,6 +20,11 @@ describe('JaegerClient', () => {
 
   beforeEach(() => {
     client = new JaegerClient();
+    vi.mocked(getConfig).mockReturnValue({
+      api: {
+        requestTimeoutMs: 10000,
+      },
+    } as ReturnType<typeof getConfig>);
     originalFetch = globalThis.fetch;
     mockFetch = vi.fn();
     (global as any).fetch = mockFetch;
@@ -216,6 +230,32 @@ describe('JaegerClient', () => {
       vi.advanceTimersByTime(10000);
 
       await expect(promise).rejects.toThrow('Request timeout after 10000ms');
+    });
+
+    it('uses configured timeout from UI config', async () => {
+      vi.mocked(getConfig).mockReturnValue({
+        api: {
+          requestTimeoutMs: 30000,
+        },
+      } as ReturnType<typeof getConfig>);
+
+      mockFetch.mockImplementation((url: string, options?: { signal?: AbortSignal }) => {
+        return new Promise((resolve, reject) => {
+          if (options?.signal) {
+            options.signal.addEventListener('abort', () => {
+              const abortError = new Error('The operation was aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
+          }
+        });
+      });
+
+      const promise = client.fetchServices();
+
+      vi.advanceTimersByTime(30000);
+
+      await expect(promise).rejects.toThrow('Request timeout after 30000ms');
     });
 
     it('clears timeout after successful request', async () => {

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -103,6 +103,7 @@ export class JaegerClient {
         name: svc.name ?? '',
         spanCount: svc.spanCount,
         errorSpanCount: svc.errorSpanCount,
+        warningSpanCount: svc.warningSpanCount,
       }));
       return {
         traceID: s.traceId,
@@ -116,6 +117,7 @@ export class JaegerClient {
         duration: Number((endNs - startNs) / 1000n) as Microseconds,
         spanCount: s.spanCount,
         errorSpanCount: s.errorSpanCount,
+        warningSpanCount: s.warningSpanCount,
         orphanSpanCount: s.orphanSpanCount,
         services,
       };
@@ -129,7 +131,10 @@ export class JaegerClient {
    * @returns Promise<Response>
    * @throws Error if request times out or network error occurs
    */
-  private async fetchWithTimeout(url: string, timeout = getConfig().api.requestTimeoutMs): Promise<Response> {
+  private async fetchWithTimeout(
+    url: string,
+    timeout = getConfig().api.requestTimeoutMs ?? 10000
+  ): Promise<Response> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout);
 

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -131,10 +131,7 @@ export class JaegerClient {
    * @returns Promise<Response>
    * @throws Error if request times out or network error occurs
    */
-  private async fetchWithTimeout(
-    url: string,
-    timeout = getConfig().api.requestTimeoutMs ?? 10000
-  ): Promise<Response> {
+  private async fetchWithTimeout(url: string, timeout = getConfig().api.requestTimeoutMs): Promise<Response> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout);
 

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -9,6 +9,7 @@
  */
 
 import prefixUrl from '../../utils/prefix-url';
+import getConfig from '../../utils/config/get-config';
 import { ServicesResponseSchema, OperationsResponseSchema, TraceSummariesResponseSchema } from './schemas';
 import type { SearchQuery } from '../../types/search';
 import type { TraceSummary, ServiceSummary } from '../../types/trace-summary';
@@ -124,11 +125,11 @@ export class JaegerClient {
   /**
    * Fetch with timeout support using AbortController.
    * @param url - The URL to fetch
-   * @param timeout - Timeout in milliseconds (default: 10 seconds)
+   * @param timeout - Timeout in milliseconds (defaults to the configured request timeout)
    * @returns Promise<Response>
    * @throws Error if request times out or network error occurs
    */
-  private async fetchWithTimeout(url: string, timeout = 10000): Promise<Response> {
+  private async fetchWithTimeout(url: string, timeout = getConfig().api.requestTimeoutMs): Promise<Response> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout);
 

--- a/packages/jaeger-ui/src/api/v3/schemas.ts
+++ b/packages/jaeger-ui/src/api/v3/schemas.ts
@@ -39,6 +39,7 @@ const permissiveServiceSummary = z.object({
   name: z.string(),
   spanCount: z.number().int().min(0).optional(),
   errorSpanCount: z.number().int().min(0).optional(),
+  warningSpanCount: z.number().int().min(0).optional(),
 });
 
 // Enrich the generated TraceSummary schema with format constraints and wire-name
@@ -65,6 +66,7 @@ const normalizeTraceId = z.preprocess(
     // Counts must be nonnegative when present; client.ts applies 0 fallbacks.
     spanCount: z.number().int().min(0).optional(),
     errorSpanCount: z.number().int().min(0).optional(),
+    warningSpanCount: z.number().int().min(0).optional(),
     orphanSpanCount: z.number().int().min(0).optional(),
     services: z.array(permissiveServiceSummary).optional(),
   })

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.test.jsx
@@ -95,6 +95,26 @@ it('<ResultItem /> should render error icon on ServiceTags that have an error sp
   expect(errorTag.querySelector('.ServicePills--errorIcon')).toBeInTheDocument();
 });
 
+it('<ResultItem /> should render warning badge when warningSpanCount > 0', () => {
+  const summaryWithWarning = {
+    ...traceSummary,
+    warningSpanCount: 2,
+  };
+
+  renderWithRouter(
+    <ResultItem
+      traceSummary={summaryWithWarning}
+      durationPercent={50}
+      linkTo={{ pathname: '/' }}
+      toggleComparison={() => {}}
+      isInDiffCohort={false}
+      disableComparision={false}
+    />
+  );
+
+  expect(screen.getByText('2 Warnings')).toBeInTheDocument();
+});
+
 it('passes router state to destination route when linkTo is a TracePageLink', async () => {
   function Destination() {
     const location = useLocation();

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchResults/ResultItem.tsx
@@ -53,6 +53,7 @@ export default function ResultItem({
     traceID,
     spanCount,
     errorSpanCount,
+    warningSpanCount,
     orphanSpanCount,
   } = traceSummary;
 
@@ -83,6 +84,11 @@ export default function ResultItem({
             {Boolean(errorSpanCount) && (
               <Tag className="ub-m1" color="red" variant="outlined">
                 {errorSpanCount} Error{(errorSpanCount ?? 0) > 1 && 's'}
+              </Tag>
+            )}
+            {Boolean(warningSpanCount) && (
+              <Tag className="ub-m1" color="warning" variant="outlined">
+                {warningSpanCount} Warning{(warningSpanCount ?? 0) > 1 && 's'}
               </Tag>
             )}
             {Boolean(orphanSpanCount) && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -194,6 +194,24 @@ SPDX-License-Identifier: Apache-2.0
   /* Adjust padding since border adds 1.5px */
 }
 
+.SpanBarRow--warningIcon {
+  background: var(--feedback-warning);
+  border-radius: 6.5px;
+  color: var(--text-inverse);
+  font-size: 0.85em;
+  margin-right: 0.25rem;
+  padding: 1px;
+}
+
+/* Hollow variant for bubbled warnings from collapsed children */
+.SpanBarRow--warningIcon--hollow {
+  background: transparent;
+  border: 1.5px solid var(--feedback-warning);
+  color: var(--feedback-warning);
+  font-weight: bold;
+  padding: 0px;
+}
+
 .SpanBarRow--rpcColorMarker {
   border-radius: 6.5px;
   display: inline-block;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback } from 'react';
-import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
+import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward, IoWarning } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
 import { formatDurationCompact, ViewedBoundsFunctionType } from './utils';
@@ -48,6 +48,8 @@ type SpanBarRowProps = {
     | TNil;
   hasOwnError: boolean;
   hasChildError: boolean;
+  hasOwnWarning: boolean;
+  hasChildWarning: boolean;
   getViewedBounds: ViewedBoundsFunctionType;
   traceStartTime: number;
   span: IOtelSpan;
@@ -79,6 +81,8 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   noInstrumentedServer,
   hasOwnError,
   hasChildError,
+  hasOwnWarning,
+  hasChildWarning,
   getViewedBounds,
   traceStartTime,
   span,
@@ -168,6 +172,10 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               {hasOwnError && <IoAlert className="SpanBarRow--errorIcon" />}
               {!hasOwnError && hasChildError && (
                 <IoAlert className="SpanBarRow--errorIcon SpanBarRow--errorIcon--hollow" />
+              )}
+              {hasOwnWarning && !hasOwnError && <IoWarning className="SpanBarRow--warningIcon" />}
+              {!hasOwnWarning && hasChildWarning && !hasOwnError && !hasChildError && (
+                <IoWarning className="SpanBarRow--warningIcon SpanBarRow--warningIcon--hollow" />
               )}
               {serviceName}{' '}
               {rpc && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -25,6 +25,8 @@ import {
   isKindClient,
   isKindProducer,
   spanContainsErredSpan,
+  hasGenAIWarning,
+  spanContainsWarningSpan,
 } from './utils';
 import { Accessors } from '../ScrollManager';
 import { parseUiFind, TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
@@ -366,6 +368,8 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
       const isSelected = selectedSpanID === spanID;
       const hasOwnError = isErrorSpan(span);
       const hasChildError = isCollapsed && spanContainsErredSpan(spans, spanIndex);
+      const hasOwnWarning = hasGenAIWarning(span);
+      const hasChildWarning = isCollapsed && spanContainsWarningSpan(spans, spanIndex);
       const hasPrunedChildren =
         prunedServices.size > 0 &&
         span.childSpans.some(child => prunedServices.has(child.resource.serviceName));
@@ -415,6 +419,8 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
             noInstrumentedServer={noInstrumentedServer}
             hasOwnError={hasOwnError}
             hasChildError={hasChildError}
+            hasOwnWarning={hasOwnWarning}
+            hasChildWarning={hasChildWarning}
             getViewedBounds={getViewedBounds()}
             traceStartTime={trace.startTime}
             span={span}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -25,9 +25,9 @@ import {
   isKindClient,
   isKindProducer,
   spanContainsErredSpan,
-  hasGenAIWarning,
   spanContainsWarningSpan,
 } from './utils';
+import { hasGenAIWarning } from '../../../utils/genai';
 import { Accessors } from '../ScrollManager';
 import { parseUiFind, TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
 import getLinks from '../../../model/link-patterns';
@@ -368,8 +368,9 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
       const isSelected = selectedSpanID === spanID;
       const hasOwnError = isErrorSpan(span);
       const hasChildError = isCollapsed && spanContainsErredSpan(spans, spanIndex);
-      const hasOwnWarning = hasGenAIWarning(span);
-      const hasChildWarning = isCollapsed && spanContainsWarningSpan(spans, spanIndex);
+      const hasOwnWarning = !hasOwnError && hasGenAIWarning(span);
+      const hasChildWarning =
+        isCollapsed && !hasOwnError && !hasChildError && spanContainsWarningSpan(spans, spanIndex);
       const hasPrunedChildren =
         prunedServices.size > 0 &&
         span.childSpans.some(child => prunedServices.has(child.resource.serviceName));

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
@@ -6,12 +6,12 @@ import {
   createViewedBoundsFunc,
   isErrorSpan,
   spanContainsErredSpan,
-  hasGenAIWarning,
   spanContainsWarningSpan,
   isKindClient,
   isKindProducer,
 } from './utils';
 import { ATTR_GEN_AI_RESPONSE_FINISH_REASONS } from '@opentelemetry/semantic-conventions/incubating';
+import { hasGenAIWarning } from '../../../utils/genai';
 
 import traceGenerator from '../../../demo/trace-generators';
 import { SpanKind, StatusCode } from '../../../types/otel';

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.test.js
@@ -6,9 +6,12 @@ import {
   createViewedBoundsFunc,
   isErrorSpan,
   spanContainsErredSpan,
+  hasGenAIWarning,
+  spanContainsWarningSpan,
   isKindClient,
   isKindProducer,
 } from './utils';
+import { ATTR_GEN_AI_RESPONSE_FINISH_REASONS } from '@opentelemetry/semantic-conventions/incubating';
 
 import traceGenerator from '../../../demo/trace-generators';
 import { SpanKind, StatusCode } from '../../../types/otel';
@@ -101,6 +104,65 @@ describe('TraceTimelineViewer/utils', () => {
         // include the index in the expect condition to know which span failed
         // (if there is a failure, that is)
         const result = [i, spanContainsErredSpan(spans, i)];
+        expect(result).toEqual([i, target]);
+      });
+    });
+  });
+
+  describe('hasGenAIWarning()', () => {
+    it('returns true when finish_reasons contains content_filter', () => {
+      const span = {
+        attributes: [{ key: ATTR_GEN_AI_RESPONSE_FINISH_REASONS, value: 'content_filter' }],
+      };
+      expect(hasGenAIWarning(span)).toBe(true);
+    });
+
+    it('returns true when finish_reasons array contains length', () => {
+      const span = {
+        attributes: [{ key: ATTR_GEN_AI_RESPONSE_FINISH_REASONS, value: ['stop', 'length'] }],
+      };
+      expect(hasGenAIWarning(span)).toBe(true);
+    });
+
+    it('returns false when finish_reasons does not contain warning reasons', () => {
+      const span = {
+        attributes: [{ key: ATTR_GEN_AI_RESPONSE_FINISH_REASONS, value: 'stop' }],
+      };
+      expect(hasGenAIWarning(span)).toBe(false);
+    });
+
+    it('returns false when finish_reasons attribute is missing', () => {
+      const span = { attributes: [] };
+      expect(hasGenAIWarning(span)).toBe(false);
+    });
+  });
+
+  describe('spanContainsWarningSpan()', () => {
+    it('returns true only when a descendant has a warning status', () => {
+      const config = `
+        1   0
+        1     0
+        0       1
+        0     0
+        1     0
+        1       1
+        0         1
+        0           0
+        1         0
+        0           1
+        0   0
+      `
+        .trim()
+        .split('\n')
+        .map(s => s.trim());
+      const expectations = config.map(s => Boolean(Number(s[0])));
+      const spans = config.map(line => ({
+        depth: line.length,
+        attributes: +line.slice(-1) ? [{ key: ATTR_GEN_AI_RESPONSE_FINISH_REASONS, value: 'length' }] : [],
+      }));
+
+      expectations.forEach((target, i) => {
+        const result = [i, spanContainsWarningSpan(spans, i)];
         expect(result).toEqual([i, target]);
       });
     });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { IOtelSpan, SpanKind, StatusCode } from '../../../types/otel';
+import { ATTR_GEN_AI_RESPONSE_FINISH_REASONS } from '@opentelemetry/semantic-conventions/incubating';
 
 export type ViewedBoundsFunctionType = (start: number, end: number) => { start: number; end: number };
 /**
@@ -68,6 +69,38 @@ export function spanContainsErredSpan(spans: ReadonlyArray<IOtelSpan>, parentSpa
   let i = parentSpanIndex + 1;
   for (; i < spans.length && spans[i].depth > depth; i++) {
     if (isErrorSpan(spans[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns `true` if the span has a GenAI warning.
+ *
+ * @param  {IOtelSpan} span  The OTEL span to check.
+ * @return {boolean}         True if the span has a GenAI warning.
+ */
+export function hasGenAIWarning(span: IOtelSpan): boolean {
+  const attr = span.attributes.find(a => a.key === ATTR_GEN_AI_RESPONSE_FINISH_REASONS);
+  if (!attr) return false;
+  const reasons = Array.isArray(attr.value) ? attr.value : [attr.value];
+  return reasons.some(r => r === 'content_filter' || r === 'length');
+}
+
+/**
+ * Returns `true` if at least one of the descendants of the `parentSpanIndex`
+ * span contains a GenAI warning.
+ *
+ * @param      {IOtelSpan[]}  spans            The OTEL spans for a trace.
+ * @param      {number}       parentSpanIndex  The index of the parent span.
+ * @return     {boolean}      Returns `true` if a descendant contains a GenAI warning.
+ */
+export function spanContainsWarningSpan(spans: ReadonlyArray<IOtelSpan>, parentSpanIndex: number): boolean {
+  const { depth } = spans[parentSpanIndex];
+  let i = parentSpanIndex + 1;
+  for (; i < spans.length && spans[i].depth > depth; i++) {
+    if (hasGenAIWarning(spans[i])) {
       return true;
     }
   }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/utils.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { IOtelSpan, SpanKind, StatusCode } from '../../../types/otel';
-import { ATTR_GEN_AI_RESPONSE_FINISH_REASONS } from '@opentelemetry/semantic-conventions/incubating';
-
+import { hasGenAIWarning } from '../../../utils/genai';
 export type ViewedBoundsFunctionType = (start: number, end: number) => { start: number; end: number };
 /**
  * Given a range (`min`, `max`) and factoring in a zoom (`viewStart`, `viewEnd`)
@@ -73,19 +72,6 @@ export function spanContainsErredSpan(spans: ReadonlyArray<IOtelSpan>, parentSpa
     }
   }
   return false;
-}
-
-/**
- * Returns `true` if the span has a GenAI warning.
- *
- * @param  {IOtelSpan} span  The OTEL span to check.
- * @return {boolean}         True if the span has a GenAI warning.
- */
-export function hasGenAIWarning(span: IOtelSpan): boolean {
-  const attr = span.attributes.find(a => a.key === ATTR_GEN_AI_RESPONSE_FINISH_REASONS);
-  if (!attr) return false;
-  const reasons = Array.isArray(attr.value) ? attr.value : [attr.value];
-  return reasons.some(r => r === 'content_filter' || r === 'length');
 }
 
 /**

--- a/packages/jaeger-ui/src/constants/default-config.ts
+++ b/packages/jaeger-ui/src/constants/default-config.ts
@@ -66,6 +66,10 @@ const defaultConfig: Config = {
     },
     maxLimit: 1500,
   },
+  api: {
+    requestTimeoutMs: 10000,
+  },
+
   traceIdDisplayLength: 7,
   backendCapabilities: {
     archiveStorage: false,

--- a/packages/jaeger-ui/src/hooks/useJaegerAssistant.test.ts
+++ b/packages/jaeger-ui/src/hooks/useJaegerAssistant.test.ts
@@ -23,6 +23,9 @@ const baseConfig = {
   useOpenTelemetryTerms: false,
   menu: [],
   backendCapabilities: { aiAssistant: false },
+  api: {
+    requestTimeoutMs: 10000,
+  },
 };
 
 describe('useJaegerAssistant', () => {

--- a/packages/jaeger-ui/src/model/trace-summary.test.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.test.ts
@@ -4,6 +4,7 @@
 import { traceToTraceSummary } from './trace-summary';
 import transformTraceData from './transform-trace-data';
 import traceGenerator from '../demo/trace-generators';
+import { ATTR_GEN_AI_RESPONSE_FINISH_REASONS } from '@opentelemetry/semantic-conventions/incubating';
 import { StatusCode, SpanKind } from '../types/otel';
 import type { IOtelTrace, IOtelSpan, IResource } from '../types/otel';
 import type { Microseconds } from '../types/units';
@@ -67,6 +68,7 @@ describe('traceToTraceSummary', () => {
     expect(summary.duration).toBe(500);
     expect(summary.spanCount).toBe(0);
     expect(summary.errorSpanCount).toBe(0);
+    expect(summary.warningSpanCount).toBe(0);
     expect(summary.orphanSpanCount).toBe(0);
     expect(summary.services).toEqual([]);
   });
@@ -106,6 +108,33 @@ describe('traceToTraceSummary', () => {
     expect(svcB.errorSpanCount).toBe(1);
   });
 
+  it('counts total and per-service warning spans', () => {
+    const s1 = makeSpan('svc-a', 's1');
+    s1.attributes = [{ key: ATTR_GEN_AI_RESPONSE_FINISH_REASONS, value: 'content_filter' }];
+    const s2 = makeSpan('svc-a', 's2');
+    const s3 = makeSpan('svc-b', 's3');
+    s3.attributes = [{ key: ATTR_GEN_AI_RESPONSE_FINISH_REASONS, value: 'length' }];
+    const trace = makeMinimalTrace({
+      spans: [s1, s2, s3],
+      services: [
+        { name: 'svc-a', numberOfSpans: 2 },
+        { name: 'svc-b', numberOfSpans: 1 },
+      ],
+    });
+    const summary = traceToTraceSummary(trace);
+
+    expect(summary.spanCount).toBe(3);
+    expect(summary.warningSpanCount).toBe(2);
+
+    const svcA = summary.services.find(s => s.name === 'svc-a')!;
+    expect(svcA.spanCount).toBe(2);
+    expect(svcA.warningSpanCount).toBe(1);
+
+    const svcB = summary.services.find(s => s.name === 'svc-b')!;
+    expect(svcB.spanCount).toBe(1);
+    expect(svcB.warningSpanCount).toBe(1);
+  });
+
   it('reports zero errors when no spans have error status', () => {
     const s1 = makeSpan('svc-a', 's1');
     const s2 = makeSpan('svc-a', 's2', StatusCode.UNSET);
@@ -116,7 +145,9 @@ describe('traceToTraceSummary', () => {
     const summary = traceToTraceSummary(trace);
 
     expect(summary.errorSpanCount).toBe(0);
+    expect(summary.warningSpanCount).toBe(0);
     expect(summary.services[0].errorSpanCount).toBe(0);
+    expect(summary.services[0].warningSpanCount).toBe(0);
   });
 
   it('propagates orphanSpanCount from the OTEL trace', () => {

--- a/packages/jaeger-ui/src/model/trace-summary.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.ts
@@ -4,7 +4,7 @@
 import { StatusCode } from '../types/otel';
 import type { IOtelTrace } from '../types/otel';
 import type { ServiceSummary, TraceSummary } from '../types/trace-summary';
-import { hasGenAIWarning } from '../components/TracePage/TraceTimelineViewer/utils';
+import { hasGenAIWarning } from '../utils/genai';
 
 export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
   const rootSpan = trace.rootSpans[0];

--- a/packages/jaeger-ui/src/model/trace-summary.ts
+++ b/packages/jaeger-ui/src/model/trace-summary.ts
@@ -4,6 +4,7 @@
 import { StatusCode } from '../types/otel';
 import type { IOtelTrace } from '../types/otel';
 import type { ServiceSummary, TraceSummary } from '../types/trace-summary';
+import { hasGenAIWarning } from '../components/TracePage/TraceTimelineViewer/utils';
 
 export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
   const rootSpan = trace.rootSpans[0];
@@ -11,12 +12,19 @@ export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
   const rootOperationName = rootSpan?.name ?? '';
 
   const errorsByService = new Map<string, number>();
+  const warningsByService = new Map<string, number>();
   let errorSpanCount = 0;
+  let warningSpanCount = 0;
   for (const span of trace.spans) {
     if (span.status.code === StatusCode.ERROR) {
       errorSpanCount++;
       const svc = span.resource.serviceName;
       errorsByService.set(svc, (errorsByService.get(svc) ?? 0) + 1);
+    }
+    if (hasGenAIWarning(span)) {
+      warningSpanCount++;
+      const svc = span.resource.serviceName;
+      warningsByService.set(svc, (warningsByService.get(svc) ?? 0) + 1);
     }
   }
 
@@ -24,6 +32,7 @@ export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
     name: s.name,
     spanCount: s.numberOfSpans,
     errorSpanCount: errorsByService.get(s.name) ?? 0,
+    warningSpanCount: warningsByService.get(s.name) ?? 0,
   }));
 
   return {
@@ -35,6 +44,7 @@ export function traceToTraceSummary(trace: IOtelTrace): TraceSummary {
     duration: trace.duration,
     spanCount: trace.spans.length,
     errorSpanCount,
+    warningSpanCount,
     orphanSpanCount: trace.orphanSpanCount,
     services,
   };

--- a/packages/jaeger-ui/src/types/config.ts
+++ b/packages/jaeger-ui/src/types/config.ts
@@ -146,6 +146,13 @@ export type Config = {
     adjustEndTime?: string;
   };
 
+  // api controls backend request behavior.
+  api: {
+    // requestTimeoutMs overrides the default timeout (in milliseconds)
+    // for requests made to the Jaeger backend.
+    requestTimeoutMs?: number;
+  };
+
   // scripts is an array of URLs of additional JavaScript files to be loaded.
   // TODO when is it useful?
   scripts?: readonly TScript[];

--- a/packages/jaeger-ui/src/types/trace-summary.ts
+++ b/packages/jaeger-ui/src/types/trace-summary.ts
@@ -7,6 +7,7 @@ export type ServiceSummary = {
   name: string;
   spanCount?: number;
   errorSpanCount?: number;
+  warningSpanCount?: number;
 };
 
 export type TraceSummary = {
@@ -18,6 +19,7 @@ export type TraceSummary = {
   duration: Microseconds;
   spanCount?: number;
   errorSpanCount?: number;
+  warningSpanCount?: number;
   orphanSpanCount?: number;
   services: ServiceSummary[];
 };

--- a/packages/jaeger-ui/src/utils/genai/index.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/index.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { IAttribute, IOtelSpan } from '../../types/otel';
-import { isGenAISpan } from './index';
+import { hasGenAIWarning, isGenAISpan } from './index';
 
 function makeSpan(attrs: IAttribute[]): IOtelSpan {
   return { attributes: attrs } as unknown as IOtelSpan;
@@ -31,5 +31,34 @@ describe('isGenAISpan', () => {
   it('does not match keys that merely contain "gen_ai" in the middle', () => {
     const span = makeSpan([{ key: 'custom.gen_ai.tag', value: 'x' }]);
     expect(isGenAISpan(span)).toBe(false);
+  });
+});
+
+describe('hasGenAIWarning', () => {
+  it('returns true when finish_reasons is a JSON array string containing length', () => {
+    const span = makeSpan([{ key: 'gen_ai.response.finish_reasons', value: '["stop", "length"]' }]);
+    expect(hasGenAIWarning(span)).toBe(true);
+  });
+
+  it('returns true when finish_reasons is a scalar string "length"', () => {
+    const span = makeSpan([{ key: 'gen_ai.response.finish_reasons', value: 'length' }]);
+    expect(hasGenAIWarning(span)).toBe(true);
+  });
+
+  it('returns true when finish_reasons is a JSON scalar string "length"', () => {
+    const span = makeSpan([{ key: 'gen_ai.response.finish_reasons', value: '"length"' }]);
+    expect(hasGenAIWarning(span)).toBe(true);
+  });
+
+  it('returns true when finish_reasons is a JS array containing content_filter', () => {
+    const span = makeSpan([
+      { key: 'gen_ai.response.finish_reasons', value: ['content_filter'] as unknown as string },
+    ]);
+    expect(hasGenAIWarning(span)).toBe(true);
+  });
+
+  it('returns false when finish_reasons is a JSON array string without warnings', () => {
+    const span = makeSpan([{ key: 'gen_ai.response.finish_reasons', value: '["stop"]' }]);
+    expect(hasGenAIWarning(span)).toBe(false);
   });
 });

--- a/packages/jaeger-ui/src/utils/genai/index.ts
+++ b/packages/jaeger-ui/src/utils/genai/index.ts
@@ -18,6 +18,16 @@ export function isGenAISpan(span: IOtelSpan): boolean {
 export function hasGenAIWarning(span: IOtelSpan): boolean {
   const attr = span.attributes.find(a => a.key === ATTR_GEN_AI_RESPONSE_FINISH_REASONS);
   if (!attr) return false;
-  const reasons = Array.isArray(attr.value) ? attr.value : [attr.value];
+
+  let val = attr.value;
+  if (typeof val === 'string') {
+    try {
+      val = JSON.parse(val);
+    } catch {
+      // fallback to scalar string if not valid JSON
+    }
+  }
+
+  const reasons = Array.isArray(val) ? val : [val];
   return reasons.some(r => r === 'content_filter' || r === 'length');
 }

--- a/packages/jaeger-ui/src/utils/genai/index.ts
+++ b/packages/jaeger-ui/src/utils/genai/index.ts
@@ -3,6 +3,21 @@
 
 import type { IOtelSpan } from '../../types/otel';
 
+import { ATTR_GEN_AI_RESPONSE_FINISH_REASONS } from '@opentelemetry/semantic-conventions/incubating';
+
 export function isGenAISpan(span: IOtelSpan): boolean {
   return span.attributes.some(attr => attr.key.startsWith('gen_ai.'));
+}
+
+/**
+ * Returns `true` if the span has a GenAI warning.
+ *
+ * @param  {IOtelSpan} span  The OTEL span to check.
+ * @return {boolean}         True if the span has a GenAI warning.
+ */
+export function hasGenAIWarning(span: IOtelSpan): boolean {
+  const attr = span.attributes.find(a => a.key === ATTR_GEN_AI_RESPONSE_FINISH_REASONS);
+  if (!attr) return false;
+  const reasons = Array.isArray(attr.value) ? attr.value : [attr.value];
+  return reasons.some(r => r === 'content_filter' || r === 'length');
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4101

## Description of the changes
- Added warning icons to the trace timeline to show GenAI `finish_reasons` warnings.
- Added a warning count badge in the trace search results.
- Used OpenTelemetry Semantic Conventions to detect the warnings.
- The UI mimics the existing error bubbling behavior (solid icon for self, hollow icon for descendants).

## How was this change tested?
- Added targeted unit tests for the new warning logic, trace summary, and UI components.
- Verified successfully using `npm test` and `npm run lint`.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most of the code

