### PR TITLE
Update Scorecard action to v2.4.4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Run analysis'
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Which problem is this PR solving?
- The Scorecard workflow is failing because `ossf/scorecard-action@v2.4.0`
  pulls its Docker image from `gcr.io/openssf/scorecard-action`, which is
  no longer accessible.

## Description of the changes
- Update the immutable `ossf/scorecard-action` pin from v2.4.0 to v2.4.4.
- v2.4.4 uses `ghcr.io/ossf/scorecard-action`, avoiding the broken GCR
  image pull while keeping the existing workflow inputs unchanged.

## How was this change tested?
- `pnpm lint` — passed (261 existing warnings, 0 errors)
- `pnpm test` — 3809/3809 tests passed
- YAML parse — passed
- `git diff --check` — passed
- Verified `ghcr.io/ossf/scorecard-action:v2.4.4` container manifest resolves successfully

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality (N/A: workflow-only dependency update; the full existing test suite passed)
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
