### PR TITLE
fix(search): Scoped uploaded trace deletion on file remove

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
@@ -17,7 +17,8 @@ import './FileLoader.css';
 const Dragger = Upload.Dragger;
 
 type FileLoaderProps = {
-  onTracesLoaded: (summaries: TraceSummary[], rawTraces: unknown[]) => void;
+  onTracesLoaded: (summaries: TraceSummary[], rawTraces: unknown[], fileId?: string) => void;
+  onTraceFileRemove?: (fileId: string) => void;
 };
 
 export type LoadResult = {
@@ -69,6 +70,8 @@ export async function loadTracesFromFile(file: File): Promise<LoadResult> {
 }
 
 export default function FileLoader(props: FileLoaderProps) {
+  const removedFilesRef = React.useRef(new Set<string>());
+
   return (
     <Dragger
       accept=".json,.jsonl"
@@ -78,13 +81,17 @@ export default function FileLoader(props: FileLoaderProps) {
         // N times (N²). We process only the current `file` argument to avoid that.
         loadTracesFromFile(file)
           .then(({ summaries, rawTraces, errorCount }) => {
+            if (removedFilesRef.current.has(file.uid)) {
+              removedFilesRef.current.delete(file.uid);
+              return;
+            }
             if (errorCount > 0) {
               message.error(
                 `${errorCount} trace${errorCount > 1 ? 's' : ''} could not be loaded from ${file.name}.`
               );
             }
             if (summaries.length > 0) {
-              props.onTracesLoaded(summaries, rawTraces);
+              props.onTracesLoaded(summaries, rawTraces, file.uid);
             } else if (errorCount === 0) {
               message.warning(`No traces found in ${file.name}.`);
             }
@@ -95,6 +102,12 @@ export default function FileLoader(props: FileLoaderProps) {
             );
           });
         return false;
+      }}
+      onRemove={file => {
+        removedFilesRef.current.add(file.uid);
+        if (props.onTraceFileRemove) {
+          props.onTraceFileRemove(file.uid);
+        }
       }}
       multiple
     >

--- a/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/index.tsx
@@ -78,7 +78,8 @@ export function SearchTracePageImpl() {
     }
   }, [searchQuery, rawUrlState, navigate]);
 
-  const { uploadedSummaries, uploadedRawTraces, handleTracesLoaded } = useUploadedTraces();
+  const { uploadedSummaries, uploadedRawTraces, handleTracesLoaded, handleTraceFileRemove } =
+    useUploadedTraces();
 
   // Merge API and uploaded summaries, deduplicating by traceID (API results take precedence).
   // Duplicates arise when the same file is uploaded twice or an uploaded trace also appears
@@ -188,7 +189,7 @@ export function SearchTracePageImpl() {
     tabItems.push({
       label: 'Upload',
       key: 'fileLoader',
-      children: <FileLoader onTracesLoaded={handleTracesLoaded} />,
+      children: <FileLoader onTracesLoaded={handleTracesLoaded} onTraceFileRemove={handleTraceFileRemove} />,
     });
   }
 

--- a/packages/jaeger-ui/src/components/SearchTracePage/useUploadedTraces.ts
+++ b/packages/jaeger-ui/src/components/SearchTracePage/useUploadedTraces.ts
@@ -11,11 +11,13 @@ import type { TraceSummary } from '../../types/trace-summary';
  */
 const UPLOADED_SUMMARIES_QUERY_KEY = ['uploadedSummaries'] as const;
 const UPLOADED_RAW_TRACES_QUERY_KEY = ['uploadedRawTraces'] as const;
+const UPLOADED_FILE_MAP_QUERY_KEY = ['uploadedTraceFileMap'] as const;
 
 type UploadedTraces = {
   uploadedSummaries: TraceSummary[];
   uploadedRawTraces: unknown[];
-  handleTracesLoaded: (summaries: TraceSummary[], rawTraces: unknown[]) => void;
+  handleTracesLoaded: (summaries: TraceSummary[], rawTraces: unknown[], fileId?: string) => void;
+  handleTraceFileRemove: (fileId: string) => void;
 };
 
 /** Returns a stable callback that clears the uploaded traces cache. */
