### PR TITLE
fix(ui): correct order of Min and Max duration fields in search form

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -627,21 +627,6 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
 
       <Row gutter={16}>
         <Col className="gutter-row" span={12}>
-          <FormItem label="Max Duration">
-            <ValidatedFormField
-              name="maxDuration"
-              value={formData.maxDuration}
-              disabled={submitting}
-              validate={validateDurationFields}
-              placeholder={placeholderDurationFields}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                handleChange({ maxDuration: e.target.value })
-              }
-            />
-          </FormItem>
-        </Col>
-
-        <Col className="gutter-row" span={12}>
           <FormItem label="Min Duration">
             <ValidatedFormField
               name="minDuration"
@@ -651,6 +636,21 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
               placeholder={placeholderDurationFields}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 handleChange({ minDuration: e.target.value })
+              }
+            />
+          </FormItem>
+        </Col>
+
+        <Col className="gutter-row" span={12}>
+          <FormItem label="Max Duration">
+            <ValidatedFormField
+              name="maxDuration"
+              value={formData.maxDuration}
+              disabled={submitting}
+              validate={validateDurationFields}
+              placeholder={placeholderDurationFields}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleChange({ maxDuration: e.target.value })
               }
             />
           </FormItem>


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4201 

## Description of the changes
- The "Max Duration" field was being rendered before "Min Duration" in the search form,
  which is counterintuitive. Every standard form convention puts the minimum value on the 
  left and maximum on the right (think price ranges, date pickers, etc.). I noticed this 
  while using the search page and it felt a bit off, so swapped the two `<Col>` blocks 
  in `SearchForm.tsx` so the order reads naturally: Min → Max.

## How was this change tested?
- Ran the existing Vitest test suite (`npm test`) — all 69 tests passed with no failures.
- Verified visually on the local dev server that the fields now appear in the correct 
  left-to-right order (Min Duration | Max Duration).
- Confirmed that form submission with both duration fields still works as expected 
  and no form state logic was affected (the field names/bindings are unchanged).

## Before:
<img width="1917" height="1198" alt="Screenshot 2026-07-10 092753" src="https://github.com/user-attachments/assets/2948f205-df64-4302-b01d-e2577e7d8757" />

## After:
<img width="1917" height="1198" alt="Screenshot 2026-07-10 094243" src="https://github.com/user-attachments/assets/d8350e41-9564-4cc0-b923-b08a278efd9e" />



## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
