### PR TITLE
feat(genai-tab): add LLM caption to the meta row and elevate agent attributes

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
@@ -25,6 +25,49 @@ function section<T extends keyof SectionDataMap>(
 }
 
 describe('extractGenAiSections', () => {
+  describe('agent section', () => {
+    it('extracts all four gen_ai.agent.* fields', () => {
+      const sections = extractGenAiSections(
+        attrs({
+          'gen_ai.agent.id': 'asst_5j66UpCpwteGg4YSxUnt7lPY',
+          'gen_ai.agent.name': 'Math Tutor',
+          'gen_ai.agent.version': '1.0.0',
+          'gen_ai.agent.description': 'Helps with math problems',
+        })
+      );
+      expect(section(sections, 'agent')).toEqual({
+        id: 'asst_5j66UpCpwteGg4YSxUnt7lPY',
+        name: 'Math Tutor',
+        version: '1.0.0',
+        description: 'Helps with math problems',
+      });
+    });
+
+    it('extracts an agent section from gen_ai.agent.name alone', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.agent.name': 'Math Tutor' }));
+      expect(section(sections, 'agent')).toEqual({
+        id: undefined,
+        name: 'Math Tutor',
+        version: undefined,
+        description: undefined,
+      });
+    });
+
+    it('produces no agent section when no gen_ai.agent.* attribute is present', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.provider.name': 'openai' }));
+      expect(section(sections, 'agent')).toBeUndefined();
+    });
+
+    it('excludes claimed gen_ai.agent.* attributes from the other section', () => {
+      const sections = extractGenAiSections(
+        attrs({ 'gen_ai.agent.name': 'Math Tutor', 'gen_ai.conversation.id': 'conv-1' })
+      );
+      expect(section(sections, 'other')?.attributes.entries()).toEqual([
+        { key: 'gen_ai.conversation.id', value: 'conv-1' },
+      ]);
+    });
+  });
+
   describe('meta section (provider/model)', () => {
     it('prefers current provider attribute names over deprecated one when they disagree', () => {
       const sections = extractGenAiSections(

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
@@ -66,6 +66,17 @@ describe('extractGenAiSections', () => {
         { key: 'gen_ai.conversation.id', value: 'conv-1' },
       ]);
     });
+
+    it('still produces an agent section for a legitimate empty-string field, instead of silently dropping it', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.agent.name': '' }));
+      expect(section(sections, 'agent')).toEqual({
+        id: undefined,
+        name: '',
+        version: undefined,
+        description: undefined,
+      });
+      expect(section(sections, 'other')).toBeUndefined();
+    });
   });
 
   describe('meta section (provider/model)', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
@@ -24,6 +24,16 @@ export type GenAiToolCall = {
   result?: unknown;
 };
 
+// Fields per the gen_ai.agent.* registry (create_agent/invoke_agent spans): id, name,
+// version, description. All are individually optional/conditionally-required per spec,
+// so a span can carry any subset.
+export type GenAiAgent = {
+  id?: string;
+  name?: string;
+  version?: string;
+  description?: string;
+};
+
 export type GenAiTokenUsage = {
   inputTokens?: number;
   outputTokens?: number;
@@ -36,6 +46,7 @@ export type GenAiTokenUsage = {
 // so a generic fallback renderer can walk `Object.entries(data)` for a
 // section type it doesn't have a specific case for.
 export type GenAiSection =
+  | { type: 'agent'; data: GenAiAgent }
   | { type: 'meta'; data: { provider?: string; model?: string } }
   | { type: 'tokens'; data: GenAiTokenUsage }
   | {
@@ -246,6 +257,15 @@ type SectionBuilder = (get: GetAttr) => GenAiSection | undefined;
 // position; the loop below walks this array (developer-controlled, fixed
 // order), not the span's attributes (whose order is instrumentation-dependent).
 const REGISTRY: SectionBuilder[] = [
+  get => {
+    const id = asString(get('gen_ai.agent.id'));
+    const name = asString(get('gen_ai.agent.name'));
+    const version = asString(get('gen_ai.agent.version'));
+    const description = asString(get('gen_ai.agent.description'));
+    return id || name || version || description
+      ? { type: 'agent', data: { id, name, version, description } }
+      : undefined;
+  },
   get => {
     // gen_ai.provider.name/gen_ai.system is a genuine current/deprecated pair -
     // `||` short-circuits so gen_ai.system is only read (and claimed) when

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
@@ -262,7 +262,11 @@ const REGISTRY: SectionBuilder[] = [
     const name = asString(get('gen_ai.agent.name'));
     const version = asString(get('gen_ai.agent.version'));
     const description = asString(get('gen_ai.agent.description'));
-    return id || name || version || description
+    // Presence, not truthiness: get() already claimed these keys, so a
+    // legitimate empty-string value must still produce a section - otherwise
+    // it's dropped here AND excluded from "Other GenAI Attributes" (already
+    // claimed), silently losing the attribute entirely.
+    return id !== undefined || name !== undefined || version !== undefined || description !== undefined
       ? { type: 'agent', data: { id, name, version, description } }
       : undefined;
   },

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
@@ -32,6 +32,7 @@ SPDX-License-Identifier: Apache-2.0
   margin-right: 4px;
 }
 
+.GenAITab--metaPrefix,
 .GenAITab--tokensPrefix {
   font-size: 13px;
   font-weight: 600;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
@@ -9,7 +9,6 @@ SPDX-License-Identifier: Apache-2.0
   gap: 16px;
 }
 
-.GenAITab--meta,
 .GenAITab--tokens {
   display: flex;
   flex-wrap: wrap;
@@ -20,19 +19,16 @@ SPDX-License-Identifier: Apache-2.0
   border-radius: 4px;
 }
 
-.GenAITab--metaItem,
 .GenAITab--tokenItem {
   font-size: 13px;
   color: var(--text-primary);
 }
 
-.GenAITab--metaLabel,
 .GenAITab--tokenLabel {
   color: var(--text-secondary);
   margin-right: 4px;
 }
 
-.GenAITab--metaPrefix,
 .GenAITab--tokensPrefix {
   font-size: 13px;
   font-weight: 600;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
@@ -123,20 +123,6 @@ SPDX-License-Identifier: Apache-2.0
   white-space: pre-wrap;
 }
 
-.GenAITab--toolSubsection {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.GenAITab--toolLabel {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
 .GenAITab--json,
 .GenAITab--pre {
   border: 1px solid var(--border-default);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -9,9 +9,18 @@ import GenAITab from '.';
 import { useMessageFormatStore } from './message-format-store';
 import type { IAttribute, IOtelSpan } from '../../../../../types/otel';
 import { makeAttributes } from '../../../../../model/attributes';
+import { classifySpan } from '../../../../../utils/genai/detect';
 
+// genAIKind is always attribute-derived in production (OtelSpanFacade computes it via
+// classifySpan, never set independently) - deriving it here the same way keeps these
+// tests from silently diverging from real span behavior.
 function makeSpan(attributes: IAttribute[]): IOtelSpan {
-  return { spanID: 'abc123', attributes: makeAttributes(attributes) } as unknown as IOtelSpan;
+  const spanAttributes = makeAttributes(attributes);
+  return {
+    spanID: 'abc123',
+    attributes: spanAttributes,
+    genAIKind: classifySpan({ attributes: spanAttributes }),
+  } as unknown as IOtelSpan;
 }
 
 describe('GenAITab', () => {
@@ -36,10 +45,11 @@ describe('GenAITab', () => {
     expect(screen.getByText('gpt-4o')).toBeInTheDocument();
   });
 
-  it('prefixes the provider/model row with "LLM:" so it reads as a labeled group like Tokens: does (#4237)', () => {
+  it('prefixes the provider/model row with "LLM:" on an actual LLM call, so it reads as a labeled group like Tokens: does (#4237)', () => {
     const { container } = render(
       <GenAITab
         span={makeSpan([
+          { key: 'gen_ai.operation.name', value: 'chat' },
           { key: 'gen_ai.provider.name', value: 'openai' },
           { key: 'gen_ai.response.model', value: 'gpt-4o' },
         ])}
@@ -50,6 +60,21 @@ describe('GenAITab', () => {
     expect(prefix).toHaveClass('GenAITab--metaPrefix');
     const metaRow = container.querySelector('.GenAITab--meta');
     expect(metaRow?.firstElementChild).toBe(prefix);
+  });
+
+  it('omits the "LLM:" prefix on a non-LLM span that also reports a provider, without hiding the provider itself', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.operation.name', value: 'invoke_agent' },
+          { key: 'gen_ai.provider.name', value: 'anthropic' },
+        ])}
+      />
+    );
+    // classifySpan() resolves this to AGENT, not LLM_CALL - captioning it "LLM:" would
+    // misrepresent an agent invocation as an LLM call, per Ansh's review on #4244.
+    expect(screen.queryByText('LLM:')).not.toBeInTheDocument();
+    expect(screen.getByText('anthropic')).toBeInTheDocument();
   });
 
   it('elevates gen_ai.agent.* attributes into their own Agent section instead of the raw Other GenAI Attributes dump (#4237)', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -36,6 +36,57 @@ describe('GenAITab', () => {
     expect(screen.getByText('gpt-4o')).toBeInTheDocument();
   });
 
+  it('prefixes the provider/model row with "LLM:" so it reads as a labeled group like Tokens: does (#4237)', () => {
+    const { container } = render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.provider.name', value: 'openai' },
+          { key: 'gen_ai.response.model', value: 'gpt-4o' },
+        ])}
+      />
+    );
+    const prefix = screen.getByText('LLM:');
+    expect(prefix).toBeInTheDocument();
+    expect(prefix).toHaveClass('GenAITab--metaPrefix');
+    const metaRow = container.querySelector('.GenAITab--meta');
+    expect(metaRow?.firstElementChild).toBe(prefix);
+  });
+
+  it('elevates gen_ai.agent.* attributes into their own Agent section instead of the raw Other GenAI Attributes dump (#4237)', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.agent.name', value: 'jaeger-gemini-sidecar' },
+          { key: 'gen_ai.agent.version', value: '0.1.0' },
+        ])}
+      />
+    );
+    expect(screen.getByText('Agent')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('jaeger-gemini-sidecar')).toBeInTheDocument();
+    expect(screen.getByText('Version')).toBeInTheDocument();
+    expect(screen.getByText('0.1.0')).toBeInTheDocument();
+    // The claimed keys must not also appear as raw gen_ai.agent.name / gen_ai.agent.version
+    // rows in the Other GenAI Attributes accordion.
+    expect(screen.queryByText('gen_ai.agent.name')).not.toBeInTheDocument();
+    expect(screen.queryByText('gen_ai.agent.version')).not.toBeInTheDocument();
+  });
+
+  it('renders an Agent section from gen_ai.agent.id and gen_ai.agent.description too', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.agent.id', value: 'asst_5j66UpCpwteGg4YSxUnt7lPY' },
+          { key: 'gen_ai.agent.description', value: 'Helps with math problems' },
+        ])}
+      />
+    );
+    expect(screen.getByText('ID')).toBeInTheDocument();
+    expect(screen.getByText('asst_5j66UpCpwteGg4YSxUnt7lPY')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Helps with math problems')).toBeInTheDocument();
+  });
+
   it('renders token usage including cached and reasoning tokens', () => {
     render(
       <GenAITab

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -112,6 +112,30 @@ describe('GenAITab', () => {
     expect(screen.getByText('Helps with math problems')).toBeInTheDocument();
   });
 
+  it('uses the shared accordion for Agent, collapsible like Other GenAI Attributes, per @yurishkuro review on #4244', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.agent.name', value: 'jaeger-gemini-sidecar' },
+          { key: 'gen_ai.agent.version', value: '0.1.0' },
+        ])}
+      />
+    );
+    // Agent starts open (it's primary content, unlike Other GenAI Attributes) - the
+    // expanded table's per-row copy button is a marker only the open table renders.
+    expect(screen.getByText('jaeger-gemini-sidecar')).toBeInTheDocument();
+    expect(screen.getAllByText('Copy').length).toBeGreaterThan(0);
+    const header = screen.getByText('Agent');
+    fireEvent.click(header);
+    // Collapsed: full table gone (no more per-row copy buttons), but name-first
+    // ordering still gives a high-signal one-line preview without expanding -
+    // exactly what the review comment asked for.
+    expect(screen.queryByText('Copy')).not.toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'Name=jaeger-gemini-sidecar')
+    ).toBeInTheDocument();
+  });
+
   it('renders token usage including cached and reasoning tokens', () => {
     render(
       <GenAITab

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -45,8 +45,8 @@ describe('GenAITab', () => {
     expect(screen.getByText('gpt-4o')).toBeInTheDocument();
   });
 
-  it('prefixes the provider/model row with "LLM:" on an actual LLM call, so it reads as a labeled group like Tokens: does (#4237)', () => {
-    const { container } = render(
+  it('captions the provider/model section "LLM" on an actual LLM call, using the shared accordion like Agent does (#4237, @yurishkuro review on #4244)', () => {
+    render(
       <GenAITab
         span={makeSpan([
           { key: 'gen_ai.operation.name', value: 'chat' },
@@ -55,14 +55,18 @@ describe('GenAITab', () => {
         ])}
       />
     );
-    const prefix = screen.getByText('LLM:');
-    expect(prefix).toBeInTheDocument();
-    expect(prefix).toHaveClass('GenAITab--metaPrefix');
-    const metaRow = container.querySelector('.GenAITab--meta');
-    expect(metaRow?.firstElementChild).toBe(prefix);
+    // Open by default (primary content) - header shows the bare label, table is visible.
+    expect(screen.getByText('LLM')).toBeInTheDocument();
+    expect(screen.getByText('openai')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4o')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('LLM'));
+    // Collapsed: label gains its trailing colon and the table is replaced by a
+    // one-line key=value preview, same behavior as the Agent accordion.
+    expect(screen.getByText('LLM:')).toBeInTheDocument();
+    expect(screen.getByText((_, element) => element?.textContent === 'Provider=openai')).toBeInTheDocument();
   });
 
-  it('omits the "LLM:" prefix on a non-LLM span that also reports a provider, without hiding the provider itself', () => {
+  it('captions the provider/model section "Model" instead of "LLM" on a non-LLM span that also reports a provider, without hiding the provider itself (Ansh review on #4244)', () => {
     render(
       <GenAITab
         span={makeSpan([
@@ -71,9 +75,11 @@ describe('GenAITab', () => {
         ])}
       />
     );
-    // classifySpan() resolves this to AGENT, not LLM_CALL - captioning it "LLM:" would
+    // classifySpan() resolves this to AGENT, not LLM_CALL - captioning it "LLM" would
     // misrepresent an agent invocation as an LLM call, per Ansh's review on #4244.
+    expect(screen.queryByText('LLM')).not.toBeInTheDocument();
     expect(screen.queryByText('LLM:')).not.toBeInTheDocument();
+    expect(screen.getByText('Model')).toBeInTheDocument();
     expect(screen.getByText('anthropic')).toBeInTheDocument();
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -159,7 +159,7 @@ const AGENT_LABELS: Partial<Record<keyof GenAiAgent, string>> = {
 };
 
 function AgentSection({ id, name, version, description }: GenAiAgent) {
-  const agent: GenAiAgent = { name, version, id, description };
+  const agent: GenAiAgent = { id, name, version, description };
   return (
     <div className="GenAITab--section">
       <h3 className="GenAITab--sectionTitle">Agent</h3>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -9,6 +9,7 @@ import {
   extractGenAiSections,
   formatTokenCount,
   tryParseJson,
+  GenAiAgent,
   GenAiMessage,
   GenAiTokenUsage,
   GenAiToolCall,
@@ -132,6 +133,7 @@ function MessageBlock({
 function MetaRow({ provider, model }: { provider?: string; model?: string }) {
   return (
     <div className="GenAITab--meta">
+      <span className="GenAITab--metaPrefix">LLM:</span>
       {provider && (
         <span className="GenAITab--metaItem">
           <span className="GenAITab--metaLabel">Provider</span> {provider}
@@ -142,6 +144,34 @@ function MetaRow({ provider, model }: { provider?: string; model?: string }) {
           <span className="GenAITab--metaLabel">Model</span> {model}
         </span>
       )}
+    </div>
+  );
+}
+
+// Cosmetic only, same rationale as TOKEN_LABELS below - a field missing from here
+// still renders under its own key, so a future gen_ai.agent.* field shows up
+// automatically without needing a matching entry added here.
+const AGENT_LABELS: Partial<Record<keyof GenAiAgent, string>> = {
+  name: 'Name',
+  version: 'Version',
+  id: 'ID',
+  description: 'Description',
+};
+
+function AgentSection({ id, name, version, description }: GenAiAgent) {
+  const agent: GenAiAgent = { name, version, id, description };
+  return (
+    <div className="GenAITab--section">
+      <h3 className="GenAITab--sectionTitle">Agent</h3>
+      {(Object.keys(agent) as Array<keyof GenAiAgent>).map(key => {
+        const value = agent[key];
+        if (!value) return null;
+        return (
+          <div key={key} className="GenAITab--toolSubsection">
+            <span className="GenAITab--toolLabel">{AGENT_LABELS[key] ?? key}</span> {value}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -291,6 +321,8 @@ export default function GenAITab({ span }: Props): React.ReactElement {
     <div className="GenAITab">
       {sections.map(section => {
         switch (section.type) {
+          case 'agent':
+            return <AgentSection key="agent" {...section.data} />;
           case 'meta':
             return <MetaRow key="meta" {...section.data} />;
           case 'tokens':

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -130,10 +130,14 @@ function MessageBlock({
   );
 }
 
-function MetaRow({ provider, model }: { provider?: string; model?: string }) {
+function MetaRow({ provider, model, isLlmCall }: { provider?: string; model?: string; isLlmCall: boolean }) {
   return (
     <div className="GenAITab--meta">
-      <span className="GenAITab--metaPrefix">LLM:</span>
+      {/* classifySpan() can also resolve to AGENT/TOOL_CALL/RETRIEVAL, which can carry
+          their own backing provider/model per the OTel GenAI semconv - captioning the
+          row "LLM:" would misrepresent those as LLM calls, so the prefix is scoped to
+          spans classifySpan() actually identifies as one. */}
+      {isLlmCall && <span className="GenAITab--metaPrefix">LLM:</span>}
       {provider && (
         <span className="GenAITab--metaItem">
           <span className="GenAITab--metaLabel">Provider</span> {provider}
@@ -330,7 +334,7 @@ export default function GenAITab({ span }: Props): React.ReactElement {
           case 'agent':
             return <AgentSection key="agent" {...section.data} />;
           case 'meta':
-            return <MetaRow key="meta" {...section.data} />;
+            return <MetaRow key="meta" {...section.data} isLlmCall={span.genAIKind === 'LLM_CALL'} />;
           case 'tokens':
             return <TokensRow key="tokens" usage={section.data} />;
           case 'conversation':

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -148,9 +148,11 @@ function MetaRow({ provider, model }: { provider?: string; model?: string }) {
   );
 }
 
-// Cosmetic only, same rationale as TOKEN_LABELS below - a field missing from here
-// still renders under its own key, so a future gen_ai.agent.* field shows up
-// automatically without needing a matching entry added here.
+// Cosmetic only: a key missing from here still renders under its raw field name
+// instead of a friendly label. This does NOT mean a new gen_ai.agent.* attribute
+// shows up automatically - it must first be added to GenAiAgent, extracted by the
+// agent builder in genAiData.ts, and listed in AGENT_FIELD_ORDER below before it
+// renders at all; only the label lookup itself is optional.
 const AGENT_LABELS: Partial<Record<keyof GenAiAgent, string>> = {
   name: 'Name',
   version: 'Version',
@@ -158,14 +160,18 @@ const AGENT_LABELS: Partial<Record<keyof GenAiAgent, string>> = {
   description: 'Description',
 };
 
+// Explicit rather than Object.keys(agent) - render order shouldn't depend on
+// object literal insertion order, and this avoids an unsafe keyof cast.
+const AGENT_FIELD_ORDER: ReadonlyArray<keyof GenAiAgent> = ['id', 'name', 'version', 'description'];
+
 function AgentSection({ id, name, version, description }: GenAiAgent) {
   const agent: GenAiAgent = { id, name, version, description };
   return (
     <div className="GenAITab--section">
       <h3 className="GenAITab--sectionTitle">Agent</h3>
-      {(Object.keys(agent) as Array<keyof GenAiAgent>).map(key => {
+      {AGENT_FIELD_ORDER.map(key => {
         const value = agent[key];
-        if (!value) return null;
+        if (value == null) return null;
         return (
           <div key={key} className="GenAITab--toolSubsection">
             <span className="GenAITab--toolLabel">{AGENT_LABELS[key] ?? key}</span> {value}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -19,7 +19,8 @@ import AccordionAttributes from '../AccordionAttributes';
 import { sharedMarkdownOptions } from '../../../../../utils/markdownOptions';
 import jsonViewStyles from '../../../../../utils/jsonViewStyles';
 import CopyIcon from '../../../../common/CopyIcon';
-import type { IOtelSpan } from '../../../../../types/otel';
+import { makeAttributes } from '../../../../../model/attributes';
+import type { AttributeValue, IAttribute, IOtelSpan } from '../../../../../types/otel';
 
 import './index.css';
 
@@ -168,24 +169,37 @@ const AGENT_LABELS: Partial<Record<keyof GenAiAgent, string>> = {
   description: 'Description',
 };
 
-// Explicit rather than Object.keys(agent) - render order shouldn't depend on
-// object literal insertion order, and this avoids an unsafe keyof cast.
-const AGENT_FIELD_ORDER: ReadonlyArray<keyof GenAiAgent> = ['id', 'name', 'version', 'description'];
+// name first: AccordionAttributes shows the first entries as a one-line preview when
+// collapsed, so leading with name gives high signal without expanding the section.
+const AGENT_FIELD_ORDER: ReadonlyArray<keyof GenAiAgent> = ['name', 'id', 'version', 'description'];
 
-function AgentDetails(agent: GenAiAgent) {
+function AgentDetails({
+  agent,
+  isOpen,
+  onToggle,
+}: {
+  agent: GenAiAgent;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const data = useMemo(
+    () =>
+      makeAttributes(
+        AGENT_FIELD_ORDER.filter(key => agent[key] != null).map(
+          (key): IAttribute => ({ key: AGENT_LABELS[key] ?? key, value: agent[key] as AttributeValue })
+        )
+      ),
+    [agent]
+  );
   return (
-    <div className="GenAITab--section">
-      <h3 className="GenAITab--sectionTitle">Agent</h3>
-      {AGENT_FIELD_ORDER.map(key => {
-        const value = agent[key];
-        if (value == null) return null;
-        return (
-          <div key={key} className="GenAITab--toolSubsection">
-            <span className="GenAITab--toolLabel">{AGENT_LABELS[key] ?? key}</span> {value}
-          </div>
-        );
-      })}
-    </div>
+    <AccordionAttributes
+      className="GenAITab--section"
+      label="Agent"
+      data={data}
+      linksGetter={null}
+      isOpen={isOpen}
+      onToggle={onToggle}
+    />
   );
 }
 
@@ -276,28 +290,30 @@ function ConversationDetails({
   );
 }
 
-function ToolCallDetails({ id, name, arguments: args, result }: GenAiToolCall) {
+function ToolCallDetails({
+  id,
+  name,
+  arguments: args,
+  result,
+  isOpen,
+  onToggle,
+}: GenAiToolCall & { isOpen: boolean; onToggle: () => void }) {
+  const data = useMemo(() => {
+    const entries: IAttribute[] = [];
+    if (id) entries.push({ key: 'ID', value: id });
+    if (args !== undefined) entries.push({ key: 'Arguments', value: args as AttributeValue });
+    if (result !== undefined) entries.push({ key: 'Result', value: result as AttributeValue });
+    return makeAttributes(entries);
+  }, [id, args, result]);
   return (
-    <div className="GenAITab--section">
-      <h3 className="GenAITab--sectionTitle">Tool Call{name && `: ${name}`}</h3>
-      {id && (
-        <div className="GenAITab--toolSubsection">
-          <span className="GenAITab--toolLabel">ID</span> {id}
-        </div>
-      )}
-      {args !== undefined && (
-        <div className="GenAITab--toolSubsection">
-          <span className="GenAITab--toolLabel">Arguments</span>
-          <JsonBlock value={args} />
-        </div>
-      )}
-      {result !== undefined && (
-        <div className="GenAITab--toolSubsection">
-          <span className="GenAITab--toolLabel">Result</span>
-          <JsonBlock value={result} />
-        </div>
-      )}
-    </div>
+    <AccordionAttributes
+      className="GenAITab--section"
+      label={`Tool Call${name ? `: ${name}` : ''}`}
+      data={data}
+      linksGetter={null}
+      isOpen={isOpen}
+      onToggle={onToggle}
+    />
   );
 }
 
@@ -308,22 +324,43 @@ function ToolCallDetails({ id, name, arguments: args, result }: GenAiToolCall) {
 // future section type added to the registry without a matching case here).
 // Per the no-data-hiding principle, an ugly-but-honest key/value dump beats
 // silently rendering nothing.
-function UnknownDetails({ type, data }: { type: string; data: Record<string, unknown> }) {
+function UnknownDetails({
+  type,
+  data: rawData,
+  isOpen,
+  onToggle,
+}: {
+  type: string;
+  data: Record<string, unknown>;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const data = useMemo(
+    () =>
+      makeAttributes(
+        Object.entries(rawData).map(([key, value]): IAttribute => ({ key, value: value as AttributeValue }))
+      ),
+    [rawData]
+  );
   return (
-    <div className="GenAITab--section">
-      <h3 className="GenAITab--sectionTitle">{type}</h3>
-      {Object.entries(data).map(([key, value]) => (
-        <div key={key} className="GenAITab--toolSubsection">
-          <span className="GenAITab--toolLabel">{key}</span>
-          <JsonBlock value={value} />
-        </div>
-      ))}
-    </div>
+    <AccordionAttributes
+      className="GenAITab--section"
+      label={type}
+      data={data}
+      linksGetter={null}
+      isOpen={isOpen}
+      onToggle={onToggle}
+    />
   );
 }
 
 export default function GenAITab({ span }: Props): React.ReactElement {
   const sections = useMemo(() => extractGenAiSections(span.attributes), [span.attributes]);
+  // Agent/Tool Call/Unknown default open since they're primary content for the span,
+  // unlike Other GenAI Attributes which is genuinely secondary overflow data.
+  const [isAgentOpen, setIsAgentOpen] = useState(true);
+  const [isToolCallOpen, setIsToolCallOpen] = useState(true);
+  const [isUnknownOpen, setIsUnknownOpen] = useState(true);
   const [isOtherOpen, setIsOtherOpen] = useState(false);
 
   if (sections.length === 0) {
@@ -335,7 +372,14 @@ export default function GenAITab({ span }: Props): React.ReactElement {
       {sections.map(section => {
         switch (section.type) {
           case 'agent':
-            return <AgentDetails key="agent" {...section.data} />;
+            return (
+              <AgentDetails
+                key="agent"
+                agent={section.data}
+                isOpen={isAgentOpen}
+                onToggle={() => setIsAgentOpen(o => !o)}
+              />
+            );
           case 'meta':
             return <LLMDetails key="meta" {...section.data} isLlmCall={span.genAIKind === 'LLM_CALL'} />;
           case 'tokens':
@@ -343,7 +387,14 @@ export default function GenAITab({ span }: Props): React.ReactElement {
           case 'conversation':
             return <ConversationDetails key="conversation" {...section.data} />;
           case 'toolCall':
-            return <ToolCallDetails key="toolCall" {...section.data} />;
+            return (
+              <ToolCallDetails
+                key="toolCall"
+                {...section.data}
+                isOpen={isToolCallOpen}
+                onToggle={() => setIsToolCallOpen(o => !o)}
+              />
+            );
           case 'other':
             return (
               <AccordionAttributes
@@ -362,6 +413,8 @@ export default function GenAITab({ span }: Props): React.ReactElement {
                 key={(section as { type: string }).type}
                 type={(section as { type: string }).type}
                 data={(section as { data: Record<string, unknown> }).data}
+                isOpen={isUnknownOpen}
+                onToggle={() => setIsUnknownOpen(o => !o)}
               />
             );
         }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -135,29 +135,34 @@ function LLMDetails({
   provider,
   model,
   isLlmCall,
+  isOpen,
+  onToggle,
 }: {
   provider?: string;
   model?: string;
   isLlmCall: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
 }) {
+  const data = useMemo(() => {
+    const entries: IAttribute[] = [];
+    if (provider) entries.push({ key: 'Provider', value: provider });
+    if (model) entries.push({ key: 'Model', value: model });
+    return makeAttributes(entries);
+  }, [provider, model]);
   return (
-    <div className="GenAITab--meta">
-      {/* classifySpan() can also resolve to AGENT/TOOL_CALL/RETRIEVAL, which can carry
-          their own backing provider/model per the OTel GenAI semconv - captioning the
-          row "LLM:" would misrepresent those as LLM calls, so the prefix is scoped to
-          spans classifySpan() actually identifies as one. */}
-      {isLlmCall && <span className="GenAITab--metaPrefix">LLM:</span>}
-      {provider && (
-        <span className="GenAITab--metaItem">
-          <span className="GenAITab--metaLabel">Provider</span> {provider}
-        </span>
-      )}
-      {model && (
-        <span className="GenAITab--metaItem">
-          <span className="GenAITab--metaLabel">Model</span> {model}
-        </span>
-      )}
-    </div>
+    <AccordionAttributes
+      className="GenAITab--section"
+      // classifySpan() can also resolve to AGENT/TOOL_CALL/RETRIEVAL, which can carry
+      // their own backing provider/model per the OTel GenAI semconv - captioning the
+      // section "LLM" would misrepresent those as LLM calls, so it's scoped to spans
+      // classifySpan() actually identifies as one.
+      label={isLlmCall ? 'LLM' : 'Model'}
+      data={data}
+      linksGetter={null}
+      isOpen={isOpen}
+      onToggle={onToggle}
+    />
   );
 }
 
@@ -356,8 +361,9 @@ function UnknownDetails({
 
 export default function GenAITab({ span }: Props): React.ReactElement {
   const sections = useMemo(() => extractGenAiSections(span.attributes), [span.attributes]);
-  // Agent/Tool Call/Unknown default open since they're primary content for the span,
-  // unlike Other GenAI Attributes which is genuinely secondary overflow data.
+  // LLM/Agent/Tool Call/Unknown default open since they're primary content for the
+  // span, unlike Other GenAI Attributes which is genuinely secondary overflow data.
+  const [isLlmOpen, setIsLlmOpen] = useState(true);
   const [isAgentOpen, setIsAgentOpen] = useState(true);
   const [isToolCallOpen, setIsToolCallOpen] = useState(true);
   const [isUnknownOpen, setIsUnknownOpen] = useState(true);
@@ -381,7 +387,15 @@ export default function GenAITab({ span }: Props): React.ReactElement {
               />
             );
           case 'meta':
-            return <LLMDetails key="meta" {...section.data} isLlmCall={span.genAIKind === 'LLM_CALL'} />;
+            return (
+              <LLMDetails
+                key="meta"
+                {...section.data}
+                isLlmCall={span.genAIKind === 'LLM_CALL'}
+                isOpen={isLlmOpen}
+                onToggle={() => setIsLlmOpen(o => !o)}
+              />
+            );
           case 'tokens':
             return <TokenDetails key="tokens" usage={section.data} />;
           case 'conversation':

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -130,7 +130,15 @@ function MessageBlock({
   );
 }
 
-function MetaRow({ provider, model, isLlmCall }: { provider?: string; model?: string; isLlmCall: boolean }) {
+function LLMDetails({
+  provider,
+  model,
+  isLlmCall,
+}: {
+  provider?: string;
+  model?: string;
+  isLlmCall: boolean;
+}) {
   return (
     <div className="GenAITab--meta">
       {/* classifySpan() can also resolve to AGENT/TOOL_CALL/RETRIEVAL, which can carry
@@ -152,11 +160,7 @@ function MetaRow({ provider, model, isLlmCall }: { provider?: string; model?: st
   );
 }
 
-// Cosmetic only: a key missing from here still renders under its raw field name
-// instead of a friendly label. This does NOT mean a new gen_ai.agent.* attribute
-// shows up automatically - it must first be added to GenAiAgent, extracted by the
-// agent builder in genAiData.ts, and listed in AGENT_FIELD_ORDER below before it
-// renders at all; only the label lookup itself is optional.
+// Map attribute keys to more reader-friendly labels.
 const AGENT_LABELS: Partial<Record<keyof GenAiAgent, string>> = {
   name: 'Name',
   version: 'Version',
@@ -168,8 +172,7 @@ const AGENT_LABELS: Partial<Record<keyof GenAiAgent, string>> = {
 // object literal insertion order, and this avoids an unsafe keyof cast.
 const AGENT_FIELD_ORDER: ReadonlyArray<keyof GenAiAgent> = ['id', 'name', 'version', 'description'];
 
-function AgentSection({ id, name, version, description }: GenAiAgent) {
-  const agent: GenAiAgent = { id, name, version, description };
+function AgentDetails(agent: GenAiAgent) {
   return (
     <div className="GenAITab--section">
       <h3 className="GenAITab--sectionTitle">Agent</h3>
@@ -197,7 +200,7 @@ const TOKEN_LABELS: Partial<Record<keyof GenAiTokenUsage, string>> = {
   reasoningOutputTokens: 'Reasoning',
 };
 
-function TokensRow({ usage }: { usage: GenAiTokenUsage }) {
+function TokenDetails({ usage }: { usage: GenAiTokenUsage }) {
   return (
     <div className="GenAITab--tokens">
       <span className="GenAITab--tokensPrefix">Tokens:</span>
@@ -214,7 +217,7 @@ function TokensRow({ usage }: { usage: GenAiTokenUsage }) {
   );
 }
 
-function ConversationSection({
+function ConversationDetails({
   systemInstructions,
   inputMessages,
   outputMessages,
@@ -273,7 +276,7 @@ function ConversationSection({
   );
 }
 
-function ToolCallSection({ id, name, arguments: args, result }: GenAiToolCall) {
+function ToolCallDetails({ id, name, arguments: args, result }: GenAiToolCall) {
   return (
     <div className="GenAITab--section">
       <h3 className="GenAITab--sectionTitle">Tool Call{name && `: ${name}`}</h3>
@@ -305,7 +308,7 @@ function ToolCallSection({ id, name, arguments: args, result }: GenAiToolCall) {
 // future section type added to the registry without a matching case here).
 // Per the no-data-hiding principle, an ugly-but-honest key/value dump beats
 // silently rendering nothing.
-function UnknownSection({ type, data }: { type: string; data: Record<string, unknown> }) {
+function UnknownDetails({ type, data }: { type: string; data: Record<string, unknown> }) {
   return (
     <div className="GenAITab--section">
       <h3 className="GenAITab--sectionTitle">{type}</h3>
@@ -332,15 +335,15 @@ export default function GenAITab({ span }: Props): React.ReactElement {
       {sections.map(section => {
         switch (section.type) {
           case 'agent':
-            return <AgentSection key="agent" {...section.data} />;
+            return <AgentDetails key="agent" {...section.data} />;
           case 'meta':
-            return <MetaRow key="meta" {...section.data} isLlmCall={span.genAIKind === 'LLM_CALL'} />;
+            return <LLMDetails key="meta" {...section.data} isLlmCall={span.genAIKind === 'LLM_CALL'} />;
           case 'tokens':
-            return <TokensRow key="tokens" usage={section.data} />;
+            return <TokenDetails key="tokens" usage={section.data} />;
           case 'conversation':
-            return <ConversationSection key="conversation" {...section.data} />;
+            return <ConversationDetails key="conversation" {...section.data} />;
           case 'toolCall':
-            return <ToolCallSection key="toolCall" {...section.data} />;
+            return <ToolCallDetails key="toolCall" {...section.data} />;
           case 'other':
             return (
               <AccordionAttributes
@@ -355,7 +358,7 @@ export default function GenAITab({ span }: Props): React.ReactElement {
             );
           default:
             return (
-              <UnknownSection
+              <UnknownDetails
                 key={(section as { type: string }).type}
                 type={(section as { type: string }).type}
                 data={(section as { data: Record<string, unknown> }).data}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/message-format-store.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/message-format-store.ts
@@ -14,7 +14,7 @@ export type MessageFormat = 'plain' | 'markdown' | 'json';
 
 const MESSAGE_FORMAT_STORAGE_PREFIX = 'jaeger.spanDetail.attributeFormat.';
 
-// The closed set of attribute names ConversationSection assigns a format preference to.
+// The closed set of attribute names ConversationDetails assigns a format preference to.
 // Listed here (rather than derived at runtime) so the store can hydrate synchronously at
 // creation, matching search-panel-store.ts / store.layout.ts.
 const MESSAGE_FORMAT_ATTRIBUTE_KEYS = [


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4237

## Description of the changes
- The provider/model row had no caption, unlike the Tokens row added in #4222. `LLMDetails` now gets its caption from the shared `AccordionAttributes` component's `label` prop - `LLM` for a span `classifySpan()` identifies as an actual LLM call, `Model` otherwise (per Ansh's review, so a provider/model reported on an Agent/Tool/Retrieval span isn't mislabeled as an LLM call) - open by default, with a `Provider`/`Model` table when expanded and a `Provider=... Model=...` summary when collapsed.
- `gen_ai.agent.*` attributes were falling into the raw "Other GenAI Attributes" key/value dump instead of being elevated like provider/model and token usage already are. Checked the current [OTel GenAI semconv registry](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md) for the full set rather than assuming just name/version - the registry has four fields: `gen_ai.agent.id`, `.name`, `.version`, `.description`. Added a builder claiming all four and an `AgentDetails` component rendering them through the same shared `AccordionAttributes` component as `LLMDetails` (name first in the display order, so `AccordionAttributes`' collapsed preview leads with the highest-signal field), and excluded once claimed from Other GenAI Attributes.
- Per @yurishkuro's later request, `ToolCallDetails` and `UnknownDetails` (the defensive fallback for a section type not yet handled) also render through the same shared accordion, so every elevated GenAI section (Agent, LLM, Tool Call, Unknown) is visually and behaviorally consistent instead of a mix of one-off components. `Tokens:` stays an inline single-line row (not a collapsible section), and `Conversation` stays a bespoke component (its per-message Markdown/JSON/Plain toggle and copy button don't fit the accordion's flat key-value shape) - both intentionally out of scope, per discussion with Yuri.

## How was this change tested?
- Real trace, not synthetic - uploaded the actual `bde4caeb` trace (`jaeger: /api/ai/chat`) via the dev server's own trace-upload feature, and compared directly against the screenshots in the issue:
  - The root `/api/ai/chat` span (`gen_ai.agent.name=jaeger-gemini-sidecar`, `.version=0.1.0`, no provider/model/tokens) - exactly the span in the issue's second screenshot - shows a standalone **Agent** section, and `gen_ai.agent.name`/`.version` no longer appear in Other GenAI Attributes.
  - The first `generate_content gemini-2.5-flash` span (`gen_ai.provider.name=gcp.gen_ai`, `.request.model`/`.response.model=gemini-2.5-flash`, input 3,803/output 45 tokens) - exactly the span and token counts in the issue's first screenshot - now shows an **LLM** accordion (open by default) with Provider/Model in a table, same collapsible pattern as **Agent**. `Tokens:` stays an inline row below it, unchanged.
  - <img width="1568" height="773" alt="LLM accordion open on the real bde4caeb trace's generate_content span - Provider gcp.gen_ai, Model gemini-2.5-flash, Tokens Input 3,803 Output 45 - matching the issue's screenshot exactly" src="https://github.com/user-attachments/assets/b45be9e1-4945-433d-b1d0-bedaf46319c4" />
- `vitest run` on `genAiData.test.ts` + `index.test.tsx`: 60/60 passing on `genAiData.test.ts`, 32/32 passing on `index.test.tsx` (92/92 total), including the accordion rendering for Agent/LLM/Tool Call/Unknown and the "Model" vs "LLM" label case for a non-LLM span with a provider/model.
- `tsc` and `oxlint` clean on the changed files.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
