### PR TITLE
fix(import): report unreachable transform backend as its own failure

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/FileLoader.tsx
@@ -90,9 +90,9 @@ export default function FileLoader(props: FileLoaderProps) {
             }
           })
           .catch((err: unknown) => {
-            message.error(
-              `Failed to parse ${file.name}: ${err instanceof Error ? err.message : String(err)}`
-            );
+            // readJsonFile's errors already name the failure (parse, read, backend), so the
+            // wrapper must not assume the file itself was at fault.
+            message.error(`Failed to load ${file.name}: ${err instanceof Error ? err.message : String(err)}`);
           });
         return false;
       }}

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -30,8 +30,11 @@ jest.spyOn(JaegerAPI, 'transformOTLP').mockImplementation(APICallRequest => {
     return Promise.resolve(jaegerTraceMulti);
   }
 
-  // This defines case where API call errors out even after detecting a `resourceSpan` in the request
-  return Promise.reject(new Error('backend transform failed'));
+  // This defines case where API call errors out even after detecting a `resourceSpan` in the request.
+  // getJSON only builds an error once it has a response, so it always carries an httpStatus.
+  const err = new Error('backend transform failed');
+  err.httpStatus = 500;
+  return Promise.reject(err);
 });
 
 describe('fileReader.readJsonFile', () => {
@@ -74,6 +77,17 @@ describe('fileReader.readJsonFile', () => {
     const file = new File([JSON.stringify(inObj)], 'foo.json');
     const p = readJsonFile({ file });
     return expect(p).rejects.toThrow(/Error converting OTLP trace to Jaeger: backend transform failed/);
+  });
+
+  it('rejects an OTLP trace by naming the backend when the transform endpoint is unreachable', () => {
+    // fetch rejects with a TypeError before any response exists, so getJSON has no httpStatus to attach
+    JaegerAPI.transformOTLP.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const inObj = JSON.parse(
+      fs.readFileSync(path.resolve(fixturesDir, 'otlp2jaeger-in-error.json'), 'utf-8')
+    );
+    const file = new File([JSON.stringify(inObj)], 'foo.json');
+    const p = readJsonFile({ file });
+    return expect(p).rejects.toThrow(/POST \/api\/transform could not be reached/);
   });
 
   it('rejects malformed JSON', () => {

--- a/packages/jaeger-ui/src/utils/readJsonFile.ts
+++ b/packages/jaeger-ui/src/utils/readJsonFile.ts
@@ -55,6 +55,17 @@ export default function readJsonFile(fileList: { file: File }): Promise<string> 
             resolve(result);
           })
           .catch((err: unknown) => {
+            // getJSON attaches httpStatus to every error it derives from a response, so an
+            // error without one means the request never reached the backend.
+            if ((err as { httpStatus?: number } | null)?.httpStatus == null) {
+              reject(
+                new Error(
+                  'Converting OTLP traces requires a Jaeger backend, but POST /api/transform could not be reached',
+                  { cause: err }
+                )
+              );
+              return;
+            }
             const cause = err instanceof Error ? `: ${err.message}` : '';
             reject(new Error(`Error converting OTLP trace to Jaeger${cause}`, { cause: err }));
           });


### PR DESCRIPTION

## Which problem is this PR solving?
- Partially resolves #4197

Legacy Jaeger JSON is parsed in the browser, but OTLP/JSON gets sent to the backend at `POST /api/transform`. If nothing is listening there, you see:

> Failed to parse otel-file-exporter-output.json: Error converting OTLP trace to Jaeger: Failed to fetch

 it blames the file. The file is fine  there's no backend. 

Now it says:

> Failed to load otel-file-exporter-output.json: Converting OTLP traces requires a Jaeger backend, but POST /api/transform could not be reached


## Description of the changes
- -`readJsonFile` now tells the two OTLP failure modes apart. `getJSON` attaches `httpStatus` to every error it builds from a response, so an error arriving without one means the request never reached the backend. Errors that do carry an `httpStatus` keep the existing message. The original error is preserved as `cause` either way.
- `FileLoader` says "Failed to load" instead of "Failed to parse" — `readJsonFile` already names the actual failure, so the wrapper shouldn't assume the file was at fault.
- I used `httpStatus` rather than `instanceof TypeError` deliberately: a TypeError thrown anywhere else in the chain would be misreported as an unreachable backend, and the network-error text differs across Chrome, Firefox and Safari.
- One note on the test diff: the shared mock rejected with a bare `Error` and no `httpStatus`, which real `getJSON` never produces — it only builds errors once a response exists. I gave it `httpStatus: 500` so it matches the real contract. The existing assertion is unchanged.

## How was this change tested?
-  pnpm start with nothing running on :16686, then dropped `packages/jaeger-ui/src/utils/fixtures/otlp2jaeger-in.json` onto the Search page.
- - New unit test covering the unreachable endpoint; the existing OTLP error-path test still passes untouched.


## Checklist
- [ x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [ x] I have signed all commits
- [ x] I have added unit tests for the new functionality
- [ x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
