### PR TITLE
fix(date): carry a rounded-up remainder instead of rendering a full unit

### DIFF
--- a/packages/jaeger-ui/src/utils/date.test.js
+++ b/packages/jaeger-ui/src/utils/date.test.js
@@ -65,6 +65,19 @@ describe('formatDuration', () => {
     const input = 0;
     expect(formatDuration(input)).toBe('0μs');
   });
+
+  it('carries a rounded-up remainder instead of printing a full unit', () => {
+    // Rounding the secondary unit up can reach the primary unit's base, which
+    // the secondary unit cannot hold ("1h 60m", "1m 60s", "1d 24h").
+    expect(formatDuration(1 * ONE_HOUR + 59 * ONE_MINUTE + 40 * ONE_SECOND)).toBe('2h');
+    expect(formatDuration(1 * ONE_MINUTE + 59.7 * ONE_SECOND)).toBe('2m');
+    expect(formatDuration(1 * ONE_DAY + 23 * ONE_HOUR + 40 * ONE_MINUTE)).toBe('2d');
+  });
+
+  it('still rounds the secondary unit when it does not overflow', () => {
+    expect(formatDuration(2 * ONE_HOUR + 30 * ONE_MINUTE + 30 * ONE_SECOND)).toBe('2h 31m');
+    expect(formatDuration(1 * ONE_HOUR + 58 * ONE_MINUTE + 40 * ONE_SECOND)).toBe('1h 59m');
+  });
 });
 
 describe('getSuitableTimeUnit', () => {

--- a/packages/jaeger-ui/src/utils/date.ts
+++ b/packages/jaeger-ui/src/utils/date.ts
@@ -178,9 +178,18 @@ export function formatDuration(duration: Microseconds): string {
     return `${_round(duration / primaryUnit.microseconds, 2)}${primaryUnit.unit}`;
   }
 
-  const primaryValue = Math.floor(duration / primaryUnit.microseconds);
+  let primaryValue = Math.floor(duration / primaryUnit.microseconds);
+  let secondaryValue = Math.round((duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious);
+
+  // Rounding the remainder up can reach a whole primary unit, which the
+  // secondary unit cannot hold: 1h 59m 40s would render as "1h 60m". Carry it
+  // into the primary unit instead.
+  if (secondaryValue === primaryUnit.ofPrevious) {
+    primaryValue += 1;
+    secondaryValue = 0;
+  }
+
   const primaryUnitString = `${primaryValue}${primaryUnit.unit}`;
-  const secondaryValue = Math.round((duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious);
   const secondaryUnitString = `${secondaryValue}${secondaryUnit.unit}`;
   return secondaryValue === 0 ? primaryUnitString : `${primaryUnitString} ${secondaryUnitString}`;
 }


### PR DESCRIPTION
## Which problem is this PR solving?

`formatDuration` rounds the secondary unit, so the rounded value can reach the primary unit's base — a value that unit cannot hold:

| input | current | expected |
|---|---|---|
| `1h 59m 40s` | `1h 60m` | `2h` |
| `1m 59.7s` | `1m 60s` | `2m` |
| `1d 23h 40m` | `1d 24h` | `2d` |
| `59m 59.6s` | `59m 60s` | — |

The rounding itself is intended — `date.test.js` documents it as "displays a maximum of 2 units and rounds the last one". What is missing is the carry when that rounding overflows.

`formatDuration` backs span duration and relative-start tooltips in `TraceSpanView`, `TraceLogsView`, `FlamegraphTable` and `FlamegraphTooltip`, so the bad string is user-visible whenever a duration lands near a unit boundary.

## Description of the changes

Carry the overflow into the primary unit and drop the secondary — the path the function already takes when the remainder rounds to zero (`2d`). Rounding is preserved for everything that does not overflow: `2h 30m 30s` still renders as `2h 31m`.

## How was this change tested?

- `vitest run src/utils/date.test.js` → **49 passed** (47 on `main`; the 2 added tests are the difference).
- Red→green: reverting only `date.ts` fails `carries a rounded-up remainder instead of printing a full unit` and passes the rest. The companion test `still rounds the secondary unit when it does not overflow` passes both before and after — it pins the behavior this change must not alter.
- Full `pnpm test`: **2951 passed** with this change vs **2949** on `main`, with an identical 144 failures / 24 failed files in both runs. Those failures are pre-existing in my local environment (`localStorage` undefined under the test environment in unrelated files) and are untouched by this change.
- `vp fmt --check` clean; `tsc -p packages/jaeger-ui/tsconfig.json` exits 0.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits (DCO)
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## Note

I could not add the required `changelog:` label — that needs write access. Happy to adjust the title or scope if you would prefer a different label. I can also open a tracking issue first if that is the preferred flow here.

One residual worth naming: `23h 59m 40s` now renders as `24h` rather than the previous `23h 60m`. Promoting it to `1d` would mean re-running unit selection after the carry, which is a larger change than this fix — say the word if you would rather have that.
