### PR TITLE
perf(model): Make deduplicateTags linear

### DIFF
--- a/packages/jaeger-ui/src/model/transform-trace-data.test.js
+++ b/packages/jaeger-ui/src/model/transform-trace-data.test.js
@@ -42,6 +42,54 @@ describe('deduplicateTags()', () => {
     ]);
     expect(tagsInfo.warnings).toEqual(['Duplicate tag "b.ip:8.8.4.4"']);
   });
+
+  it('keeps values that only collide once stringified', () => {
+    const tagsInfo = deduplicateTags([
+      { key: 'http.status_code', value: 200 },
+      { key: 'http.status_code', value: '200' },
+      { key: 'retry', value: false },
+      { key: 'retry', value: 'false' },
+    ]);
+
+    expect(tagsInfo.tags).toEqual([
+      { key: 'http.status_code', value: 200 },
+      { key: 'http.status_code', value: '200' },
+      { key: 'retry', value: false },
+      { key: 'retry', value: 'false' },
+    ]);
+    expect(tagsInfo.warnings).toEqual([]);
+  });
+
+  it('keeps distinct objects sharing a key and reports repeated references once', () => {
+    const shared = { nested: true };
+    const tagsInfo = deduplicateTags([
+      { key: 'payload', value: shared },
+      { key: 'payload', value: { nested: true } },
+      { key: 'payload', value: shared },
+    ]);
+
+    expect(tagsInfo.tags).toEqual([
+      { key: 'payload', value: shared },
+      { key: 'payload', value: { nested: true } },
+    ]);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag "payload:[object Object]"']);
+  });
+
+  it('reports one warning per distinct duplicated tag', () => {
+    const tagsInfo = deduplicateTags([
+      { key: 'a', value: '1' },
+      { key: 'a', value: '1' },
+      { key: 'a', value: '1' },
+      { key: 'b', value: '2' },
+      { key: 'b', value: '2' },
+    ]);
+
+    expect(tagsInfo.tags).toEqual([
+      { key: 'a', value: '1' },
+      { key: 'b', value: '2' },
+    ]);
+    expect(tagsInfo.warnings).toEqual(['Duplicate tag "a:1"', 'Duplicate tag "b:2"']);
+  });
 });
 
 describe('transformTraceData()', () => {

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -13,14 +13,25 @@ import OtelTraceFacade from './OtelTraceFacade';
 // exported for tests
 export function deduplicateTags(spanTags: ReadonlyArray<KeyValuePair>) {
   const warningsHash: Map<string, string> = new Map<string, string>();
-  const tags: KeyValuePair[] = spanTags.reduce<KeyValuePair[]>((uniqueTags, tag) => {
-    if (!uniqueTags.some(t => t.key === tag.key && t.value === tag.value)) {
-      uniqueTags.push(tag);
-    } else {
-      warningsHash.set(`${tag.key}:${tag.value}`, `Duplicate tag "${tag.key}:${tag.value}"`);
+  // Values already seen, bucketed by key. Scanning the accumulated tags instead
+  // costs O(n) per tag, which is measurable on spans carrying many attributes —
+  // a long gen_ai.* conversation or a large tool schema expands into hundreds on
+  // a single span. Set membership keeps the same key+value equality test at O(1).
+  const seenValuesByKey: Map<string, Set<KeyValuePair['value']>> = new Map();
+  const tags: KeyValuePair[] = [];
+  for (const tag of spanTags) {
+    let seenValues = seenValuesByKey.get(tag.key);
+    if (!seenValues) {
+      seenValues = new Set();
+      seenValuesByKey.set(tag.key, seenValues);
     }
-    return uniqueTags;
-  }, []);
+    if (seenValues.has(tag.value)) {
+      warningsHash.set(`${tag.key}:${tag.value}`, `Duplicate tag "${tag.key}:${tag.value}"`);
+    } else {
+      seenValues.add(tag.value);
+      tags.push(tag);
+    }
+  }
   const warnings = Array.from(warningsHash.values());
   return { tags, warnings };
 }


### PR DESCRIPTION
deduplicateTags built its unique list with Array.prototype.some inside a reduce, comparing each tag against every tag accepted so far. That is O(n^2) in tag count, paid once per span on every trace load.

Ordinary spans never notice, but GenAI spans routinely carry hundreds of gen_ai.* attributes, since a long conversation or a large tool schema expands into one attribute per message or field on a single span.

Replace the scan with a Map of key -> Set of seen values, making the duplicate check O(1) per tag. Measured per span, mean of 50 runs: 1000 tags goes from 4.06ms to 0.17ms (23.6x), 2000 tags from 12.37ms to 0.35ms (35.9x).

A Map of Sets is used rather than a single Set of `key:value` composite strings because the composite form is not equivalent: it would conflate values differing only by type or identity, such as 200 and '200' or two distinct objects that both stringify to [object Object]. Set membership uses SameValueZero, matching the === comparison the old code performed.

Tag order, retained tags, and warning strings are unchanged. The three new tests pass against the previous implementation as well, so they are behaviour guards rather than assertions fitted to the new code.

Resolves #4109




## Checklist
- [ x ] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [  x ] I have signed all commits
- [  ] I have added unit tests for the new functionality
- [ x ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
