### PR TITLE
feat(jaeger-ui): add keyboard navigation and ARIA accessibility to timeline spans

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.test.jsx
@@ -137,6 +137,34 @@ describe('<SpanBarRow>', () => {
     expect(defaultProps.onDetailToggled).not.toHaveBeenCalled();
   });
 
+  it('triggers onChildrenToggled when ArrowRight is pressed on a collapsed parent span', () => {
+    const onChildrenToggled = jest.fn();
+    const props = {
+      ...defaultProps,
+      isChildrenExpanded: false,
+      span: { ...defaultProps.span, hasChildren: true },
+      onChildrenToggled,
+    };
+    render(<SpanBarRow {...props} />);
+    const spanName = screen.getByRole('switch');
+    fireEvent.keyDown(spanName, { key: 'ArrowRight' });
+    expect(onChildrenToggled).toHaveBeenCalledWith(defaultProps.span.spanID);
+  });
+
+  it('triggers onChildrenToggled when ArrowLeft is pressed on an expanded parent span', () => {
+    const onChildrenToggled = jest.fn();
+    const props = {
+      ...defaultProps,
+      isChildrenExpanded: true,
+      span: { ...defaultProps.span, hasChildren: true },
+      onChildrenToggled,
+    };
+    render(<SpanBarRow {...props} />);
+    const spanName = screen.getByRole('switch');
+    fireEvent.keyDown(spanName, { key: 'ArrowLeft' });
+    expect(onChildrenToggled).toHaveBeenCalledWith(defaultProps.span.spanID);
+  });
+
   it('triggers onChildrenToggled when SpanTreeOffset is clicked', () => {
     render(<SpanBarRow {...defaultProps} />);
     const treeOffset = screen.getByTestId('span-tree-offset');

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -92,6 +92,14 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
   onChildrenToggled,
   useOtelTerms,
 }) => {
+  const {
+    duration,
+    hasChildren: isParent,
+    name: operationName,
+    attributes,
+    resource: { serviceName },
+  } = span;
+
   const _detailToggle = useCallback(() => {
     onDetailToggled(span.spanID);
   }, [onDetailToggled, span.spanID]);
@@ -105,17 +113,16 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         onDetailToggled(span.spanID);
+      } else if (e.key === 'ArrowRight' && isParent && !isChildrenExpanded) {
+        e.preventDefault();
+        onChildrenToggled(span.spanID);
+      } else if (e.key === 'ArrowLeft' && isParent && isChildrenExpanded) {
+        e.preventDefault();
+        onChildrenToggled(span.spanID);
       }
     },
-    [onDetailToggled, span.spanID]
+    [onDetailToggled, onChildrenToggled, span.spanID, isParent, isChildrenExpanded]
   );
-  const {
-    duration,
-    hasChildren: isParent,
-    name: operationName,
-    attributes,
-    resource: { serviceName },
-  } = span;
   const pills = spanPillsEnabled ? getSpanPillsForSpan(span) : [];
   // A span classified as GenAI (agent/LLM call/tool call/retrieval/etc.) already
   // renders exactly one icon via GenAISpanIcon below. Suppress the generic
@@ -167,6 +174,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
           <a
             className={`span-name ${isDetailExpanded ? 'is-detail-expanded' : ''}`}
             aria-checked={isDetailExpanded}
+            aria-label={`Span ${serviceName}: ${operationName} (${label})`}
             onClick={_detailToggle}
             onKeyDown={_detailToggleKeyDown}
             role="switch"

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -91,6 +91,12 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
     if ((e.key === 'Enter' || e.key === ' ') && onClick) {
       e.preventDefault();
       onClick();
+    } else if (e.key === 'ArrowRight' && !childrenVisible && onClick) {
+      e.preventDefault();
+      onClick();
+    } else if (e.key === 'ArrowLeft' && childrenVisible && onClick) {
+      e.preventDefault();
+      onClick();
     }
   };
 
@@ -101,9 +107,9 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
           onKeyDown: _childrenToggleKeyDown,
           tabIndex: 0,
         }),
-        role: 'switch',
-        'aria-checked': childrenVisible,
-        'aria-label': 'Expand or collapse child spans',
+        role: 'button',
+        'aria-expanded': childrenVisible,
+        'aria-label': `${childrenVisible ? 'Collapse' : 'Expand'} child spans`,
       }
     : null;
 


### PR DESCRIPTION
## Which problem is this PR solving?
 In the Trace Timeline Viewer, keyboard navigation was limited to toggling span detail via Enter/Space. Navigating large span trees without a mouse required cumbersome manual clicking, and screen reader announcements lacked comprehensive context regarding span services, operation names, and durations.

## Description of the changes
 **`SpanBarRow.tsx` & `SpanTreeOffset.tsx`**:
      Implemented W3C WAI-ARIA standard tree keyboard navigation:
      - Pressing `ArrowRight` on a collapsed parent span expands its child subtree.
      - Pressing `ArrowLeft` on an expanded parent span collapses its child subtree.
    
   Added descriptive `aria-label={`Span ${serviceName}: ${operationName} (${label})`}` for rich screen reader announcements.
   Updated tree offset ARIA labels to dynamically announce expand/collapse state.
   
 **`SpanBarRow.test.jsx`**:
   Added unit test coverage asserting `ArrowRight` and `ArrowLeft` keyboard triggers on parent spans.

## How was this change tested?
 Unit tests: all unit tests are passed locally

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits (`git commit -s`)
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR
- [x] **Light**: AI used for formatting and test case setup
