### PR TITLE
feat(assistant): Add markdown rendering and panel resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11607,6 +11607,34 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/markdown-to-jsx": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.8.2.tgz",
+      "integrity": "sha512-rWUuxKB5NsuJmSfUOuXkQ0O5qk0J/Lr3Lk6dzxKoKQI/jeHYlsVfz3zJdMLAhI46hHoXDYERWhtBOiqtWDZ4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "react": ">= 16.0.0",
+        "solid-js": ">=1.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/match-sorter": {
       "version": "8.3.0",
       "license": "MIT",
@@ -15043,6 +15071,7 @@
         "lodash": "4.18.1",
         "logfmt": "1.4.0",
         "lru-memoize": "1.1.0",
+        "markdown-to-jsx": "9.8.2",
         "match-sorter": "8.3.0",
         "memoize-one": "6.0.0",
         "object-hash": "3.0.0",

--- a/packages/jaeger-ui/package.json
+++ b/packages/jaeger-ui/package.json
@@ -61,6 +61,7 @@
     "lodash": "4.18.1",
     "logfmt": "1.4.0",
     "lru-memoize": "1.1.0",
+    "markdown-to-jsx": "9.8.2",
     "match-sorter": "8.3.0",
     "memoize-one": "6.0.0",
     "object-hash": "3.0.0",

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
@@ -124,6 +124,12 @@ SPDX-License-Identifier: Apache-2.0
   white-space: pre-wrap;
 }
 
+/* Markdown-rendered replies must collapse soft line breaks (LLMs hard-wrap
+   paragraphs); pre/code inside keep their own whitespace handling. */
+.JaegerAssistantPanel-md {
+  white-space: normal;
+}
+
 .JaegerAssistantPanel-toolCall {
   padding: 0.3rem 0.5rem;
   margin: 0.25rem 0;

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
@@ -4,9 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 .JaegerAssistantPanel {
-  flex: 0 0 min(100%, 26rem);
-  max-width: 26rem;
-  min-width: 20rem;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   border-left: 1px solid var(--border-default);
@@ -18,6 +16,21 @@ SPDX-License-Identifier: Apache-2.0
   max-height: calc(100vh - var(--nav-height));
   min-height: 0;
   overflow: hidden;
+}
+
+.JaegerAssistantPanel-resizeHandle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  cursor: ew-resize;
+  z-index: 10;
+}
+
+.JaegerAssistantPanel-resizeHandle:hover {
+  background-color: var(--interactive-primary);
+  opacity: 0.4;
 }
 
 .JaegerAssistantPanel-topBar {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.css
@@ -28,9 +28,15 @@ SPDX-License-Identifier: Apache-2.0
   z-index: 10;
 }
 
-.JaegerAssistantPanel-resizeHandle:hover {
+.JaegerAssistantPanel-resizeHandle:hover,
+.JaegerAssistantPanel-resizeHandle:focus-visible {
   background-color: var(--interactive-primary);
   opacity: 0.4;
+}
+
+.JaegerAssistantPanel-resizeHandle:focus-visible {
+  outline: 2px solid var(--interactive-primary);
+  outline-offset: -1px;
 }
 
 .JaegerAssistantPanel-topBar {

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -249,6 +249,47 @@ describe('JaegerAssistantDock', () => {
       fireEvent.mouseMove(document, { clientX: 100 });
       expect(aside.style.width).toBe('516px');
     });
+
+    it('ignores non-left mouse buttons', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500, button: 2 });
+      fireEvent.mouseMove(document, { clientX: 400 });
+      expect(aside.style.width).toBe('416px');
+      expect(document.body.style.cursor).toBe('');
+    });
+
+    it('tears down a missed drag when a new drag starts', () => {
+      const { aside, handle } = renderDock();
+      // First drag never receives mouseup (released outside the window).
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 400 });
+      expect(aside.style.width).toBe('516px');
+      // Second drag starts; the first drag's listeners must not stack.
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 450 });
+      expect(aside.style.width).toBe('566px');
+      fireEvent.mouseUp(document);
+      expect(document.body.style.cursor).toBe('');
+      fireEvent.mouseMove(document, { clientX: 100 });
+      expect(aside.style.width).toBe('566px');
+    });
+
+    it('restores body styles when unmounted mid-drag', () => {
+      agUiMock.configured = true;
+      const { container, unmount } = render(
+        <MemoryRouter>
+          <JaegerAssistantProvider>
+            <JaegerAssistantDock />
+          </JaegerAssistantProvider>
+        </MemoryRouter>
+      );
+      const handle = container.querySelector('.JaegerAssistantPanel-resizeHandle');
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      expect(document.body.style.cursor).toBe('ew-resize');
+      unmount();
+      expect(document.body.style.cursor).toBe('');
+      expect(document.body.style.userSelect).toBe('');
+    });
   });
 });
 

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -186,6 +186,70 @@ describe('JaegerAssistantDock', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ask-bootstrap-hi' }));
     await waitFor(() => expect(mockAppend).toHaveBeenCalledWith('hi'));
   });
