### PR TITLE
feat(trace): Expand span pills to hardcoded attribute set

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -298,6 +298,24 @@ describe('<SpanBarRow>', () => {
       );
       expect(screen.queryByLabelText(/http\.status_code/)).not.toBeInTheDocument();
     });
+
+    it('renders multiple pills from span attributes', () => {
+      render(
+        <SpanBarRow
+          {...defaultProps}
+          spanPillsEnabled
+          span={{
+            ...defaultProps.span,
+            attributes: makeAttributes([
+              { key: 'http.status_code', value: '200' },
+              { key: 'http.method', value: 'GET' },
+            ]),
+          }}
+        />
+      );
+      expect(screen.getByLabelText('http.status_code: 200')).toBeInTheDocument();
+      expect(screen.getByLabelText('http.method: GET')).toBeInTheDocument();
+    });
   });
 
   it('sets longLabel and hintSide to right when viewStart <= 1 - viewEnd', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.test.ts
@@ -4,7 +4,7 @@
 import { renderHook } from '@testing-library/react';
 
 import transformTraceData from '../../../model/transform-trace-data';
-import { IOtelSpan } from '../../../types/otel';
+import { AttributeValue, IOtelSpan } from '../../../types/otel';
 import { getSpanPillsForSpan, useSpanPillsEnabled } from './spanPills';
 import { makeAttributes } from '../../../model/attributes';
 
@@ -14,7 +14,7 @@ vi.mock('../../../hooks/useConfig', () => ({
   useConfig: mockUseConfig,
 }));
 
-function makeSpan(attributes: { key: string; value: string }[]): IOtelSpan {
+function makeSpan(attributes: ReadonlyArray<{ key: string; value: AttributeValue }>): IOtelSpan {
   return {
     spanID: 's1',
     attributes: makeAttributes(attributes),
@@ -106,7 +106,7 @@ describe('spanPills', () => {
       ]);
     });
 
-    it('returns multiple hardcoded pills in source order', () => {
+    it('returns multiple default pills in source order', () => {
       const span = makeSpan([
         { key: 'http.method', value: 'GET' },
         { key: 'http.status_code', value: '200' },
@@ -145,10 +145,22 @@ describe('spanPills', () => {
       ]);
     });
 
-    it('maps span.kind pill', () => {
-      expect(getSpanPillsForSpan(makeSpan([{ key: 'span.kind', value: 'server' }]))).toEqual([
-        { label: 'span.kind', value: 'server' },
+    it('formats non-string attribute values', () => {
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'http.status_code', value: 404 }]))).toEqual([
+        { label: 'http.status_code', value: '404' },
       ]);
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'http.status_code', value: 503 }]))).toEqual([
+        { label: 'http.status_code', value: '503', isError: true },
+      ]);
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'db.system', value: ['mysql', 'postgres'] }]))).toEqual([
+        { label: 'db.system', value: '["mysql","postgres"]' },
+      ]);
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'rpc.system', value: { name: 'grpc' } }]))).toEqual([
+        { label: 'rpc.system', value: '{"name":"grpc"}' },
+      ]);
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'db.system', value: new Uint8Array([1, 2, 3]) }]))).toEqual(
+        [{ label: 'db.system', value: '[1,2,3]' }]
+      );
     });
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.test.ts
@@ -105,6 +105,51 @@ describe('spanPills', () => {
         { label: 'http.status_code', value: 'not-a-number' },
       ]);
     });
