### PR TITLE
refactor(timeline): Remove dead hover-guide state

### DIFF
--- a/docs/adr/0005-current-state-management-architecture.md
+++ b/docs/adr/0005-current-state-management-architecture.md
@@ -46,8 +46,8 @@ The legacy core of the application, now reduced to a residue. The full schema of
 
 - **Location**: `src/reducers/` (`metrics`, `pathAgnosticDecorations`), `src/actions/path-agnostic-decorations.ts`, and `src/components/TracePage/TraceTimelineViewer/duck.ts`; assembled in `src/utils/configure-store.ts`. There is no `src/selectors/`.
 - **Access**:
-    - **Functional Components**: `useSelector` / `useDispatch` — `DdgNodeContent`, `VirtualizedTraceView` (for `hoverIndentGuideIds`), `SpanDetailSidePanel`.
-    - **Class Components**: `connect(mapStateToProps, mapDispatchToProps)` — `Monitor/ServicesView`, `DeepDependencies/SidePanel/DetailsPanel`, `SpanTreeOffset`, `TracePage`, `TraceTimelineViewer`. `SearchForm` and `TraceDiff` are also still wrapped, but their `mapStateToProps` ignores state entirely and the wrapper is vestigial.
+    - **Functional Components**: `useSelector` / `useDispatch` — `DdgNodeContent`, `SpanDetailSidePanel`.
+    - **Class Components**: `connect(mapStateToProps, mapDispatchToProps)` — `Monitor/ServicesView`, `DeepDependencies/SidePanel/DetailsPanel`, `TracePage`, `TraceTimelineViewer`. `SearchForm` and `TraceDiff` are also still wrapped, but their `mapStateToProps` ignores state entirely and the wrapper is vestigial.
 - **Timeline dual write**: timeline interactions dispatch a Redux action *and* call the equivalent Zustand action, Redux first so the tracking middleware observes pre-update state. The duck exists to feed `src/middlewares/track.ts`, not to serve the UI.
 - **Do not add new state here.** Per [ADR-0004](./0004-state-management-strategy.md), everything above has a scheduled removal; new shared UI state goes to Zustand and new server data to TanStack Query.
 

--- a/docs/rfc/0004-state-management-strategy.md
+++ b/docs/rfc/0004-state-management-strategy.md
@@ -978,12 +978,12 @@ This is the **largest and most performance-sensitive** slice. Split across multi
 **Suggested PR split** (status as of 2026-07-28):
 1. ✅ Layout prefs: `spanNameColumnWidth`, `sidePanelWidth`, `detailPanelMode`, `timelineBarsVisible`.
 2. ✅ Collapse/expand + detail: `childrenHiddenIDs`, `detailStates`, `shouldScrollToFirstUiFindMatch`.
-3. ⬜ Hover: `hoverIndentGuideIds` still lives only in the duck. `VirtualizedTraceView` reads it with `useSelector`, and `SpanTreeOffset` is still a `connect()`ed component whose `mapStateToProps` reads `state.traceTimeline`.
+3. ✅ Hover: resolved by deletion rather than migration. `hoverIndentGuideIds` was dead state — the indent-guide highlight that consumed it (the `is-active` class and its CSS) was removed in [#3302](https://github.com/jaegertracing/jaeger-ui/pull/3302), leaving the Redux field, its two actions, the `SpanTreeOffset` mouse-enter/leave writers, and the `VirtualizedTraceView` `useSelector` read as orphaned code that fed nothing. All removed; `SpanTreeOffset` is now a plain (unconnected) functional component. Hover is not tracked by the analytics middleware, so no dual-write was involved.
 4. ⬜ Rewire the Redux **tracking middleware** hooks that listen to timeline action types.
 
 **Why the duck is still alive**: `duck.track.ts` supplies `middlewareHooks` to `src/middlewares/track.ts`, so analytics for timeline interactions are emitted by a Redux middleware keyed on action types. Every migrated interaction therefore **dual-writes** — the components dispatch the Redux action *first*, so the middleware observes the pre-update state, then call the Zustand action. Severing that dual write requires relocating the analytics call sites off the middleware, and until then neither the duck nor `configure-store.ts` can be deleted.
 
-**Components to rewire**: `TraceTimelineViewer`, `SpanBarRow`, `SpanDetailRow`, `TimelineHeaderRow`. Rewired so far, all still dual-writing to Redux: `TracePage`, `TraceTimelineViewer`, `VirtualizedTraceView`, `SpanTreeOffset`, `SpanDetailSidePanel`.
+**Components to rewire**: `TraceTimelineViewer`, `SpanBarRow`, `SpanDetailRow`, `TimelineHeaderRow`. Rewired so far, all still dual-writing to Redux: `TracePage`, `TraceTimelineViewer`, `VirtualizedTraceView`, `SpanDetailSidePanel`. `SpanTreeOffset` no longer touches Redux (its only Redux use was the dead hover state removed in step 3).
 
 #### ✅ 1d. Deep Dependencies view modifiers (`ddg` duck - client-only fields)
 
@@ -1212,7 +1212,7 @@ The residual surface is now small enough to enumerate:
 | :--- | :--- | :--- |
 | `reducers/metrics.ts` | `Monitor/ServicesView` (`connect`) | Phase 2f — implementation open in [#4048](https://github.com/jaegertracing/jaeger-ui/pull/4048) |
 | `reducers/path-agnostic-decorations.ts`, `actions/path-agnostic-decorations.ts` | `DdgNodeContent`, `DeepDependencies/SidePanel/DetailsPanel` | Phase 2g |
-| `TraceTimelineViewer/duck.ts`, `duck.track.ts`, `middlewares/track.ts` | `TracePage`, `TraceTimelineViewer`, `VirtualizedTraceView`, `SpanTreeOffset`, `SpanDetailSidePanel` | Phase 1c steps 3–4 |
+| `TraceTimelineViewer/duck.ts`, `duck.track.ts`, `middlewares/track.ts` | `TracePage`, `TraceTimelineViewer`, `VirtualizedTraceView`, `SpanDetailSidePanel` | Phase 1c step 4 (step 3 done) |
 | Vestigial `connect()` wrappers whose `mapStateToProps` ignores state entirely | `SearchTracePage/SearchForm.tsx`, `TraceDiff/TraceDiff.tsx` | Phase 4b (mechanical) |
 | `utils/configure-store.ts`, `<Provider>` in `components/App/index.tsx`, `ReduxState` in `types/index.ts`, `types/TTraceTimeline.ts` | app shell, ~14 test files | Phase 4b/4c |
 

--- a/docs/rfc/0004-state-management-strategy.md
+++ b/docs/rfc/0004-state-management-strategy.md
@@ -983,7 +983,7 @@ This is the **largest and most performance-sensitive** slice. Split across multi
 
 **Why the duck is still alive**: `duck.track.ts` supplies `middlewareHooks` to `src/middlewares/track.ts`, so analytics for timeline interactions are emitted by a Redux middleware keyed on action types. Every migrated interaction therefore **dual-writes** — the components dispatch the Redux action *first*, so the middleware observes the pre-update state, then call the Zustand action. Severing that dual write requires relocating the analytics call sites off the middleware, and until then neither the duck nor `configure-store.ts` can be deleted.
 
-**Components to rewire**: `TraceTimelineViewer`, `SpanBarRow`, `SpanDetailRow`, `TimelineHeaderRow`. Rewired so far, all still dual-writing to Redux: `TracePage`, `TraceTimelineViewer`, `VirtualizedTraceView`, `SpanDetailSidePanel`. `SpanTreeOffset` no longer touches Redux (its only Redux use was the dead hover state removed in step 3).
+**Components to rewire**: `TraceTimelineViewer`, `SpanBarRow`, `SpanDetailRow`, `TimelineHeaderRow`. Rewired so far, all still dual-writing to Redux: `TracePage`, `TraceTimelineViewer`, `VirtualizedTraceView`, `SpanDetailSidePanel`.
 
 #### ✅ 1d. Deep Dependencies view modifiers (`ddg` duck - client-only fields)
 

--- a/docs/rfc/0006-target-state-management-architecture.md
+++ b/docs/rfc/0006-target-state-management-architecture.md
@@ -144,7 +144,7 @@ The tables below document the **intended** store shapes. For migration steps —
 **How the delivered stores differ from the shapes below.** The inventory of what exists is in [ADR-0005](../adr/0005-current-state-management-architecture.md); four divergences are worth naming here, because each one was a deliberate departure from this design rather than an omission:
 
 - The single `useTraceTimelineStore` proposed below was **delivered as two stores**, split by lifetime: `useTraceTimelineStore` (`store.timeline.ts`) for state that resets with the trace, and `useLayoutPrefsStore` (`store.layout.ts`) for preferences that outlive it. The reset rule below then needs no exceptions, which is why the split was made.
-- `hoverIndentGuideIds` is **still in Redux** — the last field held exclusively by the `traceTimeline` duck ([RFC 0004](./0004-state-management-strategy.md), Phase 1c step 3).
+- `hoverIndentGuideIds` was **dead state, deleted rather than migrated** — the indent-guide highlight that consumed it was removed in [#3302](https://github.com/jaegertracing/jaeger-ui/pull/3302), so the Redux field and its writers were dropped instead of moved to a store ([RFC 0004](./0004-state-management-strategy.md), Phase 1c step 3).
 - `prunedServices` was added to the interaction store after this was written, for the timeline service filter ([ADR-0009](../adr/0009-service-filter-trace-timeline.md)).
 - The DDG store shipped as `useDdgViewModifiersStore`, and its graph query as `useDeepDependencyGraphQuery`.
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
@@ -9,8 +9,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
 
 import SpanDetailRow from './SpanDetailRow';
 import DetailState from './SpanDetail/DetailState';
@@ -18,13 +16,6 @@ import DetailState from './SpanDetail/DetailState';
 // Mock only SpanDetail, NOT SpanTreeOffset - we want to test real SpanTreeOffset behavior
 vi.mock('./SpanDetail', () => ({
   default: () => <div data-testid="mocked-span-detail" />,
-}));
-
-// Minimal Redux store for SpanTreeOffset's connected component
-const mockStore = createStore(() => ({
-  traceTimeline: {
-    hoverIndentGuideIds: new Set(),
-  },
 }));
 
 describe('<SpanDetailRow> icon behavior', () => {
@@ -74,11 +65,7 @@ describe('<SpanDetailRow> icon behavior', () => {
   };
 
   it('does not render expand/collapse icon even when span has children', () => {
-    render(
-      <Provider store={mockStore}>
-        <SpanDetailRow {...props} />
-      </Provider>
-    );
+    render(<SpanDetailRow {...props} />);
 
     // SpanTreeOffset renders the icon inside a span with data-testid="icon-wrapper"
     // In a detail row, this icon should NOT be rendered

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -5,8 +5,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
-vi.mock('../../../utils/span-ancestor-ids');
+import SpanTreeOffset from './SpanTreeOffset';
 
 describe('SpanTreeOffset', () => {
   const ownSpanID = 'ownSpanID';
@@ -44,9 +43,6 @@ describe('SpanTreeOffset', () => {
     parentSpan.childSpans = [ownSpan];
 
     props = {
-      addHoverIndentGuideId: jest.fn(),
-      hoverIndentGuideIds: new Set(),
-      removeHoverIndentGuideId: jest.fn(),
       color: '#000000',
       span: ownSpan,
     };
@@ -55,69 +51,32 @@ describe('SpanTreeOffset', () => {
   describe('.SpanTreeOffset--indentGuide', () => {
     it('renders no .SpanTreeOffset--indentGuide if span has no ancestors', () => {
       const propsWithRootSpan = { ...props, span: rootSpan };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithRootSpan} />);
+      const { container } = render(<SpanTreeOffset {...propsWithRootSpan} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(0);
     });
 
     it('renders one .SpanTreeOffset--indentGuide per ancestor span', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+      const { container } = render(<SpanTreeOffset {...props} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(2); // rootSpan and parentSpan
       expect(indentGuides[0].getAttribute('data-ancestor-id')).toBe(rootSpanID);
       expect(indentGuides[1].getAttribute('data-ancestor-id')).toBe(parentSpanID);
     });
 
-    it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+    // Guards against the indent-guide hover highlight being silently reintroduced as dead
+    // state: the `is-active` class + CSS were removed in #3302, so hovering must paint nothing.
+    it('applies no highlight class to indent guides on hover', () => {
+      const { container } = render(<SpanTreeOffset {...props} />);
       const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
       fireEvent.mouseEnter(indentGuide, {});
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
-    });
-
-    it('does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
-
-      const event = new MouseEvent('mouseenter', {
-        bubbles: true,
-        relatedTarget,
-      });
-      fireEvent(indentGuide, event);
-
-      expect(props.addHoverIndentGuideId).not.toHaveBeenCalled();
-    });
-
-    it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      fireEvent.mouseLeave(indentGuide, {});
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
-    });
-
-    it('does not call props.removeHoverIndentGuideId on mouse leave if mouse leaves to a indentGuide with the same ancestorId', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
-
-      const event = new MouseEvent('mouseleave', {
-        bubbles: true,
-        relatedTarget,
-      });
-      fireEvent(indentGuide, event);
-
-      expect(props.removeHoverIndentGuideId).not.toHaveBeenCalled();
+      expect(container.querySelector('.is-active')).toBeNull();
     });
 
     describe('is-last class (last-child span)', () => {
       it('adds is-last to immediate parent guide when span is last child and isDetailRow is false', () => {
         // ownSpan is the only (last) child of parentSpan
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+        const { container } = render(<SpanTreeOffset {...props} />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
@@ -125,7 +84,7 @@ describe('SpanTreeOffset', () => {
 
       it('adds is-terminated (not is-last) to immediate parent guide when span is last child and isDetailRow is true', () => {
         // ownSpan is the only (last) child of parentSpan
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} isDetailRow />);
+        const { container } = render(<SpanTreeOffset {...props} isDetailRow />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).toHaveClass('is-terminated');
@@ -141,7 +100,7 @@ describe('SpanTreeOffset', () => {
         };
         // ownSpan is no longer the last child
         parentSpan.childSpans = [ownSpan, siblingSpan];
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+        const { container } = render(<SpanTreeOffset {...props} />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
@@ -152,19 +111,19 @@ describe('SpanTreeOffset', () => {
 
     describe('horizontal line', () => {
       it('renders the horizontal line for the immediate parent when isDetailRow is false', () => {
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+        const { container } = render(<SpanTreeOffset {...props} />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide.querySelector('.SpanTreeOffset--horizontalLine')).not.toBeNull();
       });
 
       it('does not render the horizontal line for the immediate parent when isDetailRow is true', () => {
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} isDetailRow />);
+        const { container } = render(<SpanTreeOffset {...props} isDetailRow />);
         const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
         expect(parentGuide.querySelector('.SpanTreeOffset--horizontalLine')).toBeNull();
       });
 
       it('does not render the horizontal line for non-immediate ancestors', () => {
-        const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
+        const { container } = render(<SpanTreeOffset {...props} />);
         const rootGuide = container.querySelector(`[data-ancestor-id="${rootSpanID}"]`);
         expect(rootGuide.querySelector('.SpanTreeOffset--horizontalLine')).toBeNull();
       });
@@ -178,12 +137,7 @@ describe('SpanTreeOffset', () => {
           childSpans: [{ spanID: 'childSpanID' }],
         };
         const { getByTestId } = render(
-          <UnconnectedSpanTreeOffset
-            {...props}
-            span={parentWithChildren}
-            isDetailRow
-            showChildrenIcon={false}
-          />
+          <SpanTreeOffset {...props} span={parentWithChildren} isDetailRow showChildrenIcon={false} />
         );
         expect(getByTestId('detail-row-self-guide')).toBeInTheDocument();
         expect(getByTestId('detail-row-self-guide')).toHaveClass('SpanTreeOffset--indentGuide');
@@ -198,14 +152,14 @@ describe('SpanTreeOffset', () => {
           childSpans: [{ spanID: 'childSpanID' }],
         };
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={parentWithChildren} showChildrenIcon={false} />
+          <SpanTreeOffset {...props} span={parentWithChildren} showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
 
       it('does not render a self-guide when span has no children', () => {
         const { queryByTestId } = render(
-          <UnconnectedSpanTreeOffset {...props} span={ownSpan} isDetailRow showChildrenIcon={false} />
+          <SpanTreeOffset {...props} span={ownSpan} isDetailRow showChildrenIcon={false} />
         );
         expect(queryByTestId('detail-row-self-guide')).toBeNull();
       });
@@ -219,12 +173,12 @@ describe('SpanTreeOffset', () => {
     beforeEach(() => {
       spanWithChildren = { ...ownSpan, hasChildren: true, childSpans: [{}] };
       const updatedProps = { ...props, span: spanWithChildren };
-      renderResult = render(<UnconnectedSpanTreeOffset {...updatedProps} />);
+      renderResult = render(<SpanTreeOffset {...updatedProps} />);
     });
 
     it('renders icon wrapper with dot if props.span.hasChildren is false', () => {
       const propsWithoutChildren = { ...props, span: ownSpan };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithoutChildren} />);
+      const { container } = render(<SpanTreeOffset {...propsWithoutChildren} />);
       const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
       expect(iconWrapper).not.toBeNull();
       expect(container.querySelector('.SpanTreeOffset--dot')).not.toBeNull();
@@ -236,7 +190,7 @@ describe('SpanTreeOffset', () => {
         span: spanWithChildren,
         showChildrenIcon: false,
       };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithIconDisabled} />);
+      const { container } = render(<SpanTreeOffset {...propsWithIconDisabled} />);
       expect(container.querySelector('.SpanTreeOffset--iconWrapper')).toBeNull();
     });
 
@@ -253,31 +207,13 @@ describe('SpanTreeOffset', () => {
         span: spanWithChildren,
         childrenVisible: true,
       };
-      const { container } = render(<UnconnectedSpanTreeOffset {...propsWithVisibleChildren} />);
+      const { container } = render(<SpanTreeOffset {...propsWithVisibleChildren} />);
       expect(container.querySelector('.SpanTreeOffset--iconWrapper')).not.toBeNull();
-    });
-
-    it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      const { container } = renderResult;
-      const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
-      fireEvent.mouseEnter(iconWrapper, {});
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
-    });
-
-    it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      const { container } = renderResult;
-      const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
-      fireEvent.mouseLeave(iconWrapper, {});
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
     });
 
     it('calls onClick when Enter is pressed on the span wrapper', () => {
       const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const { container } = render(<SpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: 'Enter' });
       expect(onClick).toHaveBeenCalledTimes(1);
@@ -285,9 +221,7 @@ describe('SpanTreeOffset', () => {
 
     it('calls onClick when Space is pressed on the span wrapper', () => {
       const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const { container } = render(<SpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: ' ' });
       expect(onClick).toHaveBeenCalledTimes(1);
@@ -295,9 +229,7 @@ describe('SpanTreeOffset', () => {
 
     it('does not call onClick for other keys on the span wrapper', () => {
       const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const { container } = render(<SpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       fireEvent.keyDown(wrapper, { key: 'Tab' });
       expect(onClick).not.toHaveBeenCalled();
@@ -305,36 +237,9 @@ describe('SpanTreeOffset', () => {
 
     it('sets tabIndex on the span wrapper when onClick is provided', () => {
       const onClick = jest.fn();
-      const { container } = render(
-        <UnconnectedSpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />
-      );
+      const { container } = render(<SpanTreeOffset {...props} span={spanWithChildren} onClick={onClick} />);
       const wrapper = container.querySelector('.SpanTreeOffset');
       expect(wrapper).toHaveAttribute('tabindex', '0');
-    });
-  });
-
-  describe('mapDispatchToProps()', () => {
-    it('creates the actions correctly', () => {
-      expect(mapDispatchToProps(() => {})).toEqual({
-        addHoverIndentGuideId: expect.any(Function),
-        removeHoverIndentGuideId: expect.any(Function),
-      });
-    });
-  });
-
-  describe('mapStateToProps()', () => {
-    it('maps state to props correctly', () => {
-      const hoverIndentGuideIds = new Set([parentSpanID]);
-      const state = {
-        traceTimeline: {
-          hoverIndentGuideIds,
-        },
-      };
-      const mappedProps = mapStateToProps(state);
-      expect(mappedProps).toEqual({
-        hoverIndentGuideIds,
-      });
-      expect(mappedProps.hoverIndentGuideIds).toBe(hoverIndentGuideIds);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -60,24 +60,15 @@ describe('SpanTreeOffset', () => {
       const { container } = render(<SpanTreeOffset {...props} />);
       const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(2); // rootSpan and parentSpan
-      expect(indentGuides[0].getAttribute('data-ancestor-id')).toBe(rootSpanID);
-      expect(indentGuides[1].getAttribute('data-ancestor-id')).toBe(parentSpanID);
-    });
-
-    // Guards against the indent-guide hover highlight being silently reintroduced as dead
-    // state: the `is-active` class + CSS were removed in #3302, so hovering must paint nothing.
-    it('applies no highlight class to indent guides on hover', () => {
-      const { container } = render(<SpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      fireEvent.mouseEnter(indentGuide, {});
-      expect(container.querySelector('.is-active')).toBeNull();
+      expect(indentGuides[0].getAttribute('data-testid')).toBe(`indent-guide-${rootSpanID}`);
+      expect(indentGuides[1].getAttribute('data-testid')).toBe(`indent-guide-${parentSpanID}`);
     });
 
     describe('is-last class (last-child span)', () => {
       it('adds is-last to immediate parent guide when span is last child and isDetailRow is false', () => {
         // ownSpan is the only (last) child of parentSpan
         const { container } = render(<SpanTreeOffset {...props} />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector(`[data-testid="indent-guide-${parentSpanID}"]`);
         expect(parentGuide).toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
       });
@@ -85,7 +76,7 @@ describe('SpanTreeOffset', () => {
       it('adds is-terminated (not is-last) to immediate parent guide when span is last child and isDetailRow is true', () => {
         // ownSpan is the only (last) child of parentSpan
         const { container } = render(<SpanTreeOffset {...props} isDetailRow />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector(`[data-testid="indent-guide-${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).toHaveClass('is-terminated');
       });
@@ -101,7 +92,7 @@ describe('SpanTreeOffset', () => {
         // ownSpan is no longer the last child
         parentSpan.childSpans = [ownSpan, siblingSpan];
         const { container } = render(<SpanTreeOffset {...props} />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector(`[data-testid="indent-guide-${parentSpanID}"]`);
         expect(parentGuide).not.toHaveClass('is-last');
         expect(parentGuide).not.toHaveClass('is-terminated');
         // restore
@@ -112,19 +103,19 @@ describe('SpanTreeOffset', () => {
     describe('horizontal line', () => {
       it('renders the horizontal line for the immediate parent when isDetailRow is false', () => {
         const { container } = render(<SpanTreeOffset {...props} />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector(`[data-testid="indent-guide-${parentSpanID}"]`);
         expect(parentGuide.querySelector('.SpanTreeOffset--horizontalLine')).not.toBeNull();
       });
 
       it('does not render the horizontal line for the immediate parent when isDetailRow is true', () => {
         const { container } = render(<SpanTreeOffset {...props} isDetailRow />);
-        const parentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
+        const parentGuide = container.querySelector(`[data-testid="indent-guide-${parentSpanID}"]`);
         expect(parentGuide.querySelector('.SpanTreeOffset--horizontalLine')).toBeNull();
       });
 
       it('does not render the horizontal line for non-immediate ancestors', () => {
         const { container } = render(<SpanTreeOffset {...props} />);
-        const rootGuide = container.querySelector(`[data-ancestor-id="${rootSpanID}"]`);
+        const rootGuide = container.querySelector(`[data-testid="indent-guide-${rootSpanID}"]`);
         expect(rootGuide.querySelector('.SpanTreeOffset--horizontalLine')).toBeNull();
       });
     });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -106,7 +106,6 @@ const SpanTreeOffset: React.FC<TProps> = ({
             style={{
               color: guideColor,
             }}
-            data-ancestor-id={ancestor.spanID}
             data-testid={`indent-guide-${ancestor.spanID}`}
           >
             {isLastAncestor && !isDetailRow && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -3,26 +3,13 @@
 
 import React, { useMemo } from 'react';
 import cx from 'classnames';
-import _get from 'lodash/get';
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
 
-import { actions } from './duck';
-import { ReduxState } from '../../../types';
 import { IOtelSpan } from '../../../types/otel';
 import colorGenerator from '../../../utils/color-generator';
 
 import './SpanTreeOffset.css';
 
-type TDispatchProps = {
-  addHoverIndentGuideId: (spanID: string) => void;
-  removeHoverIndentGuideId: (spanID: string) => void;
-};
-
 type TProps = {
-  addHoverIndentGuideId: (spanID: string) => void;
-  hoverIndentGuideIds: Set<string>;
-  removeHoverIndentGuideId: (spanID: string) => void;
   childrenVisible?: boolean;
   onClick?: () => void;
   showChildrenIcon?: boolean;
@@ -31,14 +18,12 @@ type TProps = {
   color: string;
 };
 
-export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
+const SpanTreeOffset: React.FC<TProps> = ({
   childrenVisible = false,
   onClick = undefined,
   showChildrenIcon = true,
   isDetailRow = false,
   span,
-  addHoverIndentGuideId,
-  removeHoverIndentGuideId,
   color,
 }) => {
   // Build ancestor chain directly from span.parentSpan
@@ -51,40 +36,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     }
     return chain;
   }, [span]);
-
-  /**
-   * If the mouse leaves to anywhere except another span with the same ancestor id, this span's ancestor id is
-   * removed from the set of hoverIndentGuideIds.
-   *
-   * @param {Object} event - React Synthetic event tied to mouseleave. Includes the related target which is
-   *     the element the user is now hovering.
-   * @param {string} ancestorId - The span id that the user was hovering over.
-   */
-  const handleMouseLeave = (event: React.MouseEvent<HTMLSpanElement>, ancestorId: string) => {
-    if (
-      !(event.relatedTarget instanceof HTMLSpanElement) ||
-      _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
-    ) {
-      removeHoverIndentGuideId(ancestorId);
-    }
-  };
-
-  /**
-   * If the mouse entered this span from anywhere except another span with the same ancestor id, this span's
-   * ancestorId is added to the set of hoverIndentGuideIds.
-   *
-   * @param {Object} event - React Synthetic event tied to mouseenter. Includes the related target which is
-   *     the last element the user was hovering.
-   * @param {string} ancestorId - The span id that the user is now hovering over.
-   */
-  const handleMouseEnter = (event: React.MouseEvent<HTMLSpanElement>, ancestorId: string) => {
-    if (
-      !(event.relatedTarget instanceof HTMLSpanElement) ||
-      _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
-    ) {
-      addHoverIndentGuideId(ancestorId);
-    }
-  };
 
   const { hasChildren, spanID, childSpans } = span;
   const _childrenToggleKeyDown = (e: React.KeyboardEvent) => {
@@ -157,8 +108,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
             }}
             data-ancestor-id={ancestor.spanID}
             data-testid={`indent-guide-${ancestor.spanID}`}
-            onMouseEnter={event => handleMouseEnter(event, ancestor.spanID)}
-            onMouseLeave={event => handleMouseLeave(event, ancestor.spanID)}
           >
             {isLastAncestor && !isDetailRow && (
               <span
@@ -178,8 +127,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
             'is-collapsed': !childrenVisible,
           })}
           data-testid="icon-wrapper"
-          onMouseEnter={event => handleMouseEnter(event, spanID)}
-          onMouseLeave={event => handleMouseLeave(event, spanID)}
         >
           {hasChildren ? (
             <span
@@ -206,14 +153,4 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   );
 };
 
-export function mapStateToProps(state: ReduxState): { hoverIndentGuideIds: Set<string> } {
-  const { hoverIndentGuideIds } = state.traceTimeline;
-  return { hoverIndentGuideIds };
-}
-
-export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
-  const { addHoverIndentGuideId, removeHoverIndentGuideId } = bindActionCreators(actions, dispatch);
-  return { addHoverIndentGuideId, removeHoverIndentGuideId };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(UnconnectedSpanTreeOffset);
+export default SpanTreeOffset;

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import cx from 'classnames';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import _isEqual from 'lodash/isEqual';
 
 import memoizeOne from 'memoize-one';
@@ -30,7 +30,7 @@ import { Accessors } from '../ScrollManager';
 import { parseUiFind, TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
 import getLinks from '../../../model/link-patterns';
 import colorGenerator from '../../../utils/color-generator';
-import { TNil, ReduxState } from '../../../types';
+import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
 import { IOtelSpan, IOtelTrace, IAttributes, IEvent } from '../../../types/otel';
 import TTraceTimeline from '../../../types/TTraceTimeline';
@@ -562,10 +562,9 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
 });
 
 /**
- * Functional wrapper that reads Zustand (ephemeral timeline state + layout prefs) and the
- * remaining Redux slice (hoverIndentGuideIds, uiFind), creates dual-write action handlers
- * (Redux dispatch first so the tracking middleware sees the pre-update state, then Zustand),
- * and passes everything into the class component.
+ * Functional wrapper that reads Zustand (ephemeral timeline state + layout prefs) and derives
+ * uiFind from the URL, creates dual-write action handlers (Redux dispatch first so the tracking
+ * middleware sees the pre-update state, then Zustand), and passes everything into the class component.
  */
 /* istanbul ignore next */
 function VirtualizedTraceViewWrapper(
@@ -577,7 +576,6 @@ function VirtualizedTraceViewWrapper(
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dispatch = useDispatch<any>();
-  const hoverIndentGuideIds = useSelector((state: ReduxState) => state.traceTimeline.hoverIndentGuideIds);
   const uiFind = parseUiFind(ownProps.search ?? ownProps.location.search ?? '');
 
   const spanNameColumnWidth = useLayoutPrefsStore(s => s.spanNameColumnWidth);
@@ -699,7 +697,6 @@ function VirtualizedTraceViewWrapper(
 
   const combinedProps: VirtualizedTraceViewProps = {
     ...ownProps,
-    hoverIndentGuideIds,
     uiFind,
     spanNameColumnWidth,
     sidePanelWidth,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
@@ -762,47 +762,6 @@ describe('TraceTimelineViewer/duck', () => {
     });
   });
 
-  describe('hoverIndentGuideIds', () => {
-    const existingSpanId = 'existingSpanId';
-    const newSpanId = 'newSpanId';
-
-    it('the initial state has an empty set of hoverIndentGuideIds', () => {
-      const state = store.getState();
-      expect(state.hoverIndentGuideIds).toEqual(new Set());
-    });
-
-    it('adds a spanID to an initial state', () => {
-      const action = actions.addHoverIndentGuideId(newSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set([newSpanId]));
-    });
-
-    it('adds a spanID to a populated state', () => {
-      store = createStore(reducer, {
-        hoverIndentGuideIds: new Set([existingSpanId]),
-      });
-      const action = actions.addHoverIndentGuideId(newSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set([existingSpanId, newSpanId]));
-    });
-
-    it('should not error when removing a spanID from an initial state', () => {
-      const action = actions.removeHoverIndentGuideId(newSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set());
-    });
-
-    it('remove a spanID from a populated state', () => {
-      const secondExistingSpanId = 'secondExistingSpanId';
-      store = createStore(reducer, {
-        hoverIndentGuideIds: new Set([existingSpanId, secondExistingSpanId]),
-      });
-      const action = actions.removeHoverIndentGuideId(existingSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set([secondExistingSpanId]));
-    });
-  });
-
   describe('getSelectedSpanID', () => {
     it('returns null when detailStates is empty', () => {
       expect(getSelectedSpanID(new Map())).toBeNull();

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
@@ -112,7 +112,6 @@ export function newInitialState(): TTraceTimeline {
     childrenHiddenIDs: new Set(),
     detailStates: new Map(),
     detailPanelMode,
-    hoverIndentGuideIds: new Set(),
     shouldScrollToFirstUiFindMatch: false,
     sidePanelWidth,
     spanNameColumnWidth,
@@ -122,7 +121,6 @@ export function newInitialState(): TTraceTimeline {
 }
 
 export const actionTypes = generateActionTypes('@jaeger-ui/trace-timeline-viewer', [
-  'ADD_HOVER_INDENT_GUIDE_ID',
   'CHILDREN_TOGGLE',
   'CLEAR_SHOULD_SCROLL_TO_FIRST_UI_FIND_MATCH',
   'COLLAPSE_ALL',
@@ -137,7 +135,6 @@ export const actionTypes = generateActionTypes('@jaeger-ui/trace-timeline-viewer
   'EXPAND_ALL',
   'EXPAND_ONE',
   'FOCUS_UI_FIND_MATCHES',
-  'REMOVE_HOVER_INDENT_GUIDE_ID',
   'SET_DETAIL_PANEL_MODE',
   'SET_SIDE_PANEL_WIDTH',
   'SET_SPAN_NAME_COLUMN_WIDTH',
@@ -146,7 +143,6 @@ export const actionTypes = generateActionTypes('@jaeger-ui/trace-timeline-viewer
 ]);
 
 const fullActions = createActions<TActionTypes>({
-  [actionTypes.ADD_HOVER_INDENT_GUIDE_ID]: (spanID: string) => ({ spanID }),
   [actionTypes.CHILDREN_TOGGLE]: (spanID: string) => ({ spanID }),
   [actionTypes.CLEAR_SHOULD_SCROLL_TO_FIRST_UI_FIND_MATCH]: () => ({}),
   [actionTypes.COLLAPSE_ALL]: (spans: IOtelSpan[]) => ({ spans }),
@@ -165,7 +161,6 @@ const fullActions = createActions<TActionTypes>({
     uiFind,
     allowHide,
   }),
-  [actionTypes.REMOVE_HOVER_INDENT_GUIDE_ID]: (spanID: string) => ({ spanID }),
   [actionTypes.SET_DETAIL_PANEL_MODE]: (mode: 'inline' | 'sidepanel') => ({ mode }),
   [actionTypes.SET_SIDE_PANEL_WIDTH]: (width: number) => ({ width }),
   [actionTypes.SET_SPAN_NAME_COLUMN_WIDTH]: (width: number) => ({ width }),
@@ -413,23 +408,8 @@ function detailLogItemToggle(state: TTraceTimeline, { spanID, logItem }: TSpanId
   return { ...state, detailStates };
 }
 
-function addHoverIndentGuideId(state: TTraceTimeline, { spanID }: TSpanIdValue) {
-  const newHoverIndentGuideIds = new Set(state.hoverIndentGuideIds);
-  newHoverIndentGuideIds.add(spanID);
-
-  return { ...state, hoverIndentGuideIds: newHoverIndentGuideIds };
-}
-
-function removeHoverIndentGuideId(state: TTraceTimeline, { spanID }: TSpanIdValue) {
-  const newHoverIndentGuideIds = new Set(state.hoverIndentGuideIds);
-  newHoverIndentGuideIds.delete(spanID);
-
-  return { ...state, hoverIndentGuideIds: newHoverIndentGuideIds };
-}
-
 export default handleActions<TTraceTimeline, any>(
   {
-    [actionTypes.ADD_HOVER_INDENT_GUIDE_ID]: guardReducer(addHoverIndentGuideId),
     [actionTypes.CHILDREN_TOGGLE]: guardReducer(childrenToggle),
     [actionTypes.CLEAR_SHOULD_SCROLL_TO_FIRST_UI_FIND_MATCH]: guardReducer(
       clearShouldScrollToFirstUiFindMatch
@@ -446,7 +426,6 @@ export default handleActions<TTraceTimeline, any>(
     [actionTypes.EXPAND_ALL]: guardReducer(expandAll),
     [actionTypes.EXPAND_ONE]: guardReducer(expandOne),
     [actionTypes.FOCUS_UI_FIND_MATCHES]: guardReducer(focusUiFindMatches),
-    [actionTypes.REMOVE_HOVER_INDENT_GUIDE_ID]: guardReducer(removeHoverIndentGuideId),
     [actionTypes.SET_DETAIL_PANEL_MODE]: guardReducer(setDetailPanelMode),
     [actionTypes.SET_SIDE_PANEL_WIDTH]: guardReducer(setSidePanelWidth),
     [actionTypes.SET_SPAN_NAME_COLUMN_WIDTH]: guardReducer(setColumnWidth),

--- a/packages/jaeger-ui/src/types/TTraceTimeline.ts
+++ b/packages/jaeger-ui/src/types/TTraceTimeline.ts
@@ -9,7 +9,6 @@ type TTraceTimeline = {
   childrenHiddenIDs: Set<string>;
   detailStates: Map<string, DetailState>;
   detailPanelMode: SpanDetailPanelMode;
-  hoverIndentGuideIds: Set<string>;
   shouldScrollToFirstUiFindMatch: boolean;
   sidePanelWidth: number;
   spanNameColumnWidth: number;


### PR DESCRIPTION
## Which problem is this PR solving?

The trace timeline keeps `hoverIndentGuideIds` in the Redux `traceTimeline` slice, but nothing reads it to render anything. The indent-guide hover highlight that used it (the `is-active` class and its CSS) was removed in #3302, leaving the field, its two actions, the `SpanTreeOffset` mouse-enter/leave writers, and the `VirtualizedTraceView` `useSelector` read as orphaned code. Every hover still dispatches Redux actions and clones a `Set` for no visible effect.

Full analysis and the git bisect are in #4351.

## Description of the changes

- Remove `hoverIndentGuideIds` and the `ADD_/REMOVE_HOVER_INDENT_GUIDE_ID` actions and reducers from `TraceTimelineViewer/duck.ts`; drop the field from `TTraceTimeline`.
- Remove the mouse-enter/leave handlers from `SpanTreeOffset`. It no longer needs Redux, so it becomes a plain functional component instead of a `connect()`ed one — one fewer connected component on the way to removing Redux (RFC 0004 Phase 1c/4).
- Remove the dead `useSelector` read and prop threading from `VirtualizedTraceView`.
- Drop the now-unnecessary Redux `Provider` from the `SpanDetailRow` integration test.
- Add a regression test asserting hover paints no highlight class, so the dead state cannot quietly return.
- Update RFC 0004 to record Phase 1c step 3 as resolved by deletion.

Hover is not tracked by the analytics middleware, so no dual-write is involved and nothing needs to move off `duck.track.ts`.

If the highlight removal in #3302 was not intentional and it should come back instead, I am happy to restore it on the Zustand store rather than deleting — see the options in #4351.

## How was this change tested?

`pnpm run lint`, `pnpm test`, and `pnpm run build` all pass. Rendering `SpanTreeOffset` with the hover set populated produces DOM identical to an empty set, confirming nothing consumed it.

 Resolves #4328