+
+  describe('drag-to-resize', () => {
+    function renderDock() {
+      agUiMock.configured = true;
+      const { container } = render(
+        <MemoryRouter>
+          <JaegerAssistantProvider>
+            <JaegerAssistantDock />
+          </JaegerAssistantProvider>
+        </MemoryRouter>
+      );
+      const aside = container.querySelector('aside[aria-label="Ask Jaeger assistant"]');
+      const handle = container.querySelector('.JaegerAssistantPanel-resizeHandle');
+      return { aside, handle };
+    }
+
+    it('renders a resize handle at the default width', () => {
+      const { aside, handle } = renderDock();
+      expect(handle).not.toBeNull();
+      expect(aside.style.width).toBe('416px');
+    });
+
+    it('widens the panel when dragging the handle left', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 400 });
+      expect(aside.style.width).toBe('516px');
+      fireEvent.mouseUp(document);
+    });
+
+    it('narrows the panel when dragging the handle right', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 550 });
+      expect(aside.style.width).toBe('366px');
+      fireEvent.mouseUp(document);
+    });
+
+    it('clamps width to PANEL_MAX_WIDTH', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: -1000 });
+      expect(aside.style.width).toBe('800px');
+      fireEvent.mouseUp(document);
+    });
+
+    it('clamps width to PANEL_MIN_WIDTH', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 1000 });
+      expect(aside.style.width).toBe('320px');
+      fireEvent.mouseUp(document);
+    });
+
+    it('stops resizing after mouseup', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 400 });
+      expect(aside.style.width).toBe('516px');
+      fireEvent.mouseUp(document);
+      fireEvent.mouseMove(document, { clientX: 100 });
+      expect(aside.style.width).toBe('516px');
+    });
+  });
 });
 
 describe('JaegerThreadMessageBody', () => {
@@ -206,6 +270,22 @@ describe('JaegerThreadMessageBody', () => {
     expect(screen.getByTestId('message-primitive-root')).toHaveClass(
       'JaegerAssistantPanel-message--assistant'
     );
+  });
+
+  it('renders assistant text as markdown instead of MessagePartPrimitive.Text', () => {
+    partsMock.parts = [{ type: 'text', text: 'Hello **world**' }];
+    const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(container.querySelector('[data-testid="message-part-text"]')).not.toBeInTheDocument();
+    const markdownRoot = container.querySelector('.JaegerAssistantPanel-md');
+    expect(markdownRoot).toHaveClass('JaegerAssistantPanel-messageText');
+    expect(markdownRoot.querySelector('strong')).toHaveTextContent('world');
+  });
+
+  it('still uses MessagePartPrimitive.Text for user variant even when text is present', () => {
+    partsMock.parts = [{ type: 'text', text: 'Hello **world**' }];
+    const { container } = render(<JaegerThreadMessageBody variant="user" />);
+    expect(container.querySelector('[data-testid="message-part-text"]')).toBeInTheDocument();
+    expect(container.querySelector('.JaegerAssistantPanel-md')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -274,6 +274,18 @@ describe('JaegerAssistantDock', () => {
       expect(aside.style.width).toBe('566px');
     });
 
+    it('stops the drag when the window loses focus', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 400 });
+      expect(aside.style.width).toBe('516px');
+      fireEvent.blur(window);
+      expect(document.body.style.cursor).toBe('');
+      expect(document.body.style.userSelect).toBe('');
+      fireEvent.mouseMove(document, { clientX: 100 });
+      expect(aside.style.width).toBe('516px');
+    });
+
     it('restores body styles when unmounted mid-drag', () => {
       agUiMock.configured = true;
       const { container, unmount } = render(

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.test.jsx
@@ -302,6 +302,65 @@ describe('JaegerAssistantDock', () => {
       expect(document.body.style.cursor).toBe('');
       expect(document.body.style.userSelect).toBe('');
     });
+
+    it('continues tracking the latest width across multiple moves in one drag', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.mouseDown(handle, { clientX: 500 });
+      fireEvent.mouseMove(document, { clientX: 400 });
+      expect(aside.style.width).toBe('516px');
+      fireEvent.mouseMove(document, { clientX: 350 });
+      expect(aside.style.width).toBe('566px');
+      fireEvent.mouseUp(document);
+    });
+
+    it('exposes separator role and value ARIA attributes', () => {
+      const { handle } = renderDock();
+      expect(handle).toHaveAttribute('role', 'separator');
+      expect(handle).toHaveAttribute('aria-orientation', 'vertical');
+      expect(handle).toHaveAttribute('aria-valuemin', '320');
+      expect(handle).toHaveAttribute('aria-valuemax', '800');
+      expect(handle).toHaveAttribute('aria-valuenow', '416');
+      expect(handle).toHaveAttribute('tabindex', '0');
+    });
+
+    it('grows the panel with ArrowLeft and updates aria-valuenow', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+      expect(aside.style.width).toBe('432px');
+      expect(handle).toHaveAttribute('aria-valuenow', '432');
+    });
+
+    it('shrinks the panel with ArrowRight', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.keyDown(handle, { key: 'ArrowRight' });
+      expect(aside.style.width).toBe('400px');
+    });
+
+    it('jumps to PANEL_MIN_WIDTH on Home and PANEL_MAX_WIDTH on End', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.keyDown(handle, { key: 'Home' });
+      expect(aside.style.width).toBe('320px');
+      fireEvent.keyDown(handle, { key: 'End' });
+      expect(aside.style.width).toBe('800px');
+    });
+
+    it('clamps keyboard resizing at the bounds', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.keyDown(handle, { key: 'End' });
+      expect(aside.style.width).toBe('800px');
+      fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+      expect(aside.style.width).toBe('800px');
+      fireEvent.keyDown(handle, { key: 'Home' });
+      expect(aside.style.width).toBe('320px');
+      fireEvent.keyDown(handle, { key: 'ArrowRight' });
+      expect(aside.style.width).toBe('320px');
+    });
+
+    it('ignores unrelated keys', () => {
+      const { aside, handle } = renderDock();
+      fireEvent.keyDown(handle, { key: 'Tab' });
+      expect(aside.style.width).toBe('416px');
+    });
   });
 });
 
