### PR TITLE
[Bug]: Add ARIA attributes to LoadingIndicator for screen readers

### DIFF
--- a/packages/jaeger-ui/src/components/common/LoadingIndicator.test.tsx
+++ b/packages/jaeger-ui/src/components/common/LoadingIndicator.test.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+
+import LoadingIndicator from './LoadingIndicator';
+import '@testing-library/jest-dom';
+
+describe('LoadingIndicator', () => {
+  it('renders with default props', () => {
+    render(<LoadingIndicator />);
+    const indicator = screen.getByRole('status');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  it('renders with centered class when centered prop is true', () => {
+    render(<LoadingIndicator centered />);
+    const indicator = screen.getByRole('status');
+    expect(indicator.className).toContain('is-centered');
+  });
+
+  it('renders with small class when small prop is true', () => {
+    render(<LoadingIndicator small />);
+    const indicator = screen.getByRole('status');
+    expect(indicator.className).toContain('is-small');
+  });
+
+  it('renders with custom className', () => {
+    render(<LoadingIndicator className="custom-class" />);
+    const indicator = screen.getByRole('status');
+    expect(indicator.className).toContain('custom-class');
+  });
+
+  it('has accessible role and label', () => {
+    render(<LoadingIndicator />);
+    const indicator = screen.getByRole('status');
+    expect(indicator).toHaveAttribute('role', 'status');
+    expect(indicator).toHaveAttribute('aria-label', 'Loading');
+  });
+});

--- a/packages/jaeger-ui/src/components/common/LoadingIndicator.tsx
+++ b/packages/jaeger-ui/src/components/common/LoadingIndicator.tsx
@@ -28,5 +28,5 @@ export default function LoadingIndicator({
     ${className}
   `;
 
-  return <LuLoaderCircle className={cls} {...rest} style={style} />;
+  return <LuLoaderCircle className={cls} role="status" aria-label="Loading" {...rest} style={style} />;
 }


### PR DESCRIPTION
## Summary

Adds ARIA attributes to the `LoadingIndicator` component to make loading states accessible to screen readers.

## Changes

- Add `role="status"` to `LoadingIndicator` component to indicate a live region
- Add `aria-label="Loading"` for screen reader announcement
- Add test file `LoadingIndicator.test.tsx` with accessibility test coverage

## Motivation

The `LoadingIndicator` component renders a loading spinner (`LuLoaderCircle`) without any accessibility attributes. This violates WCAG 2.1 Success Criterion 4.1.2 (Name, Role, Value) and makes the loading state invisible to assistive technologies.

Screen reader users have no way to know that content is being loaded, which creates a confusing experience.

## Testing

- Added `LoadingIndicator.test.tsx` that verifies:
  - Component has `role="status"` attribute
  - Component has `aria-label="Loading"` attribute
  - Component renders with all prop variants (centered, small, custom className)

Closes #4332
