### PR TITLE
feat(genai): Add trace execution summary

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/GenAIExecutionSummary.test.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/GenAIExecutionSummary.test.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IOtelSpan, StatusCode } from '../../../types/otel';
+import { makeAttributes } from '../../../model/attributes';
+import GenAIExecutionSummary from './GenAIExecutionSummary';
+
+function makeSpan(overrides: Partial<IOtelSpan> = {}): IOtelSpan {
+  const zero = 0 as IOtelSpan['startTime'];
+  return {
+    attributes: makeAttributes(),
+    childSpans: [],
+    depth: 0,
+    duration: zero,
+    endTime: zero,
+    events: [],
+    hasChildren: false,
+    inboundLinks: [],
+    instrumentationScope: { name: 'test' },
+    kind: 'INTERNAL' as IOtelSpan['kind'],
+    links: [],
+    name: 'test',
+    relativeStartTime: zero,
+    resource: { attributes: makeAttributes(), serviceName: 'test' },
+    spanID: 'span',
+    startTime: zero,
+    status: { code: StatusCode.OK },
+    traceID: 'trace',
+    warnings: null,
+    ...overrides,
+  };
+}
+
+describe('<GenAIExecutionSummary>', () => {
+  it('is absent when the trace has no GenAI spans', () => {
+    const { container } = render(<GenAIExecutionSummary spans={[makeSpan()]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('opens its trace-wide, non-sensitive summary from the keyboard', async () => {
+    const user = userEvent.setup();
+    render(
+      <GenAIExecutionSummary
+        spans={[
+          makeSpan({ genAIKind: 'AGENT' }),
+          makeSpan({
+            genAIKind: 'LLM_CALL',
+            attributes: makeAttributes([
+              { key: 'gen_ai.usage.input_tokens', value: 1840 },
+              { key: 'gen_ai.usage.output_tokens', value: 260 },
+            ]),
+          }),
+          makeSpan({ genAIKind: 'TOOL_CALL', status: { code: StatusCode.ERROR } }),
+        ]}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'GenAI operations: 3' });
+    button.focus();
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByText('GenAI execution summary')).toBeInTheDocument();
+    expect(screen.getByText('Agents')).toBeInTheDocument();
+    expect(screen.getByText('Model operations')).toBeInTheDocument();
+    expect(screen.getByText('Tool operations')).toBeInTheDocument();
+    expect(screen.queryByText('Retrieval operations')).not.toBeInTheDocument();
+    expect(screen.getByText('1,840')).toBeInTheDocument();
+    expect(screen.getByText('260')).toBeInTheDocument();
+    expect(screen.getByText('Failed operations')).toBeInTheDocument();
+  });
+});

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/GenAIExecutionSummary.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/GenAIExecutionSummary.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { Button, Popover } from 'antd';
+
+import { IOtelSpan } from '../../../types/otel';
+import { getGenAIExecutionSummary } from '../../../utils/genai/execution-summary';
+
+type GenAIExecutionSummaryProps = { spans: ReadonlyArray<IOtelSpan> };
+
+const formatNumber = (value: number | undefined) => (value === undefined ? '—' : value.toLocaleString());
+
+function GenAIExecutionSummaryFn({ spans }: GenAIExecutionSummaryProps) {
+  const summary = React.useMemo(() => getGenAIExecutionSummary(spans), [spans]);
+  if (!summary) return null;
+
+  const operationRows = (
+    [
+      ['Agents', summary.agentCount],
+      ['Model operations', summary.modelOperationCount],
+      ['Tool operations', summary.toolOperationCount],
+      ['Retrieval operations', summary.retrievalOperationCount],
+      ['Other GenAI', summary.otherGenAIOperationCount],
+    ] as Array<[string, number]>
+  ).filter(([, count]) => count > 0);
+
+  const content = (
+    <div className="TracePageHeader--genAIExecutionContent">
+      <div className="TracePageHeader--genAIExecutionHeading">GenAI execution summary</div>
+      <dl className="TracePageHeader--genAIExecutionList">
+        {operationRows.map(([label, count]) => (
+          <React.Fragment key={label}>
+            <dt>{label}</dt>
+            <dd>{count}</dd>
+          </React.Fragment>
+        ))}
+      </dl>
+      <div className="TracePageHeader--genAIExecutionHeading">Recorded tokens</div>
+      <dl className="TracePageHeader--genAIExecutionList">
+        <dt>Input</dt>
+        <dd>{formatNumber(summary.inputTokens)}</dd>
+        <dt>Output</dt>
+        <dd>{formatNumber(summary.outputTokens)}</dd>
+      </dl>
+      <dl className="TracePageHeader--genAIExecutionList TracePageHeader--genAIExecutionFailures">
+        <dt>Failed operations</dt>
+        <dd>{summary.failedOperationCount}</dd>
+      </dl>
+    </div>
+  );
+
+  const ariaLabel = `GenAI operations: ${summary.operationCount}`;
+  return (
+    <Popover content={content} placement="bottomLeft" trigger="click">
+      <Button aria-label={ariaLabel} className="TracePageHeader--genAIExecutionButton" type="link">
+        <span className="TracePageHeader--genAIExecutionLabel">GenAI operations:</span>
+        {summary.operationCount}
+      </Button>
+    </Popover>
+  );
+}
+
+export default React.memo(GenAIExecutionSummaryFn);

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.css
@@ -110,3 +110,57 @@ SPDX-License-Identifier: Apache-2.0
   margin-top: -0.2em;
   vertical-align: middle;
 }
+
+.TracePageHeader--genAIExecutionButton {
+  color: var(--text-primary);
+  font-weight: 600;
+  height: auto;
+  padding: 0;
+}
+
+.TracePageHeader--genAIExecutionButton:hover,
+.TracePageHeader--genAIExecutionButton:focus-visible {
+  color: var(--interactive-primary);
+}
+
+.TracePageHeader--genAIExecutionLabel {
+  color: var(--text-muted);
+  margin-right: 0.25rem;
+}
+
+.TracePageHeader--genAIExecutionButton:hover .TracePageHeader--genAIExecutionLabel,
+.TracePageHeader--genAIExecutionButton:focus-visible .TracePageHeader--genAIExecutionLabel {
+  color: inherit;
+}
+
+.TracePageHeader--genAIExecutionContent {
+  min-width: 14rem;
+}
+
+.TracePageHeader--genAIExecutionHeading {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.TracePageHeader--genAIExecutionHeading:not(:first-child) {
+  border-top: 1px solid var(--border-default);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.TracePageHeader--genAIExecutionList {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  margin: 0;
+}
+
+.TracePageHeader--genAIExecutionList dd {
+  margin-left: 1rem;
+  text-align: right;
+}
+
+.TracePageHeader--genAIExecutionFailures {
+  border-top: 1px solid var(--border-default);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+}

--- a/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TracePageHeader/TracePageHeader.tsx
@@ -33,6 +33,7 @@ import './TracePageHeader.css';
 import ExternalLinks from '../../common/ExternalLinks';
 import { getTargetEmptyOrBlank } from '../../../utils/config/get-target';
 import TraceId from '../../common/TraceId';
+import GenAIExecutionSummary from './GenAIExecutionSummary';
 
 type TracePageHeaderEmbedProps = {
   canCollapse: boolean;
@@ -170,7 +171,19 @@ export function TracePageHeaderFn(props: TracePageHeaderEmbedProps & { forwarded
     HEADER_ITEMS.map(item => {
       const { renderer, ...rest } = item;
       return { ...rest, value: renderer(trace) };
-    }).filter(item => item.value !== null);
+    })
+      .filter(item => item.value !== null)
+      .concat(
+        trace.isGenAITrace
+          ? [
+              {
+                key: 'genai-operations',
+                label: null,
+                value: <GenAIExecutionSummary spans={trace.spans} />,
+              },
+            ]
+          : []
+      );
 
   const traceShortID = trace.traceID.slice(0, 7);
 

--- a/packages/jaeger-ui/src/utils/genai/execution-summary.test.ts
+++ b/packages/jaeger-ui/src/utils/genai/execution-summary.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IOtelSpan, StatusCode } from '../../types/otel';
+import { makeAttributes } from '../../model/attributes';
+import { getGenAIExecutionSummary } from './execution-summary';
+
+function makeSpan(overrides: Partial<IOtelSpan> = {}): IOtelSpan {
+  const zero = 0 as IOtelSpan['startTime'];
+  return {
+    attributes: makeAttributes(),
+    childSpans: [],
+    depth: 0,
+    duration: zero,
+    endTime: zero,
+    events: [],
+    hasChildren: false,
+    inboundLinks: [],
+    instrumentationScope: { name: 'test' },
+    kind: 'INTERNAL' as IOtelSpan['kind'],
+    links: [],
+    name: 'test',
+    relativeStartTime: zero,
+    resource: { attributes: makeAttributes(), serviceName: 'test' },
+    spanID: 'span',
+    startTime: zero,
+    status: { code: StatusCode.OK },
+    traceID: 'trace',
+    warnings: null,
+    ...overrides,
+  };
+}
+
+describe('getGenAIExecutionSummary', () => {
+  it('returns undefined when no spans have a recognized GenAI classification', () => {
+    expect(getGenAIExecutionSummary([makeSpan()])).toBeUndefined();
+  });
+
+  it('counts operation kinds and normalized failures', () => {
+    const spans = [
+      makeSpan({ genAIKind: 'AGENT' }),
+      makeSpan({ genAIKind: 'LLM_CALL' }),
+      makeSpan({ genAIKind: 'TOOL_CALL', status: { code: StatusCode.ERROR } }),
+      makeSpan({ genAIKind: 'RETRIEVAL' }),
+      makeSpan({ genAIKind: 'UNKNOWN_GENAI' }),
+    ];
+
+    expect(getGenAIExecutionSummary(spans)).toMatchObject({
+      agentCount: 1,
+      failedOperationCount: 1,
+      modelOperationCount: 1,
+      operationCount: 5,
+      otherGenAIOperationCount: 1,
+      retrievalOperationCount: 1,
+      toolOperationCount: 1,
+    });
+  });
+
+  it('aggregates standard token usage from model operations only and preserves zero', () => {
+    const spans = [
+      makeSpan({
+        genAIKind: 'AGENT',
+        attributes: makeAttributes([
+          { key: 'gen_ai.usage.input_tokens', value: 999 },
+          { key: 'gen_ai.usage.output_tokens', value: 999 },
+        ]),
+      }),
+      makeSpan({
+        genAIKind: 'LLM_CALL',
+        attributes: makeAttributes([
+          { key: 'gen_ai.usage.input_tokens', value: 100 },
+          { key: 'gen_ai.usage.output_tokens', value: 0 },
+        ]),
+      }),
+      makeSpan({
+        genAIKind: 'LLM_CALL',
+        attributes: makeAttributes([{ key: 'gen_ai.usage.input_tokens', value: 40 }]),
+      }),
+    ];
+
+    expect(getGenAIExecutionSummary(spans)).toMatchObject({ inputTokens: 140, outputTokens: 0 });
+  });
+
+  it('leaves token totals unavailable when model spans do not record them', () => {
+    expect(getGenAIExecutionSummary([makeSpan({ genAIKind: 'LLM_CALL' })])).toMatchObject({
+      inputTokens: undefined,
+      outputTokens: undefined,
+    });
+  });
+});

--- a/packages/jaeger-ui/src/utils/genai/execution-summary.ts
+++ b/packages/jaeger-ui/src/utils/genai/execution-summary.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 The Jaeger Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IOtelSpan, StatusCode } from '../../types/otel';
+
+export interface IGenAIExecutionSummary {
+  agentCount: number;
+  failedOperationCount: number;
+  inputTokens?: number;
+  modelOperationCount: number;
+  operationCount: number;
+  otherGenAIOperationCount: number;
+  outputTokens?: number;
+  retrievalOperationCount: number;
+  toolOperationCount: number;
+}
+
+function addTokenCount(total: number | undefined, value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? (total ?? 0) + value : total;
+}
+
+/**
+ * Produces a trace-wide GenAI summary from the cached span classification.
+ * This deliberately reads only classification, normalized status, and the two
+ * aggregate token attributes; no prompt, completion, message, or tool data is read.
+ */
+export function getGenAIExecutionSummary(
+  spans: ReadonlyArray<IOtelSpan>
+): IGenAIExecutionSummary | undefined {
+  let agentCount = 0;
+  let modelOperationCount = 0;
+  let toolOperationCount = 0;
+  let retrievalOperationCount = 0;
+  let otherGenAIOperationCount = 0;
+  let failedOperationCount = 0;
+  let inputTokens: number | undefined;
+  let outputTokens: number | undefined;
+
+  for (const span of spans) {
+    if (span.genAIKind === undefined) continue;
+
+    if (span.status.code === StatusCode.ERROR) failedOperationCount++;
+
+    switch (span.genAIKind) {
+      case 'AGENT':
+        agentCount++;
+        break;
+      case 'LLM_CALL':
+        modelOperationCount++;
+        inputTokens = addTokenCount(inputTokens, span.attributes.getValue('gen_ai.usage.input_tokens'));
+        outputTokens = addTokenCount(outputTokens, span.attributes.getValue('gen_ai.usage.output_tokens'));
+        break;
+      case 'TOOL_CALL':
+        toolOperationCount++;
+        break;
+      case 'RETRIEVAL':
+        retrievalOperationCount++;
+        break;
+      default:
+        otherGenAIOperationCount++;
+    }
+  }
+
+  const operationCount =
+    agentCount +
+    modelOperationCount +
+    toolOperationCount +
+    retrievalOperationCount +
+    otherGenAIOperationCount;
+  if (operationCount === 0) return undefined;
+
+  return {
+    agentCount,
+    failedOperationCount,
+    inputTokens,
+    modelOperationCount,
+    operationCount,
+    otherGenAIOperationCount,
+    outputTokens,
+    retrievalOperationCount,
+    toolOperationCount,
+  };
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Adds trace-level GenAI execution orientation to the Trace Page header.
- Resolves #4466 

## Description of the changes

- Adds a conditional, keyboard-accessible `GenAI operations: N` header item and popover.
- Summarizes agent, model, tool, retrieval, and other GenAI operations.
- Aggregates standard input/output token usage from model spans only.
- Shows normalized failed GenAI operation counts without reading sensitive prompt, completion, message, or tool-argument content.
- Adds focused unit and component tests.

### Before
<img width="1461" height="143" alt="image" src="https://github.com/user-attachments/assets/f01e9bf3-c569-4cf5-959a-f3931594bdb2" />

### After
<img width="1592" height="157" alt="image" src="https://github.com/user-attachments/assets/c0e1efa7-b78c-4cda-b6b5-bfffb66e5beb" />
<img width="1598" height="420" alt="image" src="https://github.com/user-attachments/assets/a24a4104-f20f-44f9-8b0d-e93bc905b83f" />

https://github.com/user-attachments/assets/a0af9839-7ac9-4422-adf7-d968c1cd6c37





## How was this change tested?

- `pnpm test`
- `pnpm run fmt`
- `pnpm run lint`
- Manually checked too

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)

See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/AI_POLICY.md).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes