### PR TITLE
fix(trace): Show span pill labels as tooltips

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.css
@@ -3,6 +3,15 @@ Copyright (c) 2017 Uber Technologies, Inc.
 SPDX-License-Identifier: Apache-2.0
 */
 
+.SpanBarRow--pillWrap {
+  /* Sit above .span-name::after so hover tooltips receive pointer events. */
+  display: inline-flex;
+  max-width: 100%;
+  position: relative;
+  vertical-align: middle;
+  z-index: 1;
+}
+
 .SpanBarRow--pill {
   background: var(--surface-component-background);
   border: 1px solid var(--border-default);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -298,6 +298,21 @@ describe('<SpanBarRow>', () => {
       );
       expect(screen.queryByLabelText(/http\.status_code/)).not.toBeInTheDocument();
     });
+
+    it('shows pill.label as a tooltip on hover', async () => {
+      render(
+        <SpanBarRow
+          {...defaultProps}
+          spanPillsEnabled
+          span={{
+            ...defaultProps.span,
+            attributes: makeAttributes([{ key: 'http.status_code', value: '200' }]),
+          }}
+        />
+      );
+      fireEvent.mouseEnter(screen.getByLabelText('http.status_code: 200').parentElement);
+      expect(await screen.findByRole('tooltip')).toHaveTextContent('http.status_code');
+    });
   });
 
   it('sets longLabel and hintSide to right when viewStart <= 1 - viewEnd', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback } from 'react';
-import { Tag } from 'antd';
+import { Tag, Tooltip } from 'antd';
 import cx from 'classnames';
 import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
@@ -198,13 +198,17 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
             </span>
             <small className="endpoint-name">{rpc ? rpc.operationName : operationName}</small>
             {pills.map(pill => (
-              <Tag
-                key={pill.label}
-                aria-label={`${pill.label}: ${pill.value}`}
-                className={cx('SpanBarRow--pill', { 'is-error': pill.isError })}
-              >
-                {pill.value}
-              </Tag>
+              <Tooltip key={pill.label} mouseEnterDelay={0} title={pill.label}>
+                {/* span keeps Tooltip trigger above .span-name::after hit area */}
+                <span className="SpanBarRow--pillWrap">
+                  <Tag
+                    aria-label={`${pill.label}: ${pill.value}`}
+                    className={cx('SpanBarRow--pill', { 'is-error': pill.isError })}
+                  >
+                    {pill.value}
+                  </Tag>
+                </span>
+              </Tooltip>
             ))}
           </a>
           {hasLinks && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback } from 'react';
-import { Tag, Tooltip } from 'antd';
-import cx from 'classnames';
 import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
@@ -16,7 +14,7 @@ import Ticks from './Ticks';
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
-import { getSpanPillsForSpan } from './spanPills';
+import { getSpanPillsForSpan, SpanPill } from './spanPills';
 
 import { getSpanIconComponent } from './span-icons';
 
@@ -205,17 +203,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
             </span>
             <small className="endpoint-name">{rpc ? rpc.operationName : operationName}</small>
             {pills.map(pill => (
-              <Tooltip key={pill.label} mouseEnterDelay={0} title={pill.label}>
-                {/* span keeps Tooltip trigger above .span-name::after hit area */}
-                <span className="SpanBarRow--pillWrap">
-                  <Tag
-                    aria-label={`${pill.label}: ${pill.value}`}
-                    className={cx('SpanBarRow--pill', { 'is-error': pill.isError })}
-                  >
-                    {pill.value}
-                  </Tag>
-                </span>
-              </Tooltip>
+              <SpanPill key={pill.label} pill={pill} />
             ))}
           </a>
           {hasLinks && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/spanPills.tsx
@@ -1,6 +1,10 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+import React from 'react';
+import { Tag, Tooltip } from 'antd';
+import cx from 'classnames';
+
 import { useConfig } from '../../../hooks/useConfig';
 import { AttributeValue, IOtelSpan } from '../../../types/otel';
 
@@ -87,4 +91,21 @@ export function getSpanPillsForSpan(span: IOtelSpan): ISpanPill[] {
 /** Enabled unless explicitly disabled via config (default on). */
 export function useSpanPillsEnabled(): boolean {
   return useConfig().traceTimeline?.spanPillsEnabled !== false;
+}
+
+/** Renders a single span pill with its attribute-key tooltip. */
+export function SpanPill({ pill }: { pill: ISpanPill }) {
+  return (
+    <Tooltip mouseEnterDelay={0} title={pill.label}>
+      {/* span keeps Tooltip trigger above .span-name::after hit area */}
+      <span className="SpanBarRow--pillWrap">
+        <Tag
+          aria-label={`${pill.label}: ${pill.value}`}
+          className={cx('SpanBarRow--pill', { 'is-error': pill.isError })}
+        >
+          {pill.value}
+        </Tag>
+      </span>
+    </Tooltip>
+  );
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4218 
- Span pills show attribute values (e.g. `200`, `client`) but `ISpanPill.label` was only used for React keys and `aria-label`, so users could not tell which attribute a pill came from without opening span details.
- Follow-up to #4149 / the summary-fields work for #4017.

## Description of the changes
- Wrap each span pill `Tag` in an Ant Design `Tooltip` with `title={pill.label}` so the attribute key appears on hover.
- Add a `.SpanBarRow--pillWrap` wrapper with `position: relative; z-index: 1` so the tooltip trigger sits above `.span-name::after` and receives pointer events.
- Keep existing `aria-label={`${pill.label}: ${pill.value}`}` for screen readers.

## How was this change tested?
- Unit: `npm test -w packages/jaeger-ui -- src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx` (new hover test asserts tooltip shows `http.status_code`)
- Full suite: `npm run fmt`, `npm run lint`, `npm test`, `npm run build`
- Manual: hover pills on a trace timeline and confirm the attribute key tooltip appears; span row click-to-expand still works
<img width="550" height="492" alt="Screenshot 2026-07-18 at 11 27 53 AM" src="https://github.com/user-attachments/assets/7c22db56-f4cd-47ee-ab3d-2a8c2a1d3209" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes