### PR TITLE
fix(genai): Use the trace's own isGenAITrace for view auto-activation

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -1098,6 +1098,34 @@ describe('<TracePage>', () => {
       render(<TracePage {...genAiProps} backendCapabilities={null} />);
       expect(capturedHeaderProps.viewType).toBe(ETraceViewType.GenAITimelineViewer);
     });
+
+    // The two cases below deliberately construct a trace whose isGenAITrace
+    // disagrees with a raw gen_ai.* attribute scan. The two cannot disagree today,
+    // but that is exactly what a refinement to classifySpan produces: excluding a
+    // key makes the verdict false while the attribute is still present, and adding
+    // a non-gen_ai signal makes it true while no gen_ai.* attribute exists. Both
+    // pin that TracePage reads the trace's verdict instead of deriving its own.
+    it('does not auto-switch when isGenAITrace is false, despite a gen_ai.* attribute', () => {
+      const raw = traceGenerator.trace({});
+      raw.spans[0].tags.push({ key: 'gen_ai.tool.call.id', type: 'string', value: 'abc-123' });
+      const otelTrace = transformTraceData(raw).asOtelTrace();
+      otelTrace.isGenAITrace = false;
+      useTraceMock.mockReturnValue({ data: otelTrace, isPending: false, isError: false, error: null });
+
+      render(<TracePage {...defaultProps} id={otelTrace.traceID} />);
+      expect(capturedHeaderProps.viewType).toBe(ETraceViewType.TraceTimelineViewer);
+    });
+
+    it('auto-switches when isGenAITrace is true, despite no gen_ai.* attribute', () => {
+      const raw = traceGenerator.trace({});
+      raw.spans[0].tags.push({ key: 'db.system', type: 'string', value: 'vector' });
+      const otelTrace = transformTraceData(raw).asOtelTrace();
+      otelTrace.isGenAITrace = true;
+      useTraceMock.mockReturnValue({ data: otelTrace, isPending: false, isError: false, error: null });
+
+      render(<TracePage {...defaultProps} id={otelTrace.traceID} />);
+      expect(capturedHeaderProps.viewType).toBe(ETraceViewType.GenAITimelineViewer);
+    });
   });
 });
 

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -206,13 +206,10 @@ export function TracePageImpl(props: TProps) {
     [traceData, viewType]
   );
 
-  const traceIsGenAI = useMemo(
-    () =>
-      traceData?.spans
-        ? traceData.spans.some(s => s.attributes.keys().some(k => k.startsWith('gen_ai.')))
-        : false,
-    [traceData]
-  );
+  // Read the trace's own verdict rather than re-deriving it here. It is computed
+  // once from each span's cached genAIKind, so re-scanning attributes is both
+  // redundant and free to drift away from classifySpan as the detector evolves.
+  const traceIsGenAI = traceData?.isGenAITrace ?? false;
 
   const searchBarRef = useRef<InputRef>(null);
   const headerElmRef = useRef<HTMLElement | TNil>(null);


### PR DESCRIPTION
Resolves #4270.

`TracePage` derived its own GenAI verdict with a raw `gen_ai.*` prefix scan instead of reading `IOtelTrace.isGenAITrace`, which `OtelTraceFacade` already computes from each span's cached `genAIKind`. This replaces the scan with the trace's own value.

The two agree today, so this is not a user-visible fix on its own — it stops them from diverging. Any refinement to `classifySpan` changes the facade's verdict but not the inline scan, so auto-activation would silently keep using the unrefined definition. It also removes a redundant O(spans × attributes) walk on every trace load.

#### Testing

Two regression tests in the existing `GenAI auto-activation` block, one per direction of divergence: `isGenAITrace` false with a `gen_ai.*` attribute present (the #4053 shape), and true with none present (the vector-retrieval shape). Both fail on `main` and pass here — verified by reverting the `index.tsx` change and re-running.

Full suite green: 3614 tests, `tsc --noEmit` clean, oxlint clean on both changed files.
