### PR TITLE
fix(ui): use Select for AltViewOptions to fix keyboard navigation (#4…

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.css
@@ -4,16 +4,5 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 .AltViewOptions {
-  border: 1px solid var(--border-default);
-  border-radius: 4px;
-  height: 32px;
-  line-height: 30px;
   margin-right: 1rem;
-  padding: 0 8px;
-  display: flex;
-  align-items: center;
-}
-
-.AltViewOptions svg {
-  margin-left: 3px;
 }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
@@ -126,7 +126,11 @@ describe('AltViewOptions', () => {
     fireEvent.click(screen.getByTestId('menu-item-trace-json'));
 
     expect(trackJsonView).toHaveBeenCalled();
-    expect(windowOpenSpy).toHaveBeenCalledWith('/api/traces/test trace ID?prettyPrint=true', '_blank');
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      '/api/traces/test trace ID?prettyPrint=true',
+      '_blank',
+      'noopener,noreferrer'
+    );
   });
 
   it('handles unadjusted JSON view correctly', () => {
@@ -137,7 +141,8 @@ describe('AltViewOptions', () => {
     expect(trackRawJsonView).toHaveBeenCalled();
     expect(windowOpenSpy).toHaveBeenCalledWith(
       '/api/traces/test trace ID?raw=true&prettyPrint=true',
-      '_blank'
+      '_blank',
+      'noopener,noreferrer'
     );
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
@@ -42,14 +42,15 @@ describe('AltViewOptions', () => {
   let trackRawJsonView;
   let windowOpenSpy;
 
-  const props = {
-    viewType: ETraceViewType.TraceTimelineViewer,
-    traceID: 'test trace ID',
-    onTraceViewChange: jest.fn(),
-    disableJsonView: false,
-  };
+  let props;
 
   beforeEach(() => {
+    props = {
+      viewType: ETraceViewType.TraceTimelineViewer,
+      traceID: 'test trace ID',
+      onTraceViewChange: vi.fn(),
+      disableJsonView: false,
+    };
     trackViewChange = vi.spyOn(track, 'trackViewChange');
     trackJsonView = vi.spyOn(track, 'trackJsonView');
     trackRawJsonView = vi.spyOn(track, 'trackRawJsonView');

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
@@ -13,18 +13,17 @@ vi.mock('antd', async () => {
   const originalModule = await vi.importActual('antd');
   return {
     ...originalModule,
-    Dropdown: ({ children, menu }) => (
-      <div data-testid="dropdown">
-        {children}
-        <div data-testid="dropdown-menu">
-          {menu.items.map(item => (
+    Select: ({ value, onChange, options, 'data-testid': dataTestId }) => (
+      <div data-testid={dataTestId || 'select'}>
+        <div data-testid="select-value">{value}</div>
+        <div data-testid="select-options">
+          {options.map(item => (
             <div
-              key={item.key}
-              data-testid={`menu-item-${item.key}`}
+              key={item.value}
+              data-testid={`menu-item-${item.value}`}
               onClick={() => {
-                // Simulate clicking the link/button inside
-                if (item.label?.props?.onClick) {
-                  item.label.props.onClick();
+                if (onChange) {
+                  onChange(item.value);
                 }
               }}
             >
@@ -34,16 +33,14 @@ vi.mock('antd', async () => {
         </div>
       </div>
     ),
-    Button: ({ children, className }) => (
-      <button type="button" className={className} data-testid="dropdown-button">
-        {children}
-      </button>
-    ),
   };
 });
 
 describe('AltViewOptions', () => {
   let trackViewChange;
+  let trackJsonView;
+  let trackRawJsonView;
+  let windowOpenSpy;
 
   const props = {
     viewType: ETraceViewType.TraceTimelineViewer,
@@ -52,12 +49,15 @@ describe('AltViewOptions', () => {
     disableJsonView: false,
   };
 
-  beforeAll(() => {
-    trackViewChange = jest.spyOn(track, 'trackViewChange');
+  beforeEach(() => {
+    trackViewChange = vi.spyOn(track, 'trackViewChange');
+    trackJsonView = vi.spyOn(track, 'trackJsonView');
+    trackRawJsonView = vi.spyOn(track, 'trackRawJsonView');
+    windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.restoreAllMocks();
     cleanup();
   });
 
@@ -70,23 +70,17 @@ describe('AltViewOptions', () => {
     );
   };
 
-  it('renders dropdown button displaying the current view type', () => {
+  it('renders select with the current view type', () => {
     renderComponent();
-    const button = screen.getByTestId('dropdown-button');
-    expect(button).toHaveTextContent('Trace Timeline');
+    const selectValue = screen.getByTestId('select-value');
+    expect(selectValue).toHaveTextContent(ETraceViewType.TraceTimelineViewer);
   });
 
-  it('shows "Alternate Views" when viewType is not in MENU_ITEMS', () => {
-    renderComponent({ viewType: 'UnknownViewType' });
-    const button = screen.getByTestId('dropdown-button');
-    expect(button).toHaveTextContent('Alternate Views');
-  });
-
-  it('shows all alternate view options except current view', () => {
+  it('shows all alternate view options', () => {
     renderComponent();
 
-    expect(screen.queryByTestId('menu-item-TraceTimelineViewer')).not.toBeInTheDocument();
-
+    // Since Select receives all options, they are all in the DOM.
+    expect(screen.getByTestId('menu-item-TraceTimelineViewer')).toBeInTheDocument();
     expect(screen.getByTestId('menu-item-TraceGraph')).toBeInTheDocument();
     expect(screen.getByTestId('menu-item-TraceStatistics')).toBeInTheDocument();
     expect(screen.getByTestId('menu-item-TraceSpansView')).toBeInTheDocument();
@@ -126,53 +120,44 @@ describe('AltViewOptions', () => {
     expect(trackViewChange).toHaveBeenCalledWith(viewType);
   });
 
-  it('renders JSON links with correct URLs', () => {
+  it('handles JSON view correctly', () => {
     renderComponent();
 
-    const jsonMenuItem = screen.getByTestId('menu-item-trace-json');
-    const jsonLink = jsonMenuItem.querySelector('a');
-    expect(jsonLink).toHaveAttribute('href', '/api/traces/test trace ID?prettyPrint=true');
+    fireEvent.click(screen.getByTestId('menu-item-trace-json'));
 
-    const rawJsonMenuItem = screen.getByTestId('menu-item-trace-json-unadjusted');
-    const rawJsonLink = rawJsonMenuItem.querySelector('a');
-    expect(rawJsonLink).toHaveAttribute('href', '/api/traces/test trace ID?raw=true&prettyPrint=true');
+    expect(trackJsonView).toHaveBeenCalled();
+    expect(windowOpenSpy).toHaveBeenCalledWith('/api/traces/test trace ID?prettyPrint=true', '_blank');
   });
 
-  it('updates dropdown text when view type changes', () => {
-    const { rerender } = renderComponent({ viewType: ETraceViewType.TraceTimelineViewer });
-    expect(screen.getByTestId('dropdown-button')).toHaveTextContent('Trace Timeline');
+  it('handles unadjusted JSON view correctly', () => {
+    renderComponent();
 
-    const rerenderWithViewType = (viewType, expectedText) => {
+    fireEvent.click(screen.getByTestId('menu-item-trace-json-unadjusted'));
+
+    expect(trackRawJsonView).toHaveBeenCalled();
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      '/api/traces/test trace ID?raw=true&prettyPrint=true',
+      '_blank'
+    );
+  });
+
+  it('updates select value when view type changes', () => {
+    const { rerender } = renderComponent({ viewType: ETraceViewType.TraceTimelineViewer });
+    expect(screen.getByTestId('select-value')).toHaveTextContent(ETraceViewType.TraceTimelineViewer);
+
+    const rerenderWithViewType = viewType => {
       rerender(
         <BrowserRouter>
           <AltViewOptions {...props} viewType={viewType} />
         </BrowserRouter>
       );
-      expect(screen.getByTestId('dropdown-button')).toHaveTextContent(expectedText);
+      expect(screen.getByTestId('select-value')).toHaveTextContent(viewType);
     };
 
-    rerenderWithViewType(ETraceViewType.TraceGraph, 'Trace Graph');
-    rerenderWithViewType(ETraceViewType.TraceStatistics, 'Trace Statistics');
-    rerenderWithViewType(ETraceViewType.TraceSpansView, 'Trace Spans Table');
-    rerenderWithViewType(ETraceViewType.TraceFlamegraph, 'Trace Flamegraph');
-    rerenderWithViewType(ETraceViewType.TraceLogs, 'Trace Logs');
-  });
-
-  it('excludes current view from dropdown options for all view types', () => {
-    const viewTypes = [
-      { type: ETraceViewType.TraceTimelineViewer, testId: 'menu-item-TraceTimelineViewer' },
-      { type: ETraceViewType.TraceGraph, testId: 'menu-item-TraceGraph' },
-      { type: ETraceViewType.TraceStatistics, testId: 'menu-item-TraceStatistics' },
-      { type: ETraceViewType.TraceSpansView, testId: 'menu-item-TraceSpansView' },
-      { type: ETraceViewType.TraceFlamegraph, testId: 'menu-item-TraceFlamegraph' },
-      { type: ETraceViewType.TraceLogs, testId: 'menu-item-TraceLogs' },
-      { type: ETraceViewType.GenAITimelineViewer, testId: 'menu-item-GenAITimelineViewer' },
-    ];
-
-    viewTypes.forEach(({ type, testId }) => {
-      cleanup();
-      renderComponent({ viewType: type });
-      expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
-    });
+    rerenderWithViewType(ETraceViewType.TraceGraph);
+    rerenderWithViewType(ETraceViewType.TraceStatistics);
+    rerenderWithViewType(ETraceViewType.TraceSpansView);
+    rerenderWithViewType(ETraceViewType.TraceFlamegraph);
+    rerenderWithViewType(ETraceViewType.TraceLogs);
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -1,10 +1,5 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 import * as React from 'react';
-import { Dropdown, Button } from 'antd';
-import { IoChevronDown } from 'react-icons/io5';
-import { Link } from 'react-router-dom';
+import { Select } from 'antd';
 import './AltViewOptions.css';
 
 import { trackViewChange, trackJsonView, trackRawJsonView } from './TracePageHeader.track';
@@ -32,58 +27,45 @@ const MENU_ITEMS: { viewType: ETraceViewType; label: string }[] = [
 export default function AltViewOptions(props: Props) {
   const { onTraceViewChange, viewType, traceID, disableJsonView } = props;
 
-  const handleSelectView = (item: ETraceViewType) => {
-    trackViewChange(item);
-    onTraceViewChange(item);
+  const handleChange = (value: string) => {
+    if (value === 'trace-json') {
+      trackJsonView();
+      window.open(prefixUrl(`/api/traces/${traceID}?prettyPrint=true`), getTargetBlankOrTop());
+    } else if (value === 'trace-json-unadjusted') {
+      trackRawJsonView();
+      window.open(prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`), getTargetBlankOrTop());
+    } else {
+      trackViewChange(value as ETraceViewType);
+      onTraceViewChange(value as ETraceViewType);
+    }
   };
 
-  const dropdownItems = MENU_ITEMS.filter(item => item.viewType !== viewType).map(item => ({
-    key: item.viewType as ETraceViewType | string,
-    label: (
-      <a onClick={() => handleSelectView(item.viewType)} role="button">
-        {item.label}
-      </a>
-    ),
+  const options = MENU_ITEMS.map(item => ({
+    value: item.viewType,
+    label: item.label,
   }));
+
   if (!disableJsonView) {
-    dropdownItems.push(
+    options.push(
       {
-        key: 'trace-json',
-        label: (
-          <Link
-            to={prefixUrl(`/api/traces/${traceID}?prettyPrint=true`)}
-            rel="noopener noreferrer"
-            target={getTargetBlankOrTop()}
-            onClick={trackJsonView}
-          >
-            Trace JSON
-          </Link>
-        ),
+        value: 'trace-json',
+        label: 'Trace JSON',
       },
       {
-        key: 'trace-json-unadjusted',
-        label: (
-          <Link
-            to={prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`)}
-            rel="noopener noreferrer"
-            target={getTargetBlankOrTop()}
-            onClick={trackRawJsonView}
-          >
-            Trace JSON (unadjusted)
-          </Link>
-        ),
+        value: 'trace-json-unadjusted',
+        label: 'Trace JSON (unadjusted)',
       }
     );
   }
 
-  const currentItem = MENU_ITEMS.find(item => item.viewType === viewType);
-  const dropdownText = currentItem ? currentItem.label : 'Alternate Views';
   return (
-    <Dropdown menu={{ items: dropdownItems }} trigger={['click']}>
-      <Button className="AltViewOptions">
-        {`${dropdownText} `}
-        <IoChevronDown />
-      </Button>
-    </Dropdown>
+    <Select
+      className="AltViewOptions"
+      value={viewType}
+      onChange={handleChange}
+      options={options}
+      popupMatchSelectWidth={false}
+      data-testid="AltViewOptions"
+    />
   );
 }

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from 'react';
 import { Select } from 'antd';
 import './AltViewOptions.css';
@@ -30,10 +33,18 @@ export default function AltViewOptions(props: Props) {
   const handleChange = (value: string) => {
     if (value === 'trace-json') {
       trackJsonView();
-      window.open(prefixUrl(`/api/traces/${traceID}?prettyPrint=true`), getTargetBlankOrTop());
+      window.open(
+        prefixUrl(`/api/traces/${traceID}?prettyPrint=true`),
+        getTargetBlankOrTop(),
+        'noopener,noreferrer'
+      );
     } else if (value === 'trace-json-unadjusted') {
       trackRawJsonView();
-      window.open(prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`), getTargetBlankOrTop());
+      window.open(
+        prefixUrl(`/api/traces/${traceID}?raw=true&prettyPrint=true`),
+        getTargetBlankOrTop(),
+        'noopener,noreferrer'
+      );
     } else {
       trackViewChange(value as ETraceViewType);
       onTraceViewChange(value as ETraceViewType);

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -51,10 +51,11 @@ export default function AltViewOptions(props: Props) {
     }
   };
 
-  const options = MENU_ITEMS.map(item => ({
-    value: item.viewType,
-    label: item.label,
-  }));
+  const options: { value: ETraceViewType | 'trace-json' | 'trace-json-unadjusted'; label: string }[] =
+    MENU_ITEMS.map(item => ({
+      value: item.viewType,
+      label: item.label,
+    }));
 
   if (!disableJsonView) {
     options.push(


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4178

## Description of the changes
- Replaced the Ant Design `Dropdown` and `Button` components with `Select` inside `AltViewOptions.tsx`. This aligns the view-switching UI with the existing `SearchableSelect` components, allowing it to natively intercept arrow key events so they do not propagate down to the SpanGraph minimap.
- Migrated JSON view links from embedded `<a>` tags into the `Select`'s `onChange` handler via `window.open` to maintain keyboard accessibility.
- Cleaned up conflicting custom button styling in `AltViewOptions.css`.
- Updated `AltViewOptions.test.jsx` to mock the `Select` component and reliably assert on the updated `window.open` behavior.

## How was this change tested?
- Updated the existing Vitest unit tests in `AltViewOptions.test.jsx` to accommodate the `Select` UI paradigm. All tests pass locally.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
