### PR TITLE
fix(genai): Expand the only section

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -535,20 +535,33 @@ describe('GenAITab', () => {
     expect(screen.getByText('No GenAI-specific attributes found on this span.')).toBeInTheDocument();
   });
 
-  it('shows unhandled gen_ai attributes in a collapsed accordion instead of the empty state', () => {
+  it('auto-expands Other GenAI Attributes when it is the only section', () => {
     render(<GenAITab span={makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }])} />);
-    expect(
-      screen.getByText((_, element) => element?.textContent === 'Other GenAI Attributes:')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Other GenAI Attributes').closest('[role="switch"]')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
     expect(screen.getByText('gen_ai.operation.name')).toBeInTheDocument();
+    expect(screen.getByText('chat')).toBeInTheDocument();
     expect(screen.queryByText('No GenAI-specific attributes found on this span.')).not.toBeInTheDocument();
   });
 
-  it('expands the Other GenAI Attributes accordion on click', () => {
-    render(<GenAITab span={makeSpan([{ key: 'gen_ai.operation.name', value: 'chat' }])} />);
+  it('keeps Other GenAI Attributes collapsed when another section is present and expands it on click', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.provider.name', value: 'openai' },
+          { key: 'gen_ai.operation.name', value: 'chat' },
+        ])}
+      />
+    );
     const header = screen.getByText((_, element) => element?.textContent === 'Other GenAI Attributes:');
+    expect(header.closest('[role="switch"]')).toHaveAttribute('aria-checked', 'false');
     fireEvent.click(header);
-    expect(screen.getByText('chat')).toBeInTheDocument();
+    expect(screen.getByText('Other GenAI Attributes').closest('[role="switch"]')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
   });
 });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -362,13 +362,14 @@ function UnknownDetails({
 
 export default function GenAITab({ span }: Props): React.ReactElement {
   const sections = useMemo(() => extractGenAiSections(span.attributes), [span.attributes]);
+  const hasOnlyOtherSection = sections.length === 1 && sections[0].type === 'other';
   // LLM/Agent/Tool Call/Unknown default open since they're primary content for the
   // span, unlike Other GenAI Attributes which is genuinely secondary overflow data.
   const [isLlmOpen, setIsLlmOpen] = useState(true);
   const [isAgentOpen, setIsAgentOpen] = useState(true);
   const [isToolCallOpen, setIsToolCallOpen] = useState(true);
   const [isUnknownOpen, setIsUnknownOpen] = useState(true);
-  const [isOtherOpen, setIsOtherOpen] = useState(false);
+  const [isOtherOpen, setIsOtherOpen] = useState(hasOnlyOtherSection);
 
   if (sections.length === 0) {
     return <div className="GenAITab--empty">No GenAI-specific attributes found on this span.</div>;


### PR DESCRIPTION
## Which issue is this PR closing?

- Resolves #4415.

## What this PR does

- opens Other GenAI Attributes by default when it is the only rendered section
- keeps it collapsed when primary GenAI sections are present
- adds regression coverage for both states

## Testing

- Jaeger UI test suite: 3,616 tests passed
- TypeScript checks passed for jaeger-ui and plexus
- production Vite build passed