### PR TITLE
fix(model): Unify OtelSpanFacade's parent resolution with the render tree

### DIFF
--- a/packages/jaeger-ui/src/model/OtelSpanFacade.test.ts
+++ b/packages/jaeger-ui/src/model/OtelSpanFacade.test.ts
@@ -38,6 +38,9 @@ describe('OtelSpanFacade', () => {
       { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent-1', span: null },
       { refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'link-1', span: null },
     ],
+    // Set by transformTraceData; OtelSpanFacade reads this rather than re-deriving a parent
+    // from `references` itself. See https://github.com/jaegertracing/jaeger-ui/issues/4460.
+    parentID: 'parent-1',
     depth: 1,
     hasChildren: true,
     relativeStartTime: 100,
@@ -65,109 +68,47 @@ describe('OtelSpanFacade', () => {
   });
 
   describe('parentSpanID calculation', () => {
-    it('uses CHILD_OF reference with same traceID', () => {
+    // transformTraceData is the one place that decides who a span's parent is - by walking
+    // `references` in array order and taking the first CHILD_OF/FOLLOWS_FROM reference whose
+    // target actually exists in the trace - and records that choice as `legacySpan.parentID`.
+    // OtelSpanFacade must read that value verbatim rather than re-deriving a parent from
+    // `references` itself; a second, independently-implemented resolution (e.g. one that
+    // always prefers CHILD_OF regardless of reference order) can disagree with the
+    // childSpans tree transformTraceData already built from its own resolution.
+    // See https://github.com/jaegertracing/jaeger-ui/issues/4460.
+    it('reads parentSpanID from legacySpan.parentID', () => {
+      const span: Span = { ...mockLegacySpan, parentID: 'resolved-parent' };
+      const spanFacade = new OtelSpanFacade(span);
+      expect(spanFacade.parentSpanID).toBe('resolved-parent');
+    });
+
+    it('is undefined when legacySpan.parentID is undefined, regardless of what references imply', () => {
+      // References alone must never drive parentSpanID: even though this span carries a
+      // CHILD_OF reference, parentID undefined means transformTraceData found no valid
+      // parent for it (a root, or every reference unresolvable) and it must stay undefined.
       const span: Span = {
         ...mockLegacySpan,
-        traceID: 'trace-1',
+        parentID: undefined,
         references: [{ refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent-1', span: null }],
       };
       const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBe('parent-1');
-    });
-
-    it('ignores CHILD_OF reference with different traceID', () => {
-      const span: Span = {
-        ...mockLegacySpan,
-        traceID: 'trace-1',
-        references: [{ refType: 'CHILD_OF', traceID: 'trace-2', spanID: 'parent-1', span: null }],
-      };
-      const spanFacade = new OtelSpanFacade(span);
       expect(spanFacade.parentSpanID).toBeUndefined();
     });
 
-    it('uses earliest CHILD_OF reference when multiple exist with same traceID', () => {
+    it('follows parentID even when it names a reference that is not first in array order', () => {
+      // Regression case for #4460: a FOLLOWS_FROM reference listed before the CHILD_OF
+      // reference that transformTraceData actually picked as the tree parent. parentSpanID
+      // must match the tree, not fall back to a same-object reference scan.
       const span: Span = {
         ...mockLegacySpan,
-        traceID: 'trace-1',
+        parentID: 'tree-parent',
         references: [
-          { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent-1', span: null },
-          { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent-2', span: null },
+          { refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'earlier-in-array', span: null },
+          { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'tree-parent', span: null },
         ],
       };
       const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBe('parent-1');
-    });
-
-    it('uses FOLLOWS_FROM reference with same traceID when no CHILD_OF exists', () => {
-      const span: Span = {
-        ...mockLegacySpan,
-        traceID: 'trace-1',
-        references: [{ refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'link-1', span: null }],
-      };
-      const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBe('link-1');
-    });
-
-    it('uses earliest FOLLOWS_FROM reference when multiple exist with same traceID and no CHILD_OF', () => {
-      const span: Span = {
-        ...mockLegacySpan,
-        traceID: 'trace-1',
-        references: [
-          { refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'link-1', span: null },
-          { refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'link-2', span: null },
-        ],
-      };
-      const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBe('link-1');
-    });
-
-    it('prefers CHILD_OF with same traceID over FOLLOWS_FROM', () => {
-      const span: Span = {
-        ...mockLegacySpan,
-        traceID: 'trace-1',
-        references: [
-          { refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'link-1', span: null },
-          { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent-1', span: null },
-        ],
-      };
-      const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBe('parent-1');
-    });
-
-    it('returns undefined when no references have same traceID', () => {
-      const span: Span = {
-        ...mockLegacySpan,
-        traceID: 'trace-1',
-        references: [
-          { refType: 'CHILD_OF', traceID: 'trace-2', spanID: 'parent-1', span: null },
-          { refType: 'FOLLOWS_FROM', traceID: 'trace-3', spanID: 'link-1', span: null },
-        ],
-      };
-      const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBeUndefined();
-    });
-
-    it('returns undefined when no references exist', () => {
-      const span: Span = {
-        ...mockLegacySpan,
-        traceID: 'trace-1',
-        references: [],
-      };
-      const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBeUndefined();
-    });
-
-    it('ignores CHILD_OF with different traceID but uses FOLLOWS_FROM with same traceID', () => {
-      const span: Span = {
-        ...mockLegacySpan,
-        traceID: 'trace-1',
-        references: [
-          { refType: 'CHILD_OF', traceID: 'trace-2', spanID: 'parent-1', span: null },
-          { refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'link-1', span: null },
-        ],
-      };
-      const spanFacade = new OtelSpanFacade(span);
-      expect(spanFacade.parentSpanID).toBe('link-1');
+      expect(spanFacade.parentSpanID).toBe('tree-parent');
     });
   });
 
@@ -220,16 +161,17 @@ describe('OtelSpanFacade', () => {
   });
 
   describe('links calculation', () => {
-    it('excludes parentSpanID reference from links', () => {
-      // The mockLegacySpan has a CHILD_OF reference to 'parent-1' which is identified as parent
+    it('excludes the parentID reference from links', () => {
+      // The mockLegacySpan's parentID ('parent-1') matches its first CHILD_OF reference.
       expect(facade.parentSpanID).toBe('parent-1');
       expect(facade.links.find(l => l.spanID === 'parent-1')).toBeUndefined();
     });
 
-    it('includes other CHILD_OF references (different traceID) in links', () => {
+    it('includes other CHILD_OF references not matching parentID in links', () => {
       const span: Span = {
         ...mockLegacySpan,
         traceID: 'trace-1',
+        parentID: 'parent-1',
         references: [
           { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent-1', span: null },
           { refType: 'CHILD_OF', traceID: 'trace-2', spanID: 'other-parent', span: null },
@@ -242,11 +184,13 @@ describe('OtelSpanFacade', () => {
       expect(link?.traceID).toBe('trace-2');
     });
 
-    it('includes secondary CHILD_OF references (same traceID) in links', () => {
-      // First CHILD_OF is parent, subsequent ones should be links
+    it('includes secondary CHILD_OF references not matching parentID in links', () => {
+      // Only the reference matching parentID ('parent-1') is excluded; a second CHILD_OF to
+      // a different spanID is a genuine additional reference and stays a link.
       const span: Span = {
         ...mockLegacySpan,
         traceID: 'trace-1',
+        parentID: 'parent-1',
         references: [
           { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent-1', span: null },
           { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'secondary-parent', span: null },
@@ -266,19 +210,36 @@ describe('OtelSpanFacade', () => {
       expect(link?.traceID).toBe('trace-1');
     });
 
-    it('includes FOLLOWS_FROM reference even if it is used as parent (fallback)', () => {
-      // If no CHILD_OF exists, FOLLOWS_FROM might be used as parent,
-      // it would be standard for async spans like in producer/consumer.
-      // So if a FOLLOWS_FROM becomes the parent, it should be excluded from links.
-
+    it('excludes a FOLLOWS_FROM reference from links when parentID names it (fallback parent)', () => {
+      // Standard for async spans like producer/consumer: transformTraceData falls back to
+      // FOLLOWS_FROM as the tree parent when no CHILD_OF resolves, and records that in
+      // parentID. Links must exclude that FOLLOWS_FROM reference, not just CHILD_OF ones.
       const span: Span = {
         ...mockLegacySpan,
         traceID: 'trace-1',
+        parentID: 'parent-link',
         references: [{ refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'parent-link', span: null }],
       };
       const spanFacade = new OtelSpanFacade(span);
       expect(spanFacade.parentSpanID).toBe('parent-link');
       expect(spanFacade.links.find(l => l.spanID === 'parent-link')).toBeUndefined();
+    });
+
+    it('excludes only the first reference matching parentID when references disagree with array order (#4460)', () => {
+      // The FOLLOWS_FROM reference is listed first, but parentID says the tree actually
+      // picked the CHILD_OF reference (e.g. because the FOLLOWS_FROM target was absent from
+      // this trace when transformTraceData ran). Links must follow parentID, not position.
+      const span: Span = {
+        ...mockLegacySpan,
+        traceID: 'trace-1',
+        parentID: 'tree-parent',
+        references: [
+          { refType: 'FOLLOWS_FROM', traceID: 'trace-1', spanID: 'earlier-in-array', span: null },
+          { refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'tree-parent', span: null },
+        ],
+      };
+      const spanFacade = new OtelSpanFacade(span);
+      expect(spanFacade.links.map(l => l.spanID)).toEqual(['earlier-in-array']);
     });
   });
 

--- a/packages/jaeger-ui/src/model/OtelSpanFacade.ts
+++ b/packages/jaeger-ui/src/model/OtelSpanFacade.ts
@@ -46,15 +46,15 @@ export default class OtelSpanFacade implements IOtelSpan {
       }
     }
 
-    // Find parent span ID according to the following priority:
-    // 1. Earliest CHILD_OF reference with the same traceID
-    // 2. Otherwise, earliest FOLLOWS_FROM reference with the same traceID
-    // 3. If no reference with same traceID exists, parent is undefined
-    const { references, traceID } = this.legacySpan;
-    const parentSpanRef =
-      references.find(r => r.traceID === traceID && r.refType === 'CHILD_OF') ??
-      references.find(r => r.traceID === traceID && r.refType === 'FOLLOWS_FROM');
-    this._parentSpanID = parentSpanRef?.spanID;
+    // The tree parent is already resolved once, authoritatively, by transformTraceData - the
+    // same resolution that builds childSpans/rootSpans - and stored on the legacy span as
+    // `parentID`. Re-deriving it here independently (e.g. preferring CHILD_OF over
+    // FOLLOWS_FROM regardless of reference order, without checking the target actually
+    // exists in this trace) could disagree with that tree: a span's parentSpan would then
+    // not actually list it in parentSpan.childSpans.
+    // See https://github.com/jaegertracing/jaeger-ui/issues/4460.
+    const { references } = this.legacySpan;
+    this._parentSpanID = this.legacySpan.parentID;
 
     this._attributes = makeAttributes(OtelSpanFacade.toOtelAttributes(this.legacySpan.tags));
     this._genAIKind = classifySpan({ attributes: this._attributes });
@@ -65,8 +65,23 @@ export default class OtelSpanFacade implements IOtelSpan {
       attributes: makeAttributes(OtelSpanFacade.toOtelAttributes(log.fields)),
     }));
 
-    this._links = this.legacySpan.references
-      .filter(ref => ref !== parentSpanRef)
+    // Links are every reference except the one used as the tree parent above. Find that one
+    // reference the same way transformTraceData did (first CHILD_OF/FOLLOWS_FROM reference
+    // targeting parentID) rather than by object identity, since parentID is now the only
+    // thing carried over from that resolution.
+    let parentRefExcluded = this._parentSpanID === undefined;
+    this._links = references
+      .filter(ref => {
+        if (
+          !parentRefExcluded &&
+          (ref.refType === 'CHILD_OF' || ref.refType === 'FOLLOWS_FROM') &&
+          ref.spanID === this._parentSpanID
+        ) {
+          parentRefExcluded = true;
+          return false;
+        }
+        return true;
+      })
       .map(ref => ({
         traceID: ref.traceID,
         spanID: ref.spanID,

--- a/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import OtelTraceFacade from './OtelTraceFacade';
+import transformTraceData from './transform-trace-data';
 import { Trace, Span, Process } from '../types/trace';
 import { IOtelTrace } from '../types/otel';
 
@@ -102,6 +103,8 @@ describe('OtelTraceFacade', () => {
       ...mockSpan,
       spanID: 'child',
       references: [{ refType: 'CHILD_OF', traceID: 'trace-1', spanID: 'parent', span: parentSpan }],
+      // Mirrors what transformTraceData would have set given the childSpans wiring below.
+      parentID: 'parent',
     };
     const linkSpan: Span = { ...mockSpan, spanID: 'link' };
 
@@ -144,6 +147,122 @@ describe('OtelTraceFacade', () => {
       expect(childFacade.inboundLinks).toHaveLength(1);
       expect(childFacade.inboundLinks[0].spanID).toBe('link');
       expect(childFacade.inboundLinks[0].span).toBe(linkFacade);
+    });
+  });
+
+  describe('orphanSpanCount', () => {
+    it('is 0 for a trace with no orphans', () => {
+      expect(facade.orphanSpanCount).toBe(0);
+    });
+
+    it('reflects transformTraceData’s count rather than recomputing it from parentSpanID', () => {
+      // legacyTrace.orphanSpanCount is the authoritative count, produced by the same
+      // resolution that builds childSpans/rootSpans. It is not necessarily 0 even though
+      // every span's parentSpanID (once resolved) always points at a span present in this
+      // trace - an orphan has no parentSpanID at all; it became a root instead.
+      const orphanTrace: Trace = { ...mockLegacyTrace, orphanSpanCount: 3 };
+      expect(new OtelTraceFacade(orphanTrace).orphanSpanCount).toBe(3);
+    });
+
+    it('defaults to 0 when legacyTrace.orphanSpanCount is undefined', () => {
+      const traceWithoutCount: Trace = { ...mockLegacyTrace, orphanSpanCount: undefined };
+      expect(new OtelTraceFacade(traceWithoutCount).orphanSpanCount).toBe(0);
+    });
+  });
+
+  // End-to-end regression test for https://github.com/jaegertracing/jaeger-ui/issues/4460:
+  // OtelSpanFacade used to resolve a span's parent independently of the childSpans tree
+  // transformTraceData already built, and the two could disagree. Going through the real
+  // transformTraceData -> asOtelTrace() pipeline (rather than hand-built facades) is what
+  // actually proves the two views of the tree now agree.
+  describe('parentSpan/childSpans agreement (#4460)', () => {
+    const buildSpan = (spanID: string, startTime: number, references: Span['references'] = []) => ({
+      traceID: 'trace-1',
+      spanID,
+      processID: 'p1',
+      operationName: spanID,
+      startTime,
+      duration: 10,
+      references,
+    });
+
+    it('keeps parentSpan and childSpans consistent when a FOLLOWS_FROM reference precedes the CHILD_OF the tree actually used', () => {
+      const data = {
+        traceID: 'trace-1',
+        processes: { p1: { serviceName: 'svc', tags: [] } },
+        spans: [
+          buildSpan('root', 1000),
+          buildSpan('a', 1010),
+          buildSpan('b', 1010),
+          buildSpan('s', 1020, [
+            { refType: 'FOLLOWS_FROM' as const, spanID: 'a', traceID: 'trace-1', span: null },
+            { refType: 'CHILD_OF' as const, spanID: 'b', traceID: 'trace-1', span: null },
+          ]),
+        ],
+      };
+
+      const otel = transformTraceData(data)!.asOtelTrace();
+      const s = otel.spanMap.get('s')!;
+      const a = otel.spanMap.get('a')!;
+      const b = otel.spanMap.get('b')!;
+
+      // The render tree (array-order-first-match, per transformTraceData) places `s` under `a`.
+      expect(a.childSpans).toContain(s);
+      expect(b.childSpans).not.toContain(s);
+
+      // parentSpan must agree with that tree, not independently prefer the CHILD_OF reference.
+      expect(s.parentSpan).toBe(a);
+      expect(s.parentSpanID).toBe('a');
+
+      // The general invariant #4460 asks for: walking up and back down agree.
+      expect(s.parentSpan?.childSpans).toContain(s);
+    });
+
+    it('keeps parentSpan undefined when the resolved CHILD_OF target is absent from this trace, even though a FOLLOWS_FROM target is present', () => {
+      const data = {
+        traceID: 'trace-1',
+        processes: { p1: { serviceName: 'svc', tags: [] } },
+        spans: [
+          buildSpan('a', 1000),
+          buildSpan('s', 1010, [
+            { refType: 'CHILD_OF' as const, spanID: 'a', traceID: 'trace-1', span: null },
+            { refType: 'FOLLOWS_FROM' as const, spanID: 'missing', traceID: 'trace-1', span: null },
+          ]),
+        ],
+      };
+
+      const otel = transformTraceData(data)!.asOtelTrace();
+      const s = otel.spanMap.get('s')!;
+      const a = otel.spanMap.get('a')!;
+
+      expect(a.childSpans).toContain(s);
+      expect(s.parentSpan).toBe(a);
+      expect(s.parentSpanID).toBe('a');
+    });
+
+    it('holds span.parentSpan === undefined || span.parentSpan.childSpans.includes(span) for every span, across a generated multi-reference trace', () => {
+      // A broader sweep beyond the two hand-picked shapes above: every span that carries
+      // more than one same-trace CHILD_OF/FOLLOWS_FROM reference must still agree between
+      // parentSpan and childSpans, whichever reference transformTraceData happened to pick.
+      const spans = [
+        buildSpan('root', 1000),
+        buildSpan('m1', 1010),
+        buildSpan('m2', 1020),
+        buildSpan('multi-ref-1', 1030, [
+          { refType: 'FOLLOWS_FROM' as const, spanID: 'm1', traceID: 'trace-1', span: null },
+          { refType: 'CHILD_OF' as const, spanID: 'm2', traceID: 'trace-1', span: null },
+        ]),
+        buildSpan('multi-ref-2', 1040, [
+          { refType: 'CHILD_OF' as const, spanID: 'm1', traceID: 'trace-1', span: null },
+          { refType: 'CHILD_OF' as const, spanID: 'm2', traceID: 'trace-1', span: null },
+        ]),
+      ];
+      const data = { traceID: 'trace-1', processes: { p1: { serviceName: 'svc', tags: [] } }, spans };
+
+      const otel = transformTraceData(data)!.asOtelTrace();
+      otel.spans.forEach(span => {
+        expect(span.parentSpan === undefined || span.parentSpan.childSpans.includes(span)).toBe(true);
+      });
     });
   });
 });

--- a/packages/jaeger-ui/src/model/OtelTraceFacade.ts
+++ b/packages/jaeger-ui/src/model/OtelTraceFacade.ts
@@ -10,7 +10,6 @@ export default class OtelTraceFacade implements IOtelTrace {
   private _spans: IOtelSpan[];
   private _spanMap: Map<string, IOtelSpan>;
   private _rootSpans: IOtelSpan[];
-  private _orphanSpanCount: number;
   readonly isGenAITrace: boolean;
 
   constructor(legacyTrace: Trace) {
@@ -31,12 +30,6 @@ export default class OtelTraceFacade implements IOtelTrace {
       if (!otelSpan) throw new Error(`Root span ${s.spanID} not found in spanMap`);
       return otelSpan;
     });
-
-    // Calculate orphan span count
-    // A span is orphaned if it has a parentSpanID but the parent is not in the trace
-    this._orphanSpanCount = this._spans.filter(
-      s => s.parentSpanID && !this._spanMap.has(s.parentSpanID)
-    ).length;
 
     // Each span's genAIKind is already computed once in OtelSpanFacade's
     // constructor, so this reads cached values instead of re-scanning attributes.
@@ -114,7 +107,11 @@ export default class OtelTraceFacade implements IOtelTrace {
   }
 
   get orphanSpanCount(): number {
-    return this._orphanSpanCount;
+    // transformTraceData already counts this while resolving the same parent/child tree
+    // that childSpans/parentSpan are built from below, so it's the authoritative count -
+    // recomputing it independently from parentSpanID would now always read 0, since
+    // parentSpanID is only ever set to a spanID that resolution already found in this trace.
+    return this.legacyTrace.orphanSpanCount ?? 0;
   }
 
   hasErrors(): boolean {

--- a/packages/jaeger-ui/src/model/transform-trace-data.ts
+++ b/packages/jaeger-ui/src/model/transform-trace-data.ts
@@ -148,6 +148,12 @@ export default function transformTraceData(data: TraceData & { spans: SpanData[]
       }
     }
 
+    // Record the resolved parent's spanID on the span itself so downstream code (e.g.
+    // OtelSpanFacade) can read the one authoritative parent instead of re-deriving it from
+    // `references` with different tie-break rules, which can disagree with the childSpans
+    // tree built right here. See https://github.com/jaegertracing/jaeger-ui/issues/4460.
+    span.parentID = parent?.spanID;
+
     if (parent) {
       // It's a child
       (parent.childSpans as Span[]).push(span);

--- a/packages/jaeger-ui/src/types/trace.ts
+++ b/packages/jaeger-ui/src/types/trace.ts
@@ -56,6 +56,15 @@ export type Span = SpanData & {
   hasChildren: boolean;
   childSpans: ReadonlyArray<Span>;
   subsidiarilyReferencedBy: ReadonlyArray<SpanReference>;
+
+  // The spanID transformTraceData resolved as this span's actual tree parent: the first
+  // CHILD_OF/FOLLOWS_FROM reference (in array order) whose target exists in this trace, i.e.
+  // the same resolution that places this span in that parent's childSpans. Undefined for a
+  // root or a reference that didn't resolve. This is the one source of truth for "this
+  // span's parent" - anything that re-derives a parent from `references` independently (as
+  // OtelSpanFacade used to) can disagree with the childSpans tree built from this same
+  // resolution. See https://github.com/jaegertracing/jaeger-ui/issues/4460.
+  parentID?: string;
 };
 
 export type TraceData = {


### PR DESCRIPTION
## Problem

`IOtelSpan` exposes two ways to find a span's place in the trace tree - `parentSpan`/`parentSpanID` and `childSpans` - and they were computed by two independent algorithms that could disagree on the same span. When they disagreed, `span.parentSpan.childSpans` did not contain `span`: walking up and walking down the same object graph landed on different trees.

`parentSpan`/`parentSpanID` are live, load-bearing fields, not just typings - they drive the timeline's connector/indent-guide lines (`SpanTreeOffset`), scroll navigation (`ScrollManager`), the critical-path overlay (`CriticalPath`), and the per-trace DAG (`TraceGraph/calculateTraceDagEV`). A single divergent span could misrender in several of these simultaneously, with nothing surfacing an error.

## Root cause

- `transform-trace-data.ts` (the tree that `childSpans`/`rootSpans` are built from) walks a span's `references` **in array order** and picks the first `CHILD_OF`/`FOLLOWS_FROM` reference whose target actually exists in the trace's `spanMap`.
- `OtelSpanFacade.ts` independently recomputed the parent by **always preferring `CHILD_OF` over `FOLLOWS_FROM` regardless of array order**, and **never checked that the target existed in the trace**.
- `OtelTraceFacade.ts` then wired `childSpans` from the first (correct) resolution and `parentSpan` from the second, without reconciling them.

Whenever a span carried more than one same-trace `CHILD_OF`/`FOLLOWS_FROM` reference and the two picks diverged, `parentSpan` pointed at a span whose `childSpans` didn't actually contain it.

## Solution

`transformTraceData` already determines the one true parent per span while building `childSpans`/`rootSpans` - it just discarded which span it picked. This PR:

1. Records that choice on the span itself: `Span.parentID` (`transform-trace-data.ts`).
2. Makes `OtelSpanFacade` read `legacySpan.parentID` verbatim instead of re-deriving a parent from raw `references`, removing the divergent algorithm entirely.
3. Updates `OtelSpanFacade`'s `links` computation (which excludes "the reference used as parent") to identify that reference by matching `parentID` the same way `transformTraceData` does, rather than by object identity to a reference object that no longer exists.
4. Fixes a knock-on consequence: `OtelTraceFacade.orphanSpanCount` was computed independently as `parentSpanID set && spanMap doesn't have it`. Once `parentSpanID` is only ever set to a spanID `transformTraceData` already found in the trace, that check would always read `0` - silently losing the (legitimate) count of spans that had an unresolvable reference and became roots. Switched it to `legacyTrace.orphanSpanCount`, the authoritative count `transformTraceData` already produces from the same resolution.

No behavior change for the overwhelmingly common single-reference case - both algorithms trivially agreed there already.

## Testing

- New regression tests in `OtelTraceFacade.test.ts` go through the real `transformTraceData` → `asOtelTrace()` pipeline (not hand-built facades) to prove the fix end-to-end:
  - A `FOLLOWS_FROM` reference listed before the `CHILD_OF` reference the tree actually used: asserts `parentSpan`/`childSpans` now agree, and the general invariant `span.parentSpan === undefined || span.parentSpan.childSpans.includes(span)`.
  - A `CHILD_OF` target absent from the trace while a `FOLLOWS_FROM` target is present: asserts the facade doesn't strand `parentSpan` at a stale/wrong value.
  - A sweep over a small multi-span trace with several multi-reference spans, asserting the parent/child invariant holds for every span.
  - `orphanSpanCount` now reflects `legacyTrace.orphanSpanCount` (including a case where it's non-zero) instead of always reading `0`.
- `OtelSpanFacade.test.ts`'s `parentSpanID calculation` and `links calculation` suites were rewritten to test the new, correct contract (reading from `parentID`) instead of the removed independent-derivation algorithm; kept a `#4460`-labeled case matching the issue's exact repro shape.
- Full targeted run (`OtelSpanFacade`, `OtelTraceFacade`, `transform-trace-data`, `CriticalPath`, `ScrollManager`, `generateRowStates`, `PrunedSpanRow`, `SpanTreeOffset`, `VirtualizedTraceView`, `useServiceFilter`, `TraceGraph`, `link-patterns`, `span-ancestor-ids`): 305 tests passing.
- Full suite (`vitest run`): 3703 tests, all passing (4 unrelated files showed transient 5000ms render timeouts under full-suite parallel load on my machine; verified they pass cleanly in isolation and touch none of the changed code).
- `tsc -p packages/jaeger-ui/tsconfig.json --noEmit`: clean.
- `vp lint` on the changed files: clean (pre-existing `no-explicit-any` warnings on unrelated lines, unchanged by this diff).

## Impact

Restores the invariant that `parentSpan` and `childSpans` always agree on an `IOtelTrace`, for any span carrying more than one same-trace `CHILD_OF`/`FOLLOWS_FROM` reference - a legitimate OpenTracing/OTel shape (fan-in/batch spans, and per #4320, a same-trace span `Link` alongside a real parent). Fixes the timeline's connector-line rendering, critical-path attribution, Trace Graph DAG edges, and scroll navigation for those spans, and restores a meaningful `orphanSpanCount` on `IOtelTrace` instead of one that would have silently become always-zero.

Fixes #4460
