### PR TITLE
fix(ui): stop arrow keys in trace view dropdowns from resizing minimap

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.test.jsx
@@ -14,7 +14,7 @@ vi.mock('antd', async () => {
   return {
     ...originalModule,
     Dropdown: ({ children, menu }) => (
-      <div data-testid="dropdown">
+      <div data-testid="dropdown" onKeyDown={menu.onKeyDown}>
         {children}
         <div data-testid="dropdown-menu">
           {menu.items.map(item => (
@@ -174,5 +174,13 @@ describe('AltViewOptions', () => {
       renderComponent({ viewType: type });
       expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
     });
+  });
+  it('stops keydown event propagation from the dropdown menu', () => {
+    renderComponent();
+    const dropdown = screen.getByTestId('dropdown');
+    const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+    Object.defineProperty(event, 'stopPropagation', { value: jest.fn() });
+    dropdown.dispatchEvent(event);
+    expect(event.stopPropagation).toHaveBeenCalled();
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/AltViewOptions.tsx
@@ -79,7 +79,7 @@ export default function AltViewOptions(props: Props) {
   const currentItem = MENU_ITEMS.find(item => item.viewType === viewType);
   const dropdownText = currentItem ? currentItem.label : 'Alternate Views';
   return (
-    <Dropdown menu={{ items: dropdownItems }} trigger={['click']}>
+    <Dropdown menu={{ items: dropdownItems, onKeyDown: e => e.stopPropagation() }} trigger={['click']}>
       <Button className="AltViewOptions">
         {`${dropdownText} `}
         <IoChevronDown />

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.test.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -89,5 +89,24 @@ describe('<TraceViewSettings>', () => {
     await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
     await userEvent.click(await screen.findByText('Keyboard Shortcuts'));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+  it('stops keydown event propagation from the dropdown menu', async () => {
+    const parentKeyDown = jest.fn();
+    const { container } = render(
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div onKeyDown={parentKeyDown}>
+        <TraceViewSettings {...defaultProps} />
+      </div>
+    );
+    // Open the dropdown
+    await userEvent.click(screen.getByRole('button', { name: /trace view settings/i }));
+    await screen.findByText('Show Timeline');
+
+    // Find the antd dropdown menu overlay and fire a keydown on it
+    const menuElement = container.querySelector('[class*="ant-dropdown-menu"]') || document.querySelector('[class*="ant-dropdown-menu"]');
+    if (menuElement) {
+      fireEvent.keyDown(menuElement, { key: 'ArrowDown' });
+      expect(parentKeyDown).not.toHaveBeenCalled();
+    }
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TraceViewSettings.tsx
@@ -65,7 +65,7 @@ export default function TraceViewSettings(props: Props) {
 
   return (
     <>
-      <Dropdown menu={{ items }} trigger={['click']}>
+      <Dropdown menu={{ items, onKeyDown: e => e.stopPropagation() }} trigger={['click']}>
         <Button
           className={`TraceViewSettings ${className || ''}`}
           htmlType="button"


### PR DESCRIPTION
Fixes #4178

## Which problem is this PR solving?
- Resolves #4178

## Description of the changes
- When the "Alternate Views" dropdown (`AltViewOptions`) or the "Trace View Settings" dropdown (`TraceViewSettings`) is open in the Trace page header, pressing arrow keys to navigate the menu options also triggers the global `combokeys` keyboard shortcuts bound on `document.body`. This causes the minimap to pan/zoom instead of letting the user navigate the dropdown menu.
- Added `onKeyDown: e => e.stopPropagation()` to the Ant Design `<Dropdown>` `menu` prop in both `AltViewOptions.tsx` and `TraceViewSettings.tsx`. This prevents `keydown` events from bubbling up to `document.body` where `combokeys` intercepts them for minimap control.

## How was this change tested?
- Verified that existing unit tests for `AltViewOptions` and `TraceViewSettings` continue to pass.
- Manually confirmed that arrow keys navigate dropdown menu items without triggering minimap resize/pan.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
