### PR TITLE
fix(FileLoader): stop reporting OTLP backend-transform failures as parse errors

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.test.jsx
@@ -5,9 +5,13 @@ import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-vi.mock('../../utils/readJsonFile', () => ({
-  default: jest.fn(),
-}));
+vi.mock('../../utils/readJsonFile', async () => {
+  const actual = await vi.importActual('../../utils/readJsonFile');
+  return {
+    ...actual,
+    default: jest.fn(),
+  };
+});
 
 vi.mock('../../model/transform-trace-data', () => ({
   default: jest.fn(),
@@ -48,7 +52,7 @@ vi.mock('antd', async () => {
 });
 
 import FileLoader, { loadTracesFromFile } from './FileLoader';
-import readJsonFile from '../../utils/readJsonFile';
+import readJsonFile, { OtlpTransformError } from '../../utils/readJsonFile';
 import transformTraceData from '../../model/transform-trace-data';
 import { traceToTraceSummary } from '../../model/trace-summary';
 import { populateTraceCache } from '../../hooks/useTraceLoading';
@@ -246,6 +250,25 @@ describe('<FileLoader />', () => {
     });
 
     expect(message.error).toHaveBeenCalledWith(expect.stringContaining('not valid JSON'));
+    expect(mockOnTracesLoaded).not.toHaveBeenCalled();
+  });
+
+  it('shows a backend-required message, not "Failed to parse", when OTLP transform fails', async () => {
+    const { message } = await import('antd');
+    readJsonFile.mockRejectedValue(
+      new OtlpTransformError(
+        'OTLP import requires a reachable Jaeger backend (POST /api/transform): Failed to fetch'
+      )
+    );
+
+    render(<FileLoader onTracesLoaded={mockOnTracesLoaded} />);
+    await act(async () => {
+      global.mockBeforeUpload(makeFile('otel-file-exporter-output.json'));
+    });
+
+    expect(message.error).toHaveBeenCalledWith(
+      'otel-file-exporter-output.json: OTLP import requires a reachable Jaeger backend (POST /api/transform): Failed to fetch'
+    );
     expect(mockOnTracesLoaded).not.toHaveBeenCalled();
   });
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Upload, message } from 'antd';
 import { IoDocumentAttachOutline } from 'react-icons/io5';
 
-import readJsonFile from '../../utils/readJsonFile';
+import readJsonFile, { OtlpTransformError } from '../../utils/readJsonFile';
 import transformTraceData from '../../model/transform-trace-data';
 import { traceToTraceSummary } from '../../model/trace-summary';
 import { populateTraceCache } from '../../hooks/useTraceLoading';
