### PR TITLE
fix(stats): Make heatmap theme-aware

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
@@ -16,10 +16,14 @@ describe('generateColor', () => {
 
     expect(tableValue1[0].isDetail).toBe(false);
     expect(tableValue1[0].count).toBe(8);
-    expect(tableValue1[0].colorToPercent).toBe('rgb(248,70,70)');
+    expect(tableValue1[0].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 60%, var(--surface-primary))'
+    );
     expect(tableValue1[1].isDetail).toBe(false);
     expect(tableValue1[1].count).toBe(3);
-    expect(tableValue1[1].colorToPercent).toBe('rgb(248,173.75,173.75)');
+    expect(tableValue1[1].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 27.5%, var(--surface-primary))'
+    );
 
     tableValue1 = generateColor(tableValue1, 'count', false);
     expect(tableValue1[0].isDetail).toBe(false);
@@ -36,10 +40,14 @@ describe('generateColor', () => {
 
     expect(tableValue1[0].isDetail).toBe(false);
     expect(tableValue1[0].total).toBe(573);
-    expect(tableValue1[0].colorToPercent).toBe('rgb(248,70,70)');
+    expect(tableValue1[0].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 60%, var(--surface-primary))'
+    );
     expect(tableValue1[1].isDetail).toBe(false);
     expect(tableValue1[1].total).toBe(238);
-    expect(tableValue1[1].colorToPercent).toBe('rgb(248,167.05061082024432,167.05061082024432)');
+    expect(tableValue1[1].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 29.6%, var(--surface-primary))'
+    );
 
     tableValue1 = generateColor(tableValue1, 'count', false);
     expect(tableValue1[0].isDetail).toBe(false);
@@ -63,10 +71,14 @@ describe('generateColor', () => {
 
     expect(tableValue2[0].isDetail).toBe(false);
     expect(tableValue2[0].count).toBe(8);
-    expect(tableValue2[0].colorToPercent).toBe('rgb(248,70,70)');
+    expect(tableValue2[0].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 60%, var(--surface-primary))'
+    );
     expect(tableValue2[1].isDetail).toBe(true);
     expect(tableValue2[1].count).toBe(1);
-    expect(tableValue2[1].colorToPercent).toBe('rgb(248,215.25,215.25)');
+    expect(tableValue2[1].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 14.5%, var(--surface-primary))'
+    );
 
     tableValue2 = generateColor(tableValue2, 'count', false);
 
