### PR TITLE
perf(spanview): Use Set lookups in TraceSpanView filter

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.test.jsx
@@ -101,6 +101,20 @@ describe('<TraceSpanView>', () => {
     expect(operationSelect.value).toBe('op2');
   });
 
+  it('filters the table rows by the selected service and operation', () => {
+    const { container } = render(<TraceSpanView {...defaultProps} />);
+    const renderedServiceNames = () =>
+      Array.from(container.querySelectorAll('.ant-table-row')).map(
+        row => row.querySelector('td').textContent
+      );
+
+    fireEvent.change(screen.getByTestId('select-service'), { target: { value: 'service2' } });
+    expect(renderedServiceNames()).toEqual(['service2', 'service2', 'service2']);
+
+    fireEvent.change(screen.getByTestId('select-operation'), { target: { value: 'op3' } });
+    expect(renderedServiceNames()).toEqual(['service2']);
+  });
+
   it('check handler', () => {
     render(<TraceSpanView {...defaultProps} />);
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceSpanView/index.tsx
@@ -76,14 +76,18 @@ export default function TraceSpanView(props: Props) {
       return props.trace.spans;
     }
 
+    // Build set lookups once so each span costs O(1) per filter instead of scanning the arrays
+    const serviceNameFilter = new Set(filters.serviceName);
+    const operationNameFilter = new Set(filters.operationName);
+
     // Filter spans: a span passes if it matches all active filters
     return props.trace.spans.filter(span => {
-      if (filters.serviceName.length > 0 && !filters.serviceName.includes(span.resource.serviceName)) {
+      if (serviceNameFilter.size > 0 && !serviceNameFilter.has(span.resource.serviceName)) {
         return false;
       }
 
       // Check operationName filter (if active)
-      if (filters.operationName.length > 0 && !filters.operationName.includes(span.name)) {
+      if (operationNameFilter.size > 0 && !operationNameFilter.has(span.name)) {
         return false;
       }
       return true;


### PR DESCRIPTION
## Which problem is this PR solving?

`TraceSpanView` filters every span in a trace against the selected service and operation filters using `Array.prototype.includes`. That is a linear scan of the filter array for each span, so the filter runs in O(spans × selected filters). On large traces with several filters selected this is re-done on every render that touches the memo.

## Description of the changes

- Build a `Set` for each active filter once per memo evaluation, so each span costs O(1) per filter instead of scanning the arrays.
- Behaviour is unchanged: the same spans pass the filter, and the empty-filter short-circuit is preserved (`size > 0` replaces `length > 0`).

## How was this change tested?

Added a test to `TraceSpanView/index.test.jsx` asserting the rendered rows actually narrow when a service and then an operation are selected — the existing tests covered the dropdowns but not the resulting filtered output.

Ran the checks required by `AGENTS.md`:

```
pnpm run fmt     # exit 0, no files modified
pnpm run lint    # exit 0, no findings in changed files
pnpm test        # exit 0 — 267 files, 3519 tests passed (plexus: 9 files, 115 tests)
pnpm run build   # exit 0
```

Note: run on Node v22.17.1 while `.nvmrc` pins Node 24, so this is not exact CI parity.

AI assistance was used in preparing this change; I have reviewed every line.