### PR TITLE
fix(timeline): Use single shouldDisableCollapse implementation

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/duck.ts
@@ -22,6 +22,7 @@ import {
   MIN_TIMELINE_COLUMN_WIDTH,
 } from './store.constants';
 import { getMaxNameColumnWidth } from './store.layout';
+import { shouldDisableCollapse } from './timeline-utils';
 
 // payloads
 export type TSpanIdLogValue = { logItem: IEvent; spanID: string };
@@ -44,11 +45,6 @@ type TActionTypes =
 type TTimelineViewerActions = {
   [actionName: string]: ActionFunctionAny<Action<TActionTypes>>;
 };
-
-function shouldDisableCollapse(allSpans: IOtelSpan[], hiddenSpansIds: Set<string>) {
-  const allParentSpans = allSpans.filter(s => s.hasChildren);
-  return allParentSpans.length === hiddenSpansIds.size;
-}
 
 export function newInitialState(): TTraceTimeline {
   const { traceTimeline } = getConfig();


### PR DESCRIPTION
## Description

Remove the duplicate `shouldDisableCollapse` from `duck.ts` and import the correct one from `timeline-utils.ts`.

The `duck.ts` version used count equality:
```ts
allParentSpans.length === hiddenSpansIds.size
```

The `timeline-utils.ts` version uses set membership:
```ts
allSpans.filter(s => s.hasChildren).every(p => hiddenSpansIds.has(p.spanID))
```

These are semantically different if non-parent span IDs ever enter the hidden set. During the dual-write migration this is a latent divergence bug.

## Fix

- Deleted the local `shouldDisableCollapse` function from `duck.ts`
- Added import from `./timeline-utils`

## Testing

TypeScript compiles cleanly. The existing duck.test.js collapse/expand tests cover this behavior.

Fixes #4329