### PR TITLE
Make TimelineCollapser buttons accessible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ npm-debug.log
 scripts/release-notes.py
 scripts/draft-release.py
 .claude/settings.local.json
+
+#cheatsheet
+Cheatsheet.md

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.test.jsx
@@ -2,20 +2,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import TimelineCollapser from './TimelineCollapser';
 
 describe('<TimelineCollapser>', () => {
-  it('renders without exploding', () => {
-    const props = {
-      onCollapseAll: () => {},
-      onCollapseOne: () => {},
-      onExpandAll: () => {},
-      onExpandOne: () => {},
+  let props;
+
+  beforeEach(() => {
+    props = {
+      onCollapseAll: vi.fn(),
+      onCollapseOne: vi.fn(),
+      onExpandAll: vi.fn(),
+      onExpandOne: vi.fn(),
     };
+  });
+
+  it('renders without exploding', () => {
     const { container } = render(<TimelineCollapser {...props} />);
     expect(container).toBeDefined();
+  });
+
+  it('handles clicks correctly', () => {
+    const { getByRole } = render(<TimelineCollapser {...props} />);
+
+    fireEvent.click(getByRole('button', { name: 'Expand +1' }));
+    expect(props.onExpandOne).toHaveBeenCalled();
+
+    fireEvent.click(getByRole('button', { name: 'Collapse +1' }));
+    expect(props.onCollapseOne).toHaveBeenCalled();
+
+    fireEvent.click(getByRole('button', { name: 'Expand All' }));
+    expect(props.onExpandAll).toHaveBeenCalled();
+
+    fireEvent.click(getByRole('button', { name: 'Collapse All' }));
+    expect(props.onCollapseAll).toHaveBeenCalled();
+  });
+
+  it('handles keyboard Enter events correctly', () => {
+    const { getByRole } = render(<TimelineCollapser {...props} />);
+
+    const expandBtn = getByRole('button', { name: 'Expand +1' });
+
+    fireEvent.keyDown(expandBtn, { key: 'Enter' });
+    expect(props.onExpandOne).toHaveBeenCalled();
+  });
+
+  it('handles keyboard Space events correctly', () => {
+    const { getByRole } = render(<TimelineCollapser {...props} />);
+
+    const collapseAllBtn = getByRole('button', { name: 'Collapse All' });
+
+    fireEvent.keyDown(collapseAllBtn, { key: ' ' });
+    expect(props.onCollapseAll).toHaveBeenCalled();
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
@@ -29,29 +29,52 @@ export default function TimelineCollapser({
 
   const getContainer = () => containerRef.current || document.body;
 
+  const handleKeyDown = (e: React.KeyboardEvent<SVGElement>, handler: () => void) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handler();
+    }
+  };
+
   return (
     <div className="TimelineCollapser" ref={containerRef}>
       <Tooltip title={getTitle('Expand +1')} getPopupContainer={getContainer}>
         <IoChevronForward
           onClick={onExpandOne}
+          role="button"
+          tabIndex={0}
+          aria-label="Expand +1"
+          onKeyDown={e => handleKeyDown(e, onExpandOne)}
           className="TimelineCollapser--btn-expand TimelineCollapser--btn-size TimelineCollapser--btn-down"
         />
       </Tooltip>
       <Tooltip title={getTitle('Collapse +1')} getPopupContainer={getContainer}>
         <IoChevronForward
           onClick={onCollapseOne}
+          role="button"
+          tabIndex={0}
+          aria-label="Collapse +1"
+          onKeyDown={e => handleKeyDown(e, onCollapseOne)}
           className="TimelineCollapser--btn TimelineCollapser--btn-size"
         />
       </Tooltip>
       <Tooltip title={getTitle('Expand All')} getPopupContainer={getContainer}>
         <LuChevronsRight
           onClick={onExpandAll}
+          role="button"
+          tabIndex={0}
+          aria-label="Expand All"
+          onKeyDown={e => handleKeyDown(e, onExpandAll)}
           className="TimelineCollapser--btn-expand TimelineCollapser--btn-size TimelineCollapser--btn-down"
         />
       </Tooltip>
       <Tooltip title={getTitle('Collapse All')} getPopupContainer={getContainer}>
         <LuChevronsRight
           onClick={onCollapseAll}
+          role="button"
+          tabIndex={0}
+          aria-label="Collapse All"
+          onKeyDown={e => handleKeyDown(e, onCollapseAll)}
           className="TimelineCollapser--btn TimelineCollapser--btn-size"
         />
       </Tooltip>


### PR DESCRIPTION

## Which problem is this PR solving?
- Fixes #4303 

## Description of the changes
- Added role="button", tabIndex={0}, and descriptive aria-labels to all four SVG icons in TimelineCollapser.tsx.
- Implemented an onKeyDown handler to capture Enter and Space keypresses to trigger the respective collapse/expand actions.
- Completely rewrote the minimal test file (TimelineCollapser.test.jsx) to explicitly test for both mouse clicks and keyboard Enter/Space events using React Testing Library's fireEvent.

## How was this change tested?
- Added explicit unit tests verifying the new keyboard behaviors.
- Ran pnpm test locally to ensure the new tests pass and no existing tests were broken.
- Ran pnpm run lint and pnpm run fmt successfully.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
