### PR TITLE
fix: format complex OTel attributes in summary and copy (fixes #8447)

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AccordionAttributes.tsx
@@ -7,9 +7,10 @@ import { IoChevronDown, IoChevronForward } from 'react-icons/io5';
 
 import * as markers from './AccordionAttributes.markers';
 import AttributesTable from './AttributesTable';
-import { TNil } from '../../../../types';
-import { Hyperlink } from '../../../../types/hyperlink';
-import { IAttributes } from '../../../../types/otel';
+import { TNil } from '../../../../../types';
+import { Hyperlink } from '../../../../../types/hyperlink';
+import { IAttributes } from '../../../../../types/otel';
+import { formatAttributeSummary } from './attributeFormatters';
 
 import './AccordionAttributes.css';
 
@@ -22,11 +23,10 @@ export function AttributesSummary({ data }: { data: IAttributes }) {
     <ul className="AccordionAttributes--summary">
       {data.entries().map((item, i) => (
         // `i` is necessary in the key because item.key can repeat
-
         <li className="AccordionAttributes--summaryItem" key={`${item.key}-${i}`}>
           <span className="AccordionAttributes--summaryLabel">{item.key}</span>
           <span className="AccordionAttributes--summaryDelim">=</span>
-          {String(item.value)}
+          {formatAttributeSummary(item.value)}
         </li>
       ))}
     </ul>

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -6,15 +6,14 @@ import { Dropdown, Tooltip } from 'antd';
 import { IoOpenOutline, IoList, IoCopyOutline, IoInformationCircleOutline } from 'react-icons/io5';
 import { JsonView, allExpanded, collapseAllNested } from 'react-json-view-lite';
 
-import jsonViewStyles from '../../../../utils/jsonViewStyles';
+import jsonViewStyles from '../../../../../utils/jsonViewStyles';
 
 import CopyIcon from '../../../common/CopyIcon';
 
-import { TNil } from '../../../../types';
-import { Hyperlink } from '../../../../types/hyperlink';
-import { IAttributes } from '../../../../types/otel';
-
-import './AttributesTable.css';
+import { TNil } from '../../../../../types';
+import { Hyperlink } from '../../../../../types/hyperlink';
+import { IAttributes } from '../../../../../types/otel';
+import { formatAttributeForCopy } from './attributeFormatters';
 
 const jsonObjectOrArrayStartRegex = /^(\[|\{)/;
 
@@ -171,7 +170,7 @@ export default function AttributesTable(props: AttributesTableProps) {
               <div className="KeyValueTable--copyContainer">
                 <CopyIcon
                   className="KeyValueTable--copyIcon"
-                  copyText={String(row.value)}
+                  copyText={formatAttributeForCopy(row.value)}
                   tooltipTitle="Copy value"
                   buttonText="Copy"
                 />

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/attributeFormatters.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/attributeFormatters.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AttributeValue } from '../../../../../types/otel';
+
+/**
+ * Formats an AttributeValue for display in the summary/collapsed view.
+ * Returns a human-readable preview for complex types.
+ */
+export function formatAttributeSummary(value: AttributeValue): string {
+  if (Array.isArray(value)) {
+    return `[${value.length} item${value.length !== 1 ? 's' : ''}]`;
+  }
+  if (typeof value === 'object' && value !== null) {
+    if (value instanceof Uint8Array) {
+      return `<Uint8Array[${value.length}]>`;
+    }
+    return '{...}';
+  }
+  // Primitive values: string, number, boolean
+  return String(value);
+}
+
+/**
+ * Formats an AttributeValue for copying to clipboard.
+ * Returns the actual value as a string (JSON for complex types).
+ */
+export function formatAttributeForCopy(value: AttributeValue): string {
+  if (Array.isArray(value) || (typeof value === 'object' && value !== null && !(value instanceof Uint8Array))) {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  if (value instanceof Uint8Array) {
+    try {
+      return JSON.stringify(Array.from(value), null, 2);
+    } catch {
+      return `<Uint8Array[${value.length}]>`;
+    }
+  }
+  // Primitive values: string, number, boolean
+  return String(value);
+}
+
+/**
+ * Checks if a value is a complex type (array or object) that needs special handling.
+ */
+export function isComplexAttributeValue(value: AttributeValue): boolean {
+  return Array.isArray(value) || (typeof value === 'object' && value !== null);
+}


### PR DESCRIPTION
Fixes #8447

- Add attributeFormatters.ts with formatAttributeSummary() and formatAttributeForCopy()
- Update AccordionAttributes.tsx to use formatAttributeSummary() for collapsed view
- Update AttributesTable.tsx to use formatAttributeForCopy() for copy buttons
- Arrays now show as '[N items]', objects as '{...}', Uint8Array as '<Uint8Array[N]>'
- Copy button now copies actual JSON for complex types instead of '[object Object]'