### PR TITLE
fix(trace): offset timeline header below page header

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
@@ -10,6 +10,7 @@ SPDX-License-Identifier: Apache-2.0
   height: var(--timeline-header-row-height);
   line-height: var(--timeline-header-row-height);
   position: fixed;
+  top: var(--trace-page-header-height, 0px);
   width: 100%;
   z-index: 4;
 }

--- a/packages/jaeger-ui/src/components/TracePage/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.test.jsx
@@ -898,6 +898,7 @@ describe('<TracePage>', () => {
       const section = document.querySelector('section');
       expect(section).toBeInTheDocument();
       expect(section.style.paddingTop).toBe('100px');
+      expect(section.style.getPropertyValue('--trace-page-header-height')).toBe('100px');
 
       jest.restoreAllMocks();
     });

--- a/packages/jaeger-ui/src/components/TracePage/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/index.tsx
@@ -511,7 +511,18 @@ export function TracePageImpl(props: TProps) {
       <div className="Tracepage--headerSection" ref={headerRefCallback}>
         <TracePageHeader {...headerProps} />
       </div>
-      {headerHeight ? <section style={{ paddingTop: headerHeight }}>{view}</section> : null}
+      {headerHeight ? (
+        <section
+          style={
+            {
+              paddingTop: headerHeight,
+              '--trace-page-header-height': `${headerHeight}px`,
+            } as React.CSSProperties
+          }
+        >
+          {view}
+        </section>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expose the measured trace-page header height to the rendered view section
- position the fixed timeline header below the trace-page header
- add a regression assertion for the inherited offset

Closes #4279

## Validation
- `pnpm run fmt`
- `pnpm run lint`
- `pnpm test` (3,620 passed)
- `pnpm run build`
