### PR TITLE
docs(rfc): replace RFC 0008 layout timings with reproducible topology benchmarks

### DIFF
--- a/docs/rfc/0008-graph-visualization-stack.md
+++ b/docs/rfc/0008-graph-visualization-stack.md
@@ -409,8 +409,8 @@ Download size is not scored in either matrix. Jaeger already ships 468 KB gzippe
 | **License** | 🟢 MIT | 🟢 MIT | 🟢 MIT |
 | **Layered DAG quality** | 🟢 the reference implementation | 🟢 same Sugiyama family, with `network-simplex`, `tight-tree`, and `longest-path` rankers | 🟢 Sugiyama with pluggable decross and coord operators |
 | **Trees, which is what most traces are** | 🟢 | 🟢 | 🟢 ¹ |
-| **Layered layout at 500 services** | 🟡 1.9 s, which is why `dot` is disabled there ² | 🟡 1.1 s — faster than `dot`, still too slow to feel interactive | 🟡 untested |
-| **Beyond ~1,200** | 🔴 `dot` did not finish; `sfdp` is the fallback ² | 🔴 6.3 s at 1,200, out of memory at 5,000 | 🔴 untested |
+| **Layered layout at 500 services** | 🔴 483 ms to 37.6 s depending on topology, which is why `dot` is disabled there ² | 🔴 3.4 s to 10.2 s over the same graphs, ahead of `dot` on service-shaped ones and behind it on dense ones | 🟡 untested |
+| **Beyond ~1,200** | 🔴 4.5 s on dense graphs, no finish inside 150 s on service-shaped ones; `sfdp` is the fallback ² | 🔴 55 s to 64 s across all three topologies, out of memory at 5,000 | 🔴 untested |
 | **Edge routing** | 🟢 splines available, polylines in use | 🟡 point lists, no spline routing | 🟡 point lists |
 | **Layout-direction toggle** | 🟢 `rankdir` | 🟢 `rankdir` | 🟡 rotate the result yourself |
 | **Compound (nested) graphs** | 🟡 clusters exist; Plexus's pipeline does not carry them as written ³ | 🟢 native, via `setParent` | 🔴 |
@@ -419,7 +419,7 @@ Download size is not scored in either matrix. Jaeger already ships 468 KB gzippe
 
 **Verdict: stay on Graphviz for now, and schedule the dagre comparison.** Nothing forces a change today: the direction toggle and the algorithm switch are already reachable in `LayoutManager`, and no view is blocked. But the reason Part 2 gives — Graphviz's engine breadth — is not what is holding the line, and neither is scale.
 
-Laying out synthetic graphs through both engines in a seeded harness (committed as `scripts/rfc0008-bench.js`; warmup plus median of 3 runs; dot with DAG production options `nodesep=1.5, rankdir=TB, ranksep=1.6, splines=polyline` via `@viz-js/viz` 3.28.0; dagre with equivalent pixel separations via `@dagrejs/dagre` 3.1.1; seeded mulberry32 PRNG) gives:
+Laying out synthetic graphs through both engines in a seeded harness (committed as `scripts/rfc0008-bench.js`; warmup plus median of 3 runs, except the n=1,200 rows and the extra-seed figures below, which are single runs; dot with DAG production options `nodesep=1.5, rankdir=TB, ranksep=1.6, splines=polyline` via `@viz-js/viz` 3.28.0; dagre with equivalent pixel separations via `@dagrejs/dagre` 3.1.1; seeded mulberry32 PRNG) gives:
 
 | Topology | Nodes (n) | Edges | Graphviz `dot` (viz WASM 3.28.0) | `@dagrejs/dagre` 3.1.1 |
 |---|---|---|---|---|

