### PR TITLE
chore(plexus): Use DedicatedWorkerGlobalScope in layout worker

### DIFF
--- a/packages/plexus/src/LayoutManager/layout.worker.ts
+++ b/packages/plexus/src/LayoutManager/layout.worker.ts
@@ -12,12 +12,10 @@ import {
 } from './types';
 
 type TMessageErrorTarget = {
-  onmessageerror: ((this: Worker, ev: ErrorEvent) => any | void) | null;
+  onmessageerror: ((this: DedicatedWorkerGlobalScope, ev: ErrorEvent) => any | void) | null;
 };
 
-// TODO: Use WorkerGlobalScope instead of Worker
-
-const ctx: Worker & TMessageErrorTarget = self as any;
+const ctx: DedicatedWorkerGlobalScope & TMessageErrorTarget = self as any;
 
 let currentMeta: TLayoutWorkerMeta | null;
 


### PR DESCRIPTION
Fix the type annotation in the layout worker (packages/plexus/src/LayoutManager/layout.worker.ts). ctx was typed as Worker (the main‑thread controller type), but inside a dedicated worker the right type is DedicatedWorkerGlobalScope – which already covers postMessage, onmessage, and company.

Updated TMessageErrorTarget callback this and the ctx annotation accordingly. Dropped a stale 2017 TODO comment.

Coordinator.ts (which creates the worker from the main thread) keeps the Worker type – unchanged and correct.

Type‑only fix. tsc-lint and tests (115/115) pass. No test file exists for this component, so no unit tests added.

Closes #3860.