### PR TITLE
Remove dead hoverIndentGuideIds Redux state

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetailRow.integration.test.jsx
@@ -20,11 +20,9 @@ vi.mock('./SpanDetail', () => ({
   default: () => <div data-testid="mocked-span-detail" />,
 }));
 
-// Minimal Redux store for SpanTreeOffset's connected component
+// Minimal Redux store for integration test
 const mockStore = createStore(() => ({
-  traceTimeline: {
-    hoverIndentGuideIds: new Set(),
-  },
+  traceTimeline: {},
 }));
 
 describe('<SpanDetailRow> icon behavior', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -1,11 +1,8 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
+import { UnconnectedSpanTreeOffset } from './SpanTreeOffset';
 vi.mock('../../../utils/span-ancestor-ids');
 
 describe('SpanTreeOffset', () => {
@@ -44,9 +41,6 @@ describe('SpanTreeOffset', () => {
     parentSpan.childSpans = [ownSpan];
 
     props = {
-      addHoverIndentGuideId: jest.fn(),
-      hoverIndentGuideIds: new Set(),
-      removeHoverIndentGuideId: jest.fn(),
       color: '#000000',
       span: ownSpan,
     };
@@ -66,52 +60,6 @@ describe('SpanTreeOffset', () => {
       expect(indentGuides.length).toBe(2); // rootSpan and parentSpan
       expect(indentGuides[0].getAttribute('data-ancestor-id')).toBe(rootSpanID);
       expect(indentGuides[1].getAttribute('data-ancestor-id')).toBe(parentSpanID);
-    });
-
-    it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      fireEvent.mouseEnter(indentGuide, {});
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
-    });
-
-    it('does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
-
-      const event = new MouseEvent('mouseenter', {
-        bubbles: true,
-        relatedTarget,
-      });
-      fireEvent(indentGuide, event);
-
-      expect(props.addHoverIndentGuideId).not.toHaveBeenCalled();
-    });
-
-    it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      fireEvent.mouseLeave(indentGuide, {});
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
-    });
-
-    it('does not call props.removeHoverIndentGuideId on mouse leave if mouse leaves to a indentGuide with the same ancestorId', () => {
-      const { container } = render(<UnconnectedSpanTreeOffset {...props} />);
-      const indentGuide = container.querySelector(`[data-ancestor-id="${parentSpanID}"]`);
-      const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
-
-      const event = new MouseEvent('mouseleave', {
-        bubbles: true,
-        relatedTarget,
-      });
-      fireEvent(indentGuide, event);
-
-      expect(props.removeHoverIndentGuideId).not.toHaveBeenCalled();
     });
 
     describe('is-last class (last-child span)', () => {
@@ -257,22 +205,6 @@ describe('SpanTreeOffset', () => {
       expect(container.querySelector('.SpanTreeOffset--iconWrapper')).not.toBeNull();
     });
 
-    it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      const { container } = renderResult;
-      const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
-      fireEvent.mouseEnter(iconWrapper, {});
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
-    });
-
-    it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      const { container } = renderResult;
-      const iconWrapper = container.querySelector('.SpanTreeOffset--iconWrapper');
-      fireEvent.mouseLeave(iconWrapper, {});
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
-      expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
-    });
-
     it('calls onClick when Enter is pressed on the span wrapper', () => {
       const onClick = jest.fn();
       const { container } = render(
@@ -312,29 +244,5 @@ describe('SpanTreeOffset', () => {
       expect(wrapper).toHaveAttribute('tabindex', '0');
     });
   });
-
-  describe('mapDispatchToProps()', () => {
-    it('creates the actions correctly', () => {
-      expect(mapDispatchToProps(() => {})).toEqual({
-        addHoverIndentGuideId: expect.any(Function),
-        removeHoverIndentGuideId: expect.any(Function),
-      });
-    });
-  });
-
-  describe('mapStateToProps()', () => {
-    it('maps state to props correctly', () => {
-      const hoverIndentGuideIds = new Set([parentSpanID]);
-      const state = {
-        traceTimeline: {
-          hoverIndentGuideIds,
-        },
-      };
-      const mappedProps = mapStateToProps(state);
-      expect(mappedProps).toEqual({
-        hoverIndentGuideIds,
-      });
-      expect(mappedProps.hoverIndentGuideIds).toBe(hoverIndentGuideIds);
-    });
-  });
 });
+

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -3,26 +3,13 @@
 
 import React, { useMemo } from 'react';
 import cx from 'classnames';
