### PR TITLE
chore: remove unsafe use of _get() for static paths

### DIFF
--- a/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/traceDiffGraphUtils.ts
+++ b/packages/jaeger-ui/src/components/TraceDiff/TraceDiffGraph/traceDiffGraphUtils.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TVertexKey } from '@jaegertracing/plexus/lib/types';
-import _get from 'lodash/get';
 import _map from 'lodash/map';
 import memoizeOne from 'memoize-one';
 
@@ -20,7 +19,7 @@ function getUiFindVertexKeysFn(
   if (!uiFind) return new Set<TVertexKey>();
   const newVertexKeys: Set<TVertexKey> = new Set();
   vertices.forEach(({ key, data: { members } }) => {
-    if (_get(filterSpans(uiFind, _map(members, 'span')), 'size')) {
+    if (filterSpans(uiFind, _map(members, 'span'))?.size) {
       newVertexKeys.add(key);
     }
   });

--- a/packages/jaeger-ui/src/utils/DraggableManager/DraggableManager.ts
+++ b/packages/jaeger-ui/src/utils/DraggableManager/DraggableManager.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import _get from 'lodash/get';
 import type React from 'react';
 
 import EUpdateTypes from './EUpdateTypes';
@@ -100,7 +99,7 @@ export default class DraggableManager {
   _stopDragging() {
     window.removeEventListener('mousemove', this._handleDragEvent);
     window.removeEventListener('mouseup', this._handleDragEvent);
-    const style = _get(document, 'body.style');
+    const style = document.body?.style;
     if (style) {
       style.removeProperty('userSelect');
     }
@@ -174,7 +173,7 @@ export default class DraggableManager {
       }
       window.addEventListener('mousemove', this._handleDragEvent);
       window.addEventListener('mouseup', this._handleDragEvent);
-      const style = _get(document, 'body.style');
+      const style = document.body?.style;
       if (style) {
         style.userSelect = 'none';
       }

--- a/packages/jaeger-ui/src/utils/plexus/set-on-graph.ts
+++ b/packages/jaeger-ui/src/utils/plexus/set-on-graph.ts
@@ -1,8 +1,6 @@
 // Copyright (c) 2019 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import _get from 'lodash/get';
-
 const BASE_MATCH_SIZE = 8;
 const SCALABLE_MATCH_SIZE = 4;
 
@@ -19,7 +17,7 @@ export function setOnEdgesContainer(state: { zoomTransform?: { k: number } }) {
 
 export function setOnNodesContainer(state: { zoomTransform?: { k: number } }) {
   const { zoomTransform } = state;
-  const matchSize = BASE_MATCH_SIZE + SCALABLE_MATCH_SIZE / _get(zoomTransform, 'k', 1);
+  const matchSize = BASE_MATCH_SIZE + SCALABLE_MATCH_SIZE / (zoomTransform?.k ?? 1);
   return {
     style: {
       outline: `transparent solid ${matchSize}px`,


### PR DESCRIPTION
Ref #3604

This PR incrementally removes the `lodash/get` usage for static string paths in uncontested files, replacing them with modern optional chaining (`?.`) and nullish coalescing (`??`) operators. 

**Scope of this PR:**
- `utils/DraggableManager/DraggableManager.ts`
- `utils/plexus/set-on-graph.ts` (using `??` instead of `||` to safely preserve `0` as a legitimate value for `zoomTransform.k`)
- `components/TraceDiff/TraceDiffGraph/traceDiffGraphUtils.ts`

**Deliberate Omissions (Why some `_get` calls remain):**
As noted in the issue discussion, *"The answer might be different depending on the situation."* I have deliberately left `_get` in place where the path is a *dynamic string* or constructed at runtime, as optional chaining cannot express those dynamically resolved paths safely without type-casting or breaking abstractions. These include:
- `utils/config/process-deprecation.ts:33` (`_get(config, formerKey)`)
- `model/path-agnostic-decorations/index.tsx:34-38` (template-literal paths)
- `actions/path-agnostic-decorations.ts:80` (runtime `getPath`)
- `DeepDependencies/SidePanel/DetailsPanel.tsx:70,77` (runtime `getPath`)

Lodash `get` remains the correct tool for these dynamic situations. 

*Note: The remaining static path replacements are deliberately excluded here as they are located in highly contested files (e.g. `TracePage/index.tsx`) where multiple PRs are currently open, avoiding unnecessary merge conflicts.*

Testing:
- Covered by existing tests (`DraggableManager.test.js` and `set-on-graph.test.js`). Behavior preservation is verified.
- `pnpm lint` and `pnpm test` pass.
