### PR TITLE
fix(trace): fix view selector arrow key navigation

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
@@ -13,8 +13,13 @@ vi.mock('antd', async () => {
   const originalModule = await vi.importActual('antd');
   return {
     ...originalModule,
-    Dropdown: ({ children, menu }) => (
-      <div data-testid="dropdown">
+    Dropdown: ({ children, menu, onOpenChange }) => (
+      <div
+        data-testid="dropdown"
+        onClick={() => {
+          if (onOpenChange) onOpenChange(true);
+        }}
+      >
         {children}
         <div data-testid="dropdown-menu">
           {menu.items.map(item => (
@@ -174,5 +179,27 @@ describe('AltViewOptions', () => {
       renderComponent({ viewType: type });
       expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
     });
+  });
+
+  it('focuses the first menu item when dropdown is opened', () => {
+    const requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(cb => cb());
+    const mockMenuItem = { focus: jest.fn() };
+    const querySelectorSpy = jest.spyOn(document, 'querySelector').mockReturnValue(mockMenuItem);
+
+    renderComponent();
+
+    const dropdown = screen.getByTestId('dropdown');
+    fireEvent.click(dropdown);
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalled();
+    expect(querySelectorSpy).toHaveBeenCalledWith(
+      '.ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu-item'
+    );
+    expect(mockMenuItem.focus).toHaveBeenCalled();
+
+    requestAnimationFrameSpy.mockRestore();
+    querySelectorSpy.mockRestore();
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -76,10 +76,23 @@ export default function AltViewOptions(props: Props) {
     );
   }
 
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      // Ant Design renders dropdown menus in a portal. Wait a frame for the DOM to update,
+      // then focus the first menu item so arrow keys work immediately.
+      requestAnimationFrame(() => {
+        const menuItem = document.querySelector<HTMLElement>(
+          '.ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu-item'
+        );
+        menuItem?.focus();
+      });
+    }
+  };
+
   const currentItem = MENU_ITEMS.find(item => item.viewType === viewType);
   const dropdownText = currentItem ? currentItem.label : 'Alternate Views';
   return (
-    <Dropdown menu={{ items: dropdownItems }} trigger={['click']}>
+    <Dropdown menu={{ items: dropdownItems }} trigger={['click']} onOpenChange={handleOpenChange}>
       <Button className="AltViewOptions">
         {`${dropdownText} `}
         <IoChevronDown />

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -211,6 +211,21 @@ describe('makeShortcutCallbacks()', () => {
       expect(adjRange).toHaveBeenLastCalledWith(...shortcutConfig[key]);
     });
   });
+
+  it('does not adjust the range for events originating from a menu or popup', () => {
+    const event = {
+      preventDefault: jest.fn(),
+      target: {
+        closest: () => ({}),
+      },
+    };
+    const callbacks = makeShortcutCallbacks(adjRange);
+    Object.keys(shortcutConfig).forEach(key => {
+      callbacks[key](event);
+    });
+    expect(adjRange).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
 });
 
 describe('<TracePage>', () => {

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -134,6 +134,10 @@ export const shortcutConfig: { [name: string]: [number, number] } = {
 export function makeShortcutCallbacks(adjRange: (start: number, end: number) => void): ShortcutCallbacks {
   function getHandler([startChange, endChange]: [number, number]): CombokeysHandler {
     return function combokeyHandler(event: React.KeyboardEvent<HTMLElement>) {
+      const target = event.target as HTMLElement;
+      if (target?.closest?.('[role="menu"], .ant-dropdown, .ant-popover, .ant-modal')) {
+        return;
+      }
       event.preventDefault();
       adjRange(startChange, endChange);
     };


### PR DESCRIPTION
## Which problem is this PR solving?

* Fixes #4178

## Description of the changes

* Added a check in combokeyHandler (TracePage/index.tsx) to ignore arrow key events when the focus is inside an interactive overlay (dropdown, popover, or modal using .closest([role="menu"])). This prevents tab from changing the plane when the drop down menu is open
* Added an onOpenChange handler to theAltViewOptions dropdn to focus the first menu item when it opens. This lets users use the Up/Down arrows right away without needing to press Tab first.

## How was this change tested?

* Manually tested that the view selector dropdn can be navigated using the Up/Down arrow keys without cahnging the pane and also not increasing or dcing the cnt
* Ran npm test, npm run lint, and npm run build successfully.

## Attachment

https://github.com/user-attachments/assets/07238d4f-a95d-45a9-87ca-0fbc9d0dc442



## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [ ] I have added unit tests for the new functionality *(N/A, this fix mainly relies on DOM focus handling and event targets.)*
* [x] I have run lint and test successfully.

## AI Usage in this PR (choose one)

* [ ] **None**
* [x ] **Light** to understand the code base faster
* [ ] **Moderate**
* [ ] **Heavy**