+
+    it('returns multiple hardcoded pills in source order', () => {
+      const span = makeSpan([
+        { key: 'http.method', value: 'GET' },
+        { key: 'http.status_code', value: '200' },
+        { key: 'db.system', value: 'mysql' },
+      ]);
+      expect(getSpanPillsForSpan(span)).toEqual([
+        { label: 'http.status_code', value: '200' },
+        { label: 'http.method', value: 'GET' },
+        { label: 'db.system', value: 'mysql' },
+      ]);
+    });
+
+    it('maps http.method and falls back to http.request.method', () => {
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'http.method', value: 'POST' }]))).toEqual([
+        { label: 'http.method', value: 'POST' },
+      ]);
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'http.request.method', value: 'PUT' }]))).toEqual([
+        { label: 'http.method', value: 'PUT' },
+      ]);
+      expect(
+        getSpanPillsForSpan(
+          makeSpan([
+            { key: 'http.method', value: 'GET' },
+            { key: 'http.request.method', value: 'PUT' },
+          ])
+        )
+      ).toEqual([{ label: 'http.method', value: 'GET' }]);
+    });
+
+    it('maps db.system and rpc.system pills', () => {
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'db.system', value: 'redis' }]))).toEqual([
+        { label: 'db.system', value: 'redis' },
+      ]);
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'rpc.system', value: 'grpc' }]))).toEqual([
+        { label: 'rpc.system', value: 'grpc' },
+      ]);
+    });
+
+    it('maps span.kind pill', () => {
+      expect(getSpanPillsForSpan(makeSpan([{ key: 'span.kind', value: 'server' }]))).toEqual([
+        { label: 'span.kind', value: 'server' },
+      ]);
+    });
   });
 
   describe('useSpanPillsEnabled', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.ts
@@ -12,8 +12,7 @@ type IPillSource = {
   isError?: (value: string) => boolean;
 };
 
-// PR2: hardcoded OTel semantic-convention pills. User-selectable fields come later.
-const HARDCODED_PILL_SOURCES: readonly IPillSource[] = [
+const DEFAULT_PILL_SOURCES: readonly IPillSource[] = [
   {
     label: 'http.status_code',
     attrKeys: ['http.status_code', 'http.response.status_code'],
@@ -28,7 +27,6 @@ const HARDCODED_PILL_SOURCES: readonly IPillSource[] = [
   },
   { label: 'db.system', attrKeys: ['db.system'] },
   { label: 'rpc.system', attrKeys: ['rpc.system'] },
-  { label: 'span.kind', attrKeys: ['span.kind'] },
 ];
 
 function safeStringify(value: object): string {
@@ -77,7 +75,7 @@ function pillFromSource(span: IOtelSpan, source: IPillSource): ISpanPill | undef
 /** Builds pills for a single span. Owns which attributes become pills; callers do not. */
 export function getSpanPillsForSpan(span: IOtelSpan): ISpanPill[] {
   const pills: ISpanPill[] = [];
-  for (const source of HARDCODED_PILL_SOURCES) {
+  for (const source of DEFAULT_PILL_SOURCES) {
     const pill = pillFromSource(span, source);
     if (pill) {
       pills.push(pill);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.ts
@@ -2,33 +2,88 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useConfig } from '../../../hooks/useConfig';
-import { IOtelSpan } from '../../../types/otel';
-
-// PR1: HTTP status is the only pill source. Private — callers never see these keys.
-const HTTP_STATUS_ATTR_KEYS = ['http.status_code', 'http.response.status_code'] as const;
+import { AttributeValue, IOtelSpan } from '../../../types/otel';
 
 export type ISpanPill = { label: string; value: string; isError?: boolean };
 
-function httpStatusPill(span: IOtelSpan): ISpanPill | undefined {
-  for (const key of HTTP_STATUS_ATTR_KEYS) {
-    const attrValue = span.attributes.getValue(key);
-    const value = attrValue == null ? '' : String(attrValue);
-    if (value) {
+type IPillSource = {
+  label: string;
+  attrKeys: readonly string[];
+  isError?: (value: string) => boolean;
+};
+
+// PR2: hardcoded OTel semantic-convention pills. User-selectable fields come later.
+const HARDCODED_PILL_SOURCES: readonly IPillSource[] = [
+  {
+    label: 'http.status_code',
+    attrKeys: ['http.status_code', 'http.response.status_code'],
+    isError: value => {
       const code = Number(value.trim());
-      const pill: ISpanPill = { label: 'http.status_code', value };
-      if (code >= 500 && code < 600) {
-        pill.isError = true;
-      }
-      return pill;
+      return code >= 500 && code < 600;
+    },
+  },
+  {
+    label: 'http.method',
+    attrKeys: ['http.method', 'http.request.method'],
+  },
+  { label: 'db.system', attrKeys: ['db.system'] },
+  { label: 'rpc.system', attrKeys: ['rpc.system'] },
+  { label: 'span.kind', attrKeys: ['span.kind'] },
+];
+
+function safeStringify(value: object): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+}
+
+function formatAttributeValue(value: AttributeValue): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (value instanceof Uint8Array) {
+    return safeStringify(Array.from(value));
+  }
+  if (Array.isArray(value)) {
+    return safeStringify(value);
+  }
+  if (typeof value === 'object') {
+    return safeStringify(value);
+  }
+  return String(value);
+}
+
+function pillFromSource(span: IOtelSpan, source: IPillSource): ISpanPill | undefined {
+  for (const key of source.attrKeys) {
+    const attrValue = span.attributes.getValue(key);
+    if (attrValue == null) {
+      continue;
     }
+    const value = formatAttributeValue(attrValue);
+    if (!value) {
+      continue;
+    }
+    const pill: ISpanPill = { label: source.label, value };
+    if (source.isError?.(value)) {
+      pill.isError = true;
+    }
+    return pill;
   }
   return undefined;
 }
 
 /** Builds pills for a single span. Owns which attributes become pills; callers do not. */
 export function getSpanPillsForSpan(span: IOtelSpan): ISpanPill[] {
-  const pill = httpStatusPill(span);
-  return pill ? [pill] : [];
+  const pills: ISpanPill[] = [];
+  for (const source of HARDCODED_PILL_SOURCES) {
+    const pill = pillFromSource(span, source);
+    if (pill) {
+      pills.push(pill);
+    }
+  }
+  return pills;
 }
 
 /** Enabled unless explicitly disabled via config (default on). */


### PR DESCRIPTION
## Which problem is this PR solving?
- Part 2 of the incremental summary-fields plan for #4017 (stacked on merged PR1)
- PR1 only showed HTTP status pills; users still had to open span details for other common semantic attributes (method, DB/RPC system)

## Description of the changes
- Extend `spanPills.ts` with a private `DEFAULT_PILL_SOURCES` list that maps OTel/Jaeger attribute keys to span row pills:
  - `http.status_code` (`http.status_code`, `http.response.status_code`) — 5xx styled as errors
  - `http.method` (`http.method`, `http.request.method`)
  - `db.system`
  - `rpc.system`
- Refactor `getSpanPillsForSpan()` to emit **multiple pills per span** in source order (replacing HTTP-only logic)
- Add `formatAttributeValue()` for non-string attribute values
- **No UI changes**, pills still computed per visible span in `SpanBarRow`; no settings picker, localStorage, or `buildAvailableFields` (later PRs)

**Not in this PR:** user-selectable summary fields, trace-aware field filtering, gear settings, URL persistence

## How was this change tested?
1. Manual: open traces with HTTP/DB/RPC spans; verify multiple pills (e.g. status + method on HTTP spans, `db.system` on DB spans, where present); 5xx still red

- `npm test -w packages/jaeger-ui -- src/components/TracePage/TraceTimelineViewer/spanPills.test.ts src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx`
- `npm run fmt`
- `npm run lint`
- `npm run build`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [X] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
