### PR TITLE
perf(trace-diff): Stabilize TraceDiffHeader props to avoid unnecessar…

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.test.jsx
@@ -23,8 +23,9 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-const { useTracesMock } = vi.hoisted(() => ({
+const { useTracesMock, mockHeaderProps } = vi.hoisted(() => ({
   useTracesMock: jest.fn(),
+  mockHeaderProps: [],
 }));
 
 vi.mock('../../hooks/useTraceLoading', () => ({
@@ -33,6 +34,7 @@ vi.mock('../../hooks/useTraceLoading', () => ({
 
 vi.mock('./TraceDiffHeader', async () => {
   return mockDefault(function MockTraceDiffHeader(props) {
+    mockHeaderProps.push(props);
     return (
       <div data-testid="trace-diff-header">
         <button type="button" data-testid="diff-set-a-btn" onClick={() => props.diffSetA('newAValue')}>
@@ -84,6 +86,7 @@ describe('TraceDiff', () => {
   });
 
   beforeEach(() => {
+    mockHeaderProps.length = 0;
     useTracesMock.mockReturnValue(new Map(defaultCohort.map(id => [id, { id, state: fetchedState.DONE }])));
     getUrlSpy.mockClear();
     mockNavigate.mockClear();
@@ -205,6 +208,28 @@ describe('TraceDiff', () => {
 
       expect(screen.getByTestId('trace-diff-header')).toBeInTheDocument();
       expect(screen.getByTestId('trace-diff-graph')).toBeInTheDocument();
+    });
+    it('memoizes trace props passed to TraceDiffHeader across re-renders', () => {
+      mockHeaderProps.length = 0;
+      const { rerender } = renderWithRouter(<TraceDiffImpl {...defaultProps} />);
+
+      expect(mockHeaderProps).toHaveLength(1);
+      const firstProps = mockHeaderProps[0];
+
+      // Re-render the same component with the identical prop references
+      rerender(
+        <BrowserRouter>
+          <TraceDiffImpl {...defaultProps} />
+        </BrowserRouter>
+      );
+
+      expect(mockHeaderProps).toHaveLength(2);
+      const secondProps = mockHeaderProps[1];
+
+      // Verify reference stability
+      expect(secondProps.a).toBe(firstProps.a);
+      expect(secondProps.b).toBe(firstProps.b);
+      expect(secondProps.cohort).toBe(firstProps.cohort);
     });
   });
 

--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiff.tsx
@@ -10,7 +10,7 @@ import { getUrl, TDiffRouteParams } from './url';
 import TraceDiffGraph from './TraceDiffGraph';
 import TraceDiffHeader from './TraceDiffHeader';
 import { TOP_NAV_HEIGHT } from '../../constants';
-import { FetchedTrace, TNil, ReduxState } from '../../types';
+import { TNil, ReduxState } from '../../types';
 import TTraceDiffState from '../../types/TTraceDiffState';
 import pluckTruthy from '../../utils/ts/pluckTruthy';
 import { useTraces } from '../../hooks/useTraceLoading';
@@ -116,9 +116,12 @@ export function TraceDiffImpl({ a, b, cohort }: TStateProps & TOwnProps) {
     setGraphTopOffsetCallback();
   }, [setGraphTopOffsetCallback]);
 
-  const traceA = a ? tracesData.get(a) || { id: a } : null;
-  const traceB = b ? tracesData.get(b) || { id: b } : null;
-  const cohortData: FetchedTrace[] = cohort.map(id => tracesData.get(id) || { id });
+  const { traceA, traceB, cohortData } = React.useMemo(() => {
+    const tA = a ? tracesData.get(a) || { id: a } : null;
+    const tB = b ? tracesData.get(b) || { id: b } : null;
+    const cData = cohort.map(id => tracesData.get(id) || { id });
+    return { traceA: tA, traceB: tB, cohortData: cData };
+  }, [a, b, cohort, tracesData]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## Which problem is this PR solving?

* Resolves #4314 

## Description of the changes

This PR reduces unnecessary re-renders of `TraceDiffHeader` in the Trace Comparison page.

The derived props passed to `TraceDiffHeader` are now memoized, allowing `React.memo` to skip redundant renders when the comparison data has not changed. Unit tests have also been added to verify the updated behavior.

## How was this change tested?

* Added unit tests covering the updated behavior.
* Verified the Trace Comparison page works as expected.
* Confirmed that unnecessary re-renders are reduced.
* Ran lint and tests successfully.

## Checklist

* [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
* [x] I have signed all commits
* [x] I have added unit tests for the new functionality
* [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR

* [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
* [ ] **None**
* [ ] **Moderate**
* [ ] **Heavy**
