### PR TITLE
fix(api): include response body in error messages

### DIFF
--- a/packages/jaeger-ui/src/api/v3/client.test.ts
+++ b/packages/jaeger-ui/src/api/v3/client.test.ts
@@ -269,6 +269,58 @@ describe('JaegerClient', () => {
       tags: undefined,
     };
 
+    describe('error handling with response body', () => {
+      it('should include error response body in thrown error message', async () => {
+        const errorDetails = {
+          error: 'Invalid service name: "service$pecial"',
+          code: 400,
+          details: 'Service names can only contain alphanumeric characters',
+        };
+
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: async () => JSON.stringify(errorDetails),
+          json: async () => errorDetails,
+        });
+
+        await expect(client.fetchServices()).rejects.toThrow(
+          'Failed to fetch services: 400 Bad Request - Invalid service name: "service$pecial"'
+        );
+      });
+
+      it('should still work when response body is not JSON', async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          text: async () => 'Database connection failed: timeout after 30s',
+          json: async () => {
+            throw new Error('Invalid JSON');
+          },
+        });
+
+        await expect(client.fetchServices()).rejects.toThrow(
+          'Failed to fetch services: 500 Internal Server Error - Database connection failed: timeout after 30s'
+        );
+      });
+
+      it('should handle empty error response body gracefully', async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: async () => '',
+          json: async () => {
+            throw new Error('Invalid JSON');
+          },
+        });
+
+        await expect(client.fetchServices()).rejects.toThrow('Failed to fetch services: 404 Not Found');
+      });
+    });
+
     // Wire field is `traceId` (proto3 camelCase), not `traceID`.
     const mockApiSummary = {
       traceId: 'aaaabbbbccccdddd0000111122223333',

--- a/packages/jaeger-ui/src/api/v3/client.ts
+++ b/packages/jaeger-ui/src/api/v3/client.ts
@@ -18,17 +18,49 @@ export class JaegerClient {
   private apiRoot = prefixUrl('/api/v3');
 
   /**
+   * Extract error details from response body
+   * Handles both JSON and plain text responses
+   */
+  private async extractErrorDetails(response: Response): Promise<string> {
+    try {
+      const text = await response.text();
+      if (!text) return '';
+
+      try {
+        const json = JSON.parse(text);
+        if (typeof json.error === 'string') return json.error;
+        if (typeof json.message === 'string') return json.message;
+        if (typeof json.details === 'string') return json.details;
+        return text;
+      } catch {
+        return text;
+      }
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * Throw a detailed error with response body information
+   */
+  private async throwApiError(response: Response, context: string): Promise<never> {
+    const details = await this.extractErrorDetails(response);
+    const message = details
+      ? `Failed to ${context}: ${response.status} ${response.statusText} - ${details}`
+      : `Failed to ${context}: ${response.status} ${response.statusText}`;
+    throw new Error(message);
+  }
+
+  /**
    * Fetch the list of services from the Jaeger API.
    * @returns Promise<string[]> - Array of service names
    */
   async fetchServices(): Promise<string[]> {
     const response = await this.fetchWithTimeout(`${this.apiRoot}/services`);
     if (!response.ok) {
-      throw new Error(`Failed to fetch services: ${response.status} ${response.statusText}`);
+      await this.throwApiError(response, 'fetch services');
     }
     const data = await response.json();
-
-    // Runtime validation with Zod
     const validated = ServicesResponseSchema.parse(data);
     return validated.services;
   }
@@ -43,13 +75,9 @@ export class JaegerClient {
       `${this.apiRoot}/operations?service=${encodeURIComponent(service)}`
     );
     if (!response.ok) {
-      throw new Error(
-        `Failed to fetch span names for service "${service}": ${response.status} ${response.statusText}`
-      );
+      await this.throwApiError(response, `fetch span names for service "${service}"`);
     }
     const data = await response.json();
-
-    // Runtime validation with Zod
     const validated = OperationsResponseSchema.parse(data);
     return validated.operations;
   }
@@ -78,7 +106,7 @@ export class JaegerClient {
     const url = `${this.apiRoot}/trace-summaries?${params.toString()}`;
     const response = await this.fetchWithTimeout(url);
     if (!response.ok) {
-      throw new Error(`Failed to fetch trace summaries: ${response.status} ${response.statusText}`);
+      await this.throwApiError(response, 'fetch trace summaries');
     }
     const data = await response.json();
     const validated = TraceSummariesResponseSchema.parse(data);


### PR DESCRIPTION


## Which problem is this PR solving?
- Resolves #4280 

## Description of the changes
This PR improves error handling in the v3 API client by including the response body in thrown error messages when API requests fail.

## How was this change tested?
- Added unit tests for the new error handling behavior.
- Verified that the new tests fail on the original implementation.
- Updated the implementation and confirmed that all new tests pass.
- Ran the relevant client.test.ts test suite successfully.

## Checklist
- [-] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [-] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`
I ran the relevant frontend unit tests for this change (client.test.ts). I have not run the full make lint test suite.

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [-] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
