### PR TITLE
fix(search): Hide initial backend errors on search form

### DIFF
--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.test.jsx
@@ -665,7 +665,7 @@ describe('<SearchForm>', () => {
       expect(container.querySelector('form')).not.toBeInTheDocument();
     });
 
-    it('displays error message when services fetch fails', () => {
+    it('renders form cleanly on initial load when services fetch fails', () => {
       useServices.mockReturnValue({
         data: undefined,
         isLoading: false,
@@ -677,11 +677,11 @@ describe('<SearchForm>', () => {
       // Should still render the form
       expect(container.querySelector('form')).toBeInTheDocument();
 
-      // Should display error message for services
-      expect(container.textContent).toContain('Error loading services: Failed to fetch services');
+      // Should not display error message on initial load
+      expect(container.textContent).not.toContain('Error loading services');
     });
 
-    it('displays error message when span names fetch fails', async () => {
+    it('renders form cleanly on initial load when span names fetch fails', async () => {
       useServices.mockReturnValue({
         data: ['svcA', 'svcB'],
         isLoading: false,
@@ -699,7 +699,32 @@ describe('<SearchForm>', () => {
       // Should still render the form
       expect(container.querySelector('form')).toBeInTheDocument();
 
-      // Should display error message for operations
+      // Should not display error message on initial load
+      await waitFor(() => {
+        expect(container.textContent).not.toContain('Error loading operations');
+      });
+    });
+
+    it('displays error message after submitting when span names fetch fails', async () => {
+      useServices.mockReturnValue({
+        data: ['svcA', 'svcB'],
+        isLoading: false,
+        error: null,
+      });
+
+      useSpanNames.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Failed to fetch span names'),
+      });
+
+      const { container } = renderForm(<SearchForm {...defaultProps} initialValues={{ service: 'svcA' }} />);
+
+      // Click submit
+      const submitButton = container.querySelector(`[data-test="${markers.SUBMIT_BTN}"]`);
+      fireEvent.click(submitButton);
+
+      // Should display error message after submit
       await waitFor(() => {
         expect(container.textContent).toContain('Error loading operations: Failed to fetch span names');
       });

--- a/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
+++ b/packages/jaeger-ui/src/components/SearchTracePage/SearchForm.tsx
@@ -358,6 +358,11 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
     [spanNamesData]
   );
 
+  const { search: locationSearch } = useLocation();
+  const hasUrlSearch = Boolean(locationSearch && locationSearch.length > 1);
+  const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
+  const showErrors = hasSubmitted || submitting || hasUrlSearch;
+
   const [adjustTimeEnabled, setAdjustTimeEnabled] = useState<boolean>(() => {
     return store.getBool(ADJUST_TIME_ENABLED_KEY, Boolean(searchAdjustEndTime));
   });
@@ -380,6 +385,7 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   const handleSubmit = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
+      setHasSubmitted(true);
       const fields = formData as ISearchFormFields;
       const url = submitFormHandler(fields, searchAdjustEndTime, adjustTimeEnabled);
       clearUploadedTraces();
@@ -389,6 +395,7 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
   );
 
   const handleReset = useCallback(() => {
+    setHasSubmitted(false);
     setFormData(prev =>
       defaultFormData({ service: prev.service }, searchConfig?.defaultLookback, allowAllServices)
     );
@@ -412,8 +419,12 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
             Service <span className="SearchForm--labelCount">({services.length})</span>
           </span>
         }
-        validateStatus={servicesError ? 'error' : undefined}
-        help={servicesError ? `Error loading services: ${(servicesError as Error).message}` : undefined}
+        validateStatus={showErrors && servicesError ? 'error' : undefined}
+        help={
+          showErrors && servicesError
+            ? `Error loading services: ${(servicesError as Error).message}`
+            : undefined
+        }
       >
         <SearchableSelect
           data-testid="service"
@@ -452,8 +463,12 @@ export const SearchFormImpl: React.FC<ISearchFormImplProps> = ({
             </Tooltip>
           </span>
         }
-        validateStatus={spanNamesError ? 'error' : undefined}
-        help={spanNamesError ? `Error loading operations: ${(spanNamesError as Error).message}` : undefined}
+        validateStatus={showErrors && spanNamesError ? 'error' : undefined}
+        help={
+          showErrors && spanNamesError
+            ? `Error loading operations: ${(spanNamesError as Error).message}`
+            : undefined
+        }
       >
         <SearchableSelect
           data-testid="operation"


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #4464

## Description of the changes
- On initial landing on `/search`, backend connection errors (`servicesError` / `spanNamesError`) are no longer shown immediately under the Service and Operation dropdowns before any user action has occurred.
- Errors are displayed on the form fields once a search query has been submitted or when active search query parameters are present in the URL.
- Added unit tests in `SearchForm.test.jsx` verifying that:
  - The form renders cleanly on initial load when backend services/span names fail to fetch.
  - The form properly displays the error messages upon search submission.

## How was this change tested?
- Unit tests: `pnpm test` (all 78 SearchForm tests passing)
- Linting and type checks: `pnpm run lint` & `pnpm run tsc-lint` (0 errors)
- Code formatting: `pnpm run fmt`
- Local manual verification with `pnpm start`

## Before:
<img width="1917" height="1198" alt="Screenshot 2026-09-12 082024" src="https://github.com/user-attachments/assets/2f065a7e-4d06-43b8-8a7f-bcd0b104f71d" />


##after
--Intially
<img width="1917" height="1198" alt="image" src="https://github.com/user-attachments/assets/b4b09683-4537-4fba-9678-7ad4e4e974f9" />

--On click btn

<img width="1917" height="1198" alt="image" src="https://github.com/user-attachments/assets/47679685-c83f-4815-948f-4ea977f35cfc" />


## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
