### PR TITLE
feat(timeline): Add contextual controls to span rows

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanBarRow.tsx
@@ -10,6 +10,7 @@ import SpanTreeOffset from './SpanTreeOffset';
 import SpanBar from './SpanBar';
 import { GenAISpanIcon } from './GenAISpanIcon';
 import Ticks from './Ticks';
+import SpanRowControls from './SpanRowControls';
 
 import { TNil } from '../../../types';
 import { CriticalPathSection } from '../../../types/critical_path';
@@ -227,6 +228,7 @@ const SpanBarRow: React.FC<SpanBarRowProps> = ({
               <IoCloudUploadOutline />
             </ReferencesButton>
           )}
+          <SpanRowControls span={span} />
         </div>
       </TimelineRow.Cell>
       {timelineBarsVisible && (

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.css
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2026 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+.SpanRowControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 0.35rem;
+  margin-right: 0.25rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease-in-out;
+  position: relative;
+  z-index: 2;
+  vertical-align: middle;
+}
+
+/* Reveal controls on span row hover */
+.span-row:hover .SpanRowControls {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* If a span is focused, its controls remain visible so the reset button is always accessible */
+.SpanRowControls.is-focused {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.SpanRowControls--button {
+  background: var(--surface-component-background);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  height: 20px;
+  width: 20px;
+  padding: 0;
+  line-height: 1;
+  transition: all 0.15s ease;
+}
+
+.SpanRowControls--button:hover {
+  background: var(--surface-component-background-hover);
+  border-color: var(--interactive-primary);
+  color: var(--interactive-primary);
+}
+
+.SpanRowControls--button:focus-visible {
+  outline: 2px solid var(--interactive-primary);
+  outline-offset: 1px;
+}
+
+/* Active focus / reset button style */
+.SpanRowControls--button.is-active {
+  background: var(--interactive-primary);
+  border-color: var(--interactive-primary);
+  color: var(--text-inverse);
+}
+
+.SpanRowControls--button.is-active:hover {
+  background: var(--interactive-primary-hover);
+  border-color: var(--interactive-primary-hover);
+  color: var(--text-inverse);
+}
+
+.SpanRowControls--menuIcon {
+  font-size: 1rem;
+  vertical-align: -0.15em;
+  margin-right: 0.25rem;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.test.tsx
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import copy from 'copy-to-clipboard';
+
+import { SpanRowControls } from './index';
+import { useTraceTimelineStore } from '../store';
+import { IOtelSpan } from '../../../../types/otel';
+
+vi.mock('copy-to-clipboard', () => ({
+  default: vi.fn().mockReturnValue(true),
+}));
+
+describe('<SpanRowControls>', () => {
+  const mockParentSpan: IOtelSpan = {
+    spanID: 'span-1',
+    traceID: 'trace-1',
+    name: 'parent-op',
+    startTime: 1000,
+    endTime: 2000,
+    duration: 1000,
+    relativeStartTime: 0,
+    hasChildren: true,
+    depth: 0,
+    childSpans: [],
+    attributes: { getValue: () => undefined } as any,
+    resource: { serviceName: 'service-a', attributes: { getValue: () => undefined } as any },
+  } as unknown as IOtelSpan;
+
+  const mockLeafSpan: IOtelSpan = {
+    spanID: 'span-2',
+    traceID: 'trace-1',
+    name: 'leaf-op',
+    startTime: 1100,
+    endTime: 1500,
+    duration: 400,
+    relativeStartTime: 100,
+    hasChildren: false,
+    depth: 1,
+    childSpans: [],
+    attributes: { getValue: () => undefined } as any,
+    resource: { serviceName: 'service-b', attributes: { getValue: () => undefined } as any },
+  } as unknown as IOtelSpan;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useTraceTimelineStore.setState({
+      focusedSubtreeSpanID: null,
+      childrenHiddenIDs: new Set<string>(),
+    });
+  });
+
+  it('renders collapse, focus, and more actions buttons for parent span', () => {
+    render(<SpanRowControls span={mockParentSpan} />);
+
+    expect(screen.getByTestId('collapse-subtree-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('focus-subtree-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('more-actions-btn')).toBeInTheDocument();
+  });
+
+  it('does not render collapse button for leaf span with no children', () => {
+    render(<SpanRowControls span={mockLeafSpan} />);
+
+    expect(screen.queryByTestId('collapse-subtree-btn')).not.toBeInTheDocument();
+    expect(screen.getByTestId('focus-subtree-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('more-actions-btn')).toBeInTheDocument();
+  });
+
+  it('toggles subtree collapse when collapse button is clicked', () => {
+    const toggleSubtreeCollapse = vi.fn();
+    useTraceTimelineStore.setState({ toggleSubtreeCollapse });
+
+    render(<SpanRowControls span={mockParentSpan} />);
+    const collapseBtn = screen.getByTestId('collapse-subtree-btn');
+
+    fireEvent.click(collapseBtn);
+    expect(toggleSubtreeCollapse).toHaveBeenCalledWith(mockParentSpan);
+  });
+
+  it('toggles subtree focus when focus button is clicked', () => {
+    render(<SpanRowControls span={mockParentSpan} />);
+    const focusBtn = screen.getByTestId('focus-subtree-btn');
+
+    // Click to focus
+    fireEvent.click(focusBtn);
+    expect(useTraceTimelineStore.getState().focusedSubtreeSpanID).toBe('span-1');
+
+    // Now it should have is-active class
+    expect(focusBtn).toHaveClass('is-active');
+
+    // Click again to reset focus
+    fireEvent.click(focusBtn);
+    expect(useTraceTimelineStore.getState().focusedSubtreeSpanID).toBeNull();
+  });
+
+  it('copies deep link to clipboard on menu item click', () => {
+    render(<SpanRowControls span={mockParentSpan} />);
+    const moreBtn = screen.getByTestId('more-actions-btn');
+
+    fireEvent.click(moreBtn);
+
+    const copyDeepLinkItem = screen.getByText('Copy deep link');
+    expect(copyDeepLinkItem).toBeInTheDocument();
+
+    fireEvent.click(copyDeepLinkItem);
+    expect(copy).toHaveBeenCalledWith(expect.stringContaining('?uiFind=span-1'));
+  });
+
+  it('copies span ID to clipboard on menu item click', () => {
+    render(<SpanRowControls span={mockParentSpan} />);
+    const moreBtn = screen.getByTestId('more-actions-btn');
+
+    fireEvent.click(moreBtn);
+
+    const copySpanIdItem = screen.getByText('Copy span ID');
+    expect(copySpanIdItem).toBeInTheDocument();
+
+    fireEvent.click(copySpanIdItem);
+    expect(copy).toHaveBeenCalledWith('span-1');
+  });
+
+  it('stops event propagation when clicking controls container', () => {
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <SpanRowControls span={mockParentSpan} />
+      </div>
+    );
+
+    const controls = screen.getByTestId('span-row-controls');
+    fireEvent.click(controls);
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.test.tsx
@@ -122,6 +122,30 @@ describe('<SpanRowControls>', () => {
     expect(copy).toHaveBeenCalledWith('span-1');
   });
 
+  it('renders expand subtree label when subtree is already collapsed', () => {
+    useTraceTimelineStore.setState({
+      childrenHiddenIDs: new Set<string>(['span-1']),
+    });
+
+    render(<SpanRowControls span={mockParentSpan} />);
+    const collapseBtn = screen.getByTestId('collapse-subtree-btn');
+    expect(collapseBtn).toHaveAttribute('aria-label', 'Expand subtree');
+  });
+
+  it('stops event propagation when clicking more actions button', () => {
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <SpanRowControls span={mockParentSpan} />
+      </div>
+    );
+
+    const moreBtn = screen.getByTestId('more-actions-btn');
+    fireEvent.click(moreBtn);
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
   it('stops event propagation when clicking controls container', () => {
     const parentClick = vi.fn();
     render(

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanRowControls/index.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback } from 'react';
+import { Dropdown, Tooltip, message } from 'antd';
+import type { MenuProps } from 'antd';
+import { LuCopy, LuEllipsis, LuFocus, LuLink, LuListCollapse } from 'react-icons/lu';
+import copy from 'copy-to-clipboard';
+import cx from 'classnames';
+
+import { IOtelSpan } from '../../../../types/otel';
+import { useTraceTimelineStore } from '../store';
+
+import './index.css';
+
+type SpanRowControlsProps = {
+  span: IOtelSpan;
+};
+
+export const SpanRowControls: React.FC<SpanRowControlsProps> = ({ span }) => {
+  const focusedSubtreeSpanID = useTraceTimelineStore(s => s.focusedSubtreeSpanID);
+  const setFocusedSubtreeSpanID = useTraceTimelineStore(s => s.setFocusedSubtreeSpanID);
+  const childrenHiddenIDs = useTraceTimelineStore(s => s.childrenHiddenIDs);
+  const toggleSubtreeCollapse = useTraceTimelineStore(s => s.toggleSubtreeCollapse);
+
+  const isFocused = focusedSubtreeSpanID === span.spanID;
+  const isSubtreeCollapsed = childrenHiddenIDs.has(span.spanID);
+
+  const handleCollapseToggle = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      toggleSubtreeCollapse(span);
+    },
+    [toggleSubtreeCollapse, span]
+  );
+
+  const handleFocusToggle = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (isFocused) {
+        setFocusedSubtreeSpanID(null);
+      } else {
+        setFocusedSubtreeSpanID(span.spanID);
+      }
+    },
+    [isFocused, setFocusedSubtreeSpanID, span.spanID]
+  );
+
+  const menuItems: MenuProps['items'] = [
+    {
+      key: 'copy-deep-link',
+      icon: <LuLink className="SpanRowControls--menuIcon" />,
+      label: 'Copy deep link',
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation();
+        const deepLink = `${window.location.origin}${window.location.pathname}?uiFind=${span.spanID}`;
+        copy(deepLink);
+        message.success('Deep link copied to clipboard');
+      },
+    },
+    {
+      key: 'copy-span-id',
+      icon: <LuCopy className="SpanRowControls--menuIcon" />,
+      label: 'Copy span ID',
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation();
+        copy(span.spanID);
+        message.success('Span ID copied to clipboard');
+      },
+    },
+  ];
+
+  return (
+    <div
+      className={cx('SpanRowControls', {
+        'is-focused': isFocused,
+      })}
+      onClick={e => e.stopPropagation()}
+      data-testid="span-row-controls"
+    >
+      {span.hasChildren && (
+        <Tooltip
+          title={isSubtreeCollapsed ? 'Expand subtree' : 'Collapse subtree'}
+          placement="top"
+          mouseLeaveDelay={0}
+        >
+          <button
+            type="button"
+            className="SpanRowControls--button"
+            onClick={handleCollapseToggle}
+            aria-label={isSubtreeCollapsed ? 'Expand subtree' : 'Collapse subtree'}
+            data-testid="collapse-subtree-btn"
+          >
+            <LuListCollapse />
+          </button>
+        </Tooltip>
+      )}
+
+      <Tooltip
+        title={isFocused ? 'Reset subtree focus' : 'Focus subtree'}
+        placement="top"
+        mouseLeaveDelay={0}
+      >
+        <button
+          type="button"
+          className={cx('SpanRowControls--button', {
+            'is-active': isFocused,
+          })}
+          onClick={handleFocusToggle}
+          aria-label={isFocused ? 'Reset subtree focus' : 'Focus subtree'}
+          data-testid="focus-subtree-btn"
+        >
+          <LuFocus />
+        </button>
+      </Tooltip>
+
+      <Dropdown
+        menu={{ items: menuItems }}
+        trigger={['click']}
+        placement="bottomRight"
+        arrow={{ pointAtCenter: true }}
+      >
+        <Tooltip title="More actions" placement="top" mouseLeaveDelay={0}>
+          <button
+            type="button"
+            className="SpanRowControls--button"
+            onClick={e => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            aria-label="More actions"
+            data-testid="more-actions-btn"
+          >
+            <LuEllipsis />
+          </button>
+        </Tooltip>
+      </Dropdown>
+    </div>
+  );
+};
+
+export default React.memo(SpanRowControls);

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.test.jsx
@@ -6,6 +6,7 @@ import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { mapDispatchToProps, mapStateToProps, UnconnectedSpanTreeOffset } from './SpanTreeOffset';
+import { useTraceTimelineStore } from './store';
 vi.mock('../../../utils/span-ancestor-ids');
 
 describe('SpanTreeOffset', () => {
@@ -335,6 +336,26 @@ describe('SpanTreeOffset', () => {
         hoverIndentGuideIds,
       });
       expect(mappedProps.hoverIndentGuideIds).toBe(hoverIndentGuideIds);
+    });
+  });
+
+  describe('focusedSubtreeSpanID support', () => {
+    beforeEach(() => {
+      useTraceTimelineStore.setState({ focusedSubtreeSpanID: null });
+    });
+
+    it('returns empty ancestor chain when focusedSubtreeSpanID matches current span ID', () => {
+      useTraceTimelineStore.setState({ focusedSubtreeSpanID: ownSpanID });
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} span={ownSpan} />);
+      const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
+      expect(indentGuides.length).toBe(0);
+    });
+
+    it('stops ancestor traversal at focusedSubtreeSpanID when it matches a parent span', () => {
+      useTraceTimelineStore.setState({ focusedSubtreeSpanID: parentSpanID });
+      const { container } = render(<UnconnectedSpanTreeOffset {...props} span={ownSpan} />);
+      const indentGuides = container.querySelectorAll('.SpanTreeOffset--indentGuide');
+      expect(indentGuides.length).toBe(1);
     });
   });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -11,6 +11,7 @@ import { actions } from './duck';
 import { ReduxState } from '../../../types';
 import { IOtelSpan } from '../../../types/otel';
 import colorGenerator from '../../../utils/color-generator';
+import { useTraceTimelineStore } from './store';
 
 import './SpanTreeOffset.css';
 
@@ -41,16 +42,24 @@ export const UnconnectedSpanTreeOffset: React.FC<TProps> = ({
   removeHoverIndentGuideId,
   color,
 }) => {
-  // Build ancestor chain directly from span.parentSpan
+  const focusedSubtreeSpanID = useTraceTimelineStore(s => s.focusedSubtreeSpanID);
+
+  // Build ancestor chain directly from span.parentSpan, stopping at focusedSubtreeSpanID if active
   const ancestors = useMemo(() => {
     const chain: IOtelSpan[] = [];
+    if (focusedSubtreeSpanID && span.spanID === focusedSubtreeSpanID) {
+      return chain;
+    }
     let current = span.parentSpan;
     while (current) {
       chain.unshift(current);
+      if (focusedSubtreeSpanID && current.spanID === focusedSubtreeSpanID) {
+        break;
+      }
       current = current.parentSpan;
     }
     return chain;
-  }, [span]);
+  }, [span, focusedSubtreeSpanID]);
 
   /**
    * If the mouse leaves to anywhere except another span with the same ancestor id, this span's ancestor id is

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.test.jsx
@@ -888,4 +888,28 @@ describe('<VirtualizedTraceViewImpl>', () => {
       expect(result).toBeTruthy();
     });
   });
+
+  describe('focusedSubtreeSpanID filtering', () => {
+    it('filters rows to only the subtree when focusedSubtreeSpanID is set', () => {
+      const targetSpanID = trace.spans[1].spanID;
+      const expectedSubtreeCount = trace.spans[1].childSpans.length + 1; // root + children
+
+      const { listViewProps } = renderAndCapture({
+        ...mockProps,
+        focusedSubtreeSpanID: targetSpanID,
+      });
+
+      expect(listViewProps.dataLength).toBe(expectedSubtreeCount);
+      expect(listViewProps.getKeyFromIndex(0)).toContain(targetSpanID);
+    });
+
+    it('falls back to full trace spans when focusedSubtreeSpanID does not exist in trace', () => {
+      const { listViewProps } = renderAndCapture({
+        ...mockProps,
+        focusedSubtreeSpanID: 'non-existent-span-id',
+      });
+
+      expect(listViewProps.dataLength).toBe(trace.spans.length);
+    });
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -26,6 +26,7 @@ import {
   isKindProducer,
   spanContainsErredSpan,
 } from './utils';
+import { getSubtreeSpans } from './timeline-utils';
 import { Accessors } from '../ScrollManager';
 import { parseUiFind, TExtractUiFindFromStateReturn } from '../../common/UiFindInput';
 import getLinks from '../../../model/link-patterns';
@@ -76,6 +77,7 @@ type RouteProps = {
 type TDerivedStateProps = {
   selectedSpanID: string | null;
   prunedServices: Set<string>;
+  focusedSubtreeSpanID?: string | null;
 };
 
 type VirtualizedTraceViewProps = TVirtualizedTraceViewOwnProps &
@@ -99,12 +101,20 @@ function generateRowStatesFromTrace(
   childrenHiddenIDs: Set<string>,
   detailStates: Map<string, DetailState | TNil>,
   detailPanelMode: 'inline' | 'sidepanel',
-  prunedServices: Set<string>
+  prunedServices: Set<string>,
+  focusedSubtreeSpanID?: string | null
 ): RowState[] {
   if (!trace) {
     return [];
   }
-  return generateRowStates(trace.spans, childrenHiddenIDs, detailStates, detailPanelMode, prunedServices);
+  let spans = trace.spans;
+  if (focusedSubtreeSpanID) {
+    const focusedSpan = trace.spanMap.get(focusedSubtreeSpanID);
+    if (focusedSpan) {
+      spans = getSubtreeSpans(focusedSpan);
+    }
+  }
+  return generateRowStates(spans, childrenHiddenIDs, detailStates, detailPanelMode, prunedServices);
 }
 
 function getCssClasses(currentViewRange: [number, number]) {
@@ -134,8 +144,16 @@ export const VirtualizedTraceViewImpl = React.memo(function VirtualizedTraceView
   );
 
   const getRowStates = useCallback((): RowState[] => {
-    const { trace, childrenHiddenIDs, detailStates, detailPanelMode, prunedServices } = propsRef.current;
-    return memoizedGenerateRowStates(trace, childrenHiddenIDs, detailStates, detailPanelMode, prunedServices);
+    const { trace, childrenHiddenIDs, detailStates, detailPanelMode, prunedServices, focusedSubtreeSpanID } =
+      propsRef.current;
+    return memoizedGenerateRowStates(
+      trace,
+      childrenHiddenIDs,
+      detailStates,
+      detailPanelMode,
+      prunedServices,
+      focusedSubtreeSpanID
+    );
   }, []);
 
   const getClippingCssClasses = useCallback((): string => {
@@ -585,6 +603,7 @@ function VirtualizedTraceViewWrapper(
   const detailPanelMode = useLayoutPrefsStore(s => s.detailPanelMode);
   const timelineBarsVisible = useLayoutPrefsStore(s => s.timelineBarsVisible);
   const traceID = useTraceTimelineStore(s => s.traceID);
+  const focusedSubtreeSpanID = useTraceTimelineStore(s => s.focusedSubtreeSpanID);
   const childrenHiddenIDs = useTraceTimelineStore(s => s.childrenHiddenIDs);
   const detailStates = useTraceTimelineStore(s => s.detailStates);
   const shouldScrollToFirstUiFindMatch = useTraceTimelineStore(s => s.shouldScrollToFirstUiFindMatch);
@@ -706,6 +725,7 @@ function VirtualizedTraceViewWrapper(
     detailPanelMode,
     timelineBarsVisible,
     traceID,
+    focusedSubtreeSpanID,
     childrenHiddenIDs,
     detailStates,
     shouldScrollToFirstUiFindMatch,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.test.ts
@@ -687,3 +687,50 @@ describe('getInitialLayoutState() with storage blocked', () => {
     expect(useLayoutPrefsStore.getState().spanNameColumnWidth).toBeCloseTo(0.4);
   });
 });
+
+describe('useTraceTimelineStore: subtree focus and collapse', () => {
+  const mockChild: any = {
+    spanID: 'child-1',
+    hasChildren: false,
+    childSpans: [],
+  };
+  const mockRoot: any = {
+    spanID: 'root-1',
+    hasChildren: true,
+    childSpans: [mockChild],
+  };
+
+  beforeEach(() => {
+    useTraceTimelineStore.setState({
+      focusedSubtreeSpanID: null,
+      childrenHiddenIDs: new Set<string>(),
+    });
+  });
+
+  it('sets and clears focusedSubtreeSpanID', () => {
+    useTraceTimelineStore.getState().setFocusedSubtreeSpanID('span-xyz');
+    expect(useTraceTimelineStore.getState().focusedSubtreeSpanID).toBe('span-xyz');
+
+    useTraceTimelineStore.getState().setFocusedSubtreeSpanID(null);
+    expect(useTraceTimelineStore.getState().focusedSubtreeSpanID).toBeNull();
+  });
+
+  it('toggles subtree collapse: collapses when expanded, expands when collapsed', () => {
+    expect(useTraceTimelineStore.getState().childrenHiddenIDs.has('root-1')).toBe(false);
+
+    // First call: collapses subtree (adds root-1)
+    useTraceTimelineStore.getState().toggleSubtreeCollapse(mockRoot);
+    expect(useTraceTimelineStore.getState().childrenHiddenIDs.has('root-1')).toBe(true);
+
+    // Second call: expands subtree (removes root-1)
+    useTraceTimelineStore.getState().toggleSubtreeCollapse(mockRoot);
+    expect(useTraceTimelineStore.getState().childrenHiddenIDs.has('root-1')).toBe(false);
+  });
+
+  it('resets focusedSubtreeSpanID when setTrace is called for a new trace', () => {
+    useTraceTimelineStore.setState({ focusedSubtreeSpanID: 'span-xyz' });
+    const trace: any = { traceID: 'new-trace-id', spans: [] };
+    useTraceTimelineStore.getState().setTrace(trace);
+    expect(useTraceTimelineStore.getState().focusedSubtreeSpanID).toBeNull();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.timeline.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/store.timeline.ts
@@ -9,18 +9,22 @@ import { IOtelSpan, IOtelTrace, IEvent } from '../../../types/otel';
 import {
   applyDetailSubsectionToggle,
   calculateFocusedFindRowStates,
+  getDescendantParentSpanIDs,
   shouldDisableCollapse,
   trimFocusedDetailStatesForSidePanel,
 } from './timeline-utils';
 
 type TraceTimelineInteractionStore = {
   traceID: string | null;
+  focusedSubtreeSpanID: string | null;
   childrenHiddenIDs: Set<string>;
   detailStates: Map<string, DetailState>;
   shouldScrollToFirstUiFindMatch: boolean;
   prunedServices: Set<string>;
   setPrunedServices: (pruned: Set<string>) => void;
   clearServiceFilter: () => void;
+  setFocusedSubtreeSpanID: (spanID: string | null) => void;
+  toggleSubtreeCollapse: (span: IOtelSpan) => void;
   // Resets ephemeral fields for a new trace and optionally pre-apply a uiFind filter
   setTrace: (trace: IOtelTrace, uiFind?: string | TNil) => void;
   childrenToggle: (spanID: string) => void;
@@ -41,6 +45,7 @@ type TraceTimelineInteractionStore = {
 
 export const useTraceTimelineStore = create<TraceTimelineInteractionStore>()((set, get) => ({
   traceID: null,
+  focusedSubtreeSpanID: null,
   childrenHiddenIDs: new Set<string>(),
   detailStates: new Map<string, DetailState>(),
   shouldScrollToFirstUiFindMatch: false,
@@ -50,6 +55,25 @@ export const useTraceTimelineStore = create<TraceTimelineInteractionStore>()((se
 
   clearServiceFilter: () => set({ prunedServices: new Set<string>() }),
 
+  setFocusedSubtreeSpanID: (spanID: string | null) => set({ focusedSubtreeSpanID: spanID }),
+
+  toggleSubtreeCollapse: (span: IOtelSpan) => {
+    const { childrenHiddenIDs: current } = get();
+    const subtreeParentIDs = getDescendantParentSpanIDs(span);
+    const isCurrentlyCollapsed = current.has(span.spanID);
+    const next = new Set(current);
+    if (isCurrentlyCollapsed) {
+      for (const id of subtreeParentIDs) {
+        next.delete(id);
+      }
+    } else {
+      for (const id of subtreeParentIDs) {
+        next.add(id);
+      }
+    }
+    set({ childrenHiddenIDs: next });
+  },
+
   setTrace: (trace: IOtelTrace, uiFind?: string | TNil) => {
     const { traceID: currentTraceID } = get();
     if (trace.traceID === currentTraceID) return;
@@ -58,6 +82,7 @@ export const useTraceTimelineStore = create<TraceTimelineInteractionStore>()((se
 
     const base: Partial<TraceTimelineInteractionStore> = {
       traceID: trace.traceID,
+      focusedSubtreeSpanID: null,
       childrenHiddenIDs: new Set<string>(),
       detailStates: new Map<string, DetailState>(),
       shouldScrollToFirstUiFindMatch: false,

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { getDescendantParentSpanIDs, getSubtreeSpans } from './timeline-utils';
+import { IOtelSpan } from '../../../types/otel';
+
+describe('timeline-utils subtree helpers', () => {
+  const leaf1: IOtelSpan = {
+    spanID: 'leaf-1',
+    hasChildren: false,
+    childSpans: [],
+  } as unknown as IOtelSpan;
+
+  const leaf2: IOtelSpan = {
+    spanID: 'leaf-2',
+    hasChildren: false,
+    childSpans: [],
+  } as unknown as IOtelSpan;
+
+  const middleParent: IOtelSpan = {
+    spanID: 'middle-1',
+    hasChildren: true,
+    childSpans: [leaf2],
+  } as unknown as IOtelSpan;
+
+  const rootSpan: IOtelSpan = {
+    spanID: 'root-1',
+    hasChildren: true,
+    childSpans: [leaf1, middleParent],
+  } as unknown as IOtelSpan;
+
+  const standaloneLeaf: IOtelSpan = {
+    spanID: 'standalone-1',
+    hasChildren: false,
+  } as unknown as IOtelSpan;
+
+  describe('getSubtreeSpans', () => {
+    it('returns all descendant spans in pre-order DFS including rootSpan', () => {
+      const result = getSubtreeSpans(rootSpan);
+      expect(result).toEqual([rootSpan, leaf1, middleParent, leaf2]);
+    });
+
+    it('handles a leaf span with no childSpans property safely', () => {
+      const result = getSubtreeSpans(standaloneLeaf);
+      expect(result).toEqual([standaloneLeaf]);
+    });
+  });
+
+  describe('getDescendantParentSpanIDs', () => {
+    it('returns a Set containing IDs of all spans in the subtree that have hasChildren=true', () => {
+      const result = getDescendantParentSpanIDs(rootSpan);
+      expect(result.size).toBe(2);
+      expect(result.has('root-1')).toBe(true);
+      expect(result.has('middle-1')).toBe(true);
+      expect(result.has('leaf-1')).toBe(false);
+      expect(result.has('leaf-2')).toBe(false);
+    });
+
+    it('handles a leaf span with no childSpans property safely', () => {
+      const result = getDescendantParentSpanIDs(standaloneLeaf);
+      expect(result.size).toBe(0);
+    });
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/timeline-utils.ts
@@ -102,3 +102,39 @@ export function applyDetailSubsectionToggle(
   next.set(spanID, detailState);
   return next;
 }
+
+/**
+ * Traverses childSpans in pre-order DFS and collects all descendant spans including rootSpan.
+ */
+export function getSubtreeSpans(rootSpan: IOtelSpan): IOtelSpan[] {
+  const result: IOtelSpan[] = [];
+  function walk(s: IOtelSpan) {
+    result.push(s);
+    if (s.childSpans) {
+      for (const child of s.childSpans) {
+        walk(child);
+      }
+    }
+  }
+  walk(rootSpan);
+  return result;
+}
+
+/**
+ * Returns all span IDs in the subtree (including rootSpan.spanID) that have hasChildren: true.
+ */
+export function getDescendantParentSpanIDs(rootSpan: IOtelSpan): Set<string> {
+  const ids = new Set<string>();
+  function walk(s: IOtelSpan) {
+    if (s.hasChildren) {
+      ids.add(s.spanID);
+    }
+    if (s.childSpans) {
+      for (const child of s.childSpans) {
+        walk(child);
+      }
+    }
+  }
+  walk(rootSpan);
+  return ids;
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4418

## Description of the changes

Adds three contextual action buttons to each span row in the trace timeline view, revealed on hover:

1. **Collapse/Expand subtree** (spans with children only) — toggles visibility of all descendant spans recursively.
2. **Focus subtree** — zooms the timeline to show only the focused span and its descendants, rendering it as the root. An active (highlighted) button remains permanently visible so the user can reset with a single click.
3. **More actions (…) dropdown** — two clipboard actions:
   - *Copy deep link*: copies `<currentURL>?uiFind=<spanID>` to clipboard
   - *Copy span ID*: copies the raw hex span ID to clipboard

### Files changed

| File | Role |
|---|---|
| `SpanRowControls/index.tsx` | New component — three hover buttons backed by Zustand |
| `SpanRowControls/index.css` | Hidden by default; revealed on `.span-row:hover`; active focus button always visible |
| `SpanBarRow.tsx` | Mounts `<SpanRowControls>` inside the span name cell |
| `store.timeline.ts` | Adds `focusedSubtreeSpanID`, `setFocusedSubtreeSpanID`, `toggleSubtreeCollapse`; all reset on `setTrace()` |
| `timeline-utils.ts` | Adds `getSubtreeSpans` and `getDescendantParentSpanIDs` pure helpers |
| `VirtualizedTraceView.tsx` | Filters `trace.spans` to the subtree when `focusedSubtreeSpanID` is active |
| `SpanTreeOffset.tsx` | Trims ancestor indent guides above the focused span so it renders cleanly as root |

## Before / After

### Before
> Hovering over a span row shows no controls — no buttons appear on hover.


https://github.com/user-attachments/assets/65523f0e-2fd6-4011-8f5c-15d638559364



### After
> Three buttons appear on span row hover:
> - **Collapse subtree** — collapses/expands all descendants
> - **Focus subtree** — zooms timeline to just this span's subtree; active button stays visible to reset
> - **⋯ More actions** — dropdown with "Copy deep link" and "Copy span ID"


https://github.com/user-attachments/assets/16efdfd1-1688-427c-a333-0eb67a4619c4



## How was this change tested?

- 7 new unit tests in `SpanRowControls/index.test.tsx` covering: render (parent vs leaf span), collapse toggle, focus toggle, copy deep link, copy span ID, event propagation stop
- 2 new store tests in `store.test.ts` covering `setFocusedSubtreeSpanID` and `toggleSubtreeCollapse`
- Full suite: **3622 / 3622 tests pass** (`pnpm test`)
- `pnpm run tsc-lint` — no type errors
- `pnpm run fmt` — no formatting changes
- `pnpm run oxlint` — 0 new errors
- Manually verified in dev server on a real trace

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully

## AI Usage in this PR (choose one)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
