### PR TITLE
docs(rfc-0002): correct span.kind wire format in code sketches

### DIFF
--- a/docs/rfc/0002-otel-native-jaeger-ui.md
+++ b/docs/rfc/0002-otel-native-jaeger-ui.md
@@ -116,7 +116,8 @@ interface OtelSpan {
   // Naming & Classification
   name: string;                 // was: operationName
   kind: SpanKind;               // was: derived from tags['span.kind'] (lowercase, e.g. "server")
-                                // in OTLP-JSON wire format: "SPAN_KIND_SERVER" (strip prefix when parsing)
+                                // in OTLP-JSON wire format: a JSON number (2 = server), omitted when 0
+                                // (see "Field encodings on this route" under Milestone 3.2)
 
   // Timing
   startTime: Microseconds;      // was: startTime
@@ -553,8 +554,9 @@ The new parser replaces the role of `transformTraceData` for the OTLP route. Cov
   export function parseOtlpTrace(wireData: IOtlpTraceData): IOtelTrace {
     // 1. Validate wireData (optionally with Zod)
     // 2. Map OTLP properties to IOtelTrace
-    //    - span.kind arrives as "SPAN_KIND_SERVER" (protojson enum name);
-    //      strip the "SPAN_KIND_" prefix to map to the SpanKind enum.
+    //    - span.kind arrives as a JSON number (2 = server), omitted entirely
+    //      when 0; map the int32 to the SpanKind enum. It is NOT the protojson
+    //      enum name on this route -- see the field-encoding table below.
     // 3. ENRICH: Calculate derived properties (depth, parent/child refs, etc.)
     // 4. Return enriched IOtelTrace
   }


### PR DESCRIPTION
## Which problem is this PR solving?

#4275 added the **Field encodings on this route** table to RFC 0002 and noted that `span.kind`
arrives as a JSON number, explicitly flagging that "the sketch's comment above assumed" the
protojson enum name. The table landed, but the two code sketches it refers to were left unchanged.

So the document still says both things. The `OtelSpan` interface comment and the `parseOtlpTrace`
sketch under Milestone 3.2 tell the reader that kind arrives as `"SPAN_KIND_SERVER"` and that the
`SPAN_KIND_` prefix should be stripped, while the table fifteen lines below the sketch says it is a
JSON number omitted at zero.

The stale wording is the copy sitting inside the function body someone would start from when
implementing 3.2.

## Description of the changes

Update both sketches to match the encoding table, and point the reader at it.

## How was this change tested?

Verified against `jaegertracing/jaeger:latest` (v2.20.0, git-commit `d65f9516`):

```
$ curl -s localhost:16686/api/v3/traces/5b11c48d2df7db0cca262d6ac53e3a80
...
      "name": "/",
      "kind": 2,
      "startTimeUnixNano": "1785762657367271942",
...
```

`kind` is a bare JSON number, and a span posted over OTLP with `kind: 0` comes back with the field
absent. The checked-in fixture `packages/jaeger-ui/src/utils/fixtures/otlp2jaeger-in.json` also
carries `kind` as a number.

Documentation only; no code paths affected.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
