### PR TITLE
feat(genai): Render retrieval documents and memory records

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
@@ -801,6 +801,16 @@ describe('extractGenAiSections', () => {
       });
     });
 
+    it('builds a retrieval section for an explicitly empty documents array, distinct from no attribute at all (#4437)', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.retrieval.documents': [] }));
+      expect(section(sections, 'retrieval')).toEqual({
+        queryText: undefined,
+        topK: undefined,
+        dataSourceId: undefined,
+        documents: [],
+      });
+    });
+
     it('excludes claimed gen_ai.retrieval.*/gen_ai.data_source.id attributes from the other section', () => {
       const sections = extractGenAiSections(
         attrs({
@@ -849,6 +859,16 @@ describe('extractGenAiSections', () => {
             },
           },
         ],
+      });
+    });
+
+    it('builds a memory section for an explicitly empty records array, distinct from no attribute at all (#4437)', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.memory.records': [] }));
+      expect(section(sections, 'memory')).toEqual({
+        queryText: undefined,
+        storeId: undefined,
+        recordCount: undefined,
+        records: [],
       });
     });
 

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.test.ts
@@ -741,6 +741,130 @@ describe('extractGenAiSections', () => {
     });
   });
 
+  describe('retrieval section', () => {
+    it('extracts query, top_k, data source and documents from the langchain reference scenario shape', () => {
+      const sections = extractGenAiSections(
+        attrs({
+          'gen_ai.operation.name': 'retrieval',
+          'gen_ai.data_source.id': 'weather-knowledge-base',
+          'gen_ai.retrieval.query.text': 'What is the weather in Seattle?',
+          'gen_ai.retrieval.top_k': 3,
+          'gen_ai.retrieval.documents': JSON.stringify([
+            { content: 'Seattle weather is rainy and cool.', source_id: 'weather-knowledge-base' },
+          ]),
+        })
+      );
+      expect(section(sections, 'retrieval')).toEqual({
+        queryText: 'What is the weather in Seattle?',
+        topK: 3,
+        dataSourceId: 'weather-knowledge-base',
+        documents: [
+          { content: 'Seattle weather is rainy and cool.', rest: { source_id: 'weather-knowledge-base' } },
+        ],
+      });
+    });
+
+    it('accepts documents already parsed into an array, and keeps an unrecognized field (e.g. score) reachable', () => {
+      const sections = extractGenAiSections(
+        attrs({
+          'gen_ai.retrieval.documents': [
+            { content: 'first doc', score: 0.92 },
+            { content: 'second doc', score: 0.81 },
+          ],
+        })
+      );
+      expect(section(sections, 'retrieval')?.documents).toEqual([
+        { content: 'first doc', rest: { score: 0.92 } },
+        { content: 'second doc', rest: { score: 0.81 } },
+      ]);
+    });
+
+    it('wraps a single, non-array-wrapped document object instead of dropping it', () => {
+      const sections = extractGenAiSections(
+        attrs({ 'gen_ai.retrieval.documents': { content: 'lone document' } })
+      );
+      expect(section(sections, 'retrieval')?.documents).toEqual([{ content: 'lone document', rest: {} }]);
+    });
+
+    it('falls back to the raw string as content when a document is not valid JSON', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.retrieval.documents': 'not json' }));
+      expect(section(sections, 'retrieval')?.documents).toEqual([{ content: 'not json', rest: {} }]);
+    });
+
+    it('produces a retrieval section from the query text alone, with an empty documents list', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.retrieval.query.text': 'find docs' }));
+      expect(section(sections, 'retrieval')).toEqual({
+        queryText: 'find docs',
+        topK: undefined,
+        dataSourceId: undefined,
+        documents: [],
+      });
+    });
+
+    it('excludes claimed gen_ai.retrieval.*/gen_ai.data_source.id attributes from the other section', () => {
+      const sections = extractGenAiSections(
+        attrs({
+          'gen_ai.retrieval.query.text': 'q',
+          'gen_ai.retrieval.top_k': 3,
+          'gen_ai.data_source.id': 'kb-1',
+          'gen_ai.retrieval.documents': [{ content: 'doc' }],
+        })
+      );
+      expect(section(sections, 'other')).toBeUndefined();
+    });
+
+    it('produces no retrieval section when no retrieval attributes are present', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.provider.name': 'openai' }));
+      expect(section(sections, 'retrieval')).toBeUndefined();
+    });
+  });
+
+  describe('memory section', () => {
+    it('extracts store, query, record count and records from the google-adk reference scenario shape', () => {
+      const sections = extractGenAiSections(
+        attrs({
+          'gen_ai.operation.name': 'search_memory',
+          'gen_ai.memory.store.id': 'memory-store-1',
+          'gen_ai.memory.query.text': "What are the user's food preferences?",
+          'gen_ai.memory.record.count': 1,
+          'gen_ai.memory.records': JSON.stringify([
+            {
+              content: 'User prefers vegetarian meals and dark mode.',
+              id: '90f1f094-8013-4318-9fae-ea944187d51c',
+              metadata: { author: 'user', session_id: 'session_memory_1' },
+            },
+          ]),
+        })
+      );
+      expect(section(sections, 'memory')).toEqual({
+        queryText: "What are the user's food preferences?",
+        storeId: 'memory-store-1',
+        recordCount: 1,
+        records: [
+          {
+            content: 'User prefers vegetarian meals and dark mode.',
+            rest: {
+              id: '90f1f094-8013-4318-9fae-ea944187d51c',
+              metadata: { author: 'user', session_id: 'session_memory_1' },
+            },
+          },
+        ],
+      });
+    });
+
+    it('produces no memory section when no memory attributes are present', () => {
+      const sections = extractGenAiSections(attrs({ 'gen_ai.provider.name': 'openai' }));
+      expect(section(sections, 'memory')).toBeUndefined();
+    });
+
+    it('excludes claimed gen_ai.memory.* attributes from the other section', () => {
+      const sections = extractGenAiSections(
+        attrs({ 'gen_ai.memory.store.id': 'store-1', 'gen_ai.memory.records': [{ content: 'r' }] })
+      );
+      expect(section(sections, 'other')).toBeUndefined();
+    });
+  });
+
   describe('toolCall section', () => {
     it('extracts a tool call when any tool attribute is present', () => {
       const sections = extractGenAiSections(

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
@@ -548,8 +548,12 @@ const REGISTRY: SectionBuilder[] = [
     const queryText = asString(get('gen_ai.retrieval.query.text'));
     const topK = asNumber(get('gen_ai.retrieval.top_k'));
     const dataSourceId = asString(get('gen_ai.data_source.id'));
-    const documents = parseContentEntries(get('gen_ai.retrieval.documents'));
-    return queryText !== undefined || topK !== undefined || dataSourceId !== undefined || documents.length
+    const documentsAttr = get('gen_ai.retrieval.documents');
+    const documents = parseContentEntries(documentsAttr);
+    return queryText !== undefined ||
+      topK !== undefined ||
+      dataSourceId !== undefined ||
+      documentsAttr !== undefined
       ? { type: 'retrieval', data: { queryText, topK, dataSourceId, documents } }
       : undefined;
   },
@@ -557,8 +561,12 @@ const REGISTRY: SectionBuilder[] = [
     const queryText = asString(get('gen_ai.memory.query.text'));
     const storeId = asString(get('gen_ai.memory.store.id'));
     const recordCount = asNumber(get('gen_ai.memory.record.count'));
-    const records = parseContentEntries(get('gen_ai.memory.records'));
-    return queryText !== undefined || storeId !== undefined || recordCount !== undefined || records.length
+    const recordsAttr = get('gen_ai.memory.records');
+    const records = parseContentEntries(recordsAttr);
+    return queryText !== undefined ||
+      storeId !== undefined ||
+      recordCount !== undefined ||
+      recordsAttr !== undefined
       ? { type: 'memory', data: { queryText, storeId, recordCount, records } }
       : undefined;
   },

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/genAiData.ts
@@ -48,6 +48,31 @@ export type GenAiToolCall = {
   result?: unknown;
 };
 
+/**
+ * One entry of a retrieval-documents or memory-records list: `content` pulled out so a
+ * renderer can show it prominently, everything else (score, source_id, metadata, id, ...)
+ * kept as-is so a field neither schema fixes in advance is still reachable.
+ */
+export type GenAiContentEntry = { content: string; rest: Record<string, unknown> };
+
+// Fields per the gen_ai.retrieval.* / gen_ai.data_source.* registry (retrieval spans):
+// query text, top_k, the data source queried, and the documents it returned.
+export type GenAiRetrieval = {
+  queryText?: string;
+  topK?: number;
+  dataSourceId?: string;
+  documents: GenAiContentEntry[];
+};
+
+// Fields per the gen_ai.memory.* registry (search_memory/upsert_memory spans): the
+// memory store, the query, how many records it reports, and the records themselves.
+export type GenAiMemory = {
+  queryText?: string;
+  storeId?: string;
+  recordCount?: number;
+  records: GenAiContentEntry[];
+};
+
 // Fields per the gen_ai.agent.* registry (create_agent/invoke_agent spans): id, name,
 // version, description. All are individually optional/conditionally-required per spec,
 // so a span can carry any subset.
@@ -94,6 +119,8 @@ export type GenAiSection =
       data: { systemInstructions?: string; inputMessages: GenAiMessage[]; outputMessages: GenAiMessage[] };
     }
   | { type: 'toolCall'; data: GenAiToolCall }
+  | { type: 'retrieval'; data: GenAiRetrieval }
+  | { type: 'memory'; data: GenAiMemory }
   | { type: 'other'; data: { attributes: IAttributes } };
 
 function asString(value: AttributeValue | undefined): string | undefined {
@@ -403,6 +430,38 @@ function parseMessages(value: AttributeValue | undefined): GenAiMessage[] {
   });
 }
 
+/**
+ * Parses gen_ai.retrieval.documents / gen_ai.memory.records: a JSON-encoded string or an
+ * already-parsed array/object, each entry a `{content, ...}` object per the retrieval-documents
+ * and memory-records schemas (a document may also carry a score, a record an id and
+ * metadata, and either may carry fields neither schema anticipates). `content` is split out
+ * so a renderer can show it prominently; every other field is kept under `rest` rather than
+ * assumed away, so nothing about an entry is silently dropped.
+ */
+function parseContentEntries(value: AttributeValue | undefined): GenAiContentEntry[] {
+  if (value == null) return [];
+  let parsed: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      // Not JSON - treat the whole string as a single entry with no other fields.
+      return [{ content: value, rest: {} }];
+    }
+  }
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+  return entries.map((entry): GenAiContentEntry => {
+    if (typeof entry !== 'object' || entry === null) {
+      return { content: stringifyValue(entry), rest: {} };
+    }
+    const { content, ...rest } = entry as Record<string, unknown>;
+    return {
+      content: content === undefined ? '' : typeof content === 'string' ? content : stringifyValue(content),
+      rest,
+    };
+  });
+}
+
 export function hasAnyTokenUsage(usage: GenAiTokenUsage): boolean {
   return Object.values(usage).some(v => v != null);
 }
@@ -484,6 +543,24 @@ const REGISTRY: SectionBuilder[] = [
       audioCacheReadInputTokens: asNumber(get('gen_ai.usage.audio.cache_read.input_tokens')),
     };
     return hasAnyTokenUsage(usage) ? { type: 'tokens', data: usage } : undefined;
+  },
+  get => {
+    const queryText = asString(get('gen_ai.retrieval.query.text'));
+    const topK = asNumber(get('gen_ai.retrieval.top_k'));
+    const dataSourceId = asString(get('gen_ai.data_source.id'));
+    const documents = parseContentEntries(get('gen_ai.retrieval.documents'));
+    return queryText !== undefined || topK !== undefined || dataSourceId !== undefined || documents.length
+      ? { type: 'retrieval', data: { queryText, topK, dataSourceId, documents } }
+      : undefined;
+  },
+  get => {
+    const queryText = asString(get('gen_ai.memory.query.text'));
+    const storeId = asString(get('gen_ai.memory.store.id'));
+    const recordCount = asNumber(get('gen_ai.memory.record.count'));
+    const records = parseContentEntries(get('gen_ai.memory.records'));
+    return queryText !== undefined || storeId !== undefined || recordCount !== undefined || records.length
+      ? { type: 'memory', data: { queryText, storeId, recordCount, records } }
+      : undefined;
   },
   get => {
     // Same short-circuit-on-purpose rule as the meta builder above: only fall

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -580,6 +580,80 @@ describe('GenAITab', () => {
     expect(screen.getByText('not valid json')).toBeInTheDocument();
   });
 
+  it('renders a Retrieved documents section with its meta fields and one card per document (#4434)', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.operation.name', value: 'retrieval' },
+          { key: 'gen_ai.data_source.id', value: 'weather-knowledge-base' },
+          { key: 'gen_ai.retrieval.query.text', value: 'What is the weather in Seattle?' },
+          { key: 'gen_ai.retrieval.top_k', value: 3 },
+          {
+            key: 'gen_ai.retrieval.documents',
+            value: JSON.stringify([
+              { content: 'Seattle weather is rainy and cool.', source_id: 'weather-knowledge-base' },
+            ]),
+          },
+        ])}
+      />
+    );
+    expect(screen.getByText('Retrieved documents')).toBeInTheDocument();
+    expect(screen.getByText('What is the weather in Seattle?')).toBeInTheDocument();
+    // "weather-knowledge-base" appears twice: as the data source and again as the
+    // document's own source_id, which must still surface even though it duplicates it.
+    expect(screen.getAllByText('weather-knowledge-base')).toHaveLength(2);
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Document 1')).toBeInTheDocument();
+    expect(screen.getByText('Seattle weather is rainy and cool.')).toBeInTheDocument();
+    // source_id isn't a field the renderer fixes in advance - it must still surface.
+    expect(screen.getByText('source_id')).toBeInTheDocument();
+  });
+
+  it('does not hide retrieval documents behind Other GenAI Attributes (#4434)', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.retrieval.documents', value: [{ content: 'doc one' }, { content: 'doc two' }] },
+        ])}
+      />
+    );
+    expect(screen.getByText('Document 1')).toBeInTheDocument();
+    expect(screen.getByText('doc one')).toBeInTheDocument();
+    expect(screen.getByText('Document 2')).toBeInTheDocument();
+    expect(screen.getByText('doc two')).toBeInTheDocument();
+    expect(screen.queryByText('Other GenAI Attributes')).not.toBeInTheDocument();
+  });
+
+  it('renders a Memory section with its meta fields and one card per record (#4434)', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          { key: 'gen_ai.operation.name', value: 'search_memory' },
+          { key: 'gen_ai.memory.store.id', value: 'memory-store-1' },
+          { key: 'gen_ai.memory.query.text', value: "What are the user's food preferences?" },
+          { key: 'gen_ai.memory.record.count', value: 1 },
+          {
+            key: 'gen_ai.memory.records',
+            value: JSON.stringify([
+              {
+                content: 'User prefers vegetarian meals and dark mode.',
+                id: '90f1f094',
+                metadata: { author: 'user' },
+              },
+            ]),
+          },
+        ])}
+      />
+    );
+    expect(screen.getByText('Memory')).toBeInTheDocument();
+    expect(screen.getByText('memory-store-1')).toBeInTheDocument();
+    expect(screen.getByText("What are the user's food preferences?")).toBeInTheDocument();
+    expect(screen.getByText('Record 1')).toBeInTheDocument();
+    expect(screen.getByText('User prefers vegetarian meals and dark mode.')).toBeInTheDocument();
+    // metadata isn't a field the renderer fixes in advance - it must still surface.
+    expect(screen.getByText('metadata')).toBeInTheDocument();
+  });
+
   it('shows an empty state when the span has no gen_ai attributes', () => {
     render(<GenAITab span={makeSpan([{ key: 'http.method', value: 'GET' }])} />);
     expect(screen.getByText('No GenAI-specific attributes found on this span.')).toBeInTheDocument();

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -624,6 +624,34 @@ describe('GenAITab', () => {
     expect(screen.queryByText('Other GenAI Attributes')).not.toBeInTheDocument();
   });
 
+  it('renders a document field that is explicitly null instead of crashing (#4437)', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          {
+            key: 'gen_ai.retrieval.documents',
+            value: JSON.stringify([{ content: 'doc one', score: null }]),
+          },
+        ])}
+      />
+    );
+    expect(screen.getByText('doc one')).toBeInTheDocument();
+    expect(screen.getByText('score')).toBeInTheDocument();
+    expect(screen.getByText('null')).toBeInTheDocument();
+  });
+
+  it('renders a Retrieved documents section for an explicitly empty documents array (#4437)', () => {
+    render(<GenAITab span={makeSpan([{ key: 'gen_ai.retrieval.documents', value: [] }])} />);
+    expect(screen.getByText('Retrieved documents')).toBeInTheDocument();
+    expect(screen.queryByText('Other GenAI Attributes')).not.toBeInTheDocument();
+  });
+
+  it('renders a Memory section for an explicitly empty records array (#4437)', () => {
+    render(<GenAITab span={makeSpan([{ key: 'gen_ai.memory.records', value: [] }])} />);
+    expect(screen.getByText('Memory')).toBeInTheDocument();
+    expect(screen.queryByText('Other GenAI Attributes')).not.toBeInTheDocument();
+  });
+
   it('renders a Memory section with its meta fields and one card per record (#4434)', () => {
     render(
       <GenAITab

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -12,13 +12,17 @@ import {
   formatTokenCount,
   tryParseJson,
   GenAiAgent,
+  GenAiContentEntry,
+  GenAiMemory,
   GenAiMessage,
   GenAiPart,
+  GenAiRetrieval,
   GenAiTokenUsage,
   GenAiToolCall,
 } from './genAiData';
 import { MessageFormat, useMessageFormatStore } from './message-format-store';
 import AccordionAttributes from '../AccordionAttributes';
+import AttributesTable from '../AttributesTable';
 import { sharedMarkdownOptions } from '../../../../../utils/markdownOptions';
 import { isEmbeddedMedia, MediaType } from '../../../../../utils/media';
 import jsonViewStyles from '../../../../../utils/jsonViewStyles';
@@ -711,6 +715,76 @@ function ConversationDetails({
   );
 }
 
+/**
+ * One retrieved document or memory record: its content shown prominently, sharing the
+ * message box styling so it reads consistently with the rest of the tab, followed by
+ * whatever other fields it carries (score, metadata, id, ...) in an attributes table -
+ * present only when there is at least one such field, per neither schema fixing a set.
+ */
+function ContentEntryCard({ label, entry }: { label: string; entry: GenAiContentEntry }) {
+  const restAttributes = useMemo(
+    () =>
+      makeAttributes(
+        Object.entries(entry.rest).map(([key, value]): IAttribute => ({
+          key,
+          value: value as AttributeValue,
+        }))
+      ),
+    [entry]
+  );
+  return (
+    <div className="GenAITab--message">
+      <div className="GenAITab--messageHeader">
+        <span className="GenAITab--messageRole">{label}</span>
+      </div>
+      {entry.content && (
+        <pre className="GenAITab--messageContent GenAITab--messageContent-plain">{entry.content}</pre>
+      )}
+      {restAttributes.size > 0 && <AttributesTable data={restAttributes} linksGetter={null} />}
+    </div>
+  );
+}
+
+function RetrievalDetails({ queryText, topK, dataSourceId, documents }: GenAiRetrieval) {
+  const metaData = useMemo(() => {
+    const entries: IAttribute[] = [];
+    if (dataSourceId !== undefined) entries.push({ key: 'Data source', value: dataSourceId });
+    if (queryText !== undefined) entries.push({ key: 'Query', value: queryText });
+    if (topK !== undefined) entries.push({ key: 'Top K', value: topK });
+    return makeAttributes(entries);
+  }, [queryText, topK, dataSourceId]);
+
+  return (
+    <div className="GenAITab--section">
+      <h3 className="GenAITab--sectionTitle">Retrieved documents</h3>
+      {metaData.size > 0 && <AttributesTable data={metaData} linksGetter={null} />}
+      {documents.map((doc, i) => (
+        <ContentEntryCard key={i} label={`Document ${i + 1}`} entry={doc} />
+      ))}
+    </div>
+  );
+}
+
+function MemoryDetails({ queryText, storeId, recordCount, records }: GenAiMemory) {
+  const metaData = useMemo(() => {
+    const entries: IAttribute[] = [];
+    if (storeId !== undefined) entries.push({ key: 'Store', value: storeId });
+    if (queryText !== undefined) entries.push({ key: 'Query', value: queryText });
+    if (recordCount !== undefined) entries.push({ key: 'Record count', value: recordCount });
+    return makeAttributes(entries);
+  }, [queryText, storeId, recordCount]);
+
+  return (
+    <div className="GenAITab--section">
+      <h3 className="GenAITab--sectionTitle">Memory</h3>
+      {metaData.size > 0 && <AttributesTable data={metaData} linksGetter={null} />}
+      {records.map((record, i) => (
+        <ContentEntryCard key={i} label={`Record ${i + 1}`} entry={record} />
+      ))}
+    </div>
+  );
+}
+
 function ToolCallDetails({
   id,
   name,
@@ -817,6 +891,10 @@ export default function GenAITab({ span }: Props): React.ReactElement {
             return <TokenDetails key="tokens" usage={section.data} />;
           case 'conversation':
             return <ConversationDetails key="conversation" {...section.data} />;
+          case 'retrieval':
+            return <RetrievalDetails key="retrieval" {...section.data} />;
+          case 'memory':
+            return <MemoryDetails key="memory" {...section.data} />;
           case 'toolCall':
             return (
               <ToolCallDetails

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -727,7 +727,9 @@ function ContentEntryCard({ label, entry }: { label: string; entry: GenAiContent
       makeAttributes(
         Object.entries(entry.rest).map(([key, value]): IAttribute => ({
           key,
-          value: value as AttributeValue,
+          // A direct null (id, score, ... may legitimately be null) must not reach
+          // AttributesTable as-is: it treats null as an object and crashes rendering it.
+          value: value === null ? 'null' : (value as AttributeValue),
         }))
       ),
     [entry]


### PR DESCRIPTION
## Problem

The GenAI conventions define two operations whose payload is content a reader wants to read, and the GenAI tab has a section for neither: both end up in "Other GenAI Attributes":

* **Retrieval** (`retrieval` spans): `gen_ai.retrieval.documents`, `gen_ai.retrieval.query.text`, `gen_ai.retrieval.top_k`, `gen_ai.data_source.id`. Emitted by `langchain`, `haystack` and `llamaindex`.
* **Memory** (`search_memory` / `upsert_memory` spans): `gen_ai.memory.records`, `gen_ai.memory.query.text`, `gen_ai.memory.store.id`, `gen_ai.memory.record.count`. Emitted by `google-adk` and `aws-bedrock-agentcore`.

Both are lists of `{content, ...}` objects, and both are the answer to "why did the model say that": exactly what someone opens a RAG trace to find out, but today it's a raw JSON string buried in "Other GenAI Attributes".

## Root cause

`genAiData.ts`'s `REGISTRY` of section builders had no entry for `gen_ai.retrieval.*` or `gen_ai.memory.*`, so those attributes fell through to the catch all "other" section, and `gen_ai.retrieval.documents` / `gen_ai.memory.records` (JSON encoded lists of documents/records) were rendered as opaque strings rather than parsed content.

## Solution

Add two new section types, `retrieval` and `memory`, following the same `REGISTRY`/builder pattern already used for tokens, tool calls, and conversations:

* A shared `parseContentEntries` helper parses `gen_ai.retrieval.documents` / `gen_ai.memory.records` (a JSON string, an already parsed array, or a single object not wrapped in an array) into `{content, rest}` entries. `content` is pulled out so it can be shown prominently; everything else (score, source_id, metadata, id, ...) is kept under `rest` since neither schema fixes a set of fields.
* `RetrievalDetails` renders a "Retrieved documents" section: query text, top_k, and data source as meta attributes, then one card per document.
* `MemoryDetails` renders a "Memory" section: store, query text, and record count as meta attributes, then one card per record.
* Each card (`ContentEntryCard`) shows `content` in the same message box styling used elsewhere in the tab, with any other fields in an attributes table below.

Because the existing `get()` claiming mechanism is reused, claimed `gen_ai.retrieval.*` / `gen_ai.memory.*` keys are automatically excluded from "Other GenAI Attributes".

## Screenshots

**Retrieval span** (`gen_ai.retrieval.*`, e.g. langchain):

![Retrieved documents section](https://raw.githubusercontent.com/bhuvan-somisetty/jaeger-ui/pr-4437-screenshots-assets/.pr-screenshots/retrieval-genai-tab.png)

**Memory span** (`gen_ai.memory.*`, e.g. google-adk):

![Memory section](https://raw.githubusercontent.com/bhuvan-somisetty/jaeger-ui/pr-4437-screenshots-assets/.pr-screenshots/memory-genai-tab.png)

## Testing

* Added unit tests in `genAiData.test.ts` covering: the langchain and google adk reference scenario shapes verbatim, an already parsed array, a single document not wrapped in an array, a fallback for a document that is not valid JSON, a section built from query text alone (empty documents/records), and that claimed keys no longer leak into "other".
* Added rendering tests in `index.test.tsx` verifying the "Retrieved documents" and "Memory" sections render their meta fields and per item cards, and that documents/records are no longer hidden behind "Other GenAI Attributes".
* `vitest run` for the `GenAITab` directory: 162/162 passing.
* `tsc -p packages/jaeger-ui/tsconfig.json`: clean.

## Impact

Retrieval and memory spans from `langchain`, `haystack`, `llamaindex`, `google-adk`, and `aws-bedrock-agentcore` now render their documents/records as readable content instead of raw JSON buried in "Other GenAI Attributes". No changes to other GenAI section types.

Fixes #4434

