### PR TITLE
chore(renovate): Add 7-day minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,11 @@
   "labels": ["changelog:dependencies"],
   "suppressNotifications": ["prEditedNotification"],
   "schedule": ["on sunday"],
+  "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"]
+    "labels": ["security"],
+    "minimumReleaseAge": "0 days"
   },
   "packageRules": [
     {


### PR DESCRIPTION
Wait at least one week before proposing a dependency upgrade, avoiding broken or low-confidence releases. Security alerts bypass this delay via their own minimumReleaseAge override.
