### PR TITLE
fix(deps): Refresh import-in-the-middle

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3327,11 +3327,6 @@ packages:
       axios: ^0.x || ^1.0.0
       zod: ^3.x
 
-  acorn-import-attributes@1.9.5:
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3708,6 +3703,9 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -3954,8 +3952,8 @@ packages:
   immer@11.1.8:
     resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
 
-  import-in-the-middle@3.2.0:
-    resolution: {integrity: sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==}
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
     engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
@@ -5865,7 +5863,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
-      import-in-the-middle: 3.2.0
+      import-in-the-middle: 3.3.3
       require-in-the-middle: 8.0.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -7892,10 +7890,6 @@ snapshots:
       axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       zod: 3.25.76
 
-  acorn-import-attributes@1.9.5(acorn@8.17.0):
-    dependencies:
-      acorn: 8.17.0
-
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -8274,6 +8268,8 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
+  es-module-lexer@2.3.1: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -8544,11 +8540,10 @@ snapshots:
 
   immer@11.1.8: {}
 
-  import-in-the-middle@3.2.0:
+  import-in-the-middle@3.3.3:
     dependencies:
-      acorn: 8.17.0
-      acorn-import-attributes: 1.9.5(acorn@8.17.0)
       cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
       module-details-from-path: 1.0.4
 
   import-meta-resolve@4.2.0: {}


### PR DESCRIPTION
## Summary

- Refresh `import-in-the-middle` from 3.2.0 to 3.3.3 in `pnpm-lock.yaml`.
- Replace the Acorn production dependency path with `es-module-lexer`.
- Keep package manifests unchanged because `@opentelemetry/instrumentation` already permits this update through `^3.0.0`.

## Why

Jaeger UI v2.20.0 and current `main` resolve `@opentelemetry/instrumentation` through `import-in-the-middle@3.2.0`, which brings Acorn into the production dependency graph.

Acorn 8.17.0 itself is MIT licensed. The AGPL-licensed `test262-parser-runner` identified in the related discussions is an Acorn source-repository development dependency; it is not present in Acorn's published package or Jaeger UI's lockfile. This refresh still removes Acorn from the OpenTelemetry production path and avoids that compliance-scanner finding.

Acorn remains in Jaeger UI's development graph through ESLint and Terser.

## Impact

This is a lockfile-only dependency refresh. It does not change application code, public APIs, or package manifest constraints.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm why import-in-the-middle -r`
- `pnpm why acorn -r`
- `pnpm licenses list --prod --json`, no AGPL packages and no Acorn production path
- `pnpm run fmt`
- `pnpm run lint`
- `pnpm test`, 267 Jaeger UI files / 3,562 tests and 9 Plexus files / 115 tests passed
- `pnpm run build`

Fixes #4396
