### PR TITLE
fix(trace-viewer): correct incomplete-trace tooltip

### DIFF
--- a/packages/jaeger-ui/src/model/trace-viewer.test.ts
+++ b/packages/jaeger-ui/src/model/trace-viewer.test.ts
@@ -18,4 +18,15 @@ describe('getIncompleteTraceTooltip', () => {
     const result = getIncompleteTraceTooltip(1);
     expect(result).toContain('opening or reloading the trace');
   });
+
+  it('names the causes that reloading cannot fix', () => {
+    const result = getIncompleteTraceTooltip(1);
+    expect(result).toContain('dropped by sampling');
+    expect(result).toContain('aged out of retention');
+  });
+
+  it('makes the reload suggestion conditional', () => {
+    const result = getIncompleteTraceTooltip(1);
+    expect(result).toContain('in which case opening or reloading the trace');
+  });
 });

--- a/packages/jaeger-ui/src/model/trace-viewer.ts
+++ b/packages/jaeger-ui/src/model/trace-viewer.ts
@@ -71,8 +71,9 @@ export function getIncompleteTraceTooltip(orphanCount: number): string {
   const verb = orphanCount !== 1 ? 'have' : 'has';
   return (
     `This trace may be incomplete: ${orphanCount} ${noun} ${verb} missing parent ${noun}. ` +
-    `This can happen if the trace is still being collected when you view it. ` +
-    `Try again later by opening or reloading the trace to see whether more spans are available.`
+    `The parents may still be in flight, in which case opening or reloading the trace will ` +
+    `show more spans. They may also never arrive, if they were dropped by sampling or have ` +
+    `aged out of retention.`
   );
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Fixes #4422

## Description of the changes
- The tooltip blamed collection lag and told the user to reload. The orphan count fires for any unresolved `parentSpanID`, including parents dropped by sampling or aged out of retention, which reloading never recovers.
- Reworded in the shared `getIncompleteTraceTooltip()`. Both renderers already route through it.

## How was this change tested?
- Two tests added in `trace-viewer.test.ts`, verified failing without the change.
- `npx vitest run` on the touched files, green. Note the suite is not green on `main` (11 files fail unmodified).

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [X] I have added unit tests for the new functionality
- [X] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [X] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
