### PR TITLE
fix(dag): add default lookback to View Traces URL to prevent 400 error

### DIFF
--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.test.jsx
@@ -466,14 +466,14 @@ describe('handleViewTraces', () => {
 
     handleViewTraces(hoveredNode);
 
-    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: 'test-service' });
+    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: 'test-service', lookback: '1h' });
     expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
   });
 
   it('should handle null node gracefully', () => {
     handleViewTraces(null);
 
-    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: undefined });
+    expect(getSearchUrlSpy).toHaveBeenCalledWith({ service: undefined, lookback: '1h' });
     expect(windowOpenSpy).toHaveBeenCalledWith('http://test-url', '_blank');
   });
 });

--- a/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
+++ b/packages/jaeger-ui/src/components/DependencyGraph/DAG.tsx
@@ -58,7 +58,7 @@ export const renderNode = (
 };
 
 export const handleViewTraces = (hoveredNode: TVertex | null) => {
-  window.open(getSearchUrl({ service: hoveredNode?.key }), '_blank');
+  window.open(getSearchUrl({ service: hoveredNode?.key, lookback: '1h' }), '_blank');
 };
 
 export const createHandleNodeClick =


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #4148

When clicking **View traces** on a service node in the System Architecture DAG view, the search URL was built with only the `service` query param and no time range. The v3 API requires `start_time_min` and `start_time_max`, so the request failed with a **400 Bad Request** error.

## Description of the changes

In `handleViewTraces` inside `DAG.tsx`, pass `lookback: '1h'` alongside the service name when calling `getSearchUrl`. `SearchTracePage` already has logic in `searchQueryFromUrl` to derive concrete `start`/`end` timestamps from a `lookback` value, so this one-line change is all that is needed.

## How was this change tested?

Updated the two existing `handleViewTraces` unit tests in `DAG.test.jsx` to assert that `lookback: '1h'` is included in the params passed to `getSearchUrl`. All 69 tests in the DependencyGraph suite pass.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