-import _get from 'lodash/get';
-import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
 
-import { actions } from './duck';
-import { ReduxState } from '../../../types';
 import { IOtelSpan } from '../../../types/otel';
 import colorGenerator from '../../../utils/color-generator';
 
 import './SpanTreeOffset.css';
 
-type TDispatchProps = {
-  addHoverIndentGuideId: (spanID: string) => void;
-  removeHoverIndentGuideId: (spanID: string) => void;
-};
-
 type TProps = {
-  addHoverIndentGuideId: (spanID: string) => void;
-  hoverIndentGuideIds: Set<string>;
-  removeHoverIndentGuideId: (spanID: string) => void;
   childrenVisible?: boolean;
   onClick?: () => void;
   showChildrenIcon?: boolean;
@@ -31,14 +18,12 @@ type TProps = {
   color: string;
 };
 
-export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
+export const SpanTreeOffset: React.FC<TProps> = ({
   childrenVisible = false,
   onClick = undefined,
   showChildrenIcon = true,
   isDetailRow = false,
   span,
-  addHoverIndentGuideId,
-  removeHoverIndentGuideId,
   color,
 }) => {
   // Build ancestor chain directly from span.parentSpan
@@ -51,40 +36,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     }
     return chain;
   }, [span]);
-
-  /**
-   * If the mouse leaves to anywhere except another span with the same ancestor id, this span's ancestor id is
-   * removed from the set of hoverIndentGuideIds.
-   *
-   * @param {Object} event - React Synthetic event tied to mouseleave. Includes the related target which is
-   *     the element the user is now hovering.
-   * @param {string} ancestorId - The span id that the user was hovering over.
-   */
-  const handleMouseLeave = (event: React.MouseEvent<HTMLSpanElement>, ancestorId: string) => {
-    if (
-      !(event.relatedTarget instanceof HTMLSpanElement) ||
-      _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
-    ) {
-      removeHoverIndentGuideId(ancestorId);
-    }
-  };
-
-  /**
-   * If the mouse entered this span from anywhere except another span with the same ancestor id, this span's
-   * ancestorId is added to the set of hoverIndentGuideIds.
-   *
-   * @param {Object} event - React Synthetic event tied to mouseenter. Includes the related target which is
-   *     the last element the user was hovering.
-   * @param {string} ancestorId - The span id that the user is now hovering over.
-   */
-  const handleMouseEnter = (event: React.MouseEvent<HTMLSpanElement>, ancestorId: string) => {
-    if (
-      !(event.relatedTarget instanceof HTMLSpanElement) ||
-      _get(event, 'relatedTarget.dataset.ancestorId') !== ancestorId
-    ) {
-      addHoverIndentGuideId(ancestorId);
-    }
-  };
 
   const { hasChildren, spanID, childSpans } = span;
   const _childrenToggleKeyDown = (e: React.KeyboardEvent) => {
@@ -157,8 +108,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
             }}
             data-ancestor-id={ancestor.spanID}
             data-testid={`indent-guide-${ancestor.spanID}`}
-            onMouseEnter={event => handleMouseEnter(event, ancestor.spanID)}
-            onMouseLeave={event => handleMouseLeave(event, ancestor.spanID)}
           >
             {isLastAncestor && !isDetailRow && (
               <span
@@ -178,8 +127,6 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
             'is-collapsed': !childrenVisible,
           })}
           data-testid="icon-wrapper"
-          onMouseEnter={event => handleMouseEnter(event, spanID)}
-          onMouseLeave={event => handleMouseLeave(event, spanID)}
         >
           {hasChildren ? (
             <span
@@ -206,14 +153,7 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   );
 };
 
-export function mapStateToProps(state: ReduxState): { hoverIndentGuideIds: Set<string> } {
-  const { hoverIndentGuideIds } = state.traceTimeline;
-  return { hoverIndentGuideIds };
-}
+export const UnconnectedSpanTreeOffset = SpanTreeOffset;
 
-export function mapDispatchToProps(dispatch: Dispatch<ReduxState>): TDispatchProps {
-  const { addHoverIndentGuideId, removeHoverIndentGuideId } = bindActionCreators(actions, dispatch);
-  return { addHoverIndentGuideId, removeHoverIndentGuideId };
-}
+export default SpanTreeOffset;
 
-export default connect(mapStateToProps, mapDispatchToProps)(UnconnectedSpanTreeOffset);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import cx from 'classnames';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import _isEqual from 'lodash/isEqual';
 
 import memoizeOne from 'memoize-one';
