### PR TITLE
fix: to validates invalid JSON trace files in Upload

### DIFF
--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -82,6 +82,18 @@ describe('fileReader.readJsonFile', () => {
     return expect(p).rejects.toMatchObject(expect.any(Error));
   });
 
+  it.each(['null', 'true', '42', '"trace"'])('rejects valid JSON primitive %s', content => {
+    const file = new File([content], 'foo.json');
+    const p = readJsonFile({ file });
+    return expect(p).rejects.toThrow('Invalid JSON trace format');
+  });
+
+  it.each(['', ' \n\t '])('rejects an empty or whitespace-only file', content => {
+    const file = new File([content], 'empty.json');
+    const p = readJsonFile({ file });
+    return expect(p).rejects.toThrow('The JSON file is empty');
+  });
+
   it('loads JSON-per-line data', () => {
     const expectedOutput = jaegerTraceMulti;
     const fileContent = fs.readFileSync(path.resolve(fixturesDir, 'otlp2jaeger-multi-in.json.txt'), 'utf-8');

--- a/packages/jaeger-ui/src/utils/readJsonFile.ts
+++ b/packages/jaeger-ui/src/utils/readJsonFile.ts
@@ -29,6 +29,10 @@ export default function readJsonFile(fileList: { file: File }): Promise<string> 
         reject(new Error('Invalid result type'));
         return;
       }
+      if (reader.result.trim() === '') {
+        reject(new Error('The JSON file is empty'));
+        return;
+      }
       let traceObj;
       try {
         traceObj = JSON.parse(reader.result);
@@ -40,13 +44,21 @@ export default function readJsonFile(fileList: { file: File }): Promise<string> 
           return;
         }
       }
-      if (Array.isArray(traceObj) && traceObj.every(obj => 'resourceSpans' in obj)) {
+      if (
+        Array.isArray(traceObj) &&
+        traceObj.every(obj => obj !== null && typeof obj === 'object' && 'resourceSpans' in obj)
+      ) {
         const mergedResourceSpans = traceObj.reduce((acc, obj) => {
           acc.push(...obj.resourceSpans);
           return acc;
         }, []);
 
         traceObj = { resourceSpans: mergedResourceSpans };
+      }
+
+      if (traceObj === null || typeof traceObj !== 'object') {
+        reject(new Error('Invalid JSON trace format'));
+        return;
       }
 
       if ('resourceSpans' in traceObj) {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4430 

## Description of the changes
- Added validation to check for empty file.
- Ensure file content is not `empty` or `non object` before `'resourceSpans' in obj`.
- Added validation to reject invalid JSON trace formats as mentioned in the issue.
- Provided meaningful error messages to clearly inform the user when the uploaded file is invalid.

## How was this change tested?
- Had added testcase which covers the above validation scenarios.
- All test pass successfully: 17/17.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
