### PR TITLE
fix(test)  guard window.event after jsdom teardown

### DIFF
--- a/patches/react-dom@19.2.0.patch
+++ b/patches/react-dom@19.2.0.patch
@@ -1,0 +1,45 @@
+diff --git a/cjs/react-dom-client.development.js b/cjs/react-dom-client.development.js
+index d005d8b99c428f58cdf62f50027fb855443f98ba..023be2de6bef644caad3db2cbf874c391f60513e 100644
+--- a/cjs/react-dom-client.development.js
++++ b/cjs/react-dom-client.development.js
+@@ -17917,7 +17917,7 @@
+           ? ((root.callbackNode = null),
+             (root.callbackPriority = 0),
+             scheduleCallback$1(NormalPriority$1, function () {
+-              schedulerEvent = window.event;
++              schedulerEvent = typeof window !== 'undefined' ? window.event : void 0;
+               pendingDelayedCommitReason === IMMEDIATE_COMMIT &&
+                 (pendingDelayedCommitReason = DELAYED_PASSIVE_COMMIT);
+               flushPassiveEffects();
+@@ -18819,7 +18819,7 @@
+       }
+     }
+     function processRootScheduleInImmediateTask() {
+-      schedulerEvent = window.event;
++      schedulerEvent = typeof window !== 'undefined' ? window.event : void 0;
+       processRootScheduleInMicrotask();
+     }
+     function processRootScheduleInMicrotask() {
+@@ -18933,7 +18933,7 @@
+     }
+     function performWorkOnRootViaSchedulerTask(root, didTimeout) {
+       nestedUpdateScheduled = currentUpdateIsNested = !1;
+-      schedulerEvent = window.event;
++      schedulerEvent = typeof window !== 'undefined' ? window.event : void 0;
+       if (
+         pendingEffectsStatus !== NO_PENDING_EFFECTS &&
+         pendingEffectsStatus !== PENDING_PASSIVE_PHASE
+@@ -22137,11 +22137,11 @@
+       return !1;
+     }
+     function resolveEventType() {
+-      var event = window.event;
++      var event = typeof window !== 'undefined' ? window.event : null;
+       return event && event !== schedulerEvent ? event.type : null;
+     }
+     function resolveEventTimeStamp() {
+-      var event = window.event;
++      var event = typeof window !== 'undefined' ? window.event : null;
+       return event && event !== schedulerEvent ? event.timeStamp : -1.1;
+     }
+     function handleErrorInNextTick(error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,13 +21,16 @@ overrides:
   '@assistant-ui/tap': 0.9.9
   brace-expansion: 5.0.8
 
+patchedDependencies:
+  react-dom@19.2.0: 7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39
+
 importers:
 
   .:
     dependencies:
       '@tanstack/react-virtual':
         specifier: 3.14.2
-        version: 3.14.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.14.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react-side-effect:
         specifier: 2.1.2
         version: 2.1.2(react@19.2.0)
@@ -134,7 +137,7 @@ importers:
         version: 0.0.54
       '@assistant-ui/react':
         specifier: 0.15.2
-        version: 0.15.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@11.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
+        version: 0.15.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@11.1.8)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
       '@assistant-ui/react-ag-ui':
         specifier: 0.0.35
         version: 0.0.35(@assistant-ui/store@0.3.2(@assistant-ui/tap@0.9.9(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@assistant-ui/tap@0.9.9(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(assistant-cloud@0.1.39)(react@19.2.0)(zustand@5.0.14(@types/react@19.2.7)(immer@11.1.8)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)))
@@ -170,16 +173,16 @@ importers:
         version: 1.43.0
       '@rc-component/overflow':
         specifier: ^1.0.1
-        version: 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@tanstack/react-query':
         specifier: ^5.90.19
         version: 5.101.1(react@19.2.0)
       '@tanstack/react-virtual':
         specifier: 3.14.2
-        version: 3.14.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 3.14.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       antd:
         specifier: 6.5.0
-        version: 6.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 6.5.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       chance:
         specifier: 1.1.13
         version: 1.1.13
@@ -242,7 +245,7 @@ importers:
         version: 2.2.0(react@19.2.0)
       react-dom:
         specifier: 19.2.0
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-icons:
         specifier: 5.7.0
         version: 5.7.0(react@19.2.0)
@@ -257,10 +260,10 @@ importers:
         version: 9.3.0(@types/react@19.2.7)(react@19.2.0)(redux@5.0.1)
       react-router-dom:
         specifier: 7.18.0
-        version: 7.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 7.18.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       recharts:
         specifier: 3.10.0
-        version: 3.10.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react-is@19.2.0)(react@19.2.0)(redux@5.0.1)
+        version: 3.10.0(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react-is@19.2.0)(react@19.2.0)(redux@5.0.1)
       redux:
         specifier: 5.0.1
         version: 5.0.1
@@ -288,7 +291,7 @@ importers:
         version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: 16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -364,7 +367,7 @@ importers:
         version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.1
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@types/d3-selection':
         specifier: ^3.0.11
         version: 3.0.11
@@ -382,7 +385,7 @@ importers:
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       antd:
         specifier: 6.5.0
-        version: 6.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 6.5.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       identity-obj-proxy:
         specifier: 3.0.0
         version: 3.0.0
@@ -391,7 +394,7 @@ importers:
         version: 19.2.0
       react-dom:
         specifier: 19.2.0
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.1)(jiti@2.7.0)(less@4.8.0(supports-color@7.2.0))(terser@5.49.0)(yaml@2.9.0))
@@ -5239,46 +5242,46 @@ snapshots:
     dependencies:
       '@ant-design/fast-color': 3.0.1
 
-  '@ant-design/cssinjs-utils@2.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ant-design/cssinjs-utils@2.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@ant-design/cssinjs': 2.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@ant-design/cssinjs': 2.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@babel/runtime': 7.29.7
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@ant-design/cssinjs@2.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ant-design/cssinjs@2.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       csstype: 3.2.3
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       stylis: 4.4.0
 
   '@ant-design/fast-color@3.0.1': {}
 
   '@ant-design/icons-svg@4.5.0': {}
 
-  '@ant-design/icons@6.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ant-design/icons@6.3.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@ant-design/colors': 8.0.1
       '@ant-design/icons-svg': 4.5.0
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@ant-design/react-slick@2.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ant-design/react-slick@2.0.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       clsx: 2.1.1
       json2mq: 0.2.0
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       throttle-debounce: 5.0.2
 
   '@apidevtools/json-schema-ref-parser@11.7.2':
@@ -5349,25 +5352,25 @@ snapshots:
       - redis
       - zustand
 
-  '@assistant-ui/react@0.15.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@11.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))':
+  '@assistant-ui/react@0.15.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(immer@11.1.8)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))':
     dependencies:
       '@assistant-ui/core': 0.3.3(@assistant-ui/store@0.3.2(@assistant-ui/tap@0.9.9(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@assistant-ui/tap@0.9.9(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(assistant-cloud@0.1.39)(react@19.2.0)(zustand@5.0.14(@types/react@19.2.7)(immer@11.1.8)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0)))
       '@assistant-ui/store': 0.3.2(@assistant-ui/tap@0.9.9(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0)
       '@assistant-ui/tap': 0.9.9(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-escape-keydown': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       assistant-cloud: 0.1.39
       assistant-stream: 0.3.37
       nanoid: 6.0.1
-      radix-ui: 1.6.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      radix-ui: 1.6.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-textarea-autosize: 8.5.9(@types/react@19.2.7)(react@19.2.0)
       safe-content-frame: 0.0.25
       zod: 4.4.3
@@ -5754,11 +5757,11 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
   '@floating-ui/utils@0.2.11': {}
 
@@ -6231,116 +6234,116 @@ snapshots:
 
   '@radix-ui/primitive@1.1.7': {}
 
-  '@radix-ui/react-accessible-icon@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-accessible-icon@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-accordion@1.2.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-accordion@1.2.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-alert-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-alert-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-aspect-ratio@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-aspect-ratio@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-avatar@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-avatar@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-checkbox@1.3.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-checkbox@1.3.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-collapsible@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-collapsible@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-collection@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-collection@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -6351,15 +6354,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-context-menu@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-context-menu@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -6370,24 +6373,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       aria-hidden: 1.2.6
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
@@ -6399,30 +6402,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -6433,44 +6436,44 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-form@0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-form@0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-hover-card@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-hover-card@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -6482,303 +6485,303 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-label@2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-label@2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       aria-hidden: 1.2.6
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-menubar@1.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-menubar@1.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-navigation-menu@1.2.22(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-navigation-menu@1.2.22(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-one-time-password-field@0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-one-time-password-field@0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/number': 1.1.3
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-password-toggle-field@0.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-password-toggle-field@0.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-popover@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-popover@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       aria-hidden: 1.2.6
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-popper@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-popper@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-rect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/rect': 1.1.3
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-presence@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-presence@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-progress@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-progress@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-radio-group@1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-radio-group@1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-scroll-area@1.2.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-scroll-area@1.2.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/number': 1.1.3
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-select@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-select@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/number': 1.1.3
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       aria-hidden: 1.2.6
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-separator@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-separator@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-slider@1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-slider@1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/number': 1.1.3
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -6790,114 +6793,114 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-switch@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-switch@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-tabs@1.1.21(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-tabs@1.1.21(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-toast@1.2.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-toast@1.2.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-toggle-group@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-toggle-group@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-toggle@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-toggle@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-toolbar@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-toolbar@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -6963,11 +6966,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@radix-ui/react-visually-hidden@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-visually-hidden@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -6978,338 +6981,338 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
 
-  '@rc-component/cascader@1.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/cascader@1.17.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/select': 1.8.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/tree': 1.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/select': 1.8.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/tree': 1.3.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/checkbox@2.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/checkbox@2.0.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/collapse@1.2.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/collapse@1.2.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/color-picker@3.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/color-picker@3.1.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/context@2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/context@2.0.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/dialog@1.10.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/dialog@1.10.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/portal': 2.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/portal': 2.2.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/drawer@1.4.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/drawer@1.4.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/portal': 2.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/portal': 2.2.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/dropdown@1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/dropdown@1.0.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/form@1.8.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/form@1.8.5(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@rc-component/async-validator': 6.0.0
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/image@1.9.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/image@1.9.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/portal': 2.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/portal': 2.2.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/input-number@1.6.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/input-number@1.6.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@rc-component/mini-decimal': 1.1.4
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/input@1.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/input@1.3.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/mentions@1.10.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/mentions@1.10.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/input': 1.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/menu': 1.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/input': 1.3.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/menu': 1.4.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/menu@1.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/menu@1.4.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/overflow': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/overflow': 1.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
   '@rc-component/mini-decimal@1.1.4':
     dependencies:
       '@babel/runtime': 7.29.7
 
-  '@rc-component/motion@1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/motion@1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/mutate-observer@2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/mutate-observer@2.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/notification@2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/notification@2.0.7(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/overflow@1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/overflow@1.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/pagination@1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/pagination@1.4.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/picker@1.11.0(dayjs@1.11.19)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/picker@1.11.0(dayjs@1.11.19)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/overflow': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/overflow': 1.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       dayjs: 1.11.19
 
-  '@rc-component/portal@2.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/portal@2.2.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/progress@1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/progress@1.0.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/qrcode@2.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/qrcode@2.0.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/rate@1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/rate@1.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/resize-observer@1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/resize-observer@1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/segmented@1.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/segmented@1.3.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/select@1.8.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/select@1.8.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/overflow': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/virtual-list': 1.2.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/overflow': 1.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/virtual-list': 1.2.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/slider@1.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/slider@1.1.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/steps@1.2.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/steps@1.2.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/switch@1.0.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/switch@1.0.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/table@1.10.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/table@1.10.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/context': 2.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/virtual-list': 1.2.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/context': 2.0.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/virtual-list': 1.2.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/tabs@1.11.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/tabs@1.11.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/dropdown': 1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/menu': 1.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/dropdown': 1.0.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/menu': 1.4.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/tooltip@1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/tooltip@1.4.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/tour@2.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/tour@2.4.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/portal': 2.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/portal': 2.2.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/tree-select@1.11.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/tree-select@1.11.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/select': 1.8.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/tree': 1.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/select': 1.8.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/tree': 1.3.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/tree@1.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/tree@1.3.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/virtual-list': 1.2.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/virtual-list': 1.2.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/trigger@3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/trigger@3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/portal': 2.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/portal': 2.2.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/upload@1.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/upload@1.1.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
-  '@rc-component/util@1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/util@1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       is-mobile: 5.0.0
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-is: 18.3.1
 
-  '@rc-component/virtual-list@1.2.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@rc-component/virtual-list@1.2.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.7)(react@19.2.0)(redux@5.0.1))(react@19.2.0)':
     dependencies:
@@ -7422,11 +7425,11 @@ snapshots:
       '@tanstack/query-core': 5.101.1
       react: 19.2.0
 
-  '@tanstack/react-virtual@3.14.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@tanstack/react-virtual@3.14.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@tanstack/virtual-core': 3.17.0
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
   '@tanstack/virtual-core@3.17.0': {}
 
@@ -7451,22 +7454,22 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -7932,55 +7935,55 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  antd@6.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  antd@6.5.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@ant-design/colors': 8.0.1
-      '@ant-design/cssinjs': 2.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@ant-design/cssinjs-utils': 2.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@ant-design/cssinjs': 2.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@ant-design/cssinjs-utils': 2.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@ant-design/fast-color': 3.0.1
-      '@ant-design/icons': 6.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@ant-design/react-slick': 2.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@ant-design/icons': 6.3.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@ant-design/react-slick': 2.0.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@babel/runtime': 7.29.7
-      '@rc-component/cascader': 1.17.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/checkbox': 2.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/collapse': 1.2.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/color-picker': 3.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/dialog': 1.10.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/drawer': 1.4.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/dropdown': 1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/form': 1.8.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/image': 1.9.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/input': 1.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/input-number': 1.6.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/mentions': 1.10.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/menu': 1.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/motion': 1.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/mutate-observer': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/notification': 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/pagination': 1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/picker': 1.11.0(dayjs@1.11.19)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/progress': 1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/qrcode': 2.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/rate': 1.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/segmented': 1.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/select': 1.8.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/slider': 1.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/steps': 1.2.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/switch': 1.0.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/table': 1.10.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/tabs': 1.11.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/tooltip': 1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/tour': 2.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/tree': 1.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/tree-select': 1.11.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/upload': 1.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@rc-component/util': 1.11.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@rc-component/cascader': 1.17.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/checkbox': 2.0.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/collapse': 1.2.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/color-picker': 3.1.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/dialog': 1.10.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/drawer': 1.4.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/dropdown': 1.0.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/form': 1.8.5(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/image': 1.9.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/input': 1.3.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/input-number': 1.6.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/mentions': 1.10.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/menu': 1.4.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/mutate-observer': 2.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/notification': 2.0.7(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/pagination': 1.4.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/picker': 1.11.0(dayjs@1.11.19)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/progress': 1.0.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/qrcode': 2.0.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/rate': 1.0.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/segmented': 1.3.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/select': 1.8.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/slider': 1.1.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/steps': 1.2.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/switch': 1.0.3(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/table': 1.10.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/tabs': 1.11.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/tooltip': 1.4.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/tour': 2.4.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/tree': 1.3.2(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/tree-select': 1.11.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/upload': 1.1.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@rc-component/util': 1.11.1(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       clsx: 2.1.1
       dayjs: 1.11.19
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       scroll-into-view-if-needed: 3.1.0
       throttle-debounce: 5.0.2
     transitivePeerDependencies:
@@ -9116,55 +9119,55 @@ snapshots:
       filter-obj: 5.1.0
       split-on-first: 3.0.0
 
-  radix-ui@1.6.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  radix-ui@1.6.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-accessible-icon': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-alert-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-aspect-ratio': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-avatar': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-checkbox': 1.3.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-accessible-icon': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-alert-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-aspect-ratio': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-avatar': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-checkbox': 1.3.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-dropdown-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dropdown-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-form': 0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-hover-card': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-menubar': 1.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-one-time-password-field': 0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-password-toggle-field': 0.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-progress': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-radio-group': 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-select': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-slider': 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-form': 0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-hover-card': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-menubar': 1.1.24(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-one-time-password-field': 0.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-password-toggle-field': 0.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-progress': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-radio-group': 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-select': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slider': 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-switch': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-toast': 1.2.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-toolbar': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-tooltip': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-switch': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toast': 1.2.23(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toolbar': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-tooltip': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.7)(react@19.2.0)
@@ -9172,9 +9175,9 @@ snapshots:
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.7)(react@19.2.0)
       '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.7)(react@19.2.0)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -9183,7 +9186,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  react-dom@19.2.0(react@19.2.0):
+  react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0):
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
@@ -9230,19 +9233,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  react-router-dom@7.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router-dom@7.18.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-router: 7.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
+      react-router: 7.18.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0)
 
-  react-router@7.18.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.18.0(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.1.1
       react: 19.2.0
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
 
   react-side-effect@2.1.2(react@19.2.0):
     dependencies:
@@ -9272,7 +9275,7 @@ snapshots:
       json-parse-even-better-errors: 6.0.0
       npm-normalize-package-bin: 6.0.0
 
-  recharts@3.10.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react-is@19.2.0)(react@19.2.0)(redux@5.0.1):
+  recharts@3.10.0(@types/react@19.2.7)(react-dom@19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0))(react-is@19.2.0)(react@19.2.0)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.7)(react@19.2.0)(redux@5.0.1))(react@19.2.0)
       clsx: 2.1.1
@@ -9281,7 +9284,7 @@ snapshots:
       eventemitter3: 5.0.4
       immer: 11.1.8
       react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.0(patch_hash=7e406a0be19af70b44428b7f5728f079512e508274005f47f4b0834dc940ea39)(react@19.2.0)
       react-is: 19.2.0
       react-redux: 9.3.0(@types/react@19.2.7)(react@19.2.0)(redux@5.0.1)
       reselect: 5.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,6 @@ overrides:
   '@assistant-ui/store': 0.3.2
   '@assistant-ui/tap': 0.9.9
   brace-expansion: 5.0.8
+
+patchedDependencies:
+  react-dom@19.2.0: patches/react-dom@19.2.0.patch


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #4339 

## Description of the changes
- Patched react-dom@19.2.0 via pnpm patchedDependencies to guard all five window.event reads with tyepof window !== 'undefined'
- Added patches/react-dom@19.2.0.patch, registered it in pnpm-workspace.yaml, and updated pnpm-lock.yaml

## How was this change tested?
- Switched to node 26 to reproduce the error
- Ran pnpm test, didnt see the ReferenceError
- Fully green on node 24
- make lint test fully green on node 24
- On Node.js 26, the remaining localStorage-related failures described in the issue are still reproducible

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