@@ -563,7 +563,7 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
 
 /**
  * Functional wrapper that reads Zustand (ephemeral timeline state + layout prefs) and the
- * remaining Redux slice (hoverIndentGuideIds, uiFind), creates dual-write action handlers
+ * remaining Redux slice (uiFind), creates dual-write action handlers
  * (Redux dispatch first so the tracking middleware sees the pre-update state, then Zustand),
  * and passes everything into the class component.
  */
@@ -577,7 +577,6 @@ function VirtualizedTraceViewWrapper(
 ) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const dispatch = useDispatch<any>();
-  const hoverIndentGuideIds = useSelector((state: ReduxState) => state.traceTimeline.hoverIndentGuideIds);
   const uiFind = parseUiFind(ownProps.search ?? ownProps.location.search ?? '');
 
   const spanNameColumnWidth = useLayoutPrefsStore(s => s.spanNameColumnWidth);
@@ -699,7 +698,6 @@ function VirtualizedTraceViewWrapper(
 
   const combinedProps: VirtualizedTraceViewProps = {
     ...ownProps,
-    hoverIndentGuideIds,
     uiFind,
     spanNameColumnWidth,
     sidePanelWidth,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.test.js
@@ -762,47 +762,6 @@ describe('TraceTimelineViewer/duck', () => {
     });
   });
 