@@ -75,7 +87,7 @@ describe('generateColor', () => {
     expect(tableValue2[0].colorToPercent).toBe('transparent');
     expect(tableValue2[1].isDetail).toBe(true);
     expect(tableValue2[1].count).toBe(1);
-    expect(tableValue2[1].colorToPercent).toBe('rgb(248,248,248)');
+    expect(tableValue2[1].colorToPercent).toBe('var(--surface-tertiary)');
   });
 
   it('check generateColor with total, two NameSelectors are selcted', () => {
@@ -91,10 +103,14 @@ describe('generateColor', () => {
 
     expect(tableValue2[0].isDetail).toBe(false);
     expect(tableValue2[0].total).toBe(573);
-    expect(tableValue2[0].colorToPercent).toBe('rgb(248,70,70)');
+    expect(tableValue2[0].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 60%, var(--surface-primary))'
+    );
     expect(tableValue2[1].isDetail).toBe(true);
     expect(tableValue2[1].total).toBe(390);
-    expect(tableValue2[1].colorToPercent).toBe('rgb(248,123.01570680628271,123.01570680628271)');
+    expect(tableValue2[1].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 43.39%, var(--surface-primary))'
+    );
 
     tableValue2 = generateColor(tableValue2, 'total', false);
 
@@ -103,7 +119,7 @@ describe('generateColor', () => {
     expect(tableValue2[0].colorToPercent).toBe('transparent');
     expect(tableValue2[1].isDetail).toBe(true);
     expect(tableValue2[1].total).toBe(390);
-    expect(tableValue2[1].colorToPercent).toBe('rgb(248,248,248)');
+    expect(tableValue2[1].colorToPercent).toBe('var(--surface-tertiary)');
   });
 
   it('covers percent attribute with colorToPercent=true', () => {
@@ -114,7 +130,35 @@ describe('generateColor', () => {
 
     const output = generateColor(input, 'percent', true);
 
-    expect(output[0].colorToPercent).toBe('rgb(248,111.5,111.5)');
-    expect(output[1].colorToPercent).toBe('rgb(248,194.5,194.5)');
+    expect(output[0].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 47%, var(--surface-primary))'
+    );
+    expect(output[1].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 21%, var(--surface-primary))'
+    );
+  });
+
+  it('handles zero values without creating invalid colors', () => {
+    const input = [
+      { isDetail: false, count: 0 },
+      { isDetail: false, count: 0 },
+    ];
+
+    const output = generateColor(input, 'count', true);
+
+    expect(output[0].colorToPercent).toBe(
+      'color-mix(in srgb, var(--span-color-6) 8%, var(--surface-primary))'
+    );
+    expect(output[1].colorToPercent).toBe(output[0].colorToPercent);
+  });
+
+  it('does not mutate the input rows', () => {
+    const input = [{ isDetail: false, count: 1, colorToPercent: 'transparent' }];
+
+    const output = generateColor(input, 'count', true);
+
+    expect(output).not.toBe(input);
+    expect(output[0]).not.toBe(input[0]);
+    expect(input[0].colorToPercent).toBe('transparent');
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.ts
@@ -3,37 +3,43 @@
 
 import { ITableSpan } from './types';
 
-export default function generateColor(tableValue: ITableSpan[], attribute: string, colorToPercent: boolean) {
-  let color;
-  let colorString;
-  const tableValue2 = tableValue;
+const MIN_HEATMAP_WEIGHT = 8;
+const MAX_HEATMAP_WEIGHT = 60;
 
-  for (let i = 0; i < tableValue2.length; i++) {
-    if (colorToPercent) {
-      if (attribute === 'percent') {
-        color = 236 - 166 * (tableValue2[i].percent / 100);
-        colorString = `rgb(248,${color},${color})`;
+function getNumericValue(row: ITableSpan, attribute: string): number {
+  const value = row[attribute as keyof ITableSpan];
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
 
-        tableValue2[i].colorToPercent = colorString;
-      } else {
-        let max = 0;
-        // find hights value
-        for (let j = 0; j < tableValue2.length; j++) {
-          if (max < (tableValue2[j] as any)[attribute]) {
-            max = (tableValue2[j] as any)[attribute];
-          }
-        }
-        const onePercent = 100 / max / 100;
-        color = 236 - 166 * ((tableValue2[i] as any)[attribute] * onePercent);
-        colorString = `rgb(248,${color},${color})`;
+function getHeatmapBackground(ratio: number): string {
+  const normalizedRatio = Math.min(1, Math.max(0, ratio));
+  const weight =
+    Math.round((MIN_HEATMAP_WEIGHT + normalizedRatio * (MAX_HEATMAP_WEIGHT - MIN_HEATMAP_WEIGHT)) * 100) /
+    100;
 
-        tableValue2[i].colorToPercent = colorString;
-      }
-    } else if (tableValue2[i].isDetail) {
-      tableValue2[i].colorToPercent = `rgb(248,248,248)`;
-    } else {
-      tableValue2[i].colorToPercent = 'transparent';
+  return `color-mix(in srgb, var(--span-color-6) ${weight}%, var(--surface-primary))`;
+}
+
+export default function generateColor(tableValue: ITableSpan[], attribute: string, enabled: boolean) {
+  const maxValue =
+    enabled && attribute !== 'percent'
+      ? tableValue.reduce((max, row) => Math.max(max, getNumericValue(row, attribute)), 0)
+      : 100;
+
+  return tableValue.map(row => {
+    if (!enabled) {
+      return {
+        ...row,
+        colorToPercent: row.isDetail ? 'var(--surface-tertiary)' : 'transparent',
+      };
     }
-  }
-  return tableValue2;
+
+    const value = getNumericValue(row, attribute);
+    const ratio = maxValue > 0 ? value / maxValue : 0;
+
+    return {
+      ...row,
+      colorToPercent: getHeatmapBackground(ratio),
+    };
+  });
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3322.

Trace Statistics used hard-coded light RGB backgrounds for the `Color by` heatmap. In dark mode those backgrounds were paired with light theme text, making lower-intensity rows unreadable.

## Description of the changes

- Mixes the existing theme-aware span color into the active surface instead of generating fixed RGB values.
- Uses the theme-aware tertiary surface for detail rows when the heatmap is disabled.
- Computes the selected metric maximum once in O(n), instead of rescanning all rows for every row.
- Returns new row objects rather than mutating the input table data.
- Preserves the existing Color-by control, search behavior, sorting, pagination, and row expansion behavior.

## How was this change tested?

- `npm run fmt`
- `npm run lint`
- `npm test`
- `npm run build`

The updated unit tests cover proportional Count, Total, and Percent heatmaps, disabled-state surfaces, zero-valued metrics, and input immutability.