@@ -90,6 +90,14 @@ export default function FileLoader(props: FileLoaderProps) {
             }
           })
           .catch((err: unknown) => {
+            // The OTLP transform call reaching the backend is a network/availability
+            // failure, not a parse error - the file's JSON was already valid by the
+            // time this rejects. Report it distinctly so the message doesn't blame
+            // the file for a backend that wasn't reachable.
+            if (err instanceof OtlpTransformError) {
+              message.error(`${file.name}: ${err.message}`);
+              return;
+            }
             message.error(
               `Failed to parse ${file.name}: ${err instanceof Error ? err.message : String(err)}`
             );

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import lodash from 'lodash';
-import readJsonFile from './readJsonFile';
+import readJsonFile, { OtlpTransformError } from './readJsonFile';
 import JaegerAPI from '../api/jaeger';
 
 let OTLPTrace;
@@ -67,13 +67,24 @@ describe('fileReader.readJsonFile', () => {
     return expect(p).resolves.toMatchObject(outObj);
   });
 
-  it('rejects an OTLP trace with a message that includes the backend error', () => {
+  it('rejects an OTLP trace with a message that explains the backend transform failed, not a parse error', () => {
     const inObj = JSON.parse(
       fs.readFileSync(path.resolve(fixturesDir, 'otlp2jaeger-in-error.json'), 'utf-8')
     );
     const file = new File([JSON.stringify(inObj)], 'foo.json');
     const p = readJsonFile({ file });
-    return expect(p).rejects.toThrow(/Error converting OTLP trace to Jaeger: backend transform failed/);
+    return expect(p).rejects.toThrow(
+      /OTLP import requires a reachable Jaeger backend \(POST \/api\/transform\): backend transform failed/
+    );
+  });
+
+  it('rejects an OTLP transform failure with an OtlpTransformError, distinguishable from a parse error', async () => {
+    const inObj = JSON.parse(
+      fs.readFileSync(path.resolve(fixturesDir, 'otlp2jaeger-in-error.json'), 'utf-8')
+    );
+    const file = new File([JSON.stringify(inObj)], 'foo.json');
+
+    await expect(readJsonFile({ file })).rejects.toBeInstanceOf(OtlpTransformError);
   });
 
   it('rejects malformed JSON', () => {

--- a/packages/jaeger-ui/src/utils/readJsonFile.ts
+++ b/packages/jaeger-ui/src/utils/readJsonFile.ts
@@ -3,6 +3,18 @@
 
 import JaegerAPI from '../api/jaeger';
 
+// Distinguishes "the OTLP-to-Jaeger backend conversion failed" from every other
+// rejection readJsonFile can produce (malformed JSON, a bad FileReader result, etc).
+// Unlike those, this file's JSON was valid - the failure happened after parsing,
+// in the network call to POST /api/transform, so callers should not describe it
+// as a parse error.
+export class OtlpTransformError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'OtlpTransformError';
+  }
+}
+
 function tryParseMultiLineInput(input: string): any[] {
   const jsonStrings = input.split('\n').filter((line: string) => line.trim() !== '');
   const parsedObjects: any[] = [];
@@ -56,7 +68,12 @@ export default function readJsonFile(fileList: { file: File }): Promise<string> 
           })
           .catch((err: unknown) => {
             const cause = err instanceof Error ? `: ${err.message}` : '';
-            reject(new Error(`Error converting OTLP trace to Jaeger${cause}`, { cause: err }));
+            reject(
+              new OtlpTransformError(
+                `OTLP import requires a reachable Jaeger backend (POST /api/transform)${cause}`,
+                { cause: err }
+              )
+            );
           });
       } else {
         resolve(traceObj);


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #4197

## Description of the changes
- Dropping an OTLP/JSON trace file into the Search page importer routes it through `JaegerAPI.transformOTLP` (`POST /api/transform`), since there's no client-side OTLP-to-legacy conversion in this codebase. When that call fails — no query service reachable, an older backend without the endpoint, a static build with nothing behind it — `readJsonFile` wrapped the failure in a generic `Error`, and `FileLoader`'s catch handler prefixed it with `"Failed to parse <file>"`. The file's JSON was completely valid the whole time; the failure happens afterward, in a network call the user never sees.
- Added an `OtlpTransformError` class exported from `readJsonFile.ts` so `FileLoader` can tell this failure apart from an actual parse error and report it accurately — the file name plus a message that says the OTLP conversion needs a reachable backend, instead of blaming the file's JSON.
- This is the minimal fix from the issue (making the error message accurate). Adding a full client-side OTLP → legacy conversion path so OTLP import works fully offline is a larger, separate change and is left as follow-up work per the issue's acceptance criteria.

## How was this change tested?
- Updated the existing `readJsonFile.test.js` case that asserted the old message text, and added a new case asserting the rejection is an `OtlpTransformError` instance.
- Added a `FileLoader.test.jsx` case asserting the toast shown for an OTLP transform failure names the file and explains the backend requirement, instead of the old "Failed to parse" wording.
- `npx vitest run src/utils/readJsonFile.test.js src/components/SearchTracePage/FileLoader.test.jsx` — all 27 tests pass.
- `npx vitest run src/components/SearchTracePage/ src/utils/readJsonFile.test.js` — full directory, 293 tests pass.
- `tsc --noEmit` and `vp fmt --check` clean on all four changed files.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
