### PR TITLE
fix(graph): rebuild parent-child map per trace to fix stale self-time

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceGraph/calculateTraceDagEV.ts
@@ -11,8 +11,6 @@ import { TDenseSpanMembers } from '../../../model/trace-dag/types';
 import { IOtelSpan, IOtelTrace, SpanKind, StatusCode } from '../../../types/otel';
 import { TSumSpan, TEv } from './types';
 
-let parentChildOfMap: Record<string, IOtelSpan[]>;
-
 export function mapNonBlocking(
   edges: TEdge[],
   nodes: TDagNode<TSumSpan & TDenseSpanMembers>[]
@@ -32,39 +30,27 @@ export function mapNonBlocking(
   });
 }
 
-/**
- * Gets blocking child spans (children that contribute to parent's critical path).
- * In OTEL, CONSUMER children of PRODUCER parents are non-blocking and should be excluded
- * from critical path calculations, similar to how FOLLOWS_FROM was excluded in legacy code.
- */
-function getBlockingChildSpans(parentID: string, trace: IOtelTrace): IOtelSpan[] {
-  if (!parentChildOfMap) {
-    parentChildOfMap = {};
-    trace.spans.forEach(s => {
-      if (s.parentSpanID) {
-        const pID = s.parentSpanID;
-        // Only include blocking children (not CONSUMER spans)
-        // CONSUMER spans are non-blocking in PRODUCER-CONSUMER pairs
-        if (s.kind !== SpanKind.CONSUMER) {
-          parentChildOfMap[pID] = parentChildOfMap[pID] || [];
-          parentChildOfMap[pID].push(s);
-        }
-      }
-    });
-  }
-  return parentChildOfMap[parentID] || [];
-}
-
-function getChildOfDrange(parentID: string, trace: IOtelTrace) {
-  const childrenDrange = new DRange();
-  getBlockingChildSpans(parentID, trace).forEach(s => {
-    // -1 otherwise it will take for each child a micro (incluse,exclusive)
-    childrenDrange.add(s.startTime, s.startTime + (s.duration <= 0 ? 0 : s.duration - 1));
-  });
-  return childrenDrange;
-}
-
 function calculateTraceDag(trace: IOtelTrace): TraceDag<TSumSpan & TDenseSpanMembers> {
+  // Build the parent→blocking-children map once per trace invocation so it is
+  // never stale when the user navigates between traces in the same session.
+  const blockingChildMap: Record<string, IOtelSpan[]> = {};
+  trace.spans.forEach(s => {
+    if (s.parentSpanID && s.kind !== SpanKind.CONSUMER) {
+      // Only include blocking children (not CONSUMER spans)
+      // CONSUMER spans are non-blocking in PRODUCER-CONSUMER pairs
+      (blockingChildMap[s.parentSpanID] ??= []).push(s);
+    }
+  });
+
+  const getChildOfDrange = (parentID: string) => {
+    const childrenDrange = new DRange();
+    (blockingChildMap[parentID] || []).forEach(s => {
+      // -1 otherwise it will take for each child a micro (incluse,exclusive)
+      childrenDrange.add(s.startTime, s.startTime + (s.duration <= 0 ? 0 : s.duration - 1));
+    });
+    return childrenDrange;
+  };
+
   const baseDag = TraceDag.newFromTrace(trace);
   const dag = new TraceDag<TSumSpan & TDenseSpanMembers>();
 
@@ -73,9 +59,7 @@ function calculateTraceDag(trace: IOtelTrace): TraceDag<TSumSpan & TDenseSpanMem
     const numErrors = node.members.reduce((p, m) => p + (m.span.status.code === StatusCode.ERROR ? 1 : 0), 0);
     const childDurationsDRange = node.members.reduce((p, m) => {
       // Using DRange to handle overlapping spans (fork-join)
-      const cdr = new DRange(m.span.startTime, m.span.endTime).intersect(
-        getChildOfDrange(m.span.spanID, trace)
-      );
+      const cdr = new DRange(m.span.startTime, m.span.endTime).intersect(getChildOfDrange(m.span.spanID));
       return p + cdr.length;
     }, 0);
     const stime = ntime - childDurationsDRange;


### PR DESCRIPTION
## Which problem is this PR solving?
- Graph view shows wrong self-time for every trace after the first one viewed in a session.

## Description of the changes
- `calculateTraceDagEV.ts` had a module level cache, `parentChildOfMap`, that was only built once:

```ts
let parentChildOfMap: Record<string, IOtelSpan[]>;

function getBlockingChildSpans(parentID: string, trace: IOtelTrace): IOtelSpan[] {
  if (!parentChildOfMap) {
    parentChildOfMap = {};
    // ...builds map from trace.spans
  }
  return parentChildOfMap[parentID] || [];
}
```

  The `if (!parentChildOfMap)` guard only fires on the very first call. After that it stays truthy forever, so every trace opened afterward in the same session reuses the first trace's parent to child span data instead of its own. This silently produces wrong `selfTime` and `percentSelfTime` values in the graph view for every trace after the first.

- Fix: removed the module level variable and the two standalone functions (`getBlockingChildSpans`, `getChildOfDrange`). The parent to child map is now built fresh inside `calculateTraceDag` on every call, as a local const, so it can never leak between traces.

```ts
function calculateTraceDag(trace: IOtelTrace): TraceDag<TSumSpan & TDenseSpanMembers> {
  const baseDag = TraceDag.newFromTrace(trace);
  const dag = new TraceDag<TSumSpan & TDenseSpanMembers>();

  const blockingChildMap: Record<string, IOtelSpan[]> = {};
  trace.spans.forEach(s => {
    if (s.parentSpanID && s.kind !== SpanKind.CONSUMER) {
      (blockingChildMap[s.parentSpanID] ??= []).push(s);
    }
  });

  const getChildOfDrange = (parentID: string) => {
    const childrenDrange = new DRange();
    (blockingChildMap[parentID] || []).forEach(s => {
      childrenDrange.add(s.startTime, s.startTime + (s.duration <= 0 ? 0 : s.duration - 1));
    });
    return childrenDrange;
  };
  // ... rest unchanged
}
```

  The logic itself is unchanged, same CONSUMER filtering, same DRange boundary handling. Only the scope of the map changed, from module level to per call.

## How was this change tested?
- Ran the existing test suite for this file, all 8 tests pass 

pnpm test -- calculateTraceDagEV

- Ran the full typecheck for the package, no errors:

pnpm tsc-lint

- Manually reproduced the bug before the fix: opened trace A in graph view (correct self-time), opened trace B in graph view without reloading (wrong, near 100% self-time on every node), confirmed against trace B's timeline view that it does have real child span duration. After the fix, repeated the same steps and trace B's self-time is correct.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**
- [ ] **Light**
- [ ] **Moderate**
- [ ] **Heavy**: AI helped identify the root cause and draft the fix, based on reading the actual source. I reviewed the diff line by line, ran the existing tests and typecheck locally, and manually reproduced the bug before and after the fix in a local Jaeger instance.


