### PR TITLE
chore: eliminate as any cast on Redux Store in App Provider (#4333)

### DIFF
--- a/packages/jaeger-ui/src/components/App/index.tsx
+++ b/packages/jaeger-ui/src/components/App/index.tsx
@@ -31,7 +31,7 @@ export default function JaegerUIApp() {
   return (
     <AppQueryClientProvider>
       <ThemeProvider>
-        <Provider store={store as any}>
+        <Provider store={store}>
           <JaegerAssistantProvider>
             <Page>
               <Routes>


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #4333
Supersedes #4353 (moved to a named branch to satisfy CI check)

## Description of the changes
- Removed the explicit `as any` type cast on the Redux `store` prop in `packages/jaeger-ui/src/components/App/index.tsx`.
- Passing `<Provider store={store}>` directly now satisfies TypeScript without assertions or errors.

## How was this change tested?
- `pnpm run fmt`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy)
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes