### PR TITLE
feat(span-detail): Add attribute search/filter in AttributesTable

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.css
@@ -65,3 +65,33 @@ SPDX-License-Identifier: Apache-2.0
 .KeyValueTable--valueColumn-full {
   width: auto;
 }
+
+.KeyValueTable--filterRow {
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+}
+
+.KeyValueTable--filter {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  font-size: 12px;
+  outline: none;
+  background: var(--surface-primary);
+  color: var(--text-primary);
+}
+
+.KeyValueTable--filter:focus {
+  border-color: var(--color-secondary);
+}
+
+.KeyValueTable--filterCount {
+  margin-left: 8px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import AttributesTable, { LinkValue } from './AttributesTable';
@@ -255,5 +255,54 @@ describe('<AttributesTable>', () => {
         expect(copyIcon).toHaveAttribute('data-tooltip-title', 'Copy JSON');
       }
     });
+  });
+
+  it('does not show filter input when data has 10 or fewer entries', () => {
+    render(<AttributesTable data={makeAttributes(data)} />);
+    const filterInput = screen.queryByLabelText('Filter span attributes');
+    expect(filterInput).not.toBeInTheDocument();
+  });
+
+  it('shows filter input when data has more than 10 entries', () => {
+    const manyAttributes = Array.from({ length: 15 }, (_, i) => ({ key: `attr${i}`, value: `val${i}` }));
+    render(<AttributesTable data={makeAttributes(manyAttributes)} />);
+    const filterInput = screen.getByLabelText('Filter span attributes');
+    expect(filterInput).toBeInTheDocument();
+  });
+
+  it('filters attributes by key', () => {
+    const manyAttributes = Array.from({ length: 15 }, (_, i) => ({ key: `attr${i}`, value: `val${i}` }));
+    render(<AttributesTable data={makeAttributes(manyAttributes)} />);
+    const filterInput = screen.getByLabelText('Filter span attributes');
+
+    // Initially all rows are visible
+    let rows = screen.getAllByRole('row');
+    expect(rows.length).toBeGreaterThan(1);
+
+    // Filter by key
+    fireEvent.change(filterInput, { target: { value: 'attr5' } });
+    rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(1);
+    expect(screen.getByText('attr5')).toBeInTheDocument();
+    expect(screen.queryByText('attr0')).not.toBeInTheDocument();
+  });
+
+  it('filters attributes by value', () => {
+    const manyAttributes = Array.from({ length: 15 }, (_, i) => ({ key: `key${i}`, value: `target-value` }));
+    render(<AttributesTable data={makeAttributes(manyAttributes)} />);
+    const filterInput = screen.getByLabelText('Filter span attributes');
+
+    fireEvent.change(filterInput, { target: { value: 'target' } });
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(15);
+  });
+
+  it('shows count when filtering', () => {
+    const manyAttributes = Array.from({ length: 15 }, (_, i) => ({ key: `attr${i}`, value: `val${i}` }));
+    render(<AttributesTable data={makeAttributes(manyAttributes)} />);
+    const filterInput = screen.getByLabelText('Filter span attributes');
+
+    fireEvent.change(filterInput, { target: { value: 'attr1' } });
+    expect(screen.getByText(/of 15/)).toBeInTheDocument();
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/AttributesTable.tsx
@@ -120,14 +120,44 @@ type AttributesTableProps = {
 // Example: https://github.com/jaegertracing/jaeger-ui/assets/94157520/b518cad9-cb37-4775-a3d6-b667a1235f89
 export default function AttributesTable(props: AttributesTableProps) {
   const { data, linksGetter } = props;
+  const [filterQuery, setFilterQuery] = React.useState('');
+
+  const entries = data.entries();
+  const filteredEntries = React.useMemo(() => {
+    if (!filterQuery) return entries.map((row, i) => ({ row, originalIndex: i }));
+    const query = filterQuery.toLowerCase();
+    return entries
+      .map((row, i) => ({ row, originalIndex: i }))
+      .filter(
+        ({ row }) => row.key.toLowerCase().includes(query) || String(row.value).toLowerCase().includes(query)
+      );
+  }, [entries, filterQuery]);
+
+  const showFilter = entries.length > 10;
 
   return (
     <div className="KeyValueTable u-simple-scrollbars">
+      {showFilter && (
+        <div className="KeyValueTable--filterRow">
+          <input
+            className="KeyValueTable--filter"
+            placeholder="Filter attributes..."
+            value={filterQuery}
+            onChange={e => setFilterQuery(e.target.value)}
+            aria-label="Filter span attributes"
+          />
+          {filterQuery && (
+            <span className="KeyValueTable--filterCount">
+              {filteredEntries.length} of {entries.length}
+            </span>
+          )}
+        </div>
+      )}
       <table className="u-width-100">
         <tbody className="KeyValueTable--body">
-          {data.entries().map((row, i) => {
+          {filteredEntries.map(({ row, originalIndex }, i) => {
             const { node: jsonTable, isJsonTree } = formatValue(row.key, row.value);
-            const links = linksGetter ? linksGetter(data, i) : null;
+            const links = linksGetter ? linksGetter(data, originalIndex) : null;
             let valueMarkup;
             if (links?.length === 1) {
               valueMarkup = (


### PR DESCRIPTION
## Description

Add a lightweight filter input to the top of `AttributesTable` that live-filters rows as you type, matching against both key and value (case-insensitive).

## Changes

- **AttributesTable.tsx**: Added filter state, memoized filtering logic, and filter input UI
- **AttributesTable.css**: Added styles for filter row, input, and count display
- **AttributesTable.test.jsx**: Added tests for filter visibility, filtering by key/value, and count display

## Acceptance Criteria

- [x] Text input appears above attribute list when span has > 10 attributes
- [x] Typing filters rows in real time (case-insensitive, matches key AND value)
- [x] "N of M attributes" counter shown when filter is active
- [x] Clearing input restores all rows
- [x] Input has proper `aria-label` for screen reader accessibility
- [x] No filter input rendered when span has <= 10 attributes
- [x] `linksGetter` behavior works correctly on filtered rows (indices re-mapped to original positions)

Fixes #3897