### PR TITLE
test(genai): lock in that gen_ai.* content renders richly at any attribute level

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
@@ -258,27 +258,42 @@ describe('<AttributesTable>', () => {
   });
 });
 
-// AttributesTable takes a plain IAttributes bag - it has no notion of "span" vs "span
-// event" vs "resource", so whatever renders richly for a span attribute renders
-// identically for a span event's or a resource's attributes, since they all pass
-// through this same component (span.attributes -> Tags, resource.attributes ->
-// Process, event.attributes -> Logs). This locks in that a gen_ai.* message payload -
-// the same shape GenAITab parses from span.attributes - already renders as a JSON
-// tree here too, regardless of which of those levels it came from, without needing
-// GenAI-specific handling.
-describe('<AttributesTable> - GenAI content on non-span-attribute levels', () => {
-  const genAiMessages = [
+// AttributesTable's rich-JSON rendering is driven entirely by whether a value parses
+// as JSON - it has no notion of "span" vs "span event" vs "resource" (all three route
+// through this same component: span.attributes -> Tags, resource.attributes ->
+// Process, event.attributes -> Logs), and it has no notion of "gen_ai.*" either. Per
+// yurishkuro's review on #4335: a test that only exercises a gen_ai.* key would wrongly
+// suggest the rich rendering is conditional on the key being gen_ai.* content, when
+// it's actually unconditional - any key with a JSON-shaped value gets the same
+// treatment, gen_ai or not. The 'abcd'/unrelated-key case below is the control that
+// makes that explicit: identical JSON payload, unrelated key, same rendering.
+describe('<AttributesTable> - JSON-shaped values render richly regardless of key or level', () => {
+  const jsonPayload = [
     {
       role: 'user',
       parts: [{ type: 'text', content: 'Hello, probe message' }],
     },
   ];
-  const genAiData = [{ key: 'gen_ai.input.messages', value: JSON.stringify(genAiMessages) }];
 
-  it('renders gen_ai.* message content as a JSON tree, not raw text', () => {
-    render(<AttributesTable data={makeAttributes(genAiData)} />);
+  it('renders a gen_ai.* key with a JSON payload as a JSON tree, not raw text', () => {
+    const data = [{ key: 'gen_ai.input.messages', value: JSON.stringify(jsonPayload) }];
+    render(<AttributesTable data={makeAttributes(data)} />);
 
     const keyCell = screen.getByText('gen_ai.input.messages');
+    const keyRow = keyCell.closest('tr');
+    expect(keyRow).toHaveClass('KeyValueTable--row-jsonKey');
+
+    const valueRow = keyRow.nextElementSibling;
+    expect(valueRow).toHaveClass('KeyValueTable--row-jsonValue');
+    expect(valueRow).toHaveTextContent('user');
+    expect(valueRow).toHaveTextContent('Hello, probe message');
+  });
+
+  it('renders an unrelated, non-gen_ai key with the same JSON payload identically - the rendering is not gen_ai-specific', () => {
+    const data = [{ key: 'abcd', value: JSON.stringify(jsonPayload) }];
+    render(<AttributesTable data={makeAttributes(data)} />);
+
+    const keyCell = screen.getByText('abcd');
     const keyRow = keyCell.closest('tr');
     expect(keyRow).toHaveClass('KeyValueTable--row-jsonKey');
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
@@ -257,3 +257,34 @@ describe('<AttributesTable>', () => {
     });
   });
 });
+
+// AttributesTable takes a plain IAttributes bag - it has no notion of "span" vs "span
+// event" vs "resource", so whatever renders richly for a span attribute renders
+// identically for a span event's or a resource's attributes, since they all pass
+// through this same component (span.attributes -> Tags, resource.attributes ->
+// Process, event.attributes -> Logs). This locks in that a gen_ai.* message payload -
+// the same shape GenAITab parses from span.attributes - already renders as a JSON
+// tree here too, regardless of which of those levels it came from, without needing
+// GenAI-specific handling.
+describe('<AttributesTable> - GenAI content on non-span-attribute levels', () => {
+  const genAiMessages = [
+    {
+      role: 'user',
+      parts: [{ type: 'text', content: 'Hello, probe message' }],
+    },
+  ];
+  const genAiData = [{ key: 'gen_ai.input.messages', value: JSON.stringify(genAiMessages) }];
+
+  it('renders gen_ai.* message content as a JSON tree, not raw text', () => {
+    render(<AttributesTable data={makeAttributes(genAiData)} />);
+
+    const keyCell = screen.getByText('gen_ai.input.messages');
+    const keyRow = keyCell.closest('tr');
+    expect(keyRow).toHaveClass('KeyValueTable--row-jsonKey');
+
+    const valueRow = keyRow.nextElementSibling;
+    expect(valueRow).toHaveClass('KeyValueTable--row-jsonValue');
+    expect(valueRow).toHaveTextContent('user');
+    expect(valueRow).toHaveTextContent('Hello, probe message');
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

Follow-up to the span-events discussion on #4312 (meeting + Slack with @yurishkuro): the GenAI detail tab only reads message content from `span.attributes`, not from span events, so a `gen_ai.*` payload attached to an event (or a resource) wasn't guaranteed to render usefully.

I researched which real GenAI instrumentation actually emits data this way before writing any code: the spec does define `gen_ai.client.inference.operation.details` as a `span.add_event()`-based event (`Status: Development`, `Requirement level: Opt-In`), but neither `opentelemetry-instrumentation-openai-v2` (official OTel Python) nor `Traceloop/OpenLLMetry` emit it — both put content in span attributes. Real traces are unlikely to have this shape unless hand-instrumented.

Yuri's recommendation: don't build a custom section for this — "just ensure our standard attribute rendering is capable of switching to rich media format when the content looks like it, regardless of the level of the attribute (span or span event or link or resource or scope)," confirming "the generic one" (`AttributesTable`) as the renderer in question, not the GenAI tab's own Markdown/JSON toggle.

## What this PR actually found

`AttributesTable` (used for Tags → `span.attributes`, Process → `resource.attributes`, and Logs → `event.attributes`) takes a plain `IAttributes` bag — it has no notion of which OTel level it's rendering. Its existing JSON-shape detection already applies uniformly wherever it's used.

I verified this directly: built a synthetic trace with a span carrying zero `gen_ai.*` span attributes but one event with `gen_ai.input.messages`/`gen_ai.output.messages` JSON-encoded strings, and loaded it in the running app. Result:
- The GenAI tab correctly does not appear (`isGenAISpan` only checks `span.attributes`, unchanged, as expected).
- The event's content is not lost — expanding the Logs accordion renders `gen_ai.input.messages`/`gen_ai.output.messages` as a fully interactive, readable JSON tree (role/parts/type/content all correctly nested), with zero code changes on current `main`.

**So there was no production code to write for span/event/resource levels — this behavior already exists.** This PR adds the regression test that locks it in and documents the finding, rather than adding speculative new rendering code for something that already works.

### Explicitly out of scope: link and instrumentation-scope levels

Yuri's message named five levels (span, span event, link, resource, scope), but two of them have **no attribute rendering in the UI at all today**:
- `AccordionLinks.tsx` renders a linked span's identity (service name, span name, span ID) but never reads `link.attributes`. The legacy-trace-JSON upload path (`OtelSpanFacade.ts`) also always sets `link.attributes` to an empty `makeAttributes()` regardless of input, so link attributes aren't even populated end-to-end for uploaded traces today.
- `instrumentationScope` has zero references anywhere in the component tree — scope attributes aren't displayed at all, at any level, currently.

"Regardless of level" for these two would mean building new UI from scratch, not extending existing rendering — a different, larger scope than this PR. Leaving them for a follow-up rather than folding unrelated new UI work into a verification PR.

## Description of the changes

- Added a test in `AttributesTable.test.jsx` that renders a `gen_ai.input.messages` payload (the same message shape `GenAITab`/`genAiData.ts` parses from span attributes) through `AttributesTable` directly and asserts it renders as a JSON tree (`KeyValueTable--row-jsonKey`/`row-jsonValue`), not raw text.
- No production code changed.

## How was this change tested?

- New test: `AttributesTable.test.jsx` — 12/12 pass (was 11, added 1).
- Full adjacent suite: `TraceTimelineViewer/**` — 692/692 tests pass, no regressions.
- `tsc --noEmit` clean on the changed file.
- Manual, against the real running app (not just the test suite):
  - Synthetic fixture (span event carrying `gen_ai.*` content, no span-level `gen_ai.*` attributes): confirmed GenAI tab correctly absent, and confirmed the event's `gen_ai.input.messages`/`gen_ai.output.messages` render as an interactive JSON tree in the Logs accordion — this is the exact scenario the new test locks in.
  - Real trace (a genuine Gemini-sidecar trace, 13 spans/2 services, span-level `gen_ai.*` attributes): confirmed the existing GenAI tab (Provider/Model, Tokens, Conversation) still renders correctly and unaffected — no regression on the already-working path.
- `pnpm run lint`, `pnpm run tsc-lint` pass.

### Screenshots

The synthetic-fixture span from the manual verification above (zero `gen_ai.*` span attributes, one event carrying `gen_ai.input.messages`/`gen_ai.output.messages`) - the Logs accordion, unmodified `AttributesTable`, rendering the event's content as a full interactive JSON tree:

<img width="1568" height="773" alt="gen_ai.input.messages on a span event, rendered as an interactive JSON tree (role/parts/type/content) in the Logs accordion via unmodified AttributesTable" src="https://github.com/user-attachments/assets/89a8f292-05d0-4246-ba20-c4341110da98" />

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes

