### PR TITLE
fix(date): Prevent incorrect partial rounding-up of durations

### DIFF
--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -65,6 +65,20 @@ describe('formatDuration', () => {
     const input = 0;
     expect(formatDuration(input)).toBe('0μs');
   });
+
+  it('carries a rounded-up secondary unit into the primary unit', () => {
+    expect(formatDuration(ONE_HOUR + 59 * ONE_MINUTE + 36 * ONE_SECOND)).toBe('2h');
+    expect(formatDuration(ONE_MINUTE + 59 * ONE_SECOND + 600 * ONE_MILLISECOND)).toBe('2m');
+  });
+
+  it('does not carry when the secondary unit rounds down', () => {
+    expect(formatDuration(ONE_HOUR + 59 * ONE_MINUTE + 29 * ONE_SECOND)).toBe('1h 59m');
+    expect(formatDuration(ONE_MINUTE + 59 * ONE_SECOND + 400 * ONE_MILLISECOND)).toBe('1m 59s');
+  });
+
+  it('carries across the day boundary', () => {
+    expect(formatDuration(ONE_DAY - 20 * ONE_SECOND)).toBe('1d');
+  });
 });
 
 describe('getSuitableTimeUnit', () => {

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -167,21 +167,26 @@ export function formatSecondTime(duration: number): string {
  * formatDuration(183840000000) // => "2d 3h"
  */
 export function formatDuration(duration: Microseconds): string {
-  // Drop all units that are too large except the last one
-  const [primaryUnit, secondaryUnit] = _dropWhile(
-    UNIT_STEPS,
-    ({ microseconds }, index) => index < UNIT_STEPS.length - 1 && microseconds > duration
-  );
+  const selectUnits = (value: number) =>
+    _dropWhile(
+      UNIT_STEPS,
+      ({ microseconds }, index) => index < UNIT_STEPS.length - 1 && microseconds > value
+    );
+
+  const [primaryUnit, secondaryUnit] = selectUnits(duration);
 
   if (primaryUnit.ofPrevious === 1000) {
-    // If the unit is decimal based, display as a decimal
     return `${_round(duration / primaryUnit.microseconds, 2)}${primaryUnit.unit}`;
   }
 
-  const primaryValue = Math.floor(duration / primaryUnit.microseconds);
-  const primaryUnitString = `${primaryValue}${primaryUnit.unit}`;
-  const secondaryValue = Math.round((duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious);
-  const secondaryUnitString = `${secondaryValue}${secondaryUnit.unit}`;
+  const roundedDuration = Math.round(duration / secondaryUnit.microseconds) * secondaryUnit.microseconds;
+  const [carriedPrimaryUnit, carriedSecondaryUnit] = selectUnits(roundedDuration);
+
+  const primaryValue = Math.floor(roundedDuration / carriedPrimaryUnit.microseconds);
+  const primaryUnitString = `${primaryValue}${carriedPrimaryUnit.unit}`;
+  const secondaryValue =
+    Math.round(roundedDuration / carriedSecondaryUnit.microseconds) % carriedPrimaryUnit.ofPrevious;
+  const secondaryUnitString = `${secondaryValue}${carriedSecondaryUnit.unit}`;
   return secondaryValue === 0 ? primaryUnitString : `${primaryUnitString} ${secondaryUnitString}`;
 }
 


### PR DESCRIPTION
Before
<img width="1440" height="447" alt="Screenshot 2026-07-21 at 9 07 57 PM" src="https://github.com/user-attachments/assets/65b83134-d10f-41f4-8463-12364f5841aa" />
After
<img width="1440" height="432" alt="Screenshot 2026-07-21 at 9 20 55 PM" src="https://github.com/user-attachments/assets/cebf2dd7-909c-4ef8-8309-12c67a9031a6" />
## Which problem is this PR solving?

- Resolves #4246

`formatDuration` could render an overflowed secondary unit such as `1h 60m` or `23h 60m` instead of carrying into the next unit.

Root cause: `secondaryValue` applied `Math.round` after the modulo, so a remainder that rounded up to a full 60 (or 24) was emitted as-is.

## Description of the changes

Round the duration to the nearest secondary unit first, then re-select the units on the rounded value so the remainder carries into the primary unit and the primary/secondary values stay consistent.

| input | before | after |
| --- | --- | --- |
| 1h 59m 36s | `1h 60m` | `2h` |
| 1m 59.6s | `1m 60s` | `2m` |
| 1 day − 20s | `23h 60m` | `1d` |

Existing formatted output (`2h 31m`, `10d 14h`, decimal ms/s, etc.) is unchanged.

## Severity

Low. The bug only triggers within ~30s of a unit rollover and only for durations of a minute or more, so it is an uncommon, cosmetic rendering issue — but it is user-visible where durations are shown.

## How was this change tested?

Added carry-case assertions to `date.test.js` covering the hour, minute, and day boundaries; the existing cases are untouched and still pass.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits (DCO)
- [x] I have added unit tests for the new functionality