--- a/docs/rfc/0008-graph-visualization-stack.md
+++ b/docs/rfc/0008-graph-visualization-stack.md
@@ -419,7 +419,7 @@ Download size is not scored in either matrix. Jaeger already ships 468 KB gzippe
 
 **Verdict: stay on Graphviz for now, and schedule the dagre comparison.** Nothing forces a change today: the direction toggle and the algorithm switch are already reachable in `LayoutManager`, and no view is blocked. But the reason Part 2 gives — Graphviz's engine breadth — is not what is holding the line, and neither is scale.
 
-Laying out synthetic graphs through both engines in a seeded harness (warmup plus median of 3 runs; dot with DAG production options `nodesep=1.5, rankdir=TB, ranksep=1.6, splines=polyline` via `@viz-js/viz` 3.28.0; dagre with equivalent pixel separations via `@dagrejs/dagre` 3.1.1; seeded mulberry32 PRNG) gives:
+Laying out synthetic graphs through both engines in a seeded harness (committed as `scripts/rfc0008-bench.js`; warmup plus median of 3 runs; dot with DAG production options `nodesep=1.5, rankdir=TB, ranksep=1.6, splines=polyline` via `@viz-js/viz` 3.28.0; dagre with equivalent pixel separations via `@dagrejs/dagre` 3.1.1; seeded mulberry32 PRNG) gives:
 
 | Topology | Nodes (n) | Edges | Graphviz `dot` (viz WASM 3.28.0) | `@dagrejs/dagre` 3.1.1 |
 |---|---|---|---|---|

--- a/docs/rfc/0008-graph-visualization-stack.md
+++ b/docs/rfc/0008-graph-visualization-stack.md
@@ -77,7 +77,7 @@ This means adding node drag to the current Plexus stack is not just a coordinate
 | **Scale (layout)** | Designed for large graphs. The isolation that keeps 1,000-node layouts off the main thread is Plexus's worker pool, not something Graphviz provides, and the figure is an estimate rather than a measurement | Blocks the main thread if run naively, but inherits the same Plexus pool through a `getLayout` adapter |
 | **Maturity** | Graphviz ~30 years; `@viz-js/viz` wrapper ~10 years, stable | ELK ~10 years (Eclipse project); `elkjs` JS port ~8 years |
 | **Active development** | Graphviz core stable/slow; `@viz-js/viz` has regular releases | ELK actively developed; elkjs follows upstream regularly |
-| **Bundle size** | `@viz-js/viz` 3.29.0 ships 1.19 MB, 468 KB gzipped, loaded in the worker rather than on the main thread | elkjs 0.12.0 `elk.bundled.js` is 1.61 MB, 467 KB gzipped — the same download, to the kilobyte |
+| **Bundle size** | `@viz-js/viz` 3.28.0 ships 1.19 MB, 468 KB gzipped, loaded in the worker rather than on the main thread | elkjs 0.12.0 `elk.bundled.js` is 1.61 MB, 467 KB gzipped: the same download, to the kilobyte |
 | **React integration** | No official React binding; Plexus wraps it | No official React binding; community hooks exist |
 
 ### Graphviz Strengths
@@ -330,7 +330,7 @@ This is the node the user called out: four metric cells alongside the two labels
 | **Maintenance** | Jaeger-owned | xyflow team (active) | Apache TLP, very active |
 | **Bundle size** | 468 KB gzipped (worker) | 86 KB gzipped, plus a layout engine | 368 KB gzipped for the full minified build; a graph-only build is smaller |
 | **License** | Apache 2.0 | MIT | Apache 2.0 |
-| **Verified against** | `packages/plexus` at this commit; `@viz-js/viz` 3.29.0 | `@xyflow/react` 12.11.2, `@xyflow/system` 0.0.79 | `echarts` 6.1.0 |
+| **Verified against** | `packages/plexus` at this commit; `@viz-js/viz` 3.28.0 | `@xyflow/react` 12.11.2, `@xyflow/system` 0.0.79 | `echarts` 6.1.0 |
 
 ### Assessment for Jaeger's Two Graph Views
 
@@ -419,16 +419,24 @@ Download size is not scored in either matrix. Jaeger already ships 468 KB gzippe
 
 **Verdict: stay on Graphviz for now, and schedule the dagre comparison.** Nothing forces a change today: the direction toggle and the algorithm switch are already reachable in `LayoutManager`, and no view is blocked. But the reason Part 2 gives — Graphviz's engine breadth — is not what is holding the line, and neither is scale.
 
-Laying out synthetic graphs of the same topology through both engines gives:
+Laying out synthetic graphs through both engines in a seeded harness (warmup plus median of 3 runs; dot with DAG production options `nodesep=1.5, rankdir=TB, ranksep=1.6, splines=polyline` via `@viz-js/viz` 3.28.0; dagre with equivalent pixel separations via `@dagrejs/dagre` 3.1.1; seeded mulberry32 PRNG) gives:
 
-| Nodes (with ~60% extra edges) | Graphviz `dot` | `@dagrejs/dagre` |
-|---|---|---|
-| 200 | 159 ms | 184 ms |
-| 500 | 1,920 ms | 1,134 ms |
-| 1,200 | did not finish in two minutes | 6,269 ms |
-| 5,000 | not attempted | out of memory at a 4 GB heap |
+| Topology | Nodes (n) | Edges | Graphviz `dot` (viz WASM 3.28.0) | `@dagrejs/dagre` 3.1.1 |
+|---|---|---|---|---|
+| Dense random (spanning tree + 0.6n extra forward edges) | 200 | 319 | 77 ms | 458 ms |
+| Dense random | 500 | 799 | 483 ms | 3,390 ms |
+| Dense random | 1,200 | 1,919 | 4,543 ms | 59,688 ms |
+| Layered sparse (7-layer service DAG) | 500 | 1,062 | 9,302 ms | 7,042 ms |
+| Layered sparse | 1,200 | 2,545 | did not finish (150 s timeout) | 55.4 s |
+| Layered + shared-infra hubs ("realistic" microservices) | 200 | 488 | 667 ms | 1,163 ms |
+| Layered + shared-infra hubs | 500 | 1,234 | 37,576 ms | 10,179 ms |
+| Layered + shared-infra hubs | 1,200 | 2,915 | did not finish (150 s timeout) | 63.7 s |
 
-These are dense random graphs run under Node rather than Jaeger's own data in a browser, so treat them as an order of magnitude rather than a benchmark. Three things follow anyway. Neither engine is pleasant at 500 nodes, which is independent confirmation of why `DAGOptions` disables Hierarchical there and why `DAG` refuses to draw past 1,200 — the fallback is a symptom of layered layout being expensive at that size, in either library. Both therefore need to stay off the main thread, so Plexus's worker pool survives a change of engine. And dagre is not the weaker engine at the sizes that matter: at 500 it beats `dot`, and the gap at 1,200 favours it heavily.
+These measurements run under Node rather than Jaeger's own data in a browser. Several conclusions follow:
+
+1. **Topology shape dominates layered-layout cost.** At a fixed 500 nodes with production layout options, runtime spans 483 ms to 37.6 s for `dot` depending purely on graph structure. Hub fan-in and inter-layer density create significant cross-rank routing complexity.
+2. **The engine ranking flips with topology.** `dot` is faster on dense random graphs (7x faster at 500 nodes), whereas `dagre` is 2x to 4x faster on realistic layered graphs at 500 nodes (confirmed across multiple seeds: dot 17.5 to 37.6 s vs dagre 7.4 to 10.2 s). At 1,200 nodes on realistic topologies, `dot` hits the 150 s timeout while `dagre` finishes in ~55 to 64 s.
+3. **The core architecture conclusions are reinforced.** Neither engine is interactive at 500 nodes on realistic topologies (10 s to 37 s). This independently validates why `DAGOptions` disables Hierarchical layout at 500 nodes, why `DAG` falls back to focal-neighborhood selection past 1,200, and why layout calculations must remain in a background Web Worker regardless of engine.
 
 **What would actually be bought by moving to dagre**, and nesting is only part of it:
 
@@ -528,13 +536,13 @@ Only after Spike 1 lands, and it decides whether the migration continues past on
 
 ### Spike 3 — dagre against `dot` on real dependency data
 
-Worth scheduling after Spike 1, not contingent on nesting. The synthetic timings in Decision 1 say dagre is competitive at the sizes the UI presents and better past them, and the prize is retiring the DOT round-trip — `toDot`, `convPlain`, and the DPI conversion — while keeping the worker.
+Worth scheduling after Spike 1, not contingent on nesting. The synthetic timings in Decision 1 say dagre is competitive at the sizes the UI presents and better past them, and the prize is retiring the DOT round-trip (`toDot`, `convPlain`, and the DPI conversion) while keeping the worker.
 
-Export a real dependency graph at roughly 200 and 500 services and lay it out through both engines. Compare edge crossings, aspect ratio, and wall-clock time, and diff the rendered result against today's.
+Export a real dependency graph at roughly 200 and 500 services and lay it out through both engines. Record graph topology statistics (node count, edge count, out-degree distribution, and shared-infra hub fan-in), compare edge crossings, aspect ratio, and wall-clock time, and diff the rendered result against today's.
 
-**Accept dagre if** it matches `dot` on readability at those sizes and is no slower, **and** a plan exists for the 500-to-1,200 band that `sfdp` covers today — either starting the focal-service UX earlier or adding `d3-force` or WebCola alongside. **Reject it if** readability regresses on real data, whatever the synthetic numbers said.
+**Accept dagre if** it matches `dot` on readability at those sizes and is no slower, **and** a plan exists for the 500-to-1,200 band that `sfdp` covers today: either starting the focal-service UX earlier or adding `d3-force` or WebCola alongside. **Reject it if** readability regresses on real data, whatever the synthetic numbers said.
 
-Do not gate this on 5,000 or 25,000 nodes. Neither engine reaches that: `dot` did not finish 1,200 nodes in two minutes and dagre exhausted a 4 GB heap at 5,000. That size is the poster case, and the product's answer to it is a focal neighbourhood, not a faster layout library.
+Do not gate this on 5,000 or 25,000 nodes. Neither engine reaches that: `dot` did not finish 1,200 nodes on realistic topologies within 150 seconds and dagre exhausted a 4 GB heap at 5,000 on dense graphs. That size is the poster case, and the product's answer to it is a focal neighbourhood, not a faster layout library.
 
 ---
 

--- a/scripts/rfc0008-bench.js
+++ b/scripts/rfc0008-bench.js
@@ -200,11 +200,25 @@ function requireDagre() {
   }
 }
 
+// Smallest n each generator can honour. genDense places a spanning tree first and
+// then wants 0.6n more acyclic edges, so below 3 it asks for an edge that cannot
+// exist and its retry loop never ends. genRealistic reserves 3 hubs and 1 gateway
+// before the middle layers, so below 5 it walks past the end of its own node array.
+const MIN_N = { dense: 3, layered: 5, realistic: 5 };
+
+const USAGE = 'usage: node scripts/rfc0008-bench.js <dense|layered|realistic> <n> <dot|dagre> [seed]';
+
 async function main() {
   const [topology, nStr, engine, seedStr] = process.argv.slice(2);
-  const n = parseInt(nStr, 10);
-  if (!['dense', 'layered', 'realistic'].includes(topology) || !n || !['dot', 'dagre'].includes(engine)) {
-    console.error('usage: node scripts/rfc0008-bench.js <dense|layered|realistic> <n> <dot|dagre> [seed]');
+  const n = Number(nStr);
+  if (!['dense', 'layered', 'realistic'].includes(topology) || !['dot', 'dagre'].includes(engine)) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+  if (!Number.isInteger(n) || n < MIN_N[topology]) {
+    console.error(
+      `${USAGE}\n  n must be a whole number and at least ${MIN_N[topology]} for the ${topology} topology`
+    );
     process.exit(2);
   }
   const seed = parseInt(seedStr || '42', 10);

--- a/scripts/rfc0008-bench.js
+++ b/scripts/rfc0008-bench.js
@@ -1,0 +1,329 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Layout benchmark harness behind the timing table in
+// docs/rfc/0008-graph-visualization-stack.md (Decision 1).
+//
+// One measurement per invocation:
+//   node scripts/rfc0008-bench.js <topology> <n> <engine> [seed]
+//     topology: dense | layered | realistic
+//     engine:   dot | dagre
+//     seed:     integer, default 42 (the RFC table uses 42, plus 7 and 99
+//               for the multi-seed rows)
+// Prints one JSON line with per-run wall-clock layout times and the median.
+//
+// Env vars:
+//   RUNS=<k>  timed runs per invocation (default 3; the RFC's n=1200 rows
+//             and extra-seed rows use RUNS=1)
+//   STATS=1   skip timing and print topology statistics instead (edge count,
+//             max in-degree, rank count and widths under longest-path
+//             layering), for recording graph shape alongside timings
+//
+// Graph generation is seeded (mulberry32), so every graph is reproducible
+// from (topology, n, seed); the STATS output for a given triple must not
+// change across machines.
+//
+// The dot path mirrors plexus getLayout.ts: build the same DOT string
+// toDot.tsx produces with DAG.tsx's production options (nodesep=1.5,
+// rankdir=TB, ranksep=1.6, splines=polyline, node [shape=box,
+// fixedsize=true]), then viz.renderString(dot, { engine: 'dot',
+// format: 'plain' }). @viz-js/viz resolves from packages/plexus, so the
+// benchmark always runs against the version the repo actually pins.
+//
+// The dagre path uses the same node sizes and equivalent separations in px.
+// @dagrejs/dagre is deliberately not a repo dependency; to run that engine,
+// install it without saving (for example `pnpm add -w @dagrejs/dagre@3.1.1`
+// and discard the package.json change, or set NODE_PATH to any directory
+// that contains it). The RFC table was measured with @dagrejs/dagre 3.1.1.
+
+import { createRequire } from 'module';
+import path from 'path';
+
+// @viz-js/viz is a plexus dependency and pnpm keeps it out of the root
+// node_modules, so resolve it (and, if installed there, dagre) from
+// packages/plexus. localRequire is the fallback for a root-level or
+// NODE_PATH install of dagre.
+const plexusRequire = createRequire(
+  path.join(import.meta.dirname, '..', 'packages', 'plexus', 'package.json')
+);
+const localRequire = createRequire(import.meta.url);
+
+const NODE_W_IN = 0.83; // 60px circle-ish node at 72dpi, same for both engines
+const NODE_H_IN = 0.83;
+
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// RFC replication: "dense random graphs (with ~60% extra edges)".
+// Spanning tree over shuffled order + 60% * n extra random forward edges.
+function genDense(n, rnd) {
+  const edges = [];
+  const seen = new Set();
+  for (let i = 1; i < n; i++) {
+    const parent = Math.floor(rnd() * i);
+    edges.push([parent, i]);
+    seen.add(parent + '>' + i);
+  }
+  const extra = Math.floor(0.6 * n);
+  let added = 0;
+  while (added < extra) {
+    const a = Math.floor(rnd() * n);
+    const b = Math.floor(rnd() * n);
+    if (a === b) continue;
+    const [from, to] = a < b ? [a, b] : [b, a]; // keep acyclic
+    const key = from + '>' + to;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push([from, to]);
+    added++;
+  }
+  return edges;
+}
+
+// Realistic service-dependency topology:
+// - fixed shallow depth (7 layers: gateway -> 5 service tiers -> infra)
+// - calls go to the next layer (mostly) or skip one layer (sometimes)
+// - ~5% of nodes are shared-infra hubs (db/cache/queue) with high fan-in
+// - avg out-degree ~2.2, matching published microservice-graph shapes
+// hubProb=0 gives the 'layered' variant: same shape minus shared-infra fan-in,
+// to isolate what the hub edges cost.
+function genRealistic(n, rnd, hubProb = 0.4) {
+  const LAYERS = 7;
+  const nHubs = Math.max(3, Math.floor(n * 0.05));
+  const nGateways = Math.max(1, Math.floor(n * 0.01));
+  const nMid = n - nHubs - nGateways;
+  const layerOf = Array.from({ length: n });
+  let idx = 0;
+  const gateways = [];
+  for (let i = 0; i < nGateways; i++, idx++) {
+    layerOf[idx] = 0;
+    gateways.push(idx);
+  }
+  const midLayers = LAYERS - 2; // layers 1..LAYERS-2
+  const perLayer = Math.ceil(nMid / midLayers);
+  const layers = Array.from({ length: LAYERS }, () => []);
+  gateways.forEach(g => layers[0].push(g));
+  for (let i = 0; i < nMid; i++, idx++) {
+    const layer = 1 + Math.min(midLayers - 1, Math.floor(i / perLayer));
+    layerOf[idx] = layer;
+    layers[layer].push(idx);
+  }
+  const hubs = [];
+  for (let i = 0; i < nHubs; i++, idx++) {
+    layerOf[idx] = LAYERS - 1;
+    layers[LAYERS - 1].push(idx);
+    hubs.push(idx);
+  }
+
+  const edges = [];
+  const seen = new Set();
+  const addEdge = (a, b) => {
+    const key = a + '>' + b;
+    if (a !== b && !seen.has(key)) {
+      seen.add(key);
+      edges.push([a, b]);
+    }
+  };
+  const pick = arr => arr[Math.floor(rnd() * arr.length)];
+
+  for (let v = 0; v < n; v++) {
+    const layer = layerOf[v];
+    if (layer >= LAYERS - 1) continue; // hubs call nothing
+    // 1-4 downstream calls, skewed low: 40% one, 35% two, 20% three, 5% four
+    const r = rnd();
+    const fanout = r < 0.4 ? 1 : r < 0.75 ? 2 : r < 0.95 ? 3 : 4;
+    for (let k = 0; k < fanout; k++) {
+      // 80% next layer, 20% skip one layer
+      const target = Math.min(LAYERS - 2, layer + (rnd() < 0.8 ? 1 : 2));
+      if (layers[target].length) addEdge(v, pick(layers[target]));
+    }
+    // 40% of services also touch a shared-infra hub
+    if (layer > 0 && rnd() < hubProb) addEdge(v, pick(hubs));
+  }
+  // make sure every non-gateway node is reachable: parent from previous layer
+  for (let v = 0; v < n; v++) {
+    const layer = layerOf[v];
+    if (layer === 0) continue;
+    const hasIn = edges.some(([, b]) => b === v);
+    if (!hasIn) {
+      const prev = layers[layer - 1].length ? layers[layer - 1] : layers[0];
+      addEdge(pick(prev), v);
+    }
+  }
+  return edges;
+}
+
+// Exact shape toDot.tsx emits for DAG.tsx's dot config.
+function toDot(n, edges) {
+  const lines = [];
+  lines.push('digraph G {');
+  lines.push('  graph[nodesep=1.500, rankdir=TB, ranksep=1.600, sep=0.500, splines=polyline];');
+  lines.push('  node [shape=box, fixedsize=true, label="", color="_", fillcolor="_"];');
+  lines.push('  edge [arrowhead=none, arrowtail=none];');
+  for (let v = 0; v < n; v++) {
+    lines.push(`  "${v}" [height=${NODE_H_IN.toFixed(5)},width=${NODE_W_IN.toFixed(5)}];`);
+  }
+  const fromTo = new Map();
+  for (const [a, b] of edges) {
+    if (!fromTo.has(a)) fromTo.set(a, []);
+    fromTo.get(a).push(b);
+  }
+  for (const [from, tails] of fromTo) {
+    lines.push(`  "${from}"->{ ${tails.map(t => `"${t}"`).join(' ')} };`);
+  }
+  lines.push('}');
+  return lines.join('\n');
+}
+
+function requireDagre() {
+  try {
+    return plexusRequire('@dagrejs/dagre');
+  } catch {
+    try {
+      return localRequire('@dagrejs/dagre');
+    } catch (e2) {
+      throw new Error(
+        '@dagrejs/dagre is not installed (it is intentionally not a repo dependency). ' +
+          'Install it without saving, e.g. `pnpm add -w @dagrejs/dagre@3.1.1` and discard ' +
+          'the package.json change, or set NODE_PATH to a directory containing it.',
+        { cause: e2 }
+      );
+    }
+  }
+}
+
+async function main() {
+  const [topology, nStr, engine, seedStr] = process.argv.slice(2);
+  const n = parseInt(nStr, 10);
+  if (!['dense', 'layered', 'realistic'].includes(topology) || !n || !['dot', 'dagre'].includes(engine)) {
+    console.error('usage: node scripts/rfc0008-bench.js <dense|layered|realistic> <n> <dot|dagre> [seed]');
+    process.exit(2);
+  }
+  const seed = parseInt(seedStr || '42', 10);
+  const rnd = mulberry32(seed);
+  const edges =
+    topology === 'dense'
+      ? genDense(n, rnd)
+      : topology === 'layered'
+        ? genRealistic(n, rnd, 0)
+        : genRealistic(n, rnd);
+  if (process.env.STATS) {
+    const inDeg = {};
+    for (const [, b] of edges) inDeg[b] = (inDeg[b] || 0) + 1;
+    const degs = Object.values(inDeg).sort((x, y) => y - x);
+    // longest-path layering: rank(v) = longest path from any source, an
+    // approximation of the rank structure both engines must order
+    const rank = Array.from({ length: n }, () => 0);
+    const adj = Array.from({ length: n }, () => []);
+    const indegCnt = Array.from({ length: n }, () => 0);
+    for (const [a, b] of edges) {
+      adj[a].push(b);
+      indegCnt[b]++;
+    }
+    const q = [];
+    for (let v = 0; v < n; v++) if (indegCnt[v] === 0) q.push(v);
+    while (q.length) {
+      const v = q.shift();
+      for (const w of adj[v]) {
+        if (rank[v] + 1 > rank[w]) rank[w] = rank[v] + 1;
+        if (--indegCnt[w] === 0) q.push(w);
+      }
+    }
+    const nRanks = Math.max(...rank) + 1;
+    const widths = Array.from({ length: nRanks }, () => 0);
+    for (let v = 0; v < n; v++) widths[rank[v]]++;
+    console.log(
+      JSON.stringify({
+        topology,
+        n,
+        edges: edges.length,
+        maxInDeg: degs[0],
+        ranks: nRanks,
+        maxRankWidth: Math.max(...widths),
+        meanRankWidth: Math.round(n / nRanks),
+      })
+    );
+    return;
+  }
+
+  // Warm up each engine on a tiny graph first (JIT/WASM warmup excluded from
+  // timing), then take the measured runs and report all plus the median.
+  const RUNS = parseInt(process.env.RUNS || '3', 10);
+  const runsMs = [];
+  if (engine === 'dot') {
+    const { instance } = plexusRequire('@viz-js/viz');
+    const viz = await instance(); // one-time init, excluded from timing
+    viz.renderString(
+      toDot(5, [
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ]),
+      { engine: 'dot', format: 'plain' }
+    );
+    const dot = toDot(n, edges);
+    for (let i = 0; i < RUNS; i++) {
+      const t0 = process.hrtime.bigint();
+      const out = viz.renderString(dot, { engine: 'dot', format: 'plain' });
+      const t1 = process.hrtime.bigint();
+      runsMs.push(Number(t1 - t0) / 1e6);
+      if (!out.startsWith('graph ')) throw new Error('unexpected plain output');
+    }
+  } else {
+    const dagre = requireDagre();
+    const build = es => {
+      const g = new dagre.graphlib.Graph();
+      g.setGraph({ rankdir: 'TB', nodesep: 1.5 * 72, ranksep: 1.6 * 72 });
+      g.setDefaultEdgeLabel(() => ({}));
+      const nn = Math.max(...es.flat()) + 1;
+      for (let v = 0; v < nn; v++) {
+        g.setNode(String(v), { width: NODE_W_IN * 72, height: NODE_H_IN * 72 });
+      }
+      for (const [a, b] of es) g.setEdge(String(a), String(b));
+      return g;
+    };
+    dagre.layout(
+      build([
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ])
+    ); // warmup
+    for (let i = 0; i < RUNS; i++) {
+      const g = build(edges);
+      const t0 = process.hrtime.bigint();
+      dagre.layout(g);
+      const t1 = process.hrtime.bigint();
+      runsMs.push(Number(t1 - t0) / 1e6);
+      const n0 = g.node('0');
+      if (typeof n0.x !== 'number') throw new Error('dagre produced no coordinates');
+    }
+  }
+  const sorted = [...runsMs].sort((a, b) => a - b);
+  console.log(
+    JSON.stringify({
+      topology,
+      n,
+      engine,
+      seed,
+      edges: edges.length,
+      runs: runsMs.map(m => Math.round(m)),
+      medianMs: Math.round(sorted[Math.floor(RUNS / 2)]),
+    })
+  );
+}
+
+main().catch(e => {
+  console.error(e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Opening this follow-up to RFC 0008 (#3972) per Yuri's suggestion after I posted benchmark results on that thread.

The RFC's dagre vs dot table came from dense random graphs and the text flags it as order-of-magnitude only. I reran the comparison with a seeded harness that mirrors what plexus `getLayout.ts` actually does (same dot options `DAG.tsx` uses: `nodesep 1.5, rankdir TB, ranksep 1.6, splines polyline`, viz `renderString` with plain output), dagre given the same node sizes and separations, warmup plus median of 3 runs, at 200/500/1200 nodes, across three topology shapes: the RFC's dense random generator, a sparse layered service shape, and the same shape with shared-infra hubs.

The headline: topology shape moves layout cost by 20-80x at a fixed node count and flips which engine is faster. `dot` wins the dense shape, `dagre` wins the sparse layered ones, and both are unusable at 500 nodes on realistic shapes. That does not weaken the RFC's conclusions, it makes the focal-neighborhood and fallback design more necessary, so the recommendations are untouched.

What this changes in the doc:
- The timing table is replaced with the measured one and the harness is described so the numbers are reproducible.
- Spike 3 gets an extra acceptance step: record topology stats (node and edge counts, out-degree distribution, hub fan-in) from real exported data, since shape dominates cost.
- The viz version reference is corrected from 3.29.0 to 3.28.0, which is what package.json and the lockfile pin.

| Topology | Nodes (n) | Edges | Graphviz `dot` (viz WASM 3.28.0) | `@dagrejs/dagre` 3.1.1 |
|---|---|---|---|---|
| Dense random (spanning tree + 0.6n extra forward edges) | 200 | 319 | 77 ms | 458 ms |
| Dense random | 500 | 799 | 483 ms | 3,390 ms |
| Dense random | 1,200 | 1,919 | 4,543 ms | 59,688 ms |
| Layered sparse (7-layer service DAG) | 500 | 1,062 | 9,302 ms | 7,042 ms |
| Layered sparse | 1,200 | 2,545 | did not finish (150 s timeout) | 55.4 s |
| Layered + shared-infra hubs ("realistic" microservices) | 200 | 488 | 667 ms | 1,163 ms |
| Layered + shared-infra hubs | 500 | 1,234 | 37,576 ms | 10,179 ms |
| Layered + shared-infra hubs | 1,200 | 2,915 | did not finish (150 s timeout) | 63.7 s |

Seed sensitivity was checked on the realistic shape (seeds 42, 7, 99) and the ranking holds.
