### PR TITLE
fix(genai-tab): simplify and fix rendering of GenAI span icons

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { GenAISpanIcon } from './GenAISpanIcon';
 import type { IOtelSpan, GenAISpanKind } from '../../../types/otel';
 
@@ -44,5 +44,14 @@ describe('GenAISpanIcon', () => {
   it('falls back to the generic GenAI icon for an unrecognized genAIKind', () => {
     render(<GenAISpanIcon span={makeSpan('FUTURE_KIND' as GenAISpanKind)} />);
     expect(screen.getByRole('img', { name: 'GenAI span' })).toBeInTheDocument();
+  });
+
+  it('shows a hover tooltip explaining what the icon means (#4217)', async () => {
+    render(<GenAISpanIcon span={makeSpan('TOOL_CALL')} />);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    fireEvent.mouseEnter(screen.getByRole('img', { name: 'Tool call' }));
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Tool call');
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react';
+import { Tooltip } from 'antd';
 import { MdSmartToy, MdBolt, MdBuild, MdStorage, MdAutoAwesome } from 'react-icons/md';
 import type { IconType } from 'react-icons';
 import type { IOtelSpan, GenAISpanKind } from '../../../types/otel';
@@ -20,8 +21,10 @@ export function GenAISpanIcon({ span }: { span: IOtelSpan }): React.ReactElement
   if (kind === undefined) return null;
   const { icon: Icon, label } = KIND_META[kind] ?? KIND_META.UNKNOWN_GENAI;
   return (
-    <span role="img" aria-label={label} className="GenAISpanIcon">
-      <Icon aria-hidden="true" />
-    </span>
+    <Tooltip title={label}>
+      <span role="img" aria-label={label} className="GenAISpanIcon">
+        <Icon aria-hidden="true" />
+      </span>
+    </Tooltip>
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -358,5 +358,19 @@ describe('<SpanBarRow>', () => {
       render(<SpanBarRow {...defaultProps} span={span} />);
       expect(screen.getByRole('img', { name: 'GenAI span' })).toBeInTheDocument();
     });
+
+    it('does not also render the generic namespace icon for a span with gen_ai attributes, only the kind-specific GenAISpanIcon (#4217)', () => {
+      const span = {
+        ...defaultProps.span,
+        genAIKind: 'LLM_CALL',
+        attributes: makeAttributes([{ key: 'gen_ai.system', value: 'openai' }]),
+      };
+      const { container } = render(<SpanBarRow {...defaultProps} span={span} />);
+      // getSpanIconComponent's generic namespace icon (aria-hidden, rendered via
+      // this class) must not appear alongside GenAISpanIcon's kind-specific icon -
+      // that combination was the reported double-sparkle/double-icon rendering.
+      expect(container.querySelector('.SpanBarRow--spanTypeIcon')).not.toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'LLM call' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -372,5 +372,28 @@ describe('<SpanBarRow>', () => {
       expect(container.querySelector('.SpanBarRow--spanTypeIcon')).not.toBeInTheDocument();
       expect(screen.getByRole('img', { name: 'LLM call' })).toBeInTheDocument();
     });
+
+    it('suppresses the generic namespace icon even when a GenAI span also carries http attributes, not just gen_ai ones (#4217)', () => {
+      // Regression case found by testing against a real trace: the root HTTP
+      // server span for a GenAI agent's own endpoint carries both gen_ai.* and
+      // real http.* attributes (http.request.method, http.response.status_code,
+      // etc.). Removing only the gen_ai entry from the generic icon's namespace
+      // map was not enough - the icon then fell through to http's globe icon
+      // instead, recreating the same double-icon bug with a different pair of
+      // icons. The generic icon must be suppressed for any GenAI-classified span
+      // regardless of what other namespaces it also has attributes from.
+      const span = {
+        ...defaultProps.span,
+        genAIKind: 'AGENT',
+        attributes: makeAttributes([
+          { key: 'gen_ai.operation.name', value: 'invoke_agent' },
+          { key: 'http.request.method', value: 'POST' },
+          { key: 'http.response.status_code', value: 200 },
+        ]),
+      };
+      const { container } = render(<SpanBarRow {...defaultProps} span={span} />);
+      expect(container.querySelector('.SpanBarRow--spanTypeIcon')).not.toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Agent' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -119,7 +119,14 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
     resource: { serviceName },
   } = span;
   const pills = spanPillsEnabled ? getSpanPillsForSpan(span) : [];
-  const SpanTypeIcon = getSpanIconComponent(attributes);
+  // A span classified as GenAI (agent/LLM call/tool call/retrieval/etc.) already
+  // renders exactly one icon via GenAISpanIcon below. Suppress the generic
+  // namespace icon entirely for such spans, not just its gen_ai entry - a GenAI
+  // span commonly also carries http/db/messaging attributes (e.g. the root HTTP
+  // server span for an agent's own endpoint), and without this check the generic
+  // icon would fall through to whichever of those namespaces is left, recreating
+  // the same double-icon problem with a different second icon (#4217).
+  const SpanTypeIcon = span.genAIKind === undefined ? getSpanIconComponent(attributes) : null;
   const label = formatDurationCompact(duration);
   const viewBounds = getViewedBounds(span.startTime, span.endTime);
   const viewStart = viewBounds.start;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-icons.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-icons.test.ts
@@ -9,8 +9,12 @@ function makeAttrs(attrKeys: string[]) {
 }
 
 describe('getSpanIconComponent', () => {
-  it.each(['gen_ai', 'db', 'http', 'messaging', 'rpc'])('returns an icon for %s attributes', ns => {
+  it.each(['db', 'http', 'messaging', 'rpc'])('returns an icon for %s attributes', ns => {
     expect(getSpanIconComponent(makeAttrs([`${ns}.system`]))).not.toBeNull();
+  });
+
+  it('returns null for gen_ai attributes - GenAISpanIcon renders the kind-specific icon for those instead, not this generic one', () => {
+    expect(getSpanIconComponent(makeAttrs(['gen_ai.system']))).toBeNull();
   });
 
   it('returns null for unrecognized namespace', () => {
@@ -25,10 +29,10 @@ describe('getSpanIconComponent', () => {
     expect(getSpanIconComponent(undefined)).toBeNull();
   });
 
-  it('gen_ai takes priority over db when both present', () => {
-    const genAiOnly = getSpanIconComponent(makeAttrs(['gen_ai.system']));
-    expect(getSpanIconComponent(makeAttrs(['gen_ai.system', 'db.system']))).toBe(genAiOnly);
-    expect(getSpanIconComponent(makeAttrs(['db.system', 'gen_ai.system']))).toBe(genAiOnly);
+  it('db takes priority over http when both present', () => {
+    const dbOnly = getSpanIconComponent(makeAttrs(['db.system']));
+    expect(getSpanIconComponent(makeAttrs(['db.system', 'http.system']))).toBe(dbOnly);
+    expect(getSpanIconComponent(makeAttrs(['http.system', 'db.system']))).toBe(dbOnly);
   });
 
   it('returns a consistent icon regardless of attribute order within the same namespace', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-icons.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/span-icons.ts
@@ -3,7 +3,6 @@
 
 import type { IconType } from 'react-icons';
 import {
-  IoSparkles as GenAiIcon,
   IoServer as DbIcon,
   IoGlobe as HttpIcon,
   IoChatbubble as MessagingIcon,
@@ -12,9 +11,15 @@ import {
 
 import type { IAttributes } from '../../../types/otel';
 
+// gen_ai is deliberately not a namespace here: GenAISpanIcon already renders one
+// icon per GenAI span, classified by operation kind (agent/LLM call/tool call/
+// retrieval, falling back to a generic GenAI icon for an unclassified operation -
+// see classifySpan). A second, generic gen_ai entry in this map would render
+// alongside it on every GenAI span, which is exactly the redundant/confusing
+// double-icon rendering reported in #4217.
+//
 // Priority: lower index wins when a span has attributes from multiple namespaces.
 const NAMESPACE_PRIORITY: Partial<Record<string, number>> = {
-  gen_ai: 0,
   db: 1,
   http: 2,
   messaging: 3,
@@ -22,7 +27,6 @@ const NAMESPACE_PRIORITY: Partial<Record<string, number>> = {
 };
 
 const NAMESPACE_ICON: Partial<Record<string, IconType>> = {
-  gen_ai: GenAiIcon,
   db: DbIcon,
   http: HttpIcon,
   messaging: MessagingIcon,


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #4217. Every GenAI span in the trace timeline rendered two icons instead of one:

1. `span-icons.ts`'s generic namespace-based icon (`IoSparkles`), shown for any span with `gen_ai.*` attributes.
2. `GenAISpanIcon`'s operation-kind icon (agent/LLM call/tool call/retrieval, or `MdAutoAwesome` - a different sparkle-style icon - for a GenAI span whose operation isn't in the classification list).

Both rendered side by side on every GenAI span, which produced exactly the four problems reported:
- An agent span showed both the generic sparkle and the robot icon, with no visible distinction between them.
- Every other GenAI span showed two different sparkle-style icons next to each other, conveying no additional information over one.
- Neither icon had a hover tooltip explaining what it meant, only an `aria-label` for screen readers.
- The two icons come from different icon libraries (Ionicons vs Material Design) with different internal glyph metrics, so despite identical `vertical-align`/`font-size` CSS on both, they did not line up with each other.

## Description of the changes

- `span-icons.ts`: removed the `gen_ai` entry from `NAMESPACE_PRIORITY`/`NAMESPACE_ICON`. `classifySpan` (in `utils/genai/detect.ts`) already falls back to `UNKNOWN_GENAI` for any span with `gen_ai.*` attributes it can't classify by operation name, so `GenAISpanIcon` alone already covers every case the generic namespace entry did.
- `SpanBarRow.tsx`: suppresses the generic namespace icon entirely whenever a span is already GenAI-classified (`span.genAIKind !== undefined`), instead of relying on `span-icons.ts` to individually exclude every namespace that might co-occur with `gen_ai` attributes on the same span. This was needed because removing only the `gen_ai` entry wasn't sufficient on its own: the reported trace's root `/api/ai/chat` span carries both `gen_ai.*` attributes (it's classified `AGENT`) and genuine `http.*` attributes (it's an HTTP server span - `http.request.method`, `http.response.status_code`, etc.). Once `gen_ai` stopped winning the generic icon's namespace-priority contest, `http` won instead, so the span still rendered two icons - just a globe next to the robot instead of a sparkle next to the robot. Found by testing the first version of this fix against the real trace end-to-end (see below), not by inspection.
- `GenAISpanIcon.tsx`: wrapped the icon in an antd `Tooltip`, reusing the same per-kind `label` already used for `aria-label` (e.g. "Agent", "LLM call", "Tool call", "Retrieval", "GenAI span"). Hovering any GenAI span icon now shows what it means.
- With the generic icon suppressed, a GenAI span now renders exactly one icon, which also resolves the alignment complaint as a direct consequence - verified visually, not just logically: rendered the real `IoSparkles`/`GenAISpanIcon` SVG output through the real CSS in a browser, before and after. Before, the sparkle icon's visual mass sat clearly above a guide line marking the row's true vertical center, while the robot icon straddled it evenly - a real, visible offset between the two. After, the single remaining icon sits centered on the line.

## Screenshots

4 real spans from the exact trace behind the issue's screenshot (trace `bde4caeb`), rendered through the real components with the real CSS - before/after. Row 1 is the root `/api/ai/chat` span specifically, since that's the one that exposed the deeper root cause described above: it also carries `http.*` attributes, which is why its "before" state shows a globe icon rather than a sparkle - same underlying double-icon problem, just a different second icon depending on what else the span happens to be instrumented with.

<img width="1568" height="773" alt="Before/after: 4 real spans from the reported trace, real components, real CSS" src="https://github.com/user-attachments/assets/81974707-791a-470b-98ac-33aed635b6ef" />

**Trace file** used for testing and for the screenshot above: [benchmark-trace-bde4caeb.json](https://github.com/user-attachments/files/30154342/benchmark-trace-bde4caeb.json) (the same trace already attached to PR #4213).

## Test changes

- `span-icons.test.ts`: updated the namespace-icon test to exclude `gen_ai` from the "returns an icon" cases, added an explicit test that `gen_ai`-only attributes return `null`, and replaced the `gen_ai`-priority test with an equivalent `db`-vs-`http` priority test.
- `GenAISpanIcon.test.tsx`: added a test that hovering the icon shows a tooltip with the same text as its accessible name.
- `SpanBarRow.test.jsx`: added a test asserting a span with `gen_ai.*` attributes renders only `GenAISpanIcon`'s kind-specific icon, and a second regression test for the http+gen_ai co-occurrence case described above (a span with both `gen_ai.operation.name` and `http.*` attributes still renders exactly one icon).

## How was this change tested?

- `npm test` - `GenAISpanIcon.test.tsx`, `span-icons.test.ts`, `SpanBarRow.test.jsx`: all passing (46/46 across the three). Full `TraceTimelineViewer` suite (36 files, 644 tests): all passing, no regressions.
- `npx tsc -p packages/jaeger-ui/tsconfig.json` - no new type errors.
- `npm run lint` (oxlint + knip) - clean on all changed files.
- End-to-end verification against the actual trace behind the linked screenshot, through the real production pipeline (not synthetic data or a reimplemented check): loaded the trace's raw JSON through the real `transformTraceData` and `OtelTraceFacade`, rendered the real `SpanBarRow` for every one of its 13 real spans, and asserted the actual rendered DOM. Result: every GenAI-classified span (including the root `/api/ai/chat` span, `genAIKind=AGENT`) renders exactly one icon (`GenAISpanIcon`, zero generic icons); the one non-GenAI span (`mcp.discover_tools`) renders zero icons from either source. This test run is what caught the http+gen_ai co-occurrence gap in the first version of this fix.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
