### PR TITLE
fix: avoid unknown GenAI view

### DIFF
--- a/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
@@ -94,6 +94,24 @@ describe('OtelTraceFacade', () => {
       };
       expect(new OtelTraceFacade(genAiTrace).isGenAITrace).toBe(true);
     });
+
+    it('returns false when spans only have unrecognized GenAI attributes', () => {
+      const unknownGenAiSpan: Span = {
+        ...mockSpan,
+        spanID: 'unknown-genai-span',
+        tags: [{ key: 'gen_ai.system', value: 'openai' }],
+      };
+      const genAiTrace: Trace = {
+        ...mockLegacyTrace,
+        spans: [mockSpan, unknownGenAiSpan],
+        spanMap: new Map([
+          [mockSpan.spanID, mockSpan],
+          [unknownGenAiSpan.spanID, unknownGenAiSpan],
+        ]),
+        rootSpans: [mockSpan],
+      };
+      expect(new OtelTraceFacade(genAiTrace).isGenAITrace).toBe(false);
+    });
   });
 
   describe('span wiring', () => {

--- a/packages/jaeger-ui/src/model/OtelTraceFacade.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.ts
@@ -40,7 +40,7 @@ export default class OtelTraceFacade implements IOtelTrace {
 
     // Each span's genAIKind is already computed once in OtelSpanFacade's
     // constructor, so this reads cached values instead of re-scanning attributes.
-    this.isGenAITrace = this._spans.some(s => s.genAIKind !== undefined);
+    this.isGenAITrace = this._spans.some(s => s.genAIKind !== undefined && s.genAIKind !== 'UNKNOWN_GENAI');
 
     // Wire up parentSpan, childSpans, and link span references
     this._spans.forEach(span => {

--- a/packages/jaeger-ui/src/types/otel.ts
+++ b/packages/jaeger-ui/src/types/otel.ts
@@ -152,7 +152,7 @@ export interface IOtelTrace {
   // Number of orphan spans (spans with parent references to spans not in the trace)
   orphanSpanCount: number;
 
-  // True if any span in the trace carries a gen_ai.* attribute
+  // True if any span has a recognized GenAI classification.
   isGenAITrace: boolean;
 
   // Helper methods


### PR DESCRIPTION
## Summary
- keep traces with only unrecognized GenAI attributes on the standard timeline view
- retain recognized GenAI classifications for the GenAI view
- add regression coverage for unknown GenAI attributes

## Testing
- 
px --yes pnpm@11.23.0 --filter @jaegertracing/jaeger-ui test src/model/OtelTraceFacade.test.ts`n- 
px --yes pnpm@11.23.0 run fmt-lint`n
Fixes #4415