### PR TITLE
fix(genai): Fix span icon hover tooltip and refine type icons and labels

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.css
@@ -8,4 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   margin-right: 0.3rem;
   vertical-align: -0.18em;
   color: var(--interactive-primary);
+  /* Sit above .span-name::after so the hover tooltip receives pointer events. */
+  position: relative;
+  z-index: 1;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.test.tsx
@@ -23,12 +23,12 @@ describe('GenAISpanIcon', () => {
 
   it('renders a tool call icon for genAIKind=TOOL_CALL', () => {
     render(<GenAISpanIcon span={makeSpan('TOOL_CALL')} />);
-    expect(screen.getByRole('img', { name: 'Tool call' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'MCP Tool call' })).toBeInTheDocument();
   });
 
   it('renders an agent icon for genAIKind=AGENT', () => {
     render(<GenAISpanIcon span={makeSpan('AGENT')} />);
-    expect(screen.getByRole('img', { name: 'Agent' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'AI Agent' })).toBeInTheDocument();
   });
 
   it('renders a retrieval icon for genAIKind=RETRIEVAL', () => {
@@ -49,9 +49,9 @@ describe('GenAISpanIcon', () => {
   it('shows a hover tooltip explaining what the icon means (#4217)', async () => {
     render(<GenAISpanIcon span={makeSpan('TOOL_CALL')} />);
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
-    fireEvent.mouseEnter(screen.getByRole('img', { name: 'Tool call' }));
+    fireEvent.mouseEnter(screen.getByRole('img', { name: 'MCP Tool call' }));
     await waitFor(() => {
-      expect(screen.getByRole('tooltip')).toHaveTextContent('Tool call');
+      expect(screen.getByRole('tooltip')).toHaveTextContent('MCP Tool call');
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
@@ -3,15 +3,16 @@
 
 import * as React from 'react';
 import { Tooltip } from 'antd';
-import { MdSmartToy, MdBolt, MdBuild, MdStorage, MdAutoAwesome } from 'react-icons/md';
+import { MdSmartToy, MdBuild, MdStorage, MdAutoAwesome } from 'react-icons/md';
+import { RiGraduationCapFill } from 'react-icons/ri';
 import type { IconType } from 'react-icons';
 import type { IOtelSpan, GenAISpanKind } from '../../../types/otel';
 import './GenAISpanIcon.css';
 
 const KIND_META: Record<GenAISpanKind, { icon: IconType; label: string }> = {
-  AGENT: { icon: MdSmartToy, label: 'Agent' },
-  LLM_CALL: { icon: MdBolt, label: 'LLM call' },
-  TOOL_CALL: { icon: MdBuild, label: 'Tool call' },
+  AGENT: { icon: MdSmartToy, label: 'AI Agent' },
+  LLM_CALL: { icon: RiGraduationCapFill, label: 'LLM call' },
+  TOOL_CALL: { icon: MdBuild, label: 'MCP Tool call' },
   RETRIEVAL: { icon: MdStorage, label: 'Retrieval' },
   UNKNOWN_GENAI: { icon: MdAutoAwesome, label: 'GenAI span' },
 };

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/GenAISpanIcon.tsx
@@ -3,18 +3,25 @@
 
 import * as React from 'react';
 import { Tooltip } from 'antd';
-import { MdSmartToy, MdBuild, MdStorage, MdAutoAwesome } from 'react-icons/md';
-import { RiGraduationCapFill } from 'react-icons/ri';
+// Icons are aliased by their intended purpose so swapping a glyph only touches
+// these imports, not the KIND_META table below.
+import {
+  MdSmartToy as AgentIcon,
+  MdBuild as ToolCallIcon,
+  MdStorage as RetrievalIcon,
+  MdAutoAwesome as GenericGenAIIcon,
+} from 'react-icons/md';
+import { RiGraduationCapFill as LLMCallIcon } from 'react-icons/ri';
 import type { IconType } from 'react-icons';
 import type { IOtelSpan, GenAISpanKind } from '../../../types/otel';
 import './GenAISpanIcon.css';
 
 const KIND_META: Record<GenAISpanKind, { icon: IconType; label: string }> = {
-  AGENT: { icon: MdSmartToy, label: 'AI Agent' },
-  LLM_CALL: { icon: RiGraduationCapFill, label: 'LLM call' },
-  TOOL_CALL: { icon: MdBuild, label: 'MCP Tool call' },
-  RETRIEVAL: { icon: MdStorage, label: 'Retrieval' },
-  UNKNOWN_GENAI: { icon: MdAutoAwesome, label: 'GenAI span' },
+  AGENT: { icon: AgentIcon, label: 'AI Agent' },
+  LLM_CALL: { icon: LLMCallIcon, label: 'LLM call' },
+  TOOL_CALL: { icon: ToolCallIcon, label: 'MCP Tool call' },
+  RETRIEVAL: { icon: RetrievalIcon, label: 'Retrieval' },
+  UNKNOWN_GENAI: { icon: GenericGenAIIcon, label: 'GenAI span' },
 };
 
 export function GenAISpanIcon({ span }: { span: IOtelSpan }): React.ReactElement | null {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -358,7 +358,7 @@ describe('<SpanBarRow>', () => {
     it('shows no GenAI icon for a standard span', () => {
       render(<SpanBarRow {...defaultProps} />);
       expect(
-        screen.queryByRole('img', { name: /LLM call|Tool call|Agent|Retrieval|GenAI span/ })
+        screen.queryByRole('img', { name: /LLM call|MCP Tool call|AI Agent|Retrieval|GenAI span/ })
       ).not.toBeInTheDocument();
     });
 
@@ -371,13 +371,13 @@ describe('<SpanBarRow>', () => {
     it('shows a tool call icon when span.genAIKind=TOOL_CALL', () => {
       const span = { ...defaultProps.span, genAIKind: 'TOOL_CALL' };
       render(<SpanBarRow {...defaultProps} span={span} />);
-      expect(screen.getByRole('img', { name: 'Tool call' })).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'MCP Tool call' })).toBeInTheDocument();
     });
 
     it('shows an agent icon when span.genAIKind=AGENT', () => {
       const span = { ...defaultProps.span, genAIKind: 'AGENT' };
       render(<SpanBarRow {...defaultProps} span={span} />);
-      expect(screen.getByRole('img', { name: 'Agent' })).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'AI Agent' })).toBeInTheDocument();
     });
 
     it('shows a retrieval icon when span.genAIKind=RETRIEVAL', () => {
@@ -426,7 +426,7 @@ describe('<SpanBarRow>', () => {
       };
       const { container } = render(<SpanBarRow {...defaultProps} span={span} />);
       expect(container.querySelector('.SpanBarRow--spanTypeIcon')).not.toBeInTheDocument();
-      expect(screen.getByRole('img', { name: 'Agent' })).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'AI Agent' })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Fixes #4217 (point 3 was reopened - the hover tooltip added in #4221 wasn't actually working).

## Root cause

`.span-name::after` is an absolutely-positioned pseudo-element that extends the row's click target across the rest of the name column:

```css
.span-name::after {
  background: transparent;
  bottom: 0;
  content: ' ';
  left: 0;
  position: absolute;
  top: 0;
  width: 1000px;
}
```

Because it's a positioned box generated after all of `.span-name`'s other content, it paints above `GenAISpanIcon`'s plain in-flow `<span>` within the same stacking context - so real mouse hover lands on the `::after` overlay instead of the icon, and the `antd` `Tooltip`'s `onMouseEnter` never fires. Confirmed via `document.elementFromPoint()` at the icon's own bounding-box center: it resolved to `A.span-name`, not the icon.

This is exactly the problem `.SpanBarRow--pillWrap` already solves for span pills, in the same file, with the same fix:

```css
.SpanBarRow--pillWrap {
  /* Sit above .span-name::after so hover tooltips receive pointer events. */
  position: relative;
  z-index: 1;
}
```

`GenAISpanIcon.css` never got the same treatment, so the icon's tooltip silently never worked, even though the isolated `GenAISpanIcon.test.tsx` unit test passes - it renders the icon alone, with no `.span-name::after` overlay to reproduce the bug.

## Fix

Apply the identical `position: relative; z-index: 1;` to `.GenAISpanIcon`.

## How this was verified

Unit tests don't catch this class of bug - `jsdom` doesn't do real hit-testing, so a synthetic `fireEvent.mouseEnter` on the icon bypasses the overlay regardless. Verified for real instead:

- Ran the actual dev server (`npm start`) against a clean `upstream/main` checkout.
- Uploaded the real trace behind this issue's original screenshot (`bde4caeb`, same file already attached to #4213/#4221) via the UI's own trace-upload feature - no synthetic data.
- Confirmed the bug first: `document.elementFromPoint()` at the icon's rect center resolved to the `.span-name` link, not the icon.
- Applied the fix, confirmed HMR picked it up, confirmed `elementFromPoint()` now resolves inside the icon's own SVG.
- Did a real mouse hover (not a synthetic event) over the icon and visually confirmed the tooltip renders - across multiple icon kinds (Agent, LLM call, GenAI span) on multiple spans in the same real trace.
- Re-verified the same real hover on a clean rebuild of this exact branch off latest `upstream/main`, after discarding an unrelated repo-wide formatting run.
- `npx vitest run` on `GenAISpanIcon.test.tsx` + `SpanBarRow.test.js`: 38/38 passing, no regressions.
- `npm run tsc-lint`: clean.

**Before / after**, same real trace (`bde4caeb`), same hover coordinates, only the CSS fix differs:

![before-after](https://github.com/user-attachments/assets/1e06ca7f-6541-4cc5-97bc-a7f02e8975c5)

## Follow-up: icon and label refinements

Building on the same GenAI span-type icons, a few presentation tweaks:

- **LLM call icon**: swap the bolt (`MdBolt`) for a graduation cap (`RiGraduationCapFill`), a more fitting glyph for a model call.
- **Labels** (tooltip + `aria-label`): `Agent` → `AI Agent`, `Tool call` → `MCP Tool call` for clarity.

Unit tests updated accordingly (`GenAISpanIcon.test.tsx`, `SpanBarRow.test.jsx`).