### PR TITLE
perf(jaeger-ui): optimize critical path section merging and memoization

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { makeCriticalPathContext } from './criticalPath';
+import { makeAttributes } from '../../../model/attributes';
+import { SpanKind, StatusCode } from '../../../types/otel';
+import type { IOtelSpan, IOtelTrace } from '../../../types/otel';
+import type { CriticalPathSection } from '../../../types/critical_path';
+import type { Microseconds } from '../../../types/units';
+
+const us = (n: number) => n as Microseconds;
+
+function makeMockSpan(spanID: string, serviceName = 'service-a', childSpans: IOtelSpan[] = []): IOtelSpan {
+  return {
+    spanID,
+    traceID: 'trace-1',
+    name: `operation-${spanID}`,
+    kind: SpanKind.INTERNAL,
+    startTime: us(1000),
+    endTime: us(2000),
+    duration: us(1000),
+    attributes: makeAttributes(),
+    events: [],
+    links: [],
+    status: { code: StatusCode.OK },
+    resource: { serviceName, attributes: makeAttributes() },
+    instrumentationScope: { name: 'test' },
+    depth: 0,
+    hasChildren: childSpans.length > 0,
+    childSpans,
+    relativeStartTime: us(0),
+    inboundLinks: [],
+    warnings: null,
+  };
+}
+
+function makeMockTrace(spans: IOtelSpan[]): IOtelTrace {
+  const spanMap = new Map<string, IOtelSpan>();
+  spans.forEach(s => spanMap.set(s.spanID, s));
+  return {
+    traceID: 'trace-1',
+    spans,
+    duration: us(5000),
+    startTime: us(1000),
+    endTime: us(6000),
+    traceName: 'test-trace',
+    tracePageTitle: 'test-title',
+    traceEmoji: '',
+    services: [],
+    spanMap,
+    rootSpans: spans.length > 0 ? [spans[0]] : [],
+    orphanSpanCount: 0,
+    isGenAITrace: false,
+    hasErrors: () => false,
+  };
+}
+
+describe('criticalPath', () => {
+  describe('makeCriticalPathContext', () => {
+    it('returns empty sections when criticalPath is empty or null', () => {
+      const span = makeMockSpan('s1');
+      const trace = makeMockTrace([span]);
+
+      const ctxNull = makeCriticalPathContext(trace, null as any, new Set());
+      expect(ctxNull.sectionsFor(span, false, false)).toEqual([]);
+
+      const ctxEmpty = makeCriticalPathContext(trace, [], new Set());
+      expect(ctxEmpty.sectionsFor(span, false, false)).toEqual([]);
+    });
+
+    it('returns own sections for an uncollapsed span with no pruned children', () => {
+      const span = makeMockSpan('s1');
+      const trace = makeMockTrace([span]);
+      const criticalPath: CriticalPathSection[] = [
+        { spanID: 's1', sectionStart: us(1000), sectionEnd: us(1500) },
+      ];
+
+      const ctx = makeCriticalPathContext(trace, criticalPath, new Set());
+      const sections = ctx.sectionsFor(span, false, false);
+
+      expect(sections).toEqual([{ spanID: 's1', sectionStart: us(1000), sectionEnd: us(1500) }]);
+    });
+
+    it('merges consecutive sections for a collapsed span and its descendants', () => {
+      const child = makeMockSpan('c1');
+      const root = makeMockSpan('r1', 'service-a', [child]);
+      const trace = makeMockTrace([root, child]);
+
+      // Critical path sections ordered from later to earlier in time
+      const criticalPath: CriticalPathSection[] = [
+        { spanID: 'c1', sectionStart: us(1500), sectionEnd: us(2000) },
+        { spanID: 'r1', sectionStart: us(1000), sectionEnd: us(1500) },
+      ];
+
+      const ctx = makeCriticalPathContext(trace, criticalPath, new Set());
+      const merged = ctx.sectionsFor(root, true, false);
+
+      // Consecutive adjacent sections (1500-2000 and 1000-1500) should be merged into one (1000-2000)
+      expect(merged).toHaveLength(1);
+      expect(merged[0].sectionStart).toBe(1000);
+      expect(merged[0].sectionEnd).toBe(2000);
+    });
+
+    it('memoizes collapsed section calculations on repeated calls', () => {
+      const child = makeMockSpan('c1');
+      const root = makeMockSpan('r1', 'service-a', [child]);
+      const trace = makeMockTrace([root, child]);
+
+      const criticalPath: CriticalPathSection[] = [
+        { spanID: 'c1', sectionStart: us(1600), sectionEnd: us(2000) },
+        { spanID: 'r1', sectionStart: us(1000), sectionEnd: us(1500) },
+      ];
+
+      const ctx = makeCriticalPathContext(trace, criticalPath, new Set());
+      const firstCall = ctx.sectionsFor(root, true, false);
+      const secondCall = ctx.sectionsFor(root, true, false);
+
+      // Verify reference equality (cache hit)
+      expect(firstCall).toBe(secondCall);
+    });
+
+    it('combines own sections with pruned child sections when hasPrunedChildren is true', () => {
+      const childPruned = makeMockSpan('c-pruned', 'pruned-service');
+      const root = makeMockSpan('r1', 'service-a', [childPruned]);
+      const trace = makeMockTrace([root, childPruned]);
+
+      const criticalPath: CriticalPathSection[] = [
+        { spanID: 'r1', sectionStart: us(1000), sectionEnd: us(1200) },
+        { spanID: 'c-pruned', sectionStart: us(1200), sectionEnd: us(1800) },
+      ];
+
+      const prunedServices = new Set(['pruned-service']);
+      const ctx = makeCriticalPathContext(trace, criticalPath, prunedServices);
+
+      const sections = ctx.sectionsFor(root, false, true);
+
+      expect(sections).toHaveLength(2);
+      expect(sections[0].spanID).toBe('r1');
+      expect(sections[1].spanID).toBe('c-pruned');
+
+      // Verify reference memoization for pruned combined sections
+      const secondCall = ctx.sectionsFor(root, false, true);
+      expect(sections).toBe(secondCall);
+    });
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/criticalPath.ts
@@ -9,10 +9,10 @@ function mergeChildrenCriticalPath(
   spanID: string,
   criticalPath: CriticalPathSection[]
 ): CriticalPathSection[] {
-  if (!criticalPath) {
+  if (!criticalPath || criticalPath.length === 0) {
     return [];
   }
-  // Define an array to store the IDs of the span and its descendants (if the span is collapsed)
+  // Define a set to store the IDs of the span and its descendants (if the span is collapsed)
   const allRequiredSpanIds = new Set<string>([spanID]);
 
   // Use pre-built spanMap
@@ -34,19 +34,21 @@ function mergeChildrenCriticalPath(
     findAllDescendants(startingSpan);
   }
 
-  const criticalPathSections: CriticalPathSection[] = [];
-  criticalPath.forEach(each => {
+  // Use push + reverse to avoid O(M^2) unshift array reallocation when collecting matching sections
+  const result: CriticalPathSection[] = [];
+  for (let i = 0; i < criticalPath.length; i++) {
+    const each = criticalPath[i];
     if (allRequiredSpanIds.has(each.spanID)) {
-      if (criticalPathSections.length !== 0 && each.sectionEnd === criticalPathSections[0].sectionStart) {
+      if (result.length > 0 && each.sectionEnd === result[result.length - 1].sectionStart) {
         // Merge Critical Paths if they are consecutive
-        criticalPathSections[0].sectionStart = each.sectionStart;
+        result[result.length - 1].sectionStart = each.sectionStart;
       } else {
-        criticalPathSections.unshift({ ...each });
+        result.push({ ...each });
       }
     }
-  });
+  }
 
-  return criticalPathSections;
+  return result.reverse();
 }
 
 function buildCriticalPathIndex(criticalPath: CriticalPathSection[]) {
@@ -100,42 +102,6 @@ function buildPrunedCriticalPaths(
   return result;
 }
 
-/**
- * Critical path display invariant: a span's bar shows the critical path sections of
- * itself and all spans hidden beneath it, whether hidden by collapse or service filter.
- * - Collapsed: mergeChildrenCriticalPath collects the full subtree (pruning-unaware,
- *   which is correct — a collapsed subtree is entirely hidden regardless of filter).
- * - Expanded with pruned direct children: own sections + pruned subtree sections bubbled
- *   up via memoizedPrunedCriticalPaths. Only direct-child pruning needs handling because
- *   the service filter prunes entire subtrees, so the direct parent is always the nearest
- *   visible ancestor of a pruned span.
- */
-function getVisibleCriticalPathSections(
-  isCollapsed: boolean,
-  hasPrunedChildren: boolean,
-  trace: IOtelTrace,
-  span: IOtelSpan,
-  criticalPath: CriticalPathSection[],
-  pathBySpanID: ReturnType<typeof buildCriticalPathIndex>,
-  prunedPaths: Map<string, CriticalPathSection[]>
-) {
-  if (isCollapsed) {
-    return mergeChildrenCriticalPath(trace, span.spanID, criticalPath);
-  }
-
-  const ownSections = pathBySpanID.get(span.spanID) ?? [];
-
-  if (hasPrunedChildren) {
-    // Precomputed map of parent spanID → critical path sections from pruned subtrees.
-    const prunedSections = prunedPaths.get(span.spanID);
-    if (prunedSections && prunedSections.length > 0) {
-      return [...ownSections, ...prunedSections];
-    }
-  }
-
-  return ownSections;
-}
-
 export type CriticalPathContext = {
   sectionsFor(span: IOtelSpan, isCollapsed: boolean, hasPrunedChildren: boolean): CriticalPathSection[];
 };
@@ -147,18 +113,37 @@ export function makeCriticalPathContext(
 ): CriticalPathContext {
   const index = buildCriticalPathIndex(criticalPath);
   const pruned = buildPrunedCriticalPaths(index, prunedServices, trace.spans);
+  const collapsedCache = new Map<string, CriticalPathSection[]>();
+  const prunedCombinedCache = new Map<string, CriticalPathSection[]>();
 
   return {
     sectionsFor(span, isCollapsed, hasPrunedChildren) {
-      return getVisibleCriticalPathSections(
-        isCollapsed,
-        hasPrunedChildren,
-        trace,
-        span,
-        criticalPath,
-        index,
-        pruned
-      );
+      if (isCollapsed) {
+        let cached = collapsedCache.get(span.spanID);
+        if (!cached) {
+          cached = mergeChildrenCriticalPath(trace, span.spanID, criticalPath);
+          collapsedCache.set(span.spanID, cached);
+        }
+        return cached;
+      }
+
+      const ownSections = index.get(span.spanID) ?? [];
+
+      if (hasPrunedChildren) {
+        let cachedCombined = prunedCombinedCache.get(span.spanID);
+        if (!cachedCombined) {
+          const prunedSections = pruned.get(span.spanID);
+          if (prunedSections && prunedSections.length > 0) {
+            cachedCombined = [...ownSections, ...prunedSections];
+          } else {
+            cachedCombined = ownSections;
+          }
+          prunedCombinedCache.set(span.spanID, cachedCombined);
+        }
+        return cachedCombined;
+      }
+
+      return ownSections;
     },
   };
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- When viewing large traces (>10,000 spans) with collapsed subtrees or pruned services, calculating and merging critical path sections repeatedly calls `unshift` on array objects, resulting in $O(M^2)$ array element reallocation and main-thread stutter during timeline scrolling.

## Description of the changes
- **`criticalPath.ts`**:
  - Replaced $O(M^2)$ `criticalPathSections.unshift({ ...each })` array reallocation with linear $O(M)$ `push` + `reverse()`.
  - Introduced `collapsedCache` in `makeCriticalPathContext` to memoize merged critical path sections for collapsed span trees.
  - Introduced `prunedCombinedCache` in `makeCriticalPathContext` to memoize combined own sections + pruned child sections.
- **`criticalPath.test.ts`**:
  - Added unit test suite covering null safety, collapsed tree merging, reference memoization (cache hits), and pruned service subtrees.

## How was this change tested?
- Unit tests: `npx vitest run src/components/TracePage/TraceTimelineViewer/criticalPath.test.ts src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx` (55/55 passed)
- TypeScript check: `npx tsc -p packages/jaeger-ui/tsconfig.json` (0 errors)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits (`git commit -s`)
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR
- [x] **Light**: AI used for formatting and test case setup