@@ -339,6 +398,24 @@ describe('JaegerThreadMessageBody', () => {
     const { container } = render(<JaegerThreadMessageBody variant="user" />);
     expect(container.querySelector('[data-testid="message-part-text"]')).toBeInTheDocument();
     expect(container.querySelector('.JaegerAssistantPanel-md')).not.toBeInTheDocument();
+  });
+
+  it('routes the first streaming snapshot (empty text) through the markdown path, not MessagePartPrimitive.Text', () => {
+    // @assistant-ui/react-ag-ui emits the initial snapshot as { type: 'text', text: '' }
+    // before any delta arrives. If this fell through to MessagePartPrimitive.Text (the
+    // library's smoothing-aware primitive) for the empty snapshot and switched to
+    // AssistantMarkdownText once a delta lands, the message would swap renderers
+    // mid-stream. markdown-to-jsx correctly renders nothing for empty input, so the
+    // only observable assertion is that the plain-text path was never used.
+    partsMock.parts = [{ type: 'text', text: '' }];
+    const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(container.querySelector('[data-testid="message-part-text"]')).not.toBeInTheDocument();
+  });
+
+  it('routes an assistant text part with no text field at all through the markdown path', () => {
+    partsMock.parts = [{ type: 'text' }];
+    const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
+    expect(container.querySelector('[data-testid="message-part-text"]')).not.toBeInTheDocument();
   });
 });
 
