### PR TITLE
fix(timeline): Restore critical path hover animation in dark mode

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBar.css
@@ -51,8 +51,8 @@ SPDX-License-Identifier: Apache-2.0
   width: 10%;
   height: 100%;
   visibility: hidden;
-  background-color: white;
-  border: 1px solid white;
+  background-color: var(--critical-path-outline);
+  border: 1px solid var(--critical-path-outline);
 }
 
 .SpanBar--criticalPath:hover::before {


### PR DESCRIPTION
## Summary
- The hover animation that slides a highlight across critical path segments used a hardcoded white color, which became invisible in dark mode since the critical path bar itself is rendered white there (`--critical-path-color`).
- Switch the animation to use `--critical-path-outline`, the existing theme-aware token that already contrasts with the critical path bar in both light and dark mode.
- The theme-aware `--critical-path-color`/`--critical-path-outline` tokens were introduced in #3306, which is what made the critical path bar white in dark mode and exposed this regression.

## Test plan
- [x] `npm run fmt`
- [x] `npm run lint`
- [x] `npm test` (all 3289 jaeger-ui tests + 115 plexus tests pass)
- [x] `npm run build`
- [x] Manually verified in browser: hover animation is visible on critical path segments in both light and dark mode