### PR TITLE
fix(trace-timeline): make span-details divider draggable from the header

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
@@ -35,3 +35,10 @@ SPDX-License-Identifier: Apache-2.0
 .TimelineHeaderRow--sidePanelCell {
   border-left: 1px solid var(--border-strong);
 }
+
+/* Cap header resizers to the header row so they do not overlay the table's
+   own dividers (issue #3925: the span-details divider was only draggable in
+   the table because the header's full-height dragger intercepted it). */
+.TimelineHeaderRow .VerticalResizer--dragger {
+  height: var(--timeline-header-row-height);
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
@@ -36,9 +36,11 @@ SPDX-License-Identifier: Apache-2.0
   border-left: 1px solid var(--border-strong);
 }
 
-/* Cap header resizers to the header row so they do not overlay the table's
+/* Cap header draggers to the header row so they do not overlay the table's
    own dividers (issue #3925: the span-details divider was only draggable in
-   the table because the header's full-height dragger intercepted it). */
-.TimelineHeaderRow .VerticalResizer--dragger {
-  height: var(--timeline-header-row-height);
+   the table because the header's full-height dragger intercepted it). Scope
+   the cap to the flipped (right-side) resizer only: the name-column divider
+   has no body counterpart and relies on its full-height dragger. */
+.TimelineHeaderRow .VerticalResizer.is-flipped .VerticalResizer--dragger {
+  height: var(--timeline-header-row-height, 38px);
 }

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.css
@@ -35,12 +35,3 @@ SPDX-License-Identifier: Apache-2.0
 .TimelineHeaderRow--sidePanelCell {
   border-left: 1px solid var(--border-strong);
 }
-
-/* Cap header draggers to the header row so they do not overlay the table's
-   own dividers (issue #3925: the span-details divider was only draggable in
-   the table because the header's full-height dragger intercepted it). Scope
-   the cap to the flipped (right-side) resizer only: the name-column divider
-   has no body counterpart and relies on its full-height dragger. */
-.TimelineHeaderRow .VerticalResizer.is-flipped .VerticalResizer--dragger {
-  height: var(--timeline-header-row-height, 38px);
-}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -22,8 +22,14 @@ vi.mock('../TimelineRow', () => {
 });
 
 vi.mock('../../../common/VerticalResizer', () => ({
-  default: ({ position, min, max }) => (
-    <div data-testid="vertical-resizer" data-position={position} data-min={min} data-max={max} />
+  default: ({ position, min, max, rightSide }) => (
+    <div
+      data-testid="vertical-resizer"
+      data-position={position}
+      data-min={min}
+      data-max={max}
+      data-right-side={rightSide ? 'true' : undefined}
+    />
   ),
 }));
 
@@ -152,6 +158,23 @@ describe('<TimelineHeaderRow>', () => {
       const resizer = screen.getAllByTestId('vertical-resizer')[0];
       expect(resizer).toHaveAttribute('data-max', String(1 - sidePanelWidth));
     });
+
+    it('renders two resizers: the name-column divider and the side-panel divider', () => {
+      render(<TimelineHeaderRow {...sidePanelProps} />);
+      const resizers = screen.getAllByTestId('vertical-resizer');
+      expect(resizers).toHaveLength(2);
+      expect(resizers[0]).not.toHaveAttribute('data-right-side');
+      expect(resizers[1]).toHaveAttribute('data-right-side', 'true');
+    });
+
+    it('configures the side-panel divider like the body resizer', () => {
+      render(<TimelineHeaderRow {...sidePanelProps} />);
+      const resizers = screen.getAllByTestId('vertical-resizer');
+      expect(resizers[1]).toHaveAttribute('data-position', String(1 - sidePanelWidth));
+      // Keeps the timeline column at MIN_TIMELINE_COLUMN_WIDTH while respecting SIDE_PANEL_WIDTH_MAX.
+      expect(resizers[1]).toHaveAttribute('data-min', String(1 - Math.min(0.7, 1 - nameColumnWidth - 0.05)));
+      expect(resizers[1]).toHaveAttribute('data-max', String(1 - 0.2));
+    });
   });
 
   it('renders the TimelineCollapser', () => {
@@ -194,11 +217,12 @@ describe('<TimelineHeaderRow>', () => {
         resizerMax: 0.8,
       };
 
-      it('renders the VerticalResizer', () => {
+      it('renders only the name-column resizer (the side-panel divider is gated on bars)', () => {
         render(<TimelineHeaderRow {...treeOnlySidePanelProps} />);
-        const resizer = screen.getAllByTestId('vertical-resizer')[0];
-        expect(resizer).toBeInTheDocument();
-        expect(resizer).toHaveAttribute('data-max', '0.8');
+        const resizers = screen.getAllByTestId('vertical-resizer');
+        expect(resizers).toHaveLength(1);
+        expect(resizers[0]).not.toHaveAttribute('data-right-side');
+        expect(resizers[0]).toHaveAttribute('data-max', '0.8');
       });
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -149,7 +149,7 @@ describe('<TimelineHeaderRow>', () => {
 
     it('sets resizer max to 1 - sidePanelWidth', () => {
       render(<TimelineHeaderRow {...sidePanelProps} />);
-      const resizer = screen.getByTestId('vertical-resizer');
+      const resizer = screen.getAllByTestId('vertical-resizer')[0];
       expect(resizer).toHaveAttribute('data-max', String(1 - sidePanelWidth));
     });
   });
@@ -196,7 +196,7 @@ describe('<TimelineHeaderRow>', () => {
 
       it('renders the VerticalResizer', () => {
         render(<TimelineHeaderRow {...treeOnlySidePanelProps} />);
-        const resizer = screen.getByTestId('vertical-resizer');
+        const resizer = screen.getAllByTestId('vertical-resizer')[0];
         expect(resizer).toBeInTheDocument();
         expect(resizer).toHaveAttribute('data-max', '0.8');
       });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import TimelineHeaderRow from './TimelineHeaderRow';
@@ -20,18 +20,6 @@ vi.mock('../TimelineRow', () => {
     default: TimelineRowMock,
   };
 });
-
-vi.mock('../../../common/VerticalResizer', () => ({
-  default: ({ position, min, max, rightSide }) => (
-    <div
-      data-testid="vertical-resizer"
-      data-position={position}
-      data-min={min}
-      data-max={max}
-      data-right-side={rightSide ? 'true' : undefined}
-    />
-  ),
-}));
 
 vi.mock('./TimelineViewingLayer', () => ({
   default: ({ boundsInvalidator, viewRangeTime }) => (
@@ -68,6 +56,7 @@ describe('<TimelineHeaderRow>', () => {
     onCollapseAll: jest.fn(),
     onCollapseOne: jest.fn(),
     onColummWidthChange: jest.fn(),
+    onSidePanelWidthChange: jest.fn(),
     onExpandAll: jest.fn(),
     onExpandOne: jest.fn(),
     resizerMax: 0.85,
@@ -128,9 +117,7 @@ describe('<TimelineHeaderRow>', () => {
     const resizer = screen.getByTestId('vertical-resizer');
 
     expect(resizer).toBeInTheDocument();
-    expect(resizer).toHaveAttribute('data-position', nameColumnWidth.toString());
-    expect(resizer).toHaveAttribute('data-min', '0.15');
-    expect(resizer).toHaveAttribute('data-max', '0.85');
+    expect(resizer.querySelector('.VerticalResizer--dragger')).toHaveStyle({ left: '25%' });
   });
 
   describe('side panel visible', () => {
@@ -148,33 +135,118 @@ describe('<TimelineHeaderRow>', () => {
       expect(screen.getByText('Span Details')).toBeInTheDocument();
     });
 
+    it.each([true, false])('places dividers after the side-panel header with bars visible=%s', visible => {
+      const { container } = render(<TimelineHeaderRow {...sidePanelProps} timelineBarsVisible={visible} />);
+      const cell = container.querySelector('.TimelineHeaderRow--sidePanelCell');
+      for (const resizer of screen.getAllByTestId('vertical-resizer')) {
+        expect(cell.compareDocumentPosition(resizer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      }
+    });
+
     it('renders a custom side panel label when provided', () => {
       render(<TimelineHeaderRow {...sidePanelProps} sidePanelLabel="Trace Root" />);
       expect(screen.getByText('Trace Root')).toBeInTheDocument();
     });
 
-    it('sets resizer max to 1 - sidePanelWidth', () => {
-      render(<TimelineHeaderRow {...sidePanelProps} />);
-      const resizer = screen.getAllByTestId('vertical-resizer')[0];
-      expect(resizer).toHaveAttribute('data-max', String(1 - sidePanelWidth));
-    });
-
-    it('renders two resizers: the name-column divider and the side-panel divider', () => {
-      render(<TimelineHeaderRow {...sidePanelProps} />);
+    it.each([0.3, 0.56])('places the side-panel divider on the column boundary at width %s', width => {
+      render(<TimelineHeaderRow {...sidePanelProps} sidePanelWidth={width} />);
       const resizers = screen.getAllByTestId('vertical-resizer');
       expect(resizers).toHaveLength(2);
-      expect(resizers[0]).not.toHaveAttribute('data-right-side');
-      expect(resizers[1]).toHaveAttribute('data-right-side', 'true');
+      expect(resizers[0]).not.toHaveClass('is-flipped');
+      expect(resizers[1]).not.toHaveClass('is-flipped');
+      expect(parseFloat(resizers[1].querySelector('.VerticalResizer--dragger').style.left)).toBeCloseTo(
+        (1 - width) * 100
+      );
     });
 
-    it('configures the side-panel divider like the body resizer', () => {
-      render(<TimelineHeaderRow {...sidePanelProps} />);
-      const resizers = screen.getAllByTestId('vertical-resizer');
-      expect(resizers[1]).toHaveAttribute('data-position', String(1 - sidePanelWidth));
-      // Keeps the timeline column at MIN_TIMELINE_COLUMN_WIDTH while respecting SIDE_PANEL_WIDTH_MAX.
-      expect(resizers[1]).toHaveAttribute('data-min', String(1 - Math.min(0.7, 1 - nameColumnWidth - 0.05)));
-      expect(resizers[1]).toHaveAttribute('data-max', String(1 - 0.2));
+    it('keeps an exact-boundary drag active across a header rerender', () => {
+      const onSidePanelWidthChange = vi.fn();
+      const { rerender } = render(
+        <TimelineHeaderRow {...sidePanelProps} onSidePanelWidthChange={onSidePanelWidthChange} />
+      );
+      const resizer = screen.getAllByTestId('vertical-resizer')[1];
+      resizer.getBoundingClientRect = () => ({ left: 0, width: 1000 });
+      const dragger = resizer.querySelector('.VerticalResizer--dragger');
+      fireEvent.mouseDown(dragger, { clientX: 700, button: 0 });
+      rerender(<TimelineHeaderRow {...sidePanelProps} onSidePanelWidthChange={onSidePanelWidthChange} />);
+      fireEvent.mouseMove(window, { clientX: 600 });
+      expect(resizer).toHaveClass('isDraggingLeft');
+      fireEvent.mouseUp(window, { clientX: 600 });
+      expect(onSidePanelWidthChange).toHaveBeenCalledTimes(1);
+      expect(onSidePanelWidthChange.mock.calls[0][0]).toBeCloseTo(0.4);
     });
+
+    it.each([
+      [0.25, 0.6, 0.4],
+      [0.25, 0.1, 0.7],
+      [0.4, 0.1, 0.55],
+      [0.4, 0.95, 0.2],
+    ])(
+      'drags with name width %s to boundary %s and commits panel width %s',
+      (nameWidth, target, expected) => {
+        const onSidePanelWidthChange = vi.fn();
+        const { rerender } = render(
+          <TimelineHeaderRow
+            {...sidePanelProps}
+            nameColumnWidth={nameWidth}
+            sidePanelWidth={0.3}
+            onSidePanelWidthChange={onSidePanelWidthChange}
+          />
+        );
+        const resizer = screen.getAllByTestId('vertical-resizer')[1];
+        resizer.getBoundingClientRect = () => ({ left: 120, width: 1000 });
+        const dragger = resizer.querySelector('.VerticalResizer--dragger');
+        fireEvent.mouseDown(dragger, { clientX: 820, button: 0 });
+        fireEvent.mouseMove(window, { clientX: 120 + target * 1000 });
+        expect(onSidePanelWidthChange).not.toHaveBeenCalled();
+        const boundary = 1 - expected;
+        expect(parseFloat(dragger.style.left)).toBeCloseTo(Math.min(0.7, boundary) * 100);
+        fireEvent.mouseUp(window, { clientX: 120 + target * 1000 });
+        expect(onSidePanelWidthChange).toHaveBeenCalledTimes(1);
+        expect(onSidePanelWidthChange.mock.calls[0][0]).toBeCloseTo(expected);
+        rerender(
+          <TimelineHeaderRow
+            {...sidePanelProps}
+            nameColumnWidth={nameWidth}
+            sidePanelWidth={expected}
+            onSidePanelWidthChange={onSidePanelWidthChange}
+          />
+        );
+        expect(parseFloat(dragger.style.left)).toBeCloseTo(boundary * 100);
+      }
+    );
+
+    it.each([
+      [true, 0.3, 0.65],
+      [false, 0.75, 0.8],
+    ])(
+      'keeps name-column dragging active with bars visible=%s',
+      (timelineBarsVisible, sidePanelWidth, resizerMax) => {
+        const onColummWidthChange = vi.fn();
+        render(
+          <TimelineHeaderRow
+            {...sidePanelProps}
+            timelineBarsVisible={timelineBarsVisible}
+            sidePanelWidth={sidePanelWidth}
+            resizerMax={resizerMax}
+            onColummWidthChange={onColummWidthChange}
+          />
+        );
+        const resizer = screen.getAllByTestId('vertical-resizer')[0];
+        resizer.getBoundingClientRect = () => ({ left: 120, width: 1000 });
+        const dragger = resizer.querySelector('.VerticalResizer--dragger');
+        for (const [target, expected] of [
+          [0, 0.15],
+          [0.4, 0.4],
+          [1, resizerMax],
+        ]) {
+          fireEvent.mouseDown(dragger, { clientX: 370, button: 0 });
+          fireEvent.mouseMove(window, { clientX: 120 + target * 1000 });
+          fireEvent.mouseUp(window, { clientX: 120 + target * 1000 });
+          expect(onColummWidthChange).toHaveBeenLastCalledWith(expected);
+        }
+      }
+    );
   });
 
   it('renders the TimelineCollapser', () => {
@@ -212,7 +284,8 @@ describe('<TimelineHeaderRow>', () => {
       const treeOnlySidePanelProps = {
         ...barsHiddenProps,
         sidePanelVisible: true,
-        sidePanelWidth: 0.3,
+        nameColumnWidth: 0.25,
+        sidePanelWidth: 0.75,
         sidePanelLabel: 'Span Details',
         resizerMax: 0.8,
       };
@@ -221,8 +294,7 @@ describe('<TimelineHeaderRow>', () => {
         render(<TimelineHeaderRow {...treeOnlySidePanelProps} />);
         const resizers = screen.getAllByTestId('vertical-resizer');
         expect(resizers).toHaveLength(1);
-        expect(resizers[0]).not.toHaveAttribute('data-right-side');
-        expect(resizers[0]).toHaveAttribute('data-max', '0.8');
+        expect(resizers[0]).not.toHaveClass('is-flipped');
       });
     });
   });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -10,7 +10,7 @@ import Ticks from '../Ticks';
 import TimelineRow from '../TimelineRow';
 import { TUpdateViewRangeTimeFunction, IViewRangeTime, ViewRangeTimeUpdate } from '../../types';
 import { IOtelSpan } from '../../../../types/otel';
-import { SPAN_NAME_COLUMN_WIDTH_MIN } from '../store.constants';
+import { SIDE_PANEL_WIDTH_MAX, SIDE_PANEL_WIDTH_MIN, SPAN_NAME_COLUMN_WIDTH_MIN } from '../store.constants';
 
 import './TimelineHeaderRow.css';
 
@@ -25,6 +25,7 @@ type TimelineHeaderRowProps = {
   onCollapseAll: () => void;
   onCollapseOne: () => void;
   onColummWidthChange: (width: number) => void;
+  onSidePanelWidthChange: (width: number) => void;
   onExpandAll: () => void;
   onExpandOne: () => void;
   resizerMax: number;
@@ -47,6 +48,7 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
     onCollapseAll,
     onCollapseOne,
     onColummWidthChange,
+    onSidePanelWidthChange,
     onExpandAll,
     onExpandOne,
     resizerMax,
@@ -94,6 +96,15 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
           onChange={onColummWidthChange}
           min={SPAN_NAME_COLUMN_WIDTH_MIN}
           max={resizerMax}
+        />
+      )}
+      {sidePanelVisible && (
+        <VerticalResizer
+          position={nameColumnWidth + timelineColumnWidth}
+          onChange={onSidePanelWidthChange}
+          min={SIDE_PANEL_WIDTH_MIN}
+          max={SIDE_PANEL_WIDTH_MAX}
+          rightSide
         />
       )}
       {sidePanelVisible && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -10,7 +10,12 @@ import Ticks from '../Ticks';
 import TimelineRow from '../TimelineRow';
 import { TUpdateViewRangeTimeFunction, IViewRangeTime, ViewRangeTimeUpdate } from '../../types';
 import { IOtelSpan } from '../../../../types/otel';
-import { SIDE_PANEL_WIDTH_MAX, SIDE_PANEL_WIDTH_MIN, SPAN_NAME_COLUMN_WIDTH_MIN } from '../store.constants';
+import {
+  MIN_TIMELINE_COLUMN_WIDTH,
+  SIDE_PANEL_WIDTH_MAX,
+  SIDE_PANEL_WIDTH_MIN,
+  SPAN_NAME_COLUMN_WIDTH_MIN,
+} from '../store.constants';
 
 import './TimelineHeaderRow.css';
 
@@ -98,12 +103,12 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
           max={resizerMax}
         />
       )}
-      {sidePanelVisible && (
+      {sidePanelVisible && timelineBarsVisible && (
         <VerticalResizer
-          position={nameColumnWidth + timelineColumnWidth}
+          position={1 - sidePanelWidth}
           onChange={onSidePanelWidthChange}
-          min={SIDE_PANEL_WIDTH_MIN}
-          max={SIDE_PANEL_WIDTH_MAX}
+          min={1 - Math.min(SIDE_PANEL_WIDTH_MAX, 1 - nameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH)}
+          max={1 - SIDE_PANEL_WIDTH_MIN}
           rightSide
         />
       )}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/TimelineHeaderRow/TimelineHeaderRow.tsx
@@ -66,6 +66,10 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
     updateNextViewRangeTime,
     viewRangeTime,
   } = props;
+  const onSidePanelPositionChange = React.useCallback(
+    (newPosition: number) => onSidePanelWidthChange(1 - newPosition),
+    [onSidePanelWidthChange]
+  );
   const [viewStart, viewEnd] = viewRangeTime.current;
   const startTime = (viewStart * duration) as IOtelSpan['startTime'];
   const endTime = (viewEnd * duration) as IOtelSpan['endTime'];
@@ -95,6 +99,11 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
           <Ticks numTicks={numTicks} startTime={startTime} endTime={endTime} showLabels />
         </TimelineRow.Cell>
       )}
+      {sidePanelVisible && (
+        <TimelineRow.Cell className="ub-flex ub-px2 TimelineHeaderRow--sidePanelCell" width={sidePanelWidth}>
+          <h3 className="TimelineHeaderRow--title">{sidePanelLabel}</h3>
+        </TimelineRow.Cell>
+      )}
       {(timelineBarsVisible || sidePanelVisible) && (
         <VerticalResizer
           position={nameColumnWidth}
@@ -106,16 +115,10 @@ export default function TimelineHeaderRow(props: TimelineHeaderRowProps) {
       {sidePanelVisible && timelineBarsVisible && (
         <VerticalResizer
           position={1 - sidePanelWidth}
-          onChange={onSidePanelWidthChange}
+          onChange={onSidePanelPositionChange}
           min={1 - Math.min(SIDE_PANEL_WIDTH_MAX, 1 - nameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH)}
           max={1 - SIDE_PANEL_WIDTH_MIN}
-          rightSide
         />
-      )}
-      {sidePanelVisible && (
-        <TimelineRow.Cell className="ub-flex ub-px2 TimelineHeaderRow--sidePanelCell" width={sidePanelWidth}>
-          <h3 className="TimelineHeaderRow--title">{sidePanelLabel}</h3>
-        </TimelineRow.Cell>
       )}
     </TimelineRow>
   );

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.css
@@ -28,11 +28,6 @@ SPDX-License-Identifier: Apache-2.0
   z-index: 3;
 }
 
-/* Ensure the side-panel-width resizer paints above the fixed side panel (z-index: 3). */
-.TraceTimelineViewer--sidePanelLayout > .VerticalResizer {
-  z-index: 4;
-}
-
 /* Show a permanent column divider for all VerticalResizers within the trace timeline,
    scoped to avoid affecting other VerticalResizer usages (e.g. Deep Dependencies panel). */
 .TraceTimelineViewer .VerticalResizer--dragger {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.test.jsx
@@ -69,16 +69,17 @@ vi.mock('./spanPills', () => ({
 vi.mock('./VirtualizedTraceView', () => mockDefault(() => <div data-testid="virtualized-trace-view-mock" />));
 vi.mock('./SpanDetailSidePanel', () => mockDefault(() => <div data-testid="span-detail-side-panel-mock" />));
 vi.mock('../../common/VerticalResizer', () => ({
-  default: ({ onChange }) => (
-    <div data-testid="vertical-resizer-mock">
-      <button data-testid="vertical-resizer-change" type="button" onClick={() => onChange && onChange(0.7)} />
-    </div>
-  ),
+  default: () => <div data-testid="vertical-resizer-mock" />,
 }));
 vi.mock('./TimelineHeaderRow', () =>
   mockDefault(props => (
     <div data-testid="timeline-header-row-mock" data-side-panel-label={props.sidePanelLabel}>
       {props.serviceFilterNode}
+      <button
+        data-testid="header-side-panel-change"
+        type="button"
+        onClick={() => props.onSidePanelWidthChange(0.3)}
+      />
       <button data-testid="collapse-all-button" type="button" onClick={props.onCollapseAll}>
         Collapse All
       </button>
@@ -266,7 +267,6 @@ describe('<TraceTimelineViewer>', () => {
         render(<TraceTimelineViewerImpl {...props} />);
 
         const sidePanelActive = detailPanelMode === 'sidepanel';
-        const resizerExpected = sidePanelActive && timelineBarsVisible;
 
         if (sidePanelActive) {
           expect(screen.getByTestId('span-detail-side-panel-mock')).toBeInTheDocument();
@@ -274,11 +274,7 @@ describe('<TraceTimelineViewer>', () => {
           expect(screen.queryByTestId('span-detail-side-panel-mock')).not.toBeInTheDocument();
         }
 
-        if (resizerExpected) {
-          expect(screen.getByTestId('vertical-resizer-mock')).toBeInTheDocument();
-        } else {
-          expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
-        }
+        expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
 
         // VirtualizedTraceView is always rendered.
         expect(screen.getByTestId('virtualized-trace-view-mock')).toBeInTheDocument();
@@ -298,9 +294,9 @@ describe('<TraceTimelineViewer>', () => {
       expect(screen.getByTestId('virtualized-trace-view-mock')).toBeInTheDocument();
     });
 
-    it('renders a VerticalResizer between main and side panel when timeline bars are visible', () => {
+    it('does not render a second body resizer when timeline bars are visible', () => {
       render(<TraceTimelineViewerImpl {...props} />);
-      expect(screen.getByTestId('vertical-resizer-mock')).toBeInTheDocument();
+      expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
     });
 
     it('does not render a VerticalResizer when timeline bars are hidden', () => {
@@ -309,10 +305,9 @@ describe('<TraceTimelineViewer>', () => {
       expect(screen.queryByTestId('vertical-resizer-mock')).not.toBeInTheDocument();
     });
 
-    it('calls setSidePanelWidth (Zustand + Redux) when the VerticalResizer onChange fires', () => {
+    it('calls setSidePanelWidth (Zustand + Redux) when the header width changes', () => {
       render(<TraceTimelineViewerImpl {...props} />);
-      fireEvent.click(screen.getByTestId('vertical-resizer-change'));
-      // onChange receives newPosition=0.7 → setSidePanelWidth(1 - 0.7 ≈ 0.3)
+      fireEvent.click(screen.getByTestId('header-side-panel-change'));
       expect(mockLayoutPrefsStore.setSidePanelWidth).toHaveBeenCalledTimes(1);
       expect(mockLayoutPrefsStore.setSidePanelWidth.mock.calls[0][0]).toBeCloseTo(0.3);
       expect(props.setSidePanelWidth).toHaveBeenCalledTimes(1);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -214,6 +214,7 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
       onCollapseAll={collapseAll}
       onCollapseOne={collapseOne}
       onColummWidthChange={setSpanNameColumnWidth}
+      onSidePanelWidthChange={setSidePanelWidth}
       onExpandAll={expandAll}
       onExpandOne={expandOne}
       resizerMax={resizerMax}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/index.tsx
@@ -9,7 +9,6 @@ import { actions } from './duck';
 import {
   getSelectedSpanID,
   MIN_TIMELINE_COLUMN_WIDTH,
-  SIDE_PANEL_WIDTH_MAX,
   SIDE_PANEL_WIDTH_MIN,
   SPAN_NAME_COLUMN_WIDTH_MAX,
   SPAN_NAME_COLUMN_WIDTH_MIN,
@@ -21,7 +20,6 @@ import TimelineHeaderRow from './TimelineHeaderRow';
 import { useServiceFilter } from './useServiceFilter';
 import { useSpanPillsEnabled } from './spanPills';
 import VirtualizedTraceView from './VirtualizedTraceView';
-import VerticalResizer from '../../common/VerticalResizer';
 import { merge as mergeShortcuts } from '../keyboard-shortcuts';
 import { Accessors } from '../ScrollManager';
 import { TUpdateViewRangeTimeFunction, IViewRange, ViewRangeTimeUpdate } from '../types';
@@ -259,14 +257,6 @@ export const TraceTimelineViewerImpl = (props: TProps) => {
           <div className="TraceTimelineViewer--main" style={{ width: `${mainWidth}%` }}>
             {virtualizedView}
           </div>
-          {timelineBarsVisible && (
-            <VerticalResizer
-              position={1 - sidePanelWidth}
-              min={1 - Math.min(SIDE_PANEL_WIDTH_MAX, 1 - spanNameColumnWidth - MIN_TIMELINE_COLUMN_WIDTH)}
-              max={1 - SIDE_PANEL_WIDTH_MIN}
-              onChange={newPosition => setSidePanelWidth(1 - newPosition)}
-            />
-          )}
           <div className="TraceTimelineViewer--sidePanel" style={sidePanelStyle}>
             <SpanDetailSidePanel
               trace={trace}


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #3925

## Description of the changes

The trace timeline renders two column dividers, but only the service-name one was draggable from the fixed header row. The span-details boundary existed solely as a `VerticalResizer` inside the body layout (`index.tsx`), so dragging it from the header did nothing.

The fix follows the name-column pattern already in the header: `TimelineHeaderRow` is `position: fixed` and a `VerticalResizer` dragger's height reaches down through the table, so a single header-owned instance serves both the header row and the table rows.

- Move the span-details resizer into `TimelineHeaderRow`, wired to `setSidePanelWidth` through a new `onSidePanelWidthChange` prop, and remove the body instance from `index.tsx`. One divider owns the boundary instead of two instances coordinated by CSS.
- Keep left-origin coordinates (`position = 1 - sidePanelWidth`, flipped back in `onChange`) instead of `rightSide`. The `rightSide` variant mirrors the dragger with `scaleX(-1)`, which pushed the grip away from the actual column border at asymmetric widths (about 540px off at `sidePanelWidth = 0.56`).
- Preserve the body resizer's bounds, so the timeline column keeps `MIN_TIMELINE_COLUMN_WIDTH` and the panel keeps `SIDE_PANEL_WIDTH_MIN` / `SIDE_PANEL_WIDTH_MAX`.
- Gate the divider on `timelineBarsVisible` as well as `sidePanelVisible`. In tree-only mode the panel width is derived from `spanNameColumnWidth`, so the divider would sit on top of the name-column resizer and intercept drags without any visible effect.
- Render the side-panel header cell before the dividers, so a drag starting exactly on the boundary is not intercepted by the cell.
- Memoize the width adapter passed to the resizer, so hover-driven rerenders of the header no longer recreate the `DraggableManager` and cancel an in-flight drag.
- Drop the `.TraceTimelineViewer--sidePanelLayout > .VerticalResizer` z-index rule in `index.css`, which existed only to lift the body resizer above the fixed side panel.

Tests: added regressions for divider/cell ordering, boundary placement at asymmetric widths (0.3 and 0.56), bounds, tree-only visibility, and drag continuity across a rerender. Removed the `VerticalResizer` mock and its assertions from `index.test.jsx`, which became vacuous once `index.tsx` stopped importing the component.

## Testing done

- `vitest run` on `index.test.jsx` + `TimelineHeaderRow.test.jsx`: 40 passed.
- Full `jaeger-ui` suite: 271 files, 3706 tests passed.
- `pnpm run lint` (fmt-lint, tsc-lint, oxlint, check-license, check-copyright-year, check-tsx-naming, check-overrides, knip): clean.
- Manual check against the issue repro in side-panel mode: the grip, the header cell edge, the side panel's left edge and the main column's right edge line up on the same x, and dragging works from both the header row and the table rows.
