### PR TITLE
feat(genai): Detect RAG and agent traces from non-GenAI instrumentation

### DIFF
--- a/packages/jaeger-ui/src/constants/span-attributes.ts
+++ b/packages/jaeger-ui/src/constants/span-attributes.ts
@@ -12,3 +12,12 @@ export const GEN_AI_TOOL_NAME = 'gen_ai.tool.name';
 // A tool call's cross-span reference. Present on spans that merely *mention* a
 // tool call, so on its own it does not make a span a GenAI span.
 export const GEN_AI_TOOL_CALL_ID = 'gen_ai.tool.call.id';
+
+// Vector-store retrieval spans are emitted by the DB instrumentation, not the
+// GenAI instrumentation, so they carry db.* rather than gen_ai.* attributes.
+export const DB_SYSTEM = 'db.system';
+
+export const DB_SYSTEM_VECTOR = 'vector';
+
+// Non-spec attribute used by agent frameworks to group spans into one episode.
+export const AGENT_EPISODE_ID = 'agent.episode_id';

--- a/packages/jaeger-ui/src/utils/genai/detect.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.test.ts
@@ -111,6 +111,50 @@ describe('classifySpan', () => {
     ]);
     expect(classifySpan(span)).toBe('UNKNOWN_GENAI');
   });
+
+  it('classifies db.system=vector as RETRIEVAL even with no gen_ai.* attrs', () => {
+    expect(classifySpan(makeSpan([{ key: 'db.system', value: 'vector' }]))).toBe('RETRIEVAL');
+  });
+
+  it('classifies agent.episode_id as AGENT even with no gen_ai.* attrs', () => {
+    expect(classifySpan(makeSpan([{ key: 'agent.episode_id', value: 'ep-1' }]))).toBe('AGENT');
+  });
+
+  it('lets a recognized operation.name win over agent.episode_id', () => {
+    const span = makeSpan([
+      { key: 'agent.episode_id', value: 'ep-1' },
+      { key: 'gen_ai.operation.name', value: 'chat' },
+    ]);
+    expect(classifySpan(span)).toBe('LLM_CALL');
+  });
+
+  it('lets db.system=vector win over agent.episode_id', () => {
+    const span = makeSpan([
+      { key: 'agent.episode_id', value: 'ep-1' },
+      { key: 'db.system', value: 'vector' },
+    ]);
+    expect(classifySpan(span)).toBe('RETRIEVAL');
+  });
+
+  it('lets gen_ai.tool.name win over db.system=vector', () => {
+    const span = makeSpan([
+      { key: 'db.system', value: 'vector' },
+      { key: 'gen_ai.tool.name', value: 'search_docs' },
+    ]);
+    expect(classifySpan(span)).toBe('TOOL_CALL');
+  });
+
+  it('falls back to db.system=vector for an unrecognized operation.name', () => {
+    const span = makeSpan([
+      { key: 'gen_ai.operation.name', value: 'some_new_op' },
+      { key: 'db.system', value: 'vector' },
+    ]);
+    expect(classifySpan(span)).toBe('RETRIEVAL');
+  });
+
+  it('leaves a non-vector db.system unclassified', () => {
+    expect(classifySpan(makeSpan([{ key: 'db.system', value: 'postgresql' }]))).toBeUndefined();
+  });
 });
 
 describe('isGenAISpan', () => {
@@ -154,5 +198,18 @@ describe('isGenAITrace', () => {
 
   it('returns false for an empty span list', () => {
     expect(isGenAITrace([])).toBe(false);
+  });
+
+  it('returns true for a RAG trace whose retrieval span carries only db.* attrs', () => {
+    const spans = [
+      makeSpan([{ key: 'http.method', value: 'POST' }]),
+      makeSpan([{ key: 'db.system', value: 'vector' }]),
+    ];
+    expect(isGenAITrace(spans)).toBe(true);
+  });
+
+  it('returns true for an agent trace whose spans carry only agent.episode_id', () => {
+    const spans = [makeSpan([{ key: 'agent.episode_id', value: 'ep-1' }])];
+    expect(isGenAITrace(spans)).toBe(true);
   });
 });

--- a/packages/jaeger-ui/src/utils/genai/detect.ts
+++ b/packages/jaeger-ui/src/utils/genai/detect.ts
@@ -3,6 +3,9 @@
 
 import type { IAttributes, GenAISpanKind } from '../../types/otel';
 import {
+  AGENT_EPISODE_ID,
+  DB_SYSTEM,
+  DB_SYSTEM_VECTOR,
   GEN_AI_NAMESPACE,
   GEN_AI_OPERATION_NAME,
   GEN_AI_TOOL_CALL_ID,
@@ -28,9 +31,19 @@ const OPERATION_TO_KIND: Partial<Record<string, GenAISpanKind>> = {
  * carries a value we don't recognize. Deliberately consulted *after* the
  * operation name: that attribute is the spec's own discriminator, so a
  * recognized value always wins over these heuristics.
+ *
+ * The db.system and agent.episode_id signals also catch spans carrying no
+ * gen_ai.* attributes at all, emitted by instrumentation that is not
+ * GenAI-aware but is taking part in a GenAI workflow.
+ *
+ * agent.episode_id is checked last because frameworks stamp it on every span
+ * in an episode, not just the agent span — it is only meaningful once the
+ * more specific signals have been ruled out.
  */
 function classifyBySecondarySignals(attributes: IAttributes): GenAISpanKind | undefined {
   if (attributes.has(GEN_AI_TOOL_NAME)) return 'TOOL_CALL';
+  if (attributes.getValue(DB_SYSTEM) === DB_SYSTEM_VECTOR) return 'RETRIEVAL';
+  if (attributes.has(AGENT_EPISODE_ID)) return 'AGENT';
   return undefined;
 }
 


### PR DESCRIPTION
#### Context

This is the follow-up #4053 said it was holding back. That PR refined how GenAI spans are *classified* and explicitly deferred two signals because they change what counts as a GenAI trace, which deserved its own review rather than riding along with a classification fix.

#### What this changes

Two signals added to `classifyBySecondarySignals`, consulted — like the `gen_ai.tool.name` signal already there — only when `gen_ai.operation.name` is absent or carries a value we don't recognize:

- `db.system=vector` → `RETRIEVAL`, for vector-store lookups recorded by the DB instrumentation
- `agent.episode_id` → `AGENT`, for spans an agent framework has grouped into one episode

#### This widens isGenAITrace — that's the decision under review

Both signals fire on spans carrying **no `gen_ai.*` attributes at all**. That is the point of them, and it is a change to what the UI considers a GenAI trace: a RAG trace whose only relevant span is a vector-store lookup emitted by DB instrumentation now returns `true` from `isGenAITrace`, where before it returned `false`. Since #4271, that verdict is what drives auto-activation of the GenAI view, so such traces will now open in that view.

I think that is correct — a retrieval step is part of the agent's work regardless of which library emitted the span, and a RAG trace that doesn't register as a GenAI trace is the more surprising outcome. But it is a redefinition rather than a refinement, and it's the part worth arguing about. Two tests assert the widening directly so the behaviour change is visible in the diff rather than implied.

#### Judgment call: precedence — please push back if you disagree

`agent.episode_id` is checked **last**, after both `gen_ai.tool.name` and `db.system`, and `gen_ai.operation.name` still beats all three.

The reason is that frameworks stamp `episode_id` on every span in an episode, not just the agent span. Treating it as a primary signal would relabel an entire episode as agent spans. Concretely: a span carrying both `agent.episode_id` and `gen_ai.operation.name=chat` classifies as `LLM_CALL`, not `AGENT`.

The ordering among the secondary signals is a weaker call than the spec-first rule, and I'd rather have it challenged than assumed. Each is a one-line move.

#### On `agent.episode_id` not being a semantic convention

Worth stating plainly: `agent.episode_id` is not part of the OTel GenAI semantic conventions. `db.system` is a standard attribute, so only the `vector` value is a convention over it, but `agent.episode_id` is a framework-level key with no spec backing.

I still think it earns its place. Agent frameworks emit orchestration spans that carry no `gen_ai.*` attributes — the agent's own step is often just a span grouping the LLM and tool calls beneath it — and without a signal like this the top of an agent trace is invisible to the detector while its children are not. Because it sits last in the precedence order, it only ever applies where nothing spec-defined has already answered, so it cannot override a conforming instrumentation. If you'd rather keep the detector strictly spec-only, dropping it is a two-line change and the `db.system=vector` half stands on its own.

#### Testing

Six new classification tests plus two `isGenAITrace` tests covering the widening in both directions. The suite is green: 3629 tests, `tsc --noEmit` clean, oxlint clean on changed files.