@@ -504,11 +581,14 @@ describe('tool-call part rendering', () => {
 
   it('renders text parts correctly alongside tool-call parts', () => {
     partsMock.parts = [
-      { type: 'text' },
+      { type: 'text', text: 'Here is what I found:' },
       { type: 'tool-call', toolName: 'read_skill', status: { type: 'complete' }, result: 'done' },
     ];
     const { container } = render(<JaegerThreadMessageBody variant="assistant" />);
-    expect(container.querySelectorAll('[data-testid="message-part-text"]')).toHaveLength(1);
+    // Assistant text renders via the markdown path (AssistantMarkdownText),
+    // not MessagePartPrimitive.Text -- see JaegerThreadMessageBody tests above.
+    expect(container.querySelectorAll('[data-testid="message-part-text"]')).toHaveLength(0);
+    expect(container.querySelector('.JaegerAssistantPanel-md')).toHaveTextContent('Here is what I found:');
     expect(screen.getByText('Called read_skill')).toBeInTheDocument();
     expect(screen.getByText('done')).toBeInTheDocument();
   });

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -240,6 +240,11 @@ export function JaegerAssistantDock() {
 
   const onDragStart = React.useCallback(
     (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      // A mouseup released outside the window can be missed; tear down any
+      // in-flight drag before starting a new one so listeners never stack.
+      dragCleanupRef.current?.();
+      e.preventDefault();
       const startX = e.clientX;
       const startWidth = width;
       document.body.style.cursor = 'ew-resize';

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -12,10 +12,12 @@ import {
 } from '@assistant-ui/react';
 import { IoClose } from 'react-icons/io5';
 import { JsonView, collapseAllNested } from 'react-json-view-lite';
+import Markdown from 'markdown-to-jsx';
 
 import { useJaegerAssistant, useJaegerAssistantOptional } from './JaegerAssistantContext';
 import { useJaegerAssistantConfigured } from '../../hooks/useJaegerAssistant';
 import jsonViewStyles from '../../utils/jsonViewStyles';
+import { sharedMarkdownOptions } from '../../utils/markdownOptions';
 
 import './JaegerAssistantPanel.css';
 
@@ -117,6 +119,17 @@ function JaegerToolCallIndicator({
   );
 }
 
+function AssistantMarkdownText({ text }: { text: string }) {
+  return (
+    <Markdown
+      className="JaegerAssistantPanel-messageText JaegerAssistantPanel-md"
+      options={{ ...sharedMarkdownOptions, optimizeForStreaming: true }}
+    >
+      {text}
+    </Markdown>
+  );
+}
+
 function JaegerThreadMessageBody({ variant }: { variant: 'user' | 'assistant' }) {
   return (
     <MessagePrimitive.Root
@@ -125,6 +138,9 @@ function JaegerThreadMessageBody({ variant }: { variant: 'user' | 'assistant' })
       <MessagePrimitive.Parts>
         {({ part }) => {
           if (part.type === 'text') {
+            if (variant === 'assistant' && part.text) {
+              return <AssistantMarkdownText text={part.text} />;
+            }
             return (
               <MessagePartPrimitive.Text
                 component="div"
@@ -202,6 +218,10 @@ function JaegerAssistantThreadView({ focusComposer }: { focusComposer: boolean }
   );
 }
 
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MAX_WIDTH = 800;
+const PANEL_DEFAULT_WIDTH = 416; // 26rem at 16px base
+
 /**
  * Right dock for Ask Jaeger.
  *
@@ -213,6 +233,40 @@ function JaegerAssistantThreadView({ focusComposer }: { focusComposer: boolean }
 export function JaegerAssistantDock() {
   const assistant = useJaegerAssistantOptional();
   const assistantConfigured = useJaegerAssistantConfigured();
+  const [width, setWidth] = React.useState(PANEL_DEFAULT_WIDTH);
+  // Holds the teardown for an in-flight drag so unmounting mid-drag does not
+  // leave document listeners attached or body cursor/user-select overrides stuck.
+  const dragCleanupRef = React.useRef<(() => void) | null>(null);
+
+  const onDragStart = React.useCallback(
+    (e: React.MouseEvent) => {
+      const startX = e.clientX;
+      const startWidth = width;
+      document.body.style.cursor = 'ew-resize';
+      document.body.style.userSelect = 'none';
+
+      const onMouseMove = (ev: MouseEvent) => {
+        const delta = startX - ev.clientX;
+        setWidth(Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, startWidth + delta)));
+      };
+
+      const stopDragging = () => {
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', stopDragging);
+        dragCleanupRef.current = null;
+      };
+
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', stopDragging);
+      dragCleanupRef.current = stopDragging;
+    },
+    [width]
+  );
+
+  React.useEffect(() => () => dragCleanupRef.current?.(), []);
+
   if (!assistant || !assistantConfigured) {
     return null;
   }
@@ -224,8 +278,9 @@ export function JaegerAssistantDock() {
       className="JaegerAssistantPanel"
       aria-label="Ask Jaeger assistant"
       aria-hidden={!panelOpen}
-      style={{ display: panelOpen ? undefined : 'none' }}
+      style={{ display: panelOpen ? undefined : 'none', width, maxWidth: '100%' }}
     >
+      <div className="JaegerAssistantPanel-resizeHandle" onMouseDown={onDragStart} />
       <JaegerAssistantBootstrap />
       <header className="JaegerAssistantPanel-topBar">
         <h2 className="JaegerAssistantPanel-title">Ask Jaeger</h2>

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -17,7 +17,7 @@ import Markdown from 'markdown-to-jsx/react';
 import { useJaegerAssistant, useJaegerAssistantOptional } from './JaegerAssistantContext';
 import { useJaegerAssistantConfigured } from '../../hooks/useJaegerAssistant';
 import jsonViewStyles from '../../utils/jsonViewStyles';
-import { sharedMarkdownOptions } from '../../utils/markdownOptions';
+import { streamingMarkdownOptions } from '../../utils/markdownOptions';
 
 import './JaegerAssistantPanel.css';
 
@@ -123,7 +123,7 @@ function AssistantMarkdownText({ text }: { text: string }) {
   return (
     <Markdown
       className="JaegerAssistantPanel-messageText JaegerAssistantPanel-md"
-      options={{ ...sharedMarkdownOptions, optimizeForStreaming: true }}
+      options={streamingMarkdownOptions}
     >
       {text}
     </Markdown>
@@ -138,8 +138,8 @@ function JaegerThreadMessageBody({ variant }: { variant: 'user' | 'assistant' })
       <MessagePrimitive.Parts>
         {({ part }) => {
           if (part.type === 'text') {
-            if (variant === 'assistant' && part.text) {
-              return <AssistantMarkdownText text={part.text} />;
+            if (variant === 'assistant') {
+              return <AssistantMarkdownText text={part.text ?? ''} />;
             }
             return (
               <MessagePartPrimitive.Text
@@ -221,6 +221,11 @@ function JaegerAssistantThreadView({ focusComposer }: { focusComposer: boolean }
 const PANEL_MIN_WIDTH = 320;
 const PANEL_MAX_WIDTH = 800;
 const PANEL_DEFAULT_WIDTH = 416; // 26rem at 16px base
+const PANEL_KEYBOARD_STEP = 16;
+
+function clampPanelWidth(w: number): number {
+  return Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, w));
+}
 
 /**
  * Right dock for Ask Jaeger.
@@ -233,7 +238,15 @@ const PANEL_DEFAULT_WIDTH = 416; // 26rem at 16px base
 export function JaegerAssistantDock() {
   const assistant = useJaegerAssistantOptional();
   const assistantConfigured = useJaegerAssistantConfigured();
-  const [width, setWidth] = React.useState(PANEL_DEFAULT_WIDTH);
+  const [width, setWidthState] = React.useState(PANEL_DEFAULT_WIDTH);
+  // Mirrors `width` so onDragStart can read the current value without
+  // depending on it — a `[width]` dep would recreate onDragStart on every
+  // setWidth call during a drag (up to ~60/sec).
+  const widthRef = React.useRef(PANEL_DEFAULT_WIDTH);
+  const setWidth = React.useCallback((w: number) => {
+    widthRef.current = w;
+    setWidthState(w);
+  }, []);
   // Holds the teardown for an in-flight drag so unmounting mid-drag does not
   // leave document listeners attached or body cursor/user-select overrides stuck.
   const dragCleanupRef = React.useRef<(() => void) | null>(null);
@@ -246,13 +259,13 @@ export function JaegerAssistantDock() {
       dragCleanupRef.current?.();
       e.preventDefault();
       const startX = e.clientX;
-      const startWidth = width;
+      const startWidth = widthRef.current;
       document.body.style.cursor = 'ew-resize';
       document.body.style.userSelect = 'none';
 
       const onMouseMove = (ev: MouseEvent) => {
         const delta = startX - ev.clientX;
-        setWidth(Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, startWidth + delta)));
+        setWidth(clampPanelWidth(startWidth + delta));
       };
 
       const stopDragging = () => {
@@ -271,7 +284,35 @@ export function JaegerAssistantDock() {
       window.addEventListener('blur', stopDragging);
       dragCleanupRef.current = stopDragging;
     },
-    [width]
+    [setWidth]
+  );
+
+  const onHandleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      // ArrowLeft grows the panel and ArrowRight shrinks it, matching the
+      // mouse drag direction (dragging the left-edge handle left = bigger).
+      switch (e.key) {
+        case 'ArrowLeft':
+          e.preventDefault();
+          setWidth(clampPanelWidth(widthRef.current + PANEL_KEYBOARD_STEP));
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          setWidth(clampPanelWidth(widthRef.current - PANEL_KEYBOARD_STEP));
+          break;
+        case 'Home':
+          e.preventDefault();
+          setWidth(PANEL_MIN_WIDTH);
+          break;
+        case 'End':
+          e.preventDefault();
+          setWidth(PANEL_MAX_WIDTH);
+          break;
+        default:
+          break;
+      }
+    },
+    [setWidth]
   );
 
   React.useEffect(() => () => dragCleanupRef.current?.(), []);
@@ -289,7 +330,18 @@ export function JaegerAssistantDock() {
       aria-hidden={!panelOpen}
       style={{ display: panelOpen ? undefined : 'none', width, maxWidth: '100%' }}
     >
-      <div className="JaegerAssistantPanel-resizeHandle" onMouseDown={onDragStart} />
+      <div
+        className="JaegerAssistantPanel-resizeHandle"
+        onMouseDown={onDragStart}
+        onKeyDown={onHandleKeyDown}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize assistant panel"
+        aria-valuemin={PANEL_MIN_WIDTH}
+        aria-valuemax={PANEL_MAX_WIDTH}
+        aria-valuenow={width}
+        tabIndex={0}
+      />
       <JaegerAssistantBootstrap />
       <header className="JaegerAssistantPanel-topBar">
         <h2 className="JaegerAssistantPanel-title">Ask Jaeger</h2>

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -17,7 +17,7 @@ import Markdown from 'markdown-to-jsx/react';
 import { useJaegerAssistant, useJaegerAssistantOptional } from './JaegerAssistantContext';
 import { useJaegerAssistantConfigured } from '../../hooks/useJaegerAssistant';
 import jsonViewStyles from '../../utils/jsonViewStyles';
-import { streamingMarkdownOptions } from '../../utils/markdownOptions';
+import { sharedMarkdownOptions } from '../../utils/markdownOptions';
 
 import './JaegerAssistantPanel.css';
 
@@ -123,7 +123,7 @@ function AssistantMarkdownText({ text }: { text: string }) {
   return (
     <Markdown
       className="JaegerAssistantPanel-messageText JaegerAssistantPanel-md"
-      options={streamingMarkdownOptions}
+      options={sharedMarkdownOptions}
     >
       {text}
     </Markdown>

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -260,11 +260,15 @@ export function JaegerAssistantDock() {
         document.body.style.userSelect = '';
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', stopDragging);
+        window.removeEventListener('blur', stopDragging);
         dragCleanupRef.current = null;
       };
 
       document.addEventListener('mousemove', onMouseMove);
       document.addEventListener('mouseup', stopDragging);
+      // A mouseup outside the window never reaches the document; ending the
+      // drag when the window loses focus keeps body styles from getting stuck.
+      window.addEventListener('blur', stopDragging);
       dragCleanupRef.current = stopDragging;
     },
     [width]

--- a/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
+++ b/packages/jaeger-ui/src/components/App/JaegerAssistantPanel.tsx
@@ -12,7 +12,7 @@ import {
 } from '@assistant-ui/react';
 import { IoClose } from 'react-icons/io5';
 import { JsonView, collapseAllNested } from 'react-json-view-lite';
-import Markdown from 'markdown-to-jsx';
+import Markdown from 'markdown-to-jsx/react';
 
 import { useJaegerAssistant, useJaegerAssistantOptional } from './JaegerAssistantContext';
 import { useJaegerAssistantConfigured } from '../../hooks/useJaegerAssistant';

--- a/packages/jaeger-ui/src/utils/markdownOptions.test.tsx
+++ b/packages/jaeger-ui/src/utils/markdownOptions.test.tsx
@@ -5,25 +5,16 @@ import { render } from '@testing-library/react';
 import Markdown from 'markdown-to-jsx/react';
 import { expect, it, describe } from 'vitest';
 
-import { sharedMarkdownOptions, streamingMarkdownOptions } from './markdownOptions';
-
-describe('streamingMarkdownOptions', () => {
-  it('is the same reference across repeated reads', () => {
-    // markdown-to-jsx memoizes its parser on the options object identity. A
-    // fresh { ...sharedMarkdownOptions, optimizeForStreaming: true } literal
-    // built inline on every render would defeat that memoization on every
-    // streamed token; a module-level constant guarantees a stable reference.
-    expect(streamingMarkdownOptions).toBe(streamingMarkdownOptions);
-  });
-
-  it('carries optimizeForStreaming on top of the shared options', () => {
-    expect(streamingMarkdownOptions.optimizeForStreaming).toBe(true);
-    expect(streamingMarkdownOptions.disableParsingRawHTML).toBe(sharedMarkdownOptions.disableParsingRawHTML);
-    expect(streamingMarkdownOptions.overrides).toBe(sharedMarkdownOptions.overrides);
-  });
-});
+import { sharedMarkdownOptions } from './markdownOptions';
 
 describe('sharedMarkdownOptions', () => {
+  it('enables optimizeForStreaming for every caller, not just streamed chat replies', () => {
+    // Span attributes rendered in the (future) GenAI span detail tab can be
+    // truncated at ingestion, so tolerating unclosed tags is desirable there
+    // too -- this is not a streaming-only concern.
+    expect(sharedMarkdownOptions.optimizeForStreaming).toBe(true);
+  });
+
   describe('wrapper element', () => {
     it('always wraps output, even a single plain-text sentence with no formatting', () => {
       // Without forceWrapper, markdown-to-jsx returns the single parsed node

--- a/packages/jaeger-ui/src/utils/markdownOptions.test.tsx
+++ b/packages/jaeger-ui/src/utils/markdownOptions.test.tsx
@@ -85,6 +85,24 @@ describe('sharedMarkdownOptions', () => {
       expect(container.querySelectorAll('a').length).toBe(0);
       expect(container.textContent).toContain('empty link');
     });
+
+    it('allows an uppercase scheme, matching browsers treating schemes case-insensitively', () => {
+      const { container } = render(
+        <Markdown options={sharedMarkdownOptions}>[shout link](HTTPS://example.com)</Markdown>
+      );
+      const link = container.querySelector('a');
+      expect(link).not.toBeNull();
+      expect(link).toHaveAttribute('href', 'HTTPS://example.com');
+    });
+
+    it('allows a href with leading/trailing whitespace, trimmed before rendering', () => {
+      const { container } = render(
+        <Markdown options={sharedMarkdownOptions}>{'[padded link](  https://example.com  )'}</Markdown>
+      );
+      const link = container.querySelector('a');
+      expect(link).not.toBeNull();
+      expect(link).toHaveAttribute('href', 'https://example.com');
+    });
   });
 
   describe('image rendering', () => {

--- a/packages/jaeger-ui/src/utils/markdownOptions.test.tsx
+++ b/packages/jaeger-ui/src/utils/markdownOptions.test.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from '@testing-library/react';
+import Markdown from 'markdown-to-jsx/react';
+import { expect, it, describe } from 'vitest';
+
+import { sharedMarkdownOptions, streamingMarkdownOptions } from './markdownOptions';
+
+describe('streamingMarkdownOptions', () => {
+  it('is the same reference across repeated reads', () => {
+    // markdown-to-jsx memoizes its parser on the options object identity. A
+    // fresh { ...sharedMarkdownOptions, optimizeForStreaming: true } literal
+    // built inline on every render would defeat that memoization on every
+    // streamed token; a module-level constant guarantees a stable reference.
+    expect(streamingMarkdownOptions).toBe(streamingMarkdownOptions);
+  });
+
+  it('carries optimizeForStreaming on top of the shared options', () => {
+    expect(streamingMarkdownOptions.optimizeForStreaming).toBe(true);
+    expect(streamingMarkdownOptions.disableParsingRawHTML).toBe(sharedMarkdownOptions.disableParsingRawHTML);
+    expect(streamingMarkdownOptions.overrides).toBe(sharedMarkdownOptions.overrides);
+  });
+});
+
+describe('sharedMarkdownOptions', () => {
+  describe('wrapper element', () => {
+    it('always wraps output, even a single plain-text sentence with no formatting', () => {
+      // Without forceWrapper, markdown-to-jsx returns the single parsed node
+      // directly for simple single-node input, silently dropping the caller's
+      // className (and with it, all styling) for the common case of a short
+      // plain-text reply.
+      const { container } = render(
+        <Markdown className="caller-class" options={sharedMarkdownOptions}>
+          Here is what I found:
+        </Markdown>
+      );
+      expect(container.querySelector('.caller-class')).toBeInTheDocument();
+      expect(container.querySelector('.caller-class')).toHaveTextContent('Here is what I found:');
+    });
+  });
+
+  describe('link rendering', () => {
+    it('allows safe http/https/mailto links and adds target/rel attributes', () => {
+      const { container } = render(
+        <Markdown options={sharedMarkdownOptions}>
+          [http link](http://example.com) [https link](https://example.com) [mailto
+          link](mailto:test@example.com)
+        </Markdown>
+      );
+
+      const links = container.querySelectorAll('a');
+      expect(links.length).toBe(3);
+
+      links.forEach(link => {
+        expect(link.getAttribute('target')).toBe('_blank');
+        expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+      });
+
+      expect(links[0].getAttribute('href')).toBe('http://example.com');
+      expect(links[1].getAttribute('href')).toBe('https://example.com');
+      expect(links[2].getAttribute('href')).toBe('mailto:test@example.com');
+    });
+
+    it('blocks unsafe links (like javascript:) and renders them as spans', () => {
+      const { container } = render(
+        <Markdown options={sharedMarkdownOptions}>
+          [unsafe link](javascript:alert('XSS')) [data
+          link](data:text/html,&#60;script&#62;alert('XSS')&#60;/script&#62;)
+        </Markdown>
+      );
+
+      // Should not render any anchor tags
+      const links = container.querySelectorAll('a');
+      expect(links.length).toBe(0);
+
+      // Should render the text in spans instead
+      // Should render the text without links
+      expect(container.textContent).toContain('unsafe link');
+      expect(container.textContent).toContain('data link');
+    });
+
+    it('blocks a link with no href at all', () => {
+      const { container } = render(<Markdown options={sharedMarkdownOptions}>[empty link]()</Markdown>);
+      expect(container.querySelectorAll('a').length).toBe(0);
+      expect(container.textContent).toContain('empty link');
+    });
+  });
+
+  describe('image rendering', () => {
+    it('blocks images and renders a placeholder span', () => {
+      const { container } = render(
+        <Markdown options={sharedMarkdownOptions}>
+          ![logo](http://example.com/logo.png) ![some title](http://example.com/image.png "title here")
+        </Markdown>
+      );
+
+      // Should not render any img tags
+      const images = container.querySelectorAll('img');
+      expect(images.length).toBe(0);
+
+      // Should render placeholder spans
+      const placeholders = container.querySelectorAll('.JaegerAssistantPanel-image-placeholder');
+      expect(placeholders.length).toBe(2);
+
+      expect(placeholders[0].textContent).toBe('[Image: logo]');
+      expect(placeholders[1].textContent).toBe('[Image: some title]');
+    });
+
+    it('falls back to "unsupported" when neither alt nor title is present', () => {
+      const { container } = render(
+        <Markdown options={sharedMarkdownOptions}>![](http://example.com/logo.png)</Markdown>
+      );
+      const placeholder = container.querySelector('.JaegerAssistantPanel-image-placeholder');
+      expect(placeholder).toHaveTextContent('[Image: unsupported]');
+    });
+  });
+});

--- a/packages/jaeger-ui/src/utils/markdownOptions.ts
+++ b/packages/jaeger-ui/src/utils/markdownOptions.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MarkdownToJSX } from 'markdown-to-jsx';
+
+export const sharedMarkdownOptions: MarkdownToJSX.Options = {
+  disableParsingRawHTML: true,
+  overrides: {
+    pre: {
+      props: {
+        style: {
+          background: 'var(--surface-secondary)',
+          overflow: 'auto',
+          padding: '0.5rem',
+          borderRadius: '2px',
+          fontSize: '0.85em',
+        },
+      },
+    },
+    code: {
+      props: {
+        style: {
+          background: 'var(--surface-secondary)',
+          borderRadius: '2px',
+          padding: '0.1em 0.3em',
+          fontSize: '0.9em',
+        },
+      },
+    },
+    table: {
+      props: { style: { borderCollapse: 'collapse' as const, width: '100%', marginBottom: '0.5rem' } },
+    },
+    th: {
+      props: {
+        style: {
+          border: '1px solid var(--border-default)',
+          padding: '0.3rem 0.5rem',
+          background: 'var(--surface-secondary)',
+          fontWeight: 600,
+        },
+      },
+    },
+    td: { props: { style: { border: '1px solid var(--border-default)', padding: '0.3rem 0.5rem' } } },
+    blockquote: {
+      props: {
+        style: {
+          borderLeft: '3px solid var(--border-default)',
+          margin: '0 0 0.5rem',
+          paddingLeft: '0.75rem',
+        },
+      },
+    },
+  },
+};

--- a/packages/jaeger-ui/src/utils/markdownOptions.ts
+++ b/packages/jaeger-ui/src/utils/markdownOptions.ts
@@ -33,8 +33,16 @@ function SafeImage({ alt, title }: React.ImgHTMLAttributes<HTMLImageElement>) {
   );
 }
 
+// A stable module-level object is required: markdown-to-jsx memoizes its
+// parser on the options reference, so a fresh literal built on every render
+// would defeat that memoization and re-run the compiler on every streamed
+// token. optimizeForStreaming applies to every caller, not just the chat
+// panel -- span attributes rendered in the (future) GenAI span detail tab
+// can be truncated at ingestion, so tolerating unclosed tags is desirable
+// there too.
 export const sharedMarkdownOptions: MarkdownToJSX.Options = {
   disableParsingRawHTML: true,
+  optimizeForStreaming: true,
   // Without this, markdown-to-jsx drops the wrapper element (and with it the
   // className carrying our styling) whenever the parsed output is a single
   // node -- e.g. any one-sentence reply with no inline formatting. Callers
@@ -92,13 +100,4 @@ export const sharedMarkdownOptions: MarkdownToJSX.Options = {
       component: SafeImage,
     },
   },
-};
-
-// A stable object identity is required: markdown-to-jsx memoizes its parser
-// on the options reference, so spreading a new options object on every
-// render (e.g. { ...sharedMarkdownOptions, optimizeForStreaming: true })
-// defeats that memoization and re-runs the compiler on every streamed token.
-export const streamingMarkdownOptions: MarkdownToJSX.Options = {
-  ...sharedMarkdownOptions,
-  optimizeForStreaming: true,
 };

--- a/packages/jaeger-ui/src/utils/markdownOptions.ts
+++ b/packages/jaeger-ui/src/utils/markdownOptions.ts
@@ -5,12 +5,24 @@ import * as React from 'react';
 import type { MarkdownToJSX } from 'markdown-to-jsx';
 
 function SafeLink({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  // Browsers treat URL schemes case-insensitively and tolerate surrounding
+  // whitespace, so the allowlist check must normalize before comparing (e.g.
+  // "HTTPS://…" or a leading-space href must not be wrongly blocked). The
+  // rendered href keeps its original casing -- only the scheme comparison is
+  // normalized, since path/query segments can be legitimately case-sensitive.
+  const trimmedHref = typeof href === 'string' ? href.trim() : '';
+  const lowerHref = trimmedHref.toLowerCase();
   const isSafe =
-    href && (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('mailto:'));
+    !!trimmedHref &&
+    (lowerHref.startsWith('http://') || lowerHref.startsWith('https://') || lowerHref.startsWith('mailto:'));
   if (!isSafe) {
     return React.createElement('span', props, children);
   }
-  return React.createElement('a', { ...props, href, target: '_blank', rel: 'noopener noreferrer' }, children);
+  return React.createElement(
+    'a',
+    { ...props, href: trimmedHref, target: '_blank', rel: 'noopener noreferrer' },
+    children
+  );
 }
 
 function SafeImage({ alt, title }: React.ImgHTMLAttributes<HTMLImageElement>) {

--- a/packages/jaeger-ui/src/utils/markdownOptions.ts
+++ b/packages/jaeger-ui/src/utils/markdownOptions.ts
@@ -1,10 +1,33 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import * as React from 'react';
 import type { MarkdownToJSX } from 'markdown-to-jsx';
+
+function SafeLink({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const isSafe =
+    href && (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('mailto:'));
+  if (!isSafe) {
+    return React.createElement('span', props, children);
+  }
+  return React.createElement('a', { ...props, href, target: '_blank', rel: 'noopener noreferrer' }, children);
+}
+
+function SafeImage({ alt, title }: React.ImgHTMLAttributes<HTMLImageElement>) {
+  return React.createElement(
+    'span',
+    { className: 'JaegerAssistantPanel-image-placeholder' },
+    `[Image: ${alt || title || 'unsupported'}]`
+  );
+}
 
 export const sharedMarkdownOptions: MarkdownToJSX.Options = {
   disableParsingRawHTML: true,
+  // Without this, markdown-to-jsx drops the wrapper element (and with it the
+  // className carrying our styling) whenever the parsed output is a single
+  // node -- e.g. any one-sentence reply with no inline formatting. Callers
+  // rely on the wrapper always being present to apply consistent styling.
+  forceWrapper: true,
   overrides: {
     pre: {
       props: {
@@ -50,5 +73,20 @@ export const sharedMarkdownOptions: MarkdownToJSX.Options = {
         },
       },
     },
+    a: {
+      component: SafeLink,
+    },
+    img: {
+      component: SafeImage,
+    },
   },
+};
+
+// A stable object identity is required: markdown-to-jsx memoizes its parser
+// on the options reference, so spreading a new options object on every
+// render (e.g. { ...sharedMarkdownOptions, optimizeForStreaming: true })
+// defeats that memoization and re-runs the compiler on every streamed token.
+export const streamingMarkdownOptions: MarkdownToJSX.Options = {
+  ...sharedMarkdownOptions,
+  optimizeForStreaming: true,
 };


### PR DESCRIPTION
## Which problem is this PR solving?
- Assistant replies in the Ask Jaeger panel render as plain text, discarding the markdown structure (lists, tables, inline/fenced code, blockquotes) that LLM output typically contains
- The panel is fixed at 26rem wide, which is cramped for responses containing tables or code blocks

## Description of the changes
- Render assistant text parts with `markdown-to-jsx` (9.8.2, ~15 kB gzip), with raw-HTML parsing disabled as defense-in-depth and streaming-optimized parsing enabled; user-typed messages keep the plain-text path
- Extract the rendering config into a shared `src/utils/markdownOptions.ts` so the upcoming GenAI span detail tab can reuse identical markdown rendering; element styles use design tokens from `vars.css` so both themes work
- Add drag-to-resize on the panel's left edge (320–800 px, default 416 px), with document-listener cleanup on unmount and a `max-width: 100%` cap so the panel never overflows narrow viewports

## Screenshots and screencast
<img width="1920" height="1080" alt="Screenshot from 2026-07-02 03-07-54" src="https://github.com/user-attachments/assets/f7d0d904-8f53-495b-b98c-a692ed37df91" />

### panel resizing
[Screencast from 2026-07-02 03-08-12.webm](https://github.com/user-attachments/assets/a382be10-8867-44b6-a225-a10def20b12d)

## How was this change tested?
- 13 new unit tests (markdown vs. plain-text path selection per variant, drag widen/narrow, min/max clamping, drag stop on mouseup); the panel suite is 30 tests total with 98.7% statement / 100% function coverage on the changed component
- Full suite passes: 3,412 tests across both packages, plus `npm run lint`, `npm run tsc-lint`, and a production build
- Manual E2E against a live Jaeger backend + Gemini AI sidecar over AG-UI: verified streamed replies render tables, lists, bold, and code correctly alongside tool-call indicators, and the panel resizes smoothly

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
