### PR TITLE
refactor(timeline): Simplify SpanTreeOffset to accept precomputed ancestor data

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.test.tsx
@@ -10,8 +10,8 @@ import PrunedSpanRow from './PrunedSpanRow';
 import { IOtelSpan } from '../../../types/otel';
 
 vi.mock('./SpanTreeOffset', () =>
-  mockDefault(({ span, color }: { span: IOtelSpan; color: string }) => (
-    <span data-testid="span-tree-offset" data-depth={span.depth} data-color={color} />
+  mockDefault(({ spanID, color }: { spanID: string; color: string }) => (
+    <span data-testid="span-tree-offset" data-span-id={spanID} data-color={color} />
   ))
 );
 
@@ -52,7 +52,7 @@ describe('PrunedSpanRow', () => {
     expect(screen.getByText('5 spans pruned')).toBeInTheDocument();
   });
 
-  it('renders SpanTreeOffset at parent depth + 1 with gray color', () => {
+  it('renders SpanTreeOffset with pruned spanID and gray color', () => {
     render(
       <PrunedSpanRow
         parentSpan={makeSpan(3)}
@@ -63,7 +63,7 @@ describe('PrunedSpanRow', () => {
       />
     );
     const offset = screen.getByTestId('span-tree-offset');
-    expect(offset).toHaveAttribute('data-depth', '4');
+    expect(offset).toHaveAttribute('data-span-id', 'span-1--pruned');
     expect(offset).toHaveAttribute('data-color', '#bbb');
   });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/PrunedSpanRow.tsx
@@ -7,6 +7,7 @@ import { IoAlert } from 'react-icons/io5';
 import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
 import { IOtelSpan } from '../../../types/otel';
+import colorGenerator from '../../../utils/color-generator';
 
 import './PrunedSpanRow.css';
 
@@ -33,34 +34,30 @@ export default function PrunedSpanRow({
     prunedErrorCount > 0 ? `, ${prunedErrorCount} ${prunedErrorCount === 1 ? 'error' : 'errors'}` : '';
   const label = `${prunedChildrenCount} ${spanWord} pruned${errorSuffix}`;
 
-  // Create a fake span so SpanTreeOffset renders proper tree lines and a dot
-  // at depth = parentSpan.depth + 1. Use a synthetic parent that appends the
-  // fake span as the last child so SpanTreeOffset correctly terminates the
-  // vertical tree line (it checks parentSpan.childSpans[last].spanID === spanID).
-  const fakeSpan = useMemo(() => {
-    const spanID = `${parentSpan.spanID}--pruned`;
-    const fake = {
-      spanID,
-      depth: parentSpan.depth + 1,
-      hasChildren: false,
-      childSpans: [],
-      parentSpan: null as unknown as IOtelSpan,
-      resource: parentSpan.resource,
-    } as unknown as IOtelSpan;
-    // Prototype-based copy: syntheticParent delegates all properties (including
-    // parentSpan for ancestor walks) to the real parentSpan, with only childSpans
-    // overridden. This lets SpanTreeOffset see the placeholder as the last child.
-    const syntheticParent = Object.create(parentSpan) as IOtelSpan;
-    (syntheticParent as unknown as { childSpans: IOtelSpan[] }).childSpans = [...parentSpan.childSpans, fake];
-    (fake as { parentSpan: IOtelSpan }).parentSpan = syntheticParent;
-    return fake;
+  // Compute ancestor chain colors for SpanTreeOffset.
+  // Walk from parentSpan up to the root to build the indent guide colors.
+  const ancestorColors = useMemo(() => {
+    const colors: string[] = [];
+    let current: IOtelSpan | undefined = parentSpan;
+    while (current) {
+      colors.unshift(colorGenerator.getColorByKey(current.resource.serviceName));
+      current = current.parentSpan;
+    }
+    return colors;
   }, [parentSpan]);
 
   return (
     <TimelineRow className="span-row PrunedSpanRow">
       <TimelineRow.Cell className="span-name-column" width={nameColumnWidth}>
         <div className="span-name-wrapper">
-          <SpanTreeOffset span={fakeSpan} color={PRUNED_DOT_COLOR} />
+          <SpanTreeOffset
+            spanID={`${parentSpan.spanID}--pruned`}
+            hasChildren={false}
+            childCount={0}
+            ancestorColors={ancestorColors}
+            isLastChild
+            color={PRUNED_DOT_COLOR}
+          />
           <span className="span-name PrunedSpanRow--name">
             <span className="span-svc-name">
               {prunedErrorCount > 0 && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -11,9 +11,9 @@ import { makeAttributes } from '../../../model/attributes';
 import { GEN_AI_REQUEST_MODEL } from '../../../constants/span-attributes';
 
 vi.mock('./SpanTreeOffset', () => ({
-  default: jest.fn(({ span, childrenVisible, onClick }) => (
+  default: jest.fn(({ spanID, childrenVisible, onClick }) => (
     <div data-testid="span-tree-offset" onClick={onClick}>
-      SpanTreeOffset: {span.spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
+      SpanTreeOffset: {spanID} - {childrenVisible ? 'expanded' : 'collapsed'}
     </div>
   )),
 }));

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { IoAlert, IoGitNetwork, IoCloudUploadOutline, IoArrowForward } from 'react-icons/io5';
 import ReferencesButton from './ReferencesButton';
 import TimelineRow from './TimelineRow';
@@ -15,6 +15,7 @@ import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan } from '../../../types/otel';
 import { getSpanPillsForSpan, SpanPill } from './spanPills';
+import colorGenerator from '../../../utils/color-generator';
 
 import { getSpanIconComponent } from './span-icons';
 
@@ -92,6 +93,21 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   onChildrenToggled,
   useOtelTerms,
 }) => {
+  // Compute ancestor chain colors for SpanTreeOffset
+  const { ancestorColors, isLastChild } = useMemo(() => {
+    const colors: (string | null)[] = [];
+    let current: IOtelSpan | undefined = span.parentSpan;
+    while (current) {
+      colors.unshift(colorGenerator.getColorByKey(current.resource.serviceName));
+      current = current.parentSpan;
+    }
+    const parent = span.parentSpan;
+    const lastChild = parent
+      ? (parent.childSpans ?? [])[parent.childSpans?.length - 1]?.spanID === span.spanID
+      : false;
+    return { ancestorColors: colors, isLastChild: lastChild };
+  }, [span]);
+
   const _detailToggle = useCallback(() => {
     onDetailToggled(span.spanID);
   }, [onDetailToggled, span.spanID]);
@@ -160,7 +176,11 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
         <div className={`span-name-wrapper ${isMatchingFilter ? 'is-matching-filter' : ''}`}>
           <SpanTreeOffset
             childrenVisible={isChildrenExpanded}
-            span={span}
+            spanID={span.spanID}
+            hasChildren={isParent}
+            childCount={(span.childSpans ?? []).length}
+            ancestorColors={ancestorColors}
+            isLastChild={isLastChild}
             onClick={isParent ? _childrenToggle : undefined}
             color={color}
           />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.test.jsx
@@ -90,7 +90,7 @@ describe('<SpanDetailRow>', () => {
     expect(MockSpanTreeOffset).toHaveBeenCalledTimes(1);
     expect(MockSpanTreeOffset).toHaveBeenCalledWith(
       expect.objectContaining({
-        span: props.span,
+        spanID: props.span.spanID,
         isDetailRow: true,
       })
     );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import SpanDetail from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
@@ -10,6 +10,7 @@ import TimelineRow from './TimelineRow';
 
 import { IOtelSpan, IAttributes, IEvent } from '../../../types/otel';
 import { Hyperlink } from '../../../types/hyperlink';
+import colorGenerator from '../../../utils/color-generator';
 
 import './SpanDetailRow.css';
 
@@ -58,11 +59,36 @@ const SpanDetailRow = React.memo((props: SpanDetailRowProps) => {
     eventItemToggle,
     useOtelTerms,
   } = props;
+
+  // Compute ancestor chain colors for SpanTreeOffset
+  const { ancestorColors, isLastChild } = useMemo(() => {
+    const colors: (string | null)[] = [];
+    let current: IOtelSpan | undefined = span.parentSpan;
+    while (current) {
+      colors.unshift(colorGenerator.getColorByKey(current.resource.serviceName));
+      current = current.parentSpan;
+    }
+    const parent = span.parentSpan;
+    const lastChild = parent
+      ? (parent.childSpans ?? [])[parent.childSpans?.length - 1]?.spanID === span.spanID
+      : false;
+    return { ancestorColors: colors, isLastChild: lastChild };
+  }, [span]);
+
   return (
     <TimelineRow className="detail-row">
       {timelineBarsVisible && (
         <TimelineRow.Cell width={nameColumnWidth}>
-          <SpanTreeOffset span={span} showChildrenIcon={false} isDetailRow color={color} />
+          <SpanTreeOffset
+            spanID={span.spanID}
+            hasChildren={span.hasChildren}
+            childCount={(span.childSpans ?? []).length}
+            ancestorColors={ancestorColors}
+            isLastChild={isLastChild}
+            showChildrenIcon={false}
+            isDetailRow
+            color={color}
+          />
           <span>
             <span
               className="detail-row-expanded-accent"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -6,81 +6,54 @@ import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
-vi.mock('../../../utils/span-ancestor-ids');
 
 describe('SpanTreeOffset', () => {
   const ownSpanID = 'ownSpanID';
-  const parentSpanID = 'parentSpanID';
-  const rootSpanID = 'rootSpanID';
   let props;
-  let rootSpan;
-  let parentSpan;
-  let ownSpan;
 
   beforeEach(() => {
-    // Create span chain with parentSpan references
-    rootSpan = {
-      spanID: rootSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: null,
-      resource: { serviceName: 'root-service' },
-    };
-    parentSpan = {
-      spanID: parentSpanID,
-      hasChildren: true,
-      childSpans: [],
-      parentSpan: rootSpan,
-      resource: { serviceName: 'parent-service' },
-    };
-    ownSpan = {
+    props = {
+      addHoverIndentGuideId: vi.fn(),
+      hoverIndentGuideIds: new Set(),
+      removeHoverIndentGuideId: vi.fn(),
+      color: '#000000',
       spanID: ownSpanID,
       hasChildren: false,
-      childSpans: [],
-      parentSpan,
-      resource: { serviceName: 'own-service' },
-    };
-    rootSpan.childSpans = [parentSpan];
-    parentSpan.childSpans = [ownSpan];
-
-    props = {
-      addHoverIndentGuideId: jest.fn(),
-      hoverIndentGuideIds: new Set(),
-      removeHoverIndentGuideId: jest.fn(),
-      color: '#000000',
-      span: ownSpan,
+      childCount: 0,
+      ancestorColors: ['#aaa', '#bbb'],
+      isLastChild: true,
     };
   });
 
   describe('.SpanTreeOffset--indentGuide', () => {
-    it('renders no .SpanTreeOffset--indentGuide if span has no ancestors', () => {
-      const propsWithRootSpan = { ...props, span: rootSpan };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithRootSpan} />);
+    it('renders no .SpanTreeOffset--indentGuide if ancestorColors is empty', () => {
+      const propsWithRoot = { ...props, ancestorColors: [] };
+      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithRoot} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(0);
     });
 
-    it('renders one .SpanTreeOffset--indentGuide per ancestor span', () => {
+    it('renders one .SpanTreeOffset--indentGuide per ancestor color', () => {
       const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
-      expect(indentGuides.length).toBe(2); // rootSpan and parentSpan
-      expect(indentGuides[0].getAttribute('data-ancestor-id')).toBe(rootSpanID);
-      expect(indentGuides[1].getAttribute('data-ancestor-id')).toBe(parentSpanID);
+      expect(indentGuides.length).toBe(2);
+      expect(indentGuides[0].getAttribute('data-ancestor-id')).toBe('0');
+      expect(indentGuides[1].getAttribute('data-ancestor-id')).toBe('1');
     });
 
     it('calls props.addHoverIndentGuideId on mouse enter', () => {
       const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+      const indentGuide = container.querySelector('[data-ancestor-id="1"]');
       fireEvent.mouseEnter(indentGuide, {});
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
+      expect(props.addHoverIndentGuideId).toHaveBeenCalledWith('1');
     });
 
     it('does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId', () => {
       const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+      const indentGuide = container.querySelector('[data-ancestor-id="1"]');
       const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
+      relatedTarget.dataset.ancestorId = '1';
 
       const event = new MouseEvent('mouseenter', {
         bubbles: true,
@@ -93,17 +66,17 @@ describe('SpanTreeOffset', () => {
 
     it('calls props.removeHoverIndentGuideId on mouse leave', () => {
       const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+      const indentGuide = container.querySelector('[data-ancestor-id="1"]');
       fireEvent.mouseLeave(indentGuide, {});
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
+      expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith('1');
     });
 
     it('does not call props.removeHoverIndentGuideId on mouse leave if mouse leaves to a indentGuide with the same ancestorId', () => {
       const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+      const indentGuide = container.querySelector('[data-ancestor-id="1"]');
       const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
+      relatedTarget.dataset.ancestorId = '1';
 
       const event = new MouseEvent('mouseleave', {
         bubbles: true,
@@ -115,72 +88,56 @@ describe('SpanTreeOffset', () => {
     });
 
     describe('is-last class (last-child span)', () => {
-      it('adds is-last to immediate parent guide when span is last child and isDetailRow is false', () => {
-        // ownSpan is the only (last) child of parentSpan
+      it('adds is-last to immediate parent guide when isLastChild is true and isDetailRow is false', () => {
         const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector('[data-ancestor-id="1"]');
         expect(parentGuide).toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
       });
 
-      it('adds is-terminated (not is-last) to immediate parent guide when span is last child and isDetailRow is true', () => {
-        // ownSpan is the only (last) child of parentSpan
+      it('adds is-terminated (not is-last) to immediate parent guide when isLastChild is true and isDetailRow is true', () => {
         const { container } = render(<UnconnectedSpanTreeOffset {...props} isDetailRow />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector('[data-ancestor-id="1"]');
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).toHaveClass('is-terminated');
       });
 
-      it('does not add is-last or is-terminated to immediate parent guide when span is not the last child', () => {
-        const siblingSpan = {
-          spanID: 'siblingSpanID',
-          hasChildren: false,
-          childSpans: [],
-          parentSpan,
-          resource: { serviceName: 'sibling-service' },
-        };
-        // ownSpan is no longer the last child
-        parentSpan.childSpans = [ownSpan, siblingSpan];
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+      it('does not add is-last or is-terminated to immediate parent guide when isLastChild is false', () => {
+        const propsNotLastChild = { ...props, isLastChild: false };
+        const { container } = render(<UnconnectedSpanTreeOffset {...propsNotLastChild} />);
+        const parentGuide = container.querySelector('[data-ancestor-id="1"]');
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
-        // restore
-        parentSpan.childSpans = [ownSpan];
       });
     });
 
     describe('horizontal line', () => {
       it('renders the horizontal line for the immediate parent when isDetailRow is false', () => {
         const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector('[data-ancestor-id="1"]');
         expect(parentGuide.querySelector('.SpanTreeOffset--horizontalLine')).not.toBeNull();
       });
 
       it('does not render the horizontal line for the immediate parent when isDetailRow is true', () => {
         const { container } = render(<UnconnectedSpanTreeOffset {...props} isDetailRow />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector('[data-ancestor-id="1"]');
         expect(parentGuide.querySelector('.SpanTreeOffset--horizontalLine')).toBeNull();
       });
 
       it('does not render the horizontal line for non-immediate ancestors', () => {
         const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-        const rootGuide = container.querySelector(`[data-ancestor-id="${rootSpanID}"]`);
+        const rootGuide = container.querySelector('[data-ancestor-id="0"]');
         expect(rootGuide.querySelector('.SpanTreeOffset--horizontalLine')).toBeNull();
       });
     });
 
     describe('self-guide in detail row (parent span)', () => {
       it('renders a self-guide when isDetailRow is true and span has children', () => {
-        const parentWithChildren = {
-          ...ownSpan,
-          hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
-        };
         const { getByTestId } = render(
           <UnconnectedSpanTreeOffset
             {...props}
-            span={parentWithChildren}
+            hasChildren
+            childCount={2}
             isDetailRow
             showChildrenIcon={false}
           />
@@ -192,20 +149,21 @@ describe('SpanTreeOffset', () => {
       });
 
       it('does not render a self-guide when isDetailRow is false', () => {
-        const parentWithChildren = {
-          ...ownSpan,
-          hasChildren: true,
-          childSpans: [{ spanID: 'childSpanID' }],
-        };
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={parentWithChildren} showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset {...props} hasChildren childCount={2} showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
 
       it('does not render a self-guide when span has no children', () => {
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={ownSpan} isDetailRow showChildrenIcon={false} />
+          <UnconnectedSpanTreeOffset
+            {...props}
+            hasChildren={false}
+            childCount={0}
+            isDetailRow
+            showChildrenIcon={false}
+          />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
@@ -214,43 +172,44 @@ describe('SpanTreeOffset', () => {
 
   describe('icon', () => {
     let renderResult;
-    let spanWithChildren;
+    let propsWithChildren;
 
     beforeEach(() => {
-      spanWithChildren = { ...ownSpan, hasChildren: true, childSpans: [{}] };
-      const updatedProps = { ...props, span: spanWithChildren };
-      renderResult = render(<UnconnectedSpanTreeOffset {...updatedProps} />);
+      propsWithChildren = { ...props, hasChildren: true, childCount: 1 };
+      renderResult = render(<UnconnectedSpanTreeOffset {...propsWithChildren} />);
     });
 
-    it('renders icon wrapper with dot if props.span.hasChildren is false', () => {
-      const propsWithoutChildren = { ...props, span: ownSpan };
+    it('renders icon wrapper with dot if hasChildren is false', () => {
+      const propsWithoutChildren = { ...props, hasChildren: false, childCount: 0 };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithoutChildren} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(container.querySelector('.SpanTreeOffset--dot')).not.toBeNull();
     });
 
-    it('does not render icon wrapper if props.span.hasChildren is true and showChildrenIcon is false', () => {
+    it('does not render icon wrapper if hasChildren is true and showChildrenIcon is false', () => {
       const propsWithIconDisabled = {
         ...props,
-        span: spanWithChildren,
+        hasChildren: true,
+        childCount: 1,
         showChildrenIcon: false,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithIconDisabled} />);
       expect(container.querySelector('.SpanTreeOffset--iconWrapper')).toBeNull();
     });
 
-    it('renders icon wrapper with child count if props.span.hasChildren is true and props.childrenVisible is false', () => {
+    it('renders icon wrapper with child count if hasChildren is true and childrenVisible is false', () => {
       const { container } = renderResult;
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
-      expect(iconWrapper.textContent).toBe('1'); // One child
+      expect(iconWrapper.textContent).toBe('1');
     });
 
-    it('renders icon wrapper if props.span.hasChildren is true and props.childrenVisible is true', () => {
+    it('renders icon wrapper if hasChildren is true and childrenVisible is true', () => {
       const propsWithVisibleChildren = {
         ...props,
-        span: spanWithChildren,
+        hasChildren: true,
+        childCount: 1,
         childrenVisible: true,
       };
       const { container } = render(<UnconnectedSpanTreeOffset {...propsWithVisibleChildren} />);
@@ -274,40 +233,32 @@ describe('SpanTreeOffset', () => {
     });
 
     it('calls onClick when Enter is pressed on the span wrapper', () => {
-      const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const onClick = vi.fn();
+      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: 'Enter' });
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
     it('calls onClick when Space is pressed on the span wrapper', () => {
-      const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const onClick = vi.fn();
+      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: ' ' });
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
     it('does not call onClick for other keys on the span wrapper', () => {
-      const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const onClick = vi.fn();
+      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: 'Tab' });
       expect(onClick).not.toHaveBeenCalled();
     });
 
     it('sets tabIndex on the span wrapper when onClick is provided', () => {
-      const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const onClick = vi.fn();
+      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       expect(wrapper).toHaveAttribute('tabindex', '0');
     });
@@ -324,7 +275,7 @@ describe('SpanTreeOffset', () => {
 
   describe('mapStateToProps()', () => {
     it('maps state to props correctly', () => {
-      const hoverIndentGuideIds = new Set([parentSpanID]);
+      const hoverIndentGuideIds = new Set(['1']);
       const state = {
         traceTimeline: {
           hoverIndentGuideIds,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import cx from 'classnames';
 import _get from 'lodash/get';
 import { connect } from 'react-redux';
@@ -9,8 +9,6 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { actions } from './duck';
 import { ReduxState } from '../../../types';
-import { IOtelSpan } from '../../../types/otel';
-import colorGenerator from '../../../utils/color-generator';
 
 import './SpanTreeOffset.css';
 
@@ -27,7 +25,11 @@ type TProps = {
   onClick?: () => void;
   showChildrenIcon?: boolean;
   isDetailRow?: boolean;
-  span: IOtelSpan;
+  spanID: string;
+  hasChildren: boolean;
+  childCount: number;
+  ancestorColors: (string | null)[];
+  isLastChild: boolean;
   color: string;
 };
 
@@ -36,22 +38,15 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   onClick = undefined,
   showChildrenIcon = true,
   isDetailRow = false,
-  span,
+  spanID,
+  hasChildren,
+  childCount,
+  ancestorColors,
+  isLastChild,
   addHoverIndentGuideId,
   removeHoverIndentGuideId,
   color,
 }) => {
-  // Build ancestor chain directly from span.parentSpan
-  const ancestors = useMemo(() => {
-    const chain: IOtelSpan[] = [];
-    let current = span.parentSpan;
-    while (current) {
-      chain.unshift(current);
-      current = current.parentSpan;
-    }
-    return chain;
-  }, [span]);
-
   /**
    * If the mouse leaves to anywhere except another span with the same ancestor id, this span's ancestor id is
    * removed from the set of hoverIndentGuideIds.
@@ -86,7 +81,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     }
   };
 
-  const { hasChildren, spanID, childSpans } = span;
   const _childrenToggleKeyDown = (e: React.KeyboardEvent) => {
     if ((e.key === 'Enter' || e.key === ' ') && onClick) {
       e.preventDefault();
@@ -107,43 +101,35 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
       }
     : null;
 
-  // Get parent color for horizontal line
-  const parentSpan = span.parentSpan;
-  const parentColor = parentSpan ? colorGenerator.getColorByKey(parentSpan.resource.serviceName) : color;
-
-  // Check if this span is the last child of its parent
-  const isLastChild = parentSpan
-    ? parentSpan.childSpans[parentSpan.childSpans.length - 1]?.spanID === spanID
-    : false;
+  // The immediate parent is the last entry in ancestorColors.
+  // Its color is used for the horizontal connector line.
+  const parentColor =
+    ancestorColors.length > 0 ? (ancestorColors[ancestorColors.length - 1] ?? color) : color;
 
   return (
     <span className={`SpanTreeOffset ${hasChildren ? 'is-parent' : ''}`} {...wrapperProps}>
-      {ancestors.map((ancestor, index) => {
-        // Determine the color for this indent guide based on the ancestor
-        const guideColor = colorGenerator.getColorByKey(ancestor.resource.serviceName);
-        const isLastAncestor = index === ancestors.length - 1;
+      {ancestorColors.map((guideColor, index) => {
+        const isLastAncestor = index === ancestorColors.length - 1;
 
-        // For the immediate parent: check if current span is last child
-        // For non-immediate ancestors: check if the ancestor's branch has terminated
-        // (i.e., the descendant of this ancestor in the chain is the last child of its parent)
+        // Determine whether to terminate (hide) this ancestor's vertical line.
         let shouldTerminate = false;
 
         if (isLastAncestor) {
-          // For immediate parent, check if current span is last child
+          // For immediate parent, terminate if current span is last child
           shouldTerminate = isLastChild;
         } else {
-          // For non-immediate ancestors, check if their descendant in the chain is the last child
-          // The descendant of this ancestor in the chain is at index + 1
-          const descendantInChain = ancestors[index + 1];
-          if (descendantInChain && descendantInChain.parentSpan) {
-            const parentChildren = descendantInChain.parentSpan.childSpans;
-            shouldTerminate = parentChildren[parentChildren.length - 1]?.spanID === descendantInChain.spanID;
+          // For non-immediate ancestors: the next entry in ancestorColors
+          // represents the descendant in the chain. If that descendant's
+          // color is null, the branch has terminated at that depth.
+          const nextColor = ancestorColors[index + 1];
+          if (nextColor === null) {
+            shouldTerminate = true;
           }
         }
 
         return (
           <span
-            key={ancestor.spanID}
+            key={index}
             className={cx('SpanTreeOffset--indentGuide', {
               // In a span bar row: show top-half line to connect to the horizontal bar
               // In a detail row: treat the same case as terminated (no line) since the
@@ -153,12 +139,12 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
                 (!isLastAncestor && shouldTerminate) || (isDetailRow && isLastAncestor && isLastChild),
             })}
             style={{
-              color: guideColor,
+              color: guideColor ?? undefined,
             }}
-            data-ancestor-id={ancestor.spanID}
-            data-testid={`indent-guide-${ancestor.spanID}`}
-            onMouseEnter={event => handleMouseEnter(event, ancestor.spanID)}
-            onMouseLeave={event => handleMouseLeave(event, ancestor.spanID)}
+            data-ancestor-id={index}
+            data-testid={`indent-guide-${index}`}
+            onMouseEnter={event => handleMouseEnter(event, String(index))}
+            onMouseLeave={event => handleMouseLeave(event, String(index))}
           >
             {isLastAncestor && !isDetailRow && (
               <span
@@ -192,7 +178,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
                 } as React.CSSProperties
               }
             >
-              {childSpans.length}
+              {childCount}
             </span>
           ) : (
             <span


### PR DESCRIPTION
## Summary

SpanTreeOffset currently accepts a full IOtelSpan and walks the parentSpan linked list internally to build the ancestor chain for rendering indent guides. This forces callers like PrunedSpanRow to construct fully linked chains of fake IOtelSpan objects, including prototype tricks to satisfy the last-child check.

This PR makes SpanTreeOffset a pure rendering widget by accepting precomputed ancestorColors array and isLastChild boolean instead of a full span. Callers now compute the ancestor chain once and pass the data directly.

## Changes

- **SpanTreeOffset.tsx**: Replace `span: IOtelSpan` prop with `spanID`, `hasChildren`, `childCount`, `ancestorColors`, `isLastChild`. Remove internal ancestor chain walking.
- **SpanBarRow.tsx**: Compute ancestorColors from span.parentSpan via useMemo and pass to SpanTreeOffset.
- **SpanDetailRow.tsx**: Same pattern as SpanBarRow.
- **PrunedSpanRow.tsx**: Simplified significantly - removed fake span and synthetic parent construction. Now computes ancestorColors from parentSpan directly.
- **Tests**: Updated to match new props API. Tests are simpler - use plain arrays instead of span graph setup.

## Testing

- All 3518 tests pass across 267 test files
- TypeScript type checking passes
- Linting passes (no new warnings)
- Formatting passes

## Related

Closes #3770
