### PR TITLE
fix(analytics): Preserve zero event values

### DIFF
--- a/packages/jaeger-ui/src/utils/tracking/ga.test.js
+++ b/packages/jaeger-ui/src/utils/tracking/ga.test.js
@@ -175,6 +175,13 @@ describe('google analytics tracking', () => {
     expect(window.dataLayer[1][2].event_value).toBe(9);
   });
 
+  it('sets event_value when value is zero', () => {
+    tracking.trackEvent('jaeger/cat', 'act', 0);
+    tracking.trackEvent('jaeger/cat', 'act', 'lbl', 0);
+    expect(window.dataLayer[0][2].event_value).toBe(0);
+    expect(window.dataLayer[1][2].event_value).toBe(0);
+  });
+
   it('init() exits when isEnabled() is false', () => {
     getAppEnvironment.mockReturnValueOnce('production');
     const noGA = GA.default({ tracking: {} }, 'vS', 'vL');

--- a/packages/jaeger-ui/src/utils/tracking/ga.ts
+++ b/packages/jaeger-ui/src/utils/tracking/ga.ts
@@ -340,7 +340,7 @@ const GA: IWebAnalyticsFunc = (config: Config, versionShort: string, versionLong
     gtag('event', event.action, {
       event_category: event.category,
       ...(event.label && { event_label: event.label }),
-      ...(event.value && { event_value: event.value }),
+      ...(event.value != null && { event_value: event.value }),
     });
   };
 


### PR DESCRIPTION
## Which issue is this PR closing?

Closes #4282.

## What does this PR do?

Preserves `event_value` when an analytics event supplies a value of zero.

The payload previously used a truthiness check, which omitted `0` even though it is a valid numeric event value. The condition now excludes only `null` and `undefined`.

Regression coverage verifies both supported numeric call forms:

- `trackEvent(category, action, 0)`
- `trackEvent(category, action, label, 0)`

## Testing

- `pnpm --filter @jaegertracing/jaeger-ui test src/utils/tracking/ga.test.js`
- `pnpm run fmt`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`