### PR TITLE
chore: drop _get from SpanTreeOffset hover handlers

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -3,7 +3,6 @@
 
 import React, { useMemo } from 'react';
 import cx from 'classnames';
-import _get from 'lodash/get';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -63,7 +62,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   const handleMouseLeave = (event: React.MouseEvent<HTMLSpanElement>, ancestorId: string) => {
     if (
       !(event.relatedTarget instanceof HTMLSpanElement) ||
-      _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
+      event.relatedTarget.dataset.ancestorId !== ancestorId
     ) {
       removeHoverIndentGuideId(ancestorId);
     }
@@ -80,7 +79,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   const handleMouseEnter = (event: React.MouseEvent<HTMLSpanElement>, ancestorId: string) => {
     if (
       !(event.relatedTarget instanceof HTMLSpanElement) ||
-      _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
+      event.relatedTarget.dataset.ancestorId !== ancestorId
     ) {
       addHoverIndentGuideId(ancestorId);
     }


### PR DESCRIPTION
## Which problem is this PR solving

Part of #3604.

`SpanTreeOffset`'s two hover handlers already narrow the target, and then reach for `_get` anyway to read the property off it:

```ts
if (
  !(event.relatedTarget instanceof HTMLSpanElement) ||
  _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
) {
```

Because `||` short-circuits, the right-hand side is only evaluated once the `instanceof` guard has established the type. So the direct access is already fully checked by the compiler, and the `_get` call throws that away in favour of a path expressed as a string the compiler cannot verify — exactly the pattern #3604 asks to remove.

This is the narrower half of the issue: no judgement call about dynamic paths, since the guard immediately above makes the safe access provably equivalent.

## Description of the changes

```diff
-import _get from 'lodash/get';
...
   !(event.relatedTarget instanceof HTMLSpanElement) ||
-  _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
+  event.relatedTarget.dataset.ancestorId !== ancestorId
```

Applied to both `handleMouseLeave` and `handleMouseEnter`, which removes the file's last `_get` and with it the `lodash/get` import.

No behaviour change. `dataset` is always present on an `HTMLSpanElement`, and a missing `data-ancestor-id` yields `undefined` under either form, so the comparison against `ancestorId` is unchanged.

I deliberately kept this to one file rather than sweeping the remaining call sites, per the guidance on #3604 that these should go in smaller PRs because the right answer differs per site. This does not overlap #4338, which covers `traceDiffGraphUtils.ts`, `DraggableManager.ts` and `set-on-graph.ts`.

## How was this change tested?

- `pnpm test` — 267 files, 3545 tests passing, plus plexus 115 passing
- `tsc --noEmit` on `packages/jaeger-ui` — clean, which is the point: the direct access type-checks
- `pnpm run fmt` and `vp lint` ran through lint-staged on commit

The existing `SpanTreeOffset` tests already cover both hover paths, including the case where `relatedTarget` is not a span, so the behaviour is pinned by tests that predate this change.
