### PR TITLE
test(config): remove ignored root-level server.deps block from vitest config

### DIFF
--- a/packages/jaeger-ui/vitest.config.ts
+++ b/packages/jaeger-ui/vitest.config.ts
@@ -48,16 +48,6 @@ export default defineConfig({
       '\\.(css|less)$': 'identity-obj-proxy',
     },
   },
-  server: {
-    deps: {
-      // Inline all node_modules through Vite's transform pipeline.
-      // The threads pool uses SSR resolve conditions that prefer .mjs files,
-      // causing CJS/ESM named-export interop failures for packages like
-      // react-router and cookie. inline:true fixes this class of problem
-      // universally rather than playing whack-a-mole with individual packages.
-      inline: true,
-    },
-  },
   resolve: {
     alias: {
       // More-specific alias must come first


### PR DESCRIPTION
## Which problem is this PR solving?

Part of #3996 (work item 1: narrow `server.deps.inline` in `vitest.config.ts`).

## Description of the changes

Work item 1 assumed the root-level `server.deps.inline: true` block was pushing all of `node_modules` through Vite's SSR transform pipeline and driving the suite's import/environment cost. Measuring it shows the block is **dead config**: Vitest 4 reads dependency-inlining options from `test.server.deps`, and a root-level `server.deps` is silently ignored. This PR removes the block instead of narrowing it — narrowing a no-op would have locked in a misleading config that appears load-bearing.

Evidence (Vitest 4.1.9, Node 24.18, macOS arm64, warm transform cache, full suite = 263 files / 3324 tests):

| Config | Result | Wall-clock |
|---|---|---|
| `main` as-is (root-level `inline: true`) | all pass | 46.9 s |
| root-level `inline: [/^react-router/, 'cookie']` | all pass | 45.2 s |
| **block removed entirely (this PR)** | **all pass** | **46.1–46.3 s** |
| `inline: true` moved to the live location `test.server.deps` | **3 files fail**, transform 7.5 s → 24 s | 51.4 s |

Two observations pin down that the block does nothing on `main`:

1. Removing it changes neither pass/fail nor timing (all identical within run-to-run noise).
2. Moving the same setting to the live `test.server.deps` location changes things drastically (slower, 3 failing files) — none of which happens on `main`, so the root-level block cannot be taking effect.

The CJS/ESM interop failures the block's comment describes (`react-router`, `cookie` named exports under the threads pool's SSR resolve conditions) no longer reproduce under default externalization — the full suite passes with no inline list at all — so no replacement list is needed.

Implication for the #3996 roadmap (posted to the issue as well): item 1's expected large win does not exist — the cumulative `import` (~133 s) and `environment` (~200 s) costs are the *default-externalization* baseline, dominated by per-file jsdom environment setup, which only isolation-level changes (item 2) can reduce.

## How was this change tested?

```bash
cd packages/jaeger-ui
npx vitest run --reporter=default --reporter=json --outputFile.json=/tmp/after.json
# Test Files  263 passed (263)
# Tests       3324 passed (3324)
# Duration    46.26s (transform 8.16s, setup 24.94s, import 135.91s, tests 67.05s, environment 199.57s)
```

Baseline on `main` measured the same way before the change (46.90 s, same pass counts); each configuration above was run twice, discarding the first (cold-cache) run. `npm run lint` passes.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality — n/a, config-only removal with no behavior change (suite is the test)
- [x] I have run lint and test steps successfully
