### PR TITLE
chore(genai-tab): prefix the token usage row with "Tokens:"

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
@@ -32,6 +32,12 @@ SPDX-License-Identifier: Apache-2.0
   margin-right: 4px;
 }
 
+.GenAITab--tokensPrefix {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
 .GenAITab--section {
   display: flex;
   flex-direction: column;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -44,6 +44,24 @@ describe('GenAITab', () => {
     expect(screen.getByText('20')).toBeInTheDocument();
   });
 
+  it('prefixes the token usage row with "Tokens:" so the numbers are labeled as a group (#4219)', () => {
+    const { container } = render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.usage.input_tokens', value: 100 },
+          { key: 'gen_ai.usage.output_tokens', value: 50 },
+        ])}
+      />
+    );
+    const prefix = screen.getByText('Tokens:');
+    expect(prefix).toBeInTheDocument();
+    expect(prefix).toHaveClass('GenAITab--tokensPrefix');
+    // The prefix must actually lead the row, not just be present somewhere on
+    // the page - assert it precedes the Input/Output items in document order.
+    const tokensRow = container.querySelector('.GenAITab--tokens');
+    expect(tokensRow?.firstElementChild).toBe(prefix);
+  });
+
   it('renders a zero input token count, not treating it as missing', () => {
     render(<GenAITab span={makeSpan([{ key: 'gen_ai.usage.input_tokens', value: 0 }])} />);
     expect(screen.getByText('Input')).toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -89,6 +89,7 @@ const TOKEN_LABELS: Partial<Record<keyof GenAiTokenUsage, string>> = {
 function TokensRow({ usage }: { usage: GenAiTokenUsage }) {
   return (
     <div className="GenAITab--tokens">
+      <span className="GenAITab--tokensPrefix">Tokens:</span>
       {(Object.keys(usage) as Array<keyof GenAiTokenUsage>).map(key => {
         const value = usage[key];
         if (value == null) return null;


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #4219. The Input/Output token counts row in the GenAI tab had no label indicating what the numbers represent as a group - just "Input 3,803  Output 45" with no lead-in, unlike other rows in the same tab.

## Description of the changes

- `GenAITab/index.tsx`: added a `"Tokens:"` prefix as the first element of the token usage row (`TokensRow`), before the per-token Input/Output/Cached/Reasoning items.
- `GenAITab/index.css`: added `.GenAITab--tokensPrefix`, styled bold with primary text color so it reads as a group heading rather than another per-item label like the existing `.GenAITab--tokenLabel` styling.

## Screenshots

Real before/after, using the actual data from the span in the linked issue's screenshot (trace `bde4caeb`, `generate_content gemini-2.5-flash` span, Input 3,803 / Output 45 tokens), rendered through the real component with the real CSS:

<img width="1568" height="773" alt="Before/after: real token data, real component, real CSS" src="https://github.com/user-attachments/assets/8866a5c0-4c2c-4dff-8d9d-e7a5c4cb1c5b" />

**Trace file** used for testing and for the screenshot above: [benchmark-trace-bde4caeb.json](https://github.com/user-attachments/files/30155283/benchmark-trace-bde4caeb.json).

## Test changes

- `index.test.tsx`: added a test asserting the `"Tokens:"` prefix is present, carries the `GenAITab--tokensPrefix` class, and is the first child of the tokens row (not just present somewhere on the page).

## How was this change tested?

- `npm test` - `GenAITab/index.test.tsx`: 15/15 passing. Full `GenAITab` suite (2 files): 64/64 passing, no regressions.
- `npx tsc -p packages/jaeger-ui/tsconfig.json` - no new type errors.
- `npm run lint` (oxlint + knip) - clean on all changed files.
- Rendered the real `GenAITab` component with attributes extracted directly from the real reported trace's real `generate_content` span (not synthetic data) and asserted the real token values (3,803 / 45) render correctly alongside the new prefix.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
