### PR TITLE
fix(tooltip): update flamegraph tooltip position with cursor

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.test.jsx
@@ -412,19 +412,35 @@ describe('<TraceFlamegraph />', () => {
       expect(mockChart.search).toHaveBeenCalledWith('svc-a: myOp');
     });
 
-    it('mousemove over g.frame shows tooltip', async () => {
-      render(<TraceFlamegraph trace={otelTrace} />);
+    it('updates tooltip position when mouse moves within the same g.frame', async () => {
+      const { container } = render(<TraceFlamegraph trace={otelTrace} />);
+
       const svg = screen.getByTestId('flamegraph-chart').querySelector('svg');
       const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
       g.classList.add('frame');
-      g.__data__ = { data: { name: 'svc: op', value: 500000, duration: 500000, count: 3 } };
+      g.__data__ = {
+        data: {
+          name: 'svc: op',
+          value: 100,
+          duration: 100,
+          count: 1,
+        },
+      };
       svg.appendChild(g);
 
       await act(() => {
         g.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 200, clientY: 300 }));
       });
-      expect(screen.getByText('svc: op')).toBeInTheDocument();
-      expect(screen.getByText('3')).toBeInTheDocument();
+
+      let tooltip = container.querySelector('.Flamegraph-tooltip');
+      expect(tooltip).toHaveStyle({ left: '210px', top: '310px' });
+
+      await act(() => {
+        g.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 210, clientY: 310 }));
+      });
+
+      tooltip = container.querySelector('.Flamegraph-tooltip');
+      expect(tooltip).toHaveStyle({ left: '220px', top: '320px' });
     });
 
     it('mousemove without g.frame hides tooltip', async () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
@@ -162,13 +162,13 @@ const TraceFlamegraph = ({ trace }: any) => {
           }
           return;
         }
-        if (target === hoveredFrameRef.current) return;
         hoveredFrameRef.current = target;
         const d3Data = (target as any).__data__;
         const name = d3Data?.data?.name || '';
         const value = d3Data?.data?.duration ?? d3Data?.data?.value ?? 0;
         const count = d3Data?.data?.count || 1;
         setTooltip({ x: e.clientX, y: e.clientY, name, value, count });
+        if (target === hoveredFrameRef.current) return;
       });
       svgEl.addEventListener('mouseleave', () => {
         hoveredFrameRef.current = null;

--- a/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx
@@ -168,7 +168,6 @@ const TraceFlamegraph = ({ trace }: any) => {
         const value = d3Data?.data?.duration ?? d3Data?.data?.value ?? 0;
         const count = d3Data?.data?.count || 1;
         setTooltip({ x: e.clientX, y: e.clientY, name, value, count });
-        if (target === hoveredFrameRef.current) return;
       });
       svgEl.addEventListener('mouseleave', () => {
         hoveredFrameRef.current = null;


### PR DESCRIPTION
## Which problem is this PR solving?
-  Resolves #4379 

## Description 
- Fixed the Flamegraph tooltip so its position is updated when the cursor moves within the same frame.
- Updated the mouse handling logic in `packages/jaeger-ui/src/components/TracePage/TraceFlamegraph/index.tsx` so the tooltip position is not skipped when the hovered frame has not changed.
- The **tooltip** now follows the cursor while moving inside the same **Flamegraph frame.**

## Changes
- Reproduced the issue by opening a trace and hovering over a Flamegraph frame.
- Moved the cursor within the same frame and confirmed that the tooltip follows the cursor.
- Verified that the tooltip still appears correctly when moving between different frames.
- Ran the relevant tests and lint checks.

## screenshot
https://github.com/user-attachments/assets/fd1947b5-aa30-401e-995d-386f9f085c68

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
