### PR TITLE
feat(genai): Collapse and expand a whole conversation

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.css
@@ -41,11 +41,38 @@ SPDX-License-Identifier: Apache-2.0
   gap: 8px;
 }
 
+.GenAITab--sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .GenAITab--sectionTitle {
   font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
+}
+
+.GenAITab--sectionActions {
+  display: flex;
+  gap: 8px;
+}
+
+.GenAITab--sectionAction {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+.GenAITab--sectionAction:hover {
+  color: var(--text-primary);
+  text-decoration: underline;
 }
 
 .GenAITab--message {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.test.tsx
@@ -707,6 +707,77 @@ describe('GenAITab message collapsing', () => {
     expect(message.querySelector('.GenAITab--messagePreview')).toBeNull();
     expect(shownView(within(message).getByLabelText(/Content format/))).toBe('Markdown');
   });
+
+  // The section's own controls act on every message at once. They are deliberately not
+  // toggles: neither reports aria-expanded, since neither owns a region of its own, and a
+  // third expandable button would also make the per-message counts above ambiguous.
+  function collapseAll() {
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all messages' }));
+  }
+
+  function expandAll() {
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all messages' }));
+  }
+
+  it('folds every message when collapse all is used, not just the one last touched', () => {
+    const { container } = renderConversation();
+
+    collapseAll();
+
+    expect(container.querySelectorAll('.GenAITab--messagePreview')).toHaveLength(2);
+    expect(screen.queryAllByRole('button', { expanded: true })).toHaveLength(0);
+  });
+
+  it('opens every message when expand all is used, including ones folded individually', () => {
+    const { container } = renderConversation();
+    const messages = container.querySelectorAll('.GenAITab--message');
+    fireEvent.click(within(messages[0] as HTMLElement).getByRole('button', { expanded: true }));
+
+    expandAll();
+
+    expect(container.querySelectorAll('.GenAITab--messagePreview')).toHaveLength(0);
+    expect(screen.getAllByRole('button', { expanded: true })).toHaveLength(2);
+  });
+
+  it('leaves a single message still foldable on its own after expand all', () => {
+    const { container } = renderConversation();
+    collapseAll();
+
+    expandAll();
+    const messages = container.querySelectorAll('.GenAITab--message');
+    fireEvent.click(within(messages[1] as HTMLElement).getByRole('button', { expanded: true }));
+
+    expect(messages[1].querySelector('.GenAITab--messagePreview')?.textContent).toBe('Second message.');
+    expect(messages[0].querySelector('.GenAITab--messagePreview')).toBeNull();
+  });
+
+  it('leaves a single message still expandable on its own after collapse all', () => {
+    const { container } = renderConversation();
+
+    collapseAll();
+    const messages = container.querySelectorAll('.GenAITab--message');
+    fireEvent.click(within(messages[0] as HTMLElement).getByRole('button', { expanded: false }));
+
+    expect(messages[0].querySelector('.GenAITab--messagePreview')).toBeNull();
+    expect(messages[1].querySelector('.GenAITab--messagePreview')?.textContent).toBe('Second message.');
+  });
+
+  it('offers no section controls for a conversation of one message, which its own toggle already covers', () => {
+    render(
+      <GenAITab
+        span={makeSpan([
+          {
+            key: 'gen_ai.output.messages',
+            value: [{ role: 'assistant', content: 'The only message.' }],
+          },
+        ])}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Collapse all messages' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Expand all messages' })).toBeNull();
+    expect(screen.getAllByRole('button', { expanded: true })).toHaveLength(1);
+  });
 });
 
 describe('GenAITab media rendering', () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/GenAITab/index.tsx
@@ -437,6 +437,8 @@ function MessageBlock({
   formatOverride,
   onFormatChange,
   messageNumber,
+  isCollapsed,
+  onCollapsedChange,
 }: {
   message: GenAiMessage;
   // Remembered format for this message's attribute, seeding each part's initial view; null
@@ -444,8 +446,12 @@ function MessageBlock({
   formatOverride: MessageFormat | null;
   onFormatChange: (format: MessageFormat) => void;
   messageNumber: number;
+  // Folded state lives in ConversationDetails, which is the only place that can act on
+  // every message at once. A message still owns its own toggle; it just no longer owns
+  // the answer, so the section's Collapse all and this button cannot disagree.
+  isCollapsed: boolean;
+  onCollapsedChange: (isCollapsed: boolean) => void;
 }) {
-  const [isCollapsed, setIsCollapsed] = useState(false);
   // Chosen view per part, and the sources the reader has asked to load. Both are held here
   // rather than in the rows, which unmount whenever a view switches away from Media:
   // without that, going to Plain text and back would ask again for an image that was on
@@ -487,7 +493,7 @@ function MessageBlock({
           className="GenAITab--messageToggle"
           aria-expanded={!isCollapsed}
           aria-label={`Message ${messageNumber} (${role})`}
-          onClick={() => setIsCollapsed(!isCollapsed)}
+          onClick={() => onCollapsedChange(!isCollapsed)}
         >
           {isCollapsed ? (
             <IoChevronForward className="GenAITab--messageToggleIcon" />
@@ -695,9 +701,46 @@ function ConversationDetails({
     });
   });
 
+  // Folded state for every message, keyed the same way the rows are. `messages` is rebuilt
+  // on every render, so this is seeded in a lazy initializer rather than an effect: an
+  // effect keyed on that array would refire on each new array identity and throw away
+  // whatever the reader had folded.
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(messages.map(({ key }) => [key, false]))
+  );
+
+  // Collapse all and Expand all are absolute: they write every message, so the section
+  // afterwards is entirely folded or entirely open rather than partly either.
+  const setAllCollapsed = (isCollapsed: boolean) =>
+    setCollapsed(Object.fromEntries(messages.map(({ key }) => [key, isCollapsed])));
+
   return (
     <div className="GenAITab--section">
-      <h3 className="GenAITab--sectionTitle">Conversation</h3>
+      <div className="GenAITab--sectionHeader">
+        <h3 className="GenAITab--sectionTitle">Conversation</h3>
+        {/* Acting on the section as a whole only means anything once there are two
+            messages to act on; below that the message's own toggle already is the pair. */}
+        {messages.length > 1 && (
+          <div className="GenAITab--sectionActions">
+            <button
+              type="button"
+              className="GenAITab--sectionAction"
+              aria-label="Collapse all messages"
+              onClick={() => setAllCollapsed(true)}
+            >
+              Collapse all
+            </button>
+            <button
+              type="button"
+              className="GenAITab--sectionAction"
+              aria-label="Expand all messages"
+              onClick={() => setAllCollapsed(false)}
+            >
+              Expand all
+            </button>
+          </div>
+        )}
+      </div>
       {messages.map(({ key, message, attributeKey }, i) => (
         <MessageBlock
           key={key}
@@ -705,6 +748,11 @@ function ConversationDetails({
           formatOverride={getFormatOverride(attributeKey)}
           onFormatChange={f => setFormat(attributeKey, f)}
           messageNumber={i + 1}
+          // A key absent from the record is a message that arrived after the record was
+          // built, which reads as expanded rather than as folded by something the reader
+          // never did.
+          isCollapsed={collapsed[key] ?? false}
+          onCollapsedChange={next => setCollapsed(current => ({ ...current, [key]: next }))}
         />
       ))}
     </div>


### PR DESCRIPTION
#### Which problem is this PR solving?

#4425 added per-message collapse toggles, but there was no way to collapse or expand the whole conversation at once. For longer conversations, that meant clicking through every message.

Part of #4427.

#### Description of the changes

The Conversation header now has **Collapse all / Expand all** controls when there are at least two messages.

The bulk controls and per-message toggles all update the same state, so they can't get out of sync. The collapsed state was also moved from MessageBlock into ConversationDetails, keyed by the existing message keys (system, input-N, output-N).

The initial state is set with a lazy initializer instead of an effect. Since the messages array gets recreated on each render, using an effect here would reset the collapsed state unnecessarily.

The bulk buttons don't use aria-expanded since they don't control a single region. The existing per-message accessibility behavior stays unchanged.

Nothing is persisted. The state only lasts for the mounted tab, same as the existing collapse state and format choice.

Auto-collapsing long conversations is intentionally left out for #4427. That needs a separate decision on what counts as "long" and which messages should be collapsed.

#### How was this change tested?

Added 5 tests covering:

* Collapse all
* Expand all, including individually collapsed messages
* Individual toggles after bulk actions
* Hiding the bulk controls for a single message
* Existing per-message collapse behavior

Full suite: **3822 passing across 280 files** (3817 on main).

`oxlint` exits 0 with the same 311 pre-existing warnings, and `tsc-lint` is clean.