-  describe('hoverIndentGuideIds', () => {
-    const existingSpanId = 'existingSpanId';
-    const newSpanId = 'newSpanId';
-
-    it('the initial state has an empty set of hoverIndentGuideIds', () => {
-      const state = store.getState();
-      expect(state.hoverIndentGuideIds).toEqual(new Set());
-    });
-
-    it('adds a spanID to an initial state', () => {
-      const action = actions.addHoverIndentGuideId(newSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set([newSpanId]));
-    });
-
-    it('adds a spanID to a populated state', () => {
-      store = createStore(reducer, {
-        hoverIndentGuideIds: new Set([existingSpanId]),
-      });
-      const action = actions.addHoverIndentGuideId(newSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set([existingSpanId, newSpanId]));
-    });
-
-    it('should not error when removing a spanID from an initial state', () => {
-      const action = actions.removeHoverIndentGuideId(newSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set());
-    });
-
-    it('remove a spanID from a populated state', () => {
-      const secondExistingSpanId = 'secondExistingSpanId';
-      store = createStore(reducer, {
-        hoverIndentGuideIds: new Set([existingSpanId, secondExistingSpanId]),
-      });
-      const action = actions.removeHoverIndentGuideId(existingSpanId);
-      store.dispatch(action);
-      expect(store.getState().hoverIndentGuideIds).toEqual(new Set([secondExistingSpanId]));
-    });
-  });
-
   describe('getSelectedSpanID', () => {
     it('returns null when detailStates is empty', () => {
       expect(getSelectedSpanID(new Map())).toBeNull();

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
@@ -112,7 +112,6 @@ export function newInitialState(): TTraceTimeline {
     childrenHiddenIDs: new Set(),
     detailStates: new Map(),
     detailPanelMode,
-    hoverIndentGuideIds: new Set(),
     shouldScrollToFirstUiFindMatch: false,
     sidePanelWidth,
     spanNameColumnWidth,
@@ -122,7 +121,6 @@ export function newInitialState(): TTraceTimeline {
 }
 
 export const actionTypes = generateActionTypes('@jaeger-ui/trace-timeline-viewer', [
-  'ADD_HOVER_INDENT_GUIDE_ID',
   'CHILDREN_TOGGLE',
   'CLEAR_SHOULD_SCROLL_TO_FIRST_UI_FIND_MATCH',
   'COLLAPSE_ALL',
@@ -137,7 +135,6 @@ export const actionTypes = generateActionTypes('@jaeger-ui/trace-timeline-viewer
   'EXPAND_ALL',
   'EXPAND_ONE',
   'FOCUS_UI_FIND_MATCHES',
-  'REMOVE_HOVER_INDENT_GUIDE_ID',
   'SET_DETAIL_PANEL_MODE',
   'SET_SIDE_PANEL_WIDTH',
   'SET_SPAN_NAME_COLUMN_WIDTH',
@@ -146,7 +143,6 @@ export const actionTypes = generateActionTypes('@jaeger-ui/trace-timeline-viewer
 ]);
 
 const fullActions = createActions<TActionTypes>({
-  [actionTypes.ADD_HOVER_INDENT_GUIDE_ID]: (spanID: string) => ({ spanID }),
   [actionTypes.CHILDREN_TOGGLE]: (spanID: string) => ({ spanID }),
   [actionTypes.CLEAR_SHOULD_SCROLL_TO_FIRST_UI_FIND_MATCH]: () => ({}),
   [actionTypes.COLLAPSE_ALL]: (spans: IOtelSpan[]) => ({ spans }),
@@ -165,7 +161,6 @@ const fullActions = createActions<TActionTypes>({
     uiFind,
     allowHide,
   }),
-  [actionTypes.REMOVE_HOVER_INDENT_GUIDE_ID]: (spanID: string) => ({ spanID }),
   [actionTypes.SET_DETAIL_PANEL_MODE]: (mode: 'inline' | 'sidepanel') => ({ mode }),
   [actionTypes.SET_SIDE_PANEL_WIDTH]: (width: number) => ({ width }),
   [actionTypes.SET_SPAN_NAME_COLUMN_WIDTH]: (width: number) => ({ width }),
@@ -413,23 +408,8 @@ function detailLogItemToggle(state: TTraceTimeline, { spanID, logItem }: TSpanId
   return { ...state, detailStates };
 }
 
-function addHoverIndentGuideId(state: TTraceTimeline, { spanID }: TSpanIdValue) {
-  const newHoverIndentGuideIds = new Set(state.hoverIndentGuideIds);
-  newHoverIndentGuideIds.add(spanID);
-
-  return { ...state, hoverIndentGuideIds: newHoverIndentGuideIds };
-}
-
-function removeHoverIndentGuideId(state: TTraceTimeline, { spanID }: TSpanIdValue) {
-  const newHoverIndentGuideIds = new Set(state.hoverIndentGuideIds);
-  newHoverIndentGuideIds.delete(spanID);
-
-  return { ...state, hoverIndentGuideIds: newHoverIndentGuideIds };
-}
-
 export default handleActions<TTraceTimeline, any>(
   {
-    [actionTypes.ADD_HOVER_INDENT_GUIDE_ID]: guardReducer(addHoverIndentGuideId),
     [actionTypes.CHILDREN_TOGGLE]: guardReducer(childrenToggle),
     [actionTypes.CLEAR_SHOULD_SCROLL_TO_FIRST_UI_FIND_MATCH]: guardReducer(
       clearShouldScrollToFirstUiFindMatch
@@ -446,7 +426,6 @@ export default handleActions<TTraceTimeline, any>(
     [actionTypes.EXPAND_ALL]: guardReducer(expandAll),
     [actionTypes.EXPAND_ONE]: guardReducer(expandOne),
     [actionTypes.FOCUS_UI_FIND_MATCHES]: guardReducer(focusUiFindMatches),
-    [actionTypes.REMOVE_HOVER_INDENT_GUIDE_ID]: guardReducer(removeHoverIndentGuideId),
     [actionTypes.SET_DETAIL_PANEL_MODE]: guardReducer(setDetailPanelMode),
     [actionTypes.SET_SIDE_PANEL_WIDTH]: guardReducer(setSidePanelWidth),
     [actionTypes.SET_SPAN_NAME_COLUMN_WIDTH]: guardReducer(setColumnWidth),

--- a/packages/jaeger-ui/src/types/TTraceTimeline.ts
+++ b/packages/jaeger-ui/src/types/TTraceTimeline.ts
@@ -9,7 +9,6 @@ type TTraceTimeline = {
   childrenHiddenIDs: Set<string>;
   detailStates: Map<string, DetailState>;
   detailPanelMode: SpanDetailPanelMode;
-  hoverIndentGuideIds: Set<string>;
   shouldScrollToFirstUiFindMatch: boolean;
   sidePanelWidth: number;
   spanNameColumnWidth: number;


### PR DESCRIPTION
## Description
Resolves #4328

Hovering an indent guide in the trace timeline previously dispatched Redux actions that updated `hoverIndentGuideIds`, but no UI component read or rendered from that state since #3302 removed the CSS classes and styles.

This PR removes the dead Redux state, actions, reducers, `useSelector`, `connect()`, and mouse event handlers. This eliminates unnecessary Redux dispatches, `Set` allocations, and re-renders on mouse movement across indent guides.

## Checklist
- [x] Signed commit (`git commit -s`)
- [x] All tests passing (`pnpm test`)
- [x] Lint & type checks passing (`pnpm run lint`)
