### PR TITLE
fix(tests): provide Storage when Node 25+ shadows jsdom's implementation

### DIFF
--- a/packages/jaeger-ui/test/vitest-setup.ts
+++ b/packages/jaeger-ui/test/vitest-setup.ts
@@ -12,6 +12,55 @@ rafPolyfill();
 // TextEncoder is not provided by JSDOM
 global.TextEncoder = TextEncoder as typeof global.TextEncoder;
 
+// Node 25+ defines localStorage/sessionStorage as globals, so Vitest keeps those
+// over jsdom's, and Node's are undefined without --localstorage-file (vitest#10867).
+if (!globalThis.localStorage || !globalThis.sessionStorage) {
+  const backings = new WeakMap<Storage, Map<string, string>>();
+  const backing = (self: Storage) => {
+    let map = backings.get(self);
+    if (!map) {
+      map = new Map();
+      backings.set(self, map);
+    }
+    return map;
+  };
+
+  // On the prototype, not the instance, because tests spy on Storage.prototype.
+  const def = (name: string, value: unknown) =>
+    Object.defineProperty(Storage.prototype, name, { value, configurable: true, writable: true });
+
+  Object.defineProperty(Storage.prototype, 'length', {
+    configurable: true,
+    get(this: Storage) {
+      return backing(this).size;
+    },
+  });
+  def('key', function (this: Storage, index: number) {
+    return [...backing(this).keys()][index] ?? null;
+  });
+  def('getItem', function (this: Storage, key: string) {
+    const map = backing(this);
+    return map.has(String(key)) ? (map.get(String(key)) as string) : null;
+  });
+  def('setItem', function (this: Storage, key: string, value: string) {
+    backing(this).set(String(key), String(value));
+  });
+  def('removeItem', function (this: Storage, key: string) {
+    backing(this).delete(String(key));
+  });
+  def('clear', function (this: Storage) {
+    backing(this).clear();
+  });
+
+  for (const key of ['localStorage', 'sessionStorage'] as const) {
+    Object.defineProperty(globalThis, key, {
+      value: Object.create(Storage.prototype) as Storage,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
 // Alias jest → vi so existing test files work without modification.
 // Note: jest.mock() calls are NOT covered by this alias — they are renamed to
 // vi.mock() so Vitest's transform can hoist them. See PR H3 for details.


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4340 
- On Node 25+ the test suite fails with 24 failing files and 145 failing tests, all `TypeError: Cannot read properties of undefined` on `localStorage.clear`, `.getItem` or `.setItem`. On Node 24 the same suite is green. `engines` declares `"node": ">=24.16.0"`, which permits Node 26, so a clean checkout fails for anyone whose system Node is newer than `.nvmrc`. CI does not catch it because `setup-node` reads the same unbounded range and resolves below 26.

## Description of the changes
- Node 25+ defines `localStorage`/`sessionStorage` as globals, so Vitest's `getWindowKeys` keeps those over jsdom's, and Node's are `undefined` without `--localstorage-file`. Fixed upstream only in Vitest 5 (vitest-dev/vitest#10867), which is still beta.
- Installs an in-memory `Storage` in `test/vitest-setup.ts`, next to the existing `TextEncoder` and `ResizeObserver` shims. Methods go on `Storage.prototype` because tests spy on it.
- Guarded by `if (!globalThis.localStorage || !globalThis.sessionStorage)`, so nothing runs on Node 24.
 

## How was this change tested?
- Full suite, same flags, only the Node binary changed:
 
 | | Node 24.19.0 | Node 26.4.0 |
  |---|---:|---:|
  | before | 3527 pass | **145 fail** |
  | after | 3527 pass | **3527 pass** |

- `make lint test` passes on Node 24.
- No new tests: this is harness setup, covered by the 3527 existing tests, 145 of which fail without it.
- Node 26 still exits non-zero from an unrelated `ReferenceError: window is not defined` in the React scheduler after teardown, reported separately in #4339 . It reproduces with and without this change. If you would rather bound `engines` to `<26`, happy to send that instead.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
