### PR TITLE
feat(monitor): Sync Monitor filters to URL on change

### DIFF
--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -862,6 +862,67 @@ describe('<MonitorATMServicesView> URL query params', () => {
   });
 });
 
+describe('<MonitorATMServicesView> URL write-back', () => {
+  const mockFetchAllServiceMetrics = jest.fn();
+  const mockFetchAggregatedServiceMetrics = jest.fn();
+  const mockNavigate = jest.fn();
+
+  const baseProps = {
+    ...props,
+    fetchAllServiceMetrics: mockFetchAllServiceMetrics,
+    fetchAggregatedServiceMetrics: mockFetchAggregatedServiceMetrics,
+    navigate: mockNavigate,
+  };
+
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+    store.getString.mockReturnValue(undefined);
+    store.getNumber.mockReturnValue(undefined);
+    useServices.mockReturnValue({ data: ['service1', 'service2'], isLoading: false });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    useServices.mockReset();
+    useServices.mockImplementation(defaultUseServicesImpl);
+    cleanup();
+  });
+
+  it('updates the URL when the user changes the service filter', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="" />);
+
+    await user.selectOptions(screen.getByTestId('select-a-service-input'), 'service2');
+
+    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('service=service2'), { replace: true });
+  });
+
+  it('updates the URL when the user changes the span kind filter', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="?service=service1" />);
+
+    await user.selectOptions(screen.getByTestId('span-kind-selector'), 'client');
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.stringMatching(/service=service1.*spanKind=client|spanKind=client.*service=service1/),
+      { replace: true }
+    );
+  });
+
+  it('preserves unrelated query params when updating the URL', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<MonitorATMServicesView {...baseProps} search="?uiEmbed=v0" />);
+
+    await user.selectOptions(screen.getByTestId('select-a-service-input'), 'service2');
+
+    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('uiEmbed=v0'), { replace: true });
+    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('service=service2'), {
+      replace: true,
+    });
+  });
+});
+
 describe('<MonitorATMServicesView> on page switch', () => {
   const stateOnPageSwitch = {
     services: {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.test.jsx
@@ -921,6 +921,34 @@ describe('<MonitorATMServicesView> URL write-back', () => {
       replace: true,
     });
   });
+
+  it('persists a URL-seeded filter after write-back updates search', async () => {
+    const user = userEvent.setup();
+    let rerenderView = () => {};
+
+    const navigate = jest.fn(url => {
+      const nextSearch = url.includes('?') ? url.slice(url.indexOf('?')) : '';
+      rerenderView(
+        <MemoryRouter>
+          <MonitorATMServicesView {...baseProps} navigate={navigate} search={nextSearch} />
+        </MemoryRouter>
+      );
+    });
+
+    const { rerender } = renderWithRouter(
+      <MonitorATMServicesView {...baseProps} navigate={navigate} search="?spanKind=client" />
+    );
+    rerenderView = rerender;
+
+    expect(store.set).not.toHaveBeenCalledWith('lastAtmSearchSpanKind', expect.anything());
+
+    await user.selectOptions(screen.getByTestId('span-kind-selector'), 'server');
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalled();
+      expect(store.set).toHaveBeenCalledWith('lastAtmSearchSpanKind', 'server');
+    });
+  });
 });
 
 describe('<MonitorATMServicesView> on page switch', () => {

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -10,6 +10,7 @@ import store from '../../../utils/storage';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { Link } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
 import * as jaegerApiActions from '../../../actions/jaeger-api';
 import OperationTableDetails from './operationDetailsTable';
 import ServiceGraph from './serviceGraph';
@@ -42,7 +43,7 @@ import withRouteProps from '../../../utils/withRouteProps';
 
 import SearchableSelect from '../../common/SearchableSelect';
 import { useServices } from '../../../hooks/useTraceDiscovery';
-import { getUrlState } from '../url';
+import { getUrl, getUrlState } from '../url';
 
 type TReduxProps = {
   metrics: MetricsReduxState;
@@ -50,6 +51,7 @@ type TReduxProps = {
 
 type TOwnProps = {
   search?: string;
+  navigate?: NavigateFunction;
 };
 
 type TProps = TReduxProps & TDispatchProps & TOwnProps;
@@ -128,7 +130,7 @@ const convertServiceErrorRateToPercentages = (serviceErrorRate: null | ServiceMe
 };
 
 export function MonitorATMServicesViewImpl(props: TProps) {
-  const { fetchAllServiceMetrics, fetchAggregatedServiceMetrics, metrics, search = '' } = props;
+  const { fetchAllServiceMetrics, fetchAggregatedServiceMetrics, metrics, search = '', navigate } = props;
   const { data: services = [], isLoading: servicesLoading } = useServices();
   const docsLink = getConfig().monitor?.docsLink;
   const graphDivWrapper = useRef<HTMLDivElement>(null);
@@ -169,25 +171,52 @@ export function MonitorATMServicesViewImpl(props: TProps) {
     return resolveService(selectedService, services);
   }, [services, selectedService]);
 
-  const handleServiceChange = useCallback((value: string) => {
-    urlOwned.current.service = false;
-    setSelectedService(value);
-    trackSelectService(value);
-  }, []);
+  const syncFiltersToUrl = useCallback(
+    (filters: { service: string; spanKind: spanKinds; timeframe: number }) => {
+      if (!navigate) return;
+      navigate(getUrl(filters, search), { replace: true });
+    },
+    [navigate, search]
+  );
 
-  const handleSpanKindChange = useCallback((value: string) => {
-    urlOwned.current.spanKind = false;
-    setSelectedSpanKind(value as spanKinds);
-    const { label } = spanKindOptions.find(option => option.value === value)!;
-    trackSelectSpanKind(label);
-  }, []);
+  const handleServiceChange = useCallback(
+    (value: string) => {
+      urlOwned.current.service = false;
+      setSelectedService(value);
+      trackSelectService(value);
+      syncFiltersToUrl({ service: value, spanKind: selectedSpanKind, timeframe: selectedTimeFrame });
+    },
+    [selectedSpanKind, selectedTimeFrame, syncFiltersToUrl]
+  );
 
-  const handleTimeFrameChange = useCallback((value: number) => {
-    urlOwned.current.timeframe = false;
-    setSelectedTimeFrame(value);
-    const { label } = timeFrameOptions.find(option => option.value === value)!;
-    trackSelectTimeframe(label);
-  }, []);
+  const handleSpanKindChange = useCallback(
+    (value: string) => {
+      const spanKind = value as spanKinds;
+      urlOwned.current.spanKind = false;
+      setSelectedSpanKind(spanKind);
+      const { label } = spanKindOptions.find(option => option.value === value)!;
+      trackSelectSpanKind(label);
+      const service = resolveService(selectedService, services);
+      if (service) {
+        syncFiltersToUrl({ service, spanKind, timeframe: selectedTimeFrame });
+      }
+    },
+    [selectedService, selectedTimeFrame, services, syncFiltersToUrl]
+  );
+
+  const handleTimeFrameChange = useCallback(
+    (value: number) => {
+      urlOwned.current.timeframe = false;
+      setSelectedTimeFrame(value);
+      const { label } = timeFrameOptions.find(option => option.value === value)!;
+      trackSelectTimeframe(label);
+      const service = resolveService(selectedService, services);
+      if (service) {
+        syncFiltersToUrl({ service, spanKind: selectedSpanKind, timeframe: value });
+      }
+    },
+    [selectedService, selectedSpanKind, services, syncFiltersToUrl]
+  );
 
   const fetchMetrics = useCallback(() => {
     const currentService = resolveService(selectedService, services);

--- a/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
+++ b/packages/jaeger-ui/src/components/Monitor/ServicesView/index.tsx
@@ -147,10 +147,14 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   const [selectedTimeFrame, setSelectedTimeFrame] = useState<number>(initialFilters.selectedTimeFrame);
 
   const urlOwned = useRef(initialFilters.urlOwned);
+  const isInternalUrlSync = useRef(false);
 
   useEffect(() => {
     const filters = getFiltersFromSearch(search);
-    urlOwned.current = filters.urlOwned;
+    if (!isInternalUrlSync.current) {
+      urlOwned.current = filters.urlOwned;
+    }
+    isInternalUrlSync.current = false;
     setSelectedService(filters.selectedService);
     setSelectedSpanKind(filters.selectedSpanKind);
     setSelectedTimeFrame(filters.selectedTimeFrame);
@@ -174,6 +178,7 @@ export function MonitorATMServicesViewImpl(props: TProps) {
   const syncFiltersToUrl = useCallback(
     (filters: { service: string; spanKind: spanKinds; timeframe: number }) => {
       if (!navigate) return;
+      isInternalUrlSync.current = true;
       navigate(getUrl(filters, search), { replace: true });
     },
     [navigate, search]

--- a/packages/jaeger-ui/src/components/Monitor/url.test.js
+++ b/packages/jaeger-ui/src/components/Monitor/url.test.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2021 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import queryString from 'query-string';
+
 import { ROUTE_PATH, matches, getUrl, getUrlState } from './url';
 
 describe('Monitor/url', () => {
@@ -12,6 +14,24 @@ describe('Monitor/url', () => {
 
   it('getUrl', () => {
     expect(getUrl()).toBe(ROUTE_PATH);
+    expect(getUrl({ service: 'myservice', spanKind: 'client', timeframe: 3600000 })).toBe(
+      `${ROUTE_PATH}?service=myservice&spanKind=client&timeframe=3600000`
+    );
+  });
+
+  it('getUrl preserves unrelated query params', () => {
+    const url = getUrl(
+      { service: 'myservice', spanKind: 'server', timeframe: 3600000 },
+      '?uiEmbed=v0&foo=bar'
+    );
+    const query = queryString.parse(url.split('?')[1]);
+    expect(query).toEqual({
+      uiEmbed: 'v0',
+      foo: 'bar',
+      service: 'myservice',
+      spanKind: 'server',
+      timeframe: '3600000',
+    });
   });
 
   describe('getUrlState', () => {

--- a/packages/jaeger-ui/src/components/Monitor/url.ts
+++ b/packages/jaeger-ui/src/components/Monitor/url.ts
@@ -17,8 +17,23 @@ export function matches(path: string) {
   return Boolean(matchPath(ROUTE_PATH, path));
 }
 
-export function getUrl() {
-  return ROUTE_PATH;
+export type TMonitorUrlParams = {
+  service: string;
+  spanKind: spanKinds;
+  timeframe: number;
+};
+
+export function getUrl(params?: TMonitorUrlParams, currentSearch = ''): string {
+  if (!params) return ROUTE_PATH;
+
+  const merged = {
+    ...queryString.parse(currentSearch),
+    service: params.service,
+    spanKind: params.spanKind,
+    timeframe: params.timeframe,
+  };
+
+  return `${ROUTE_PATH}?${queryString.stringify(merged)}`;
 }
 
 export type TMonitorUrlState = {


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #2482 (follow-up to #4119)
- Completes two-way URL sync for Monitor filters: the first PR read service, spanKind, and timeframe from the URL; this PR writes them back when the user changes filters so URLs are shareable/bookmarkable.

## Description of the changes

- Extend getUrl() in Monitor/url.ts to accept filter params and merge them with the current query string (preserves unrelated params like uiEmbed).
- Update ServicesView filter handlers to call navigate(getUrl(...), { replace: true }) on service, span kind, and timeframe changes, following the same pattern as Quality Metrics.
- navigate is injected via existing withRouteProps wiring on the connected component.
- Add unit tests for getUrl() write-back and navigate calls on filter changes.

## How was this change tested?

1. Unit tests:

    - npm test -w packages/jaeger-ui -- src/components/Monitor/url.test.js
    - npm test -w packages/jaeger-ui -- src/components/Monitor/ServicesView/index.test.jsx

2. Repo checks: npm run fmt, npm run lint, npm test, npm run build
3. Manual:

    - Open /monitor, change service / span kind / timeframe → address bar updates
    - Copy URL into a new tab → filters match
    - Open /monitor?uiEmbed=v0, change filters → uiEmbed is preserved


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