@@ -24,6 +26,7 @@ export function useClearUploadedTraces(): () => void {
   return useCallback(() => {
     queryClient.setQueryData(UPLOADED_SUMMARIES_QUERY_KEY, []);
     queryClient.setQueryData(UPLOADED_RAW_TRACES_QUERY_KEY, []);
+    queryClient.setQueryData(UPLOADED_FILE_MAP_QUERY_KEY, {});
   }, [queryClient]);
 }
 
@@ -51,8 +54,15 @@ export function useUploadedTraces(): UploadedTraces {
     gcTime: Infinity,
   });
 
+  useQuery<Record<string, string[]>>({
+    queryKey: UPLOADED_FILE_MAP_QUERY_KEY,
+    queryFn: skipToken,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
   const handleTracesLoaded = useCallback(
-    (summaries: TraceSummary[], rawTraces: unknown[]) => {
+    (summaries: TraceSummary[], rawTraces: unknown[], fileId?: string) => {
       queryClient.setQueryData<TraceSummary[]>(UPLOADED_SUMMARIES_QUERY_KEY, prev => {
         const existing = prev ?? [];
         const seen = new Set(existing.map(s => s.traceID));
@@ -76,9 +86,43 @@ export function useUploadedTraces(): UploadedTraces {
         });
         return [...existing, ...incoming];
       });
+
+      if (fileId) {
+        queryClient.setQueryData<Record<string, string[]>>(UPLOADED_FILE_MAP_QUERY_KEY, prev => {
+          return { ...prev, [fileId]: summaries.map(s => s.traceID) };
+        });
+      }
     },
     [queryClient]
   );
 
-  return { uploadedSummaries, uploadedRawTraces, handleTracesLoaded };
+  const handleTraceFileRemove = useCallback(
+    (fileId: string) => {
+      const currentMap =
+        queryClient.getQueryData<Record<string, string[]>>(UPLOADED_FILE_MAP_QUERY_KEY) ?? {};
+      const traceIDsToRemove = currentMap[fileId];
+      if (!traceIDsToRemove || traceIDsToRemove.length === 0) return;
+
+      const idsSet = new Set(traceIDsToRemove);
+
+      queryClient.setQueryData<TraceSummary[]>(UPLOADED_SUMMARIES_QUERY_KEY, prev => {
+        return (prev ?? []).filter(s => !idsSet.has(s.traceID));
+      });
+
+      queryClient.setQueryData<unknown[]>(UPLOADED_RAW_TRACES_QUERY_KEY, prev => {
+        const traceIDOf = (r: unknown) =>
+          r != null && typeof r === 'object' ? String((r as Record<string, unknown>).traceID) : '';
+        return (prev ?? []).filter(r => !idsSet.has(traceIDOf(r)));
+      });
+
+      queryClient.setQueryData<Record<string, string[]>>(UPLOADED_FILE_MAP_QUERY_KEY, prev => {
+        const newMap = { ...prev };
+        delete newMap[fileId];
+        return newMap;
+      });
+    },
+    [queryClient]
+  );
+
+  return { uploadedSummaries, uploadedRawTraces, handleTracesLoaded, handleTraceFileRemove };
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4203

Unlike the previous PR #4204 which used a global cache clear, this PR implements the maintainers' requested approach of mapping the `file.uid` to the extracted trace IDs to enable precise, scoped deletion.

## Description of the changes
- Added `UPLOADED_FILE_MAP_QUERY_KEY` to `useUploadedTraces.ts` to map `fileId -> traceID[]`.
- Created `handleTraceFileRemove` which selectively filters out only the specific traces associated with the removed file from `UPLOADED_SUMMARIES` and `UPLOADED_RAW_TRACES`.
- Wired up `Upload.Dragger`'s `onRemove` callback to trigger this scoped cleanup.
- Used a `removedFilesRef` set to gracefully abort cache updates if a file is removed before its traces finish parsing.

## How was this change tested?
- Verified that traces are cleared correctly upon removing their corresponding uploaded file.
- Verified that existing automated tests pass.
- Verified that deleting one uploaded file does not delete traces from another simultaneously uploaded file.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